### PR TITLE
Apply type `cfg` to `Send` and `Sync` implementations

### DIFF
--- a/crates/libs/bindgen/src/types/cpp_interface.rs
+++ b/crates/libs/bindgen/src/types/cpp_interface.rs
@@ -211,6 +211,15 @@ impl CppInterface {
 
             result.combine(vtbl);
 
+            if self.def.is_agile() {
+                result.combine(quote! {
+                    #cfg
+                    unsafe impl Send for #name {}
+                    #cfg
+                    unsafe impl Sync for #name {}
+                });
+            }
+
             let impl_name: TokenStream = format!("{}_Impl", self.def.name()).into();
 
             let cfg = if writer.config.package {
@@ -387,15 +396,6 @@ impl CppInterface {
                     }
                 }
             });
-
-            if self.def.is_agile() {
-                result.combine(quote! {
-                    #cfg
-                    unsafe impl Send for #name {}
-                    #cfg
-                    unsafe impl Sync for #name {}
-                });
-            }
 
             result
         }

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct2D/Common/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct2D/Common/mod.rs
@@ -470,6 +470,8 @@ pub struct ID2D1SimplifiedGeometrySink_Vtbl {
     pub EndFigure: unsafe extern "system" fn(*mut core::ffi::c_void, D2D1_FIGURE_END),
     pub Close: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID2D1SimplifiedGeometrySink {}
+unsafe impl Sync for ID2D1SimplifiedGeometrySink {}
 pub trait ID2D1SimplifiedGeometrySink_Impl: windows_core::IUnknownImpl {
     fn SetFillMode(&self, fillmode: D2D1_FILL_MODE);
     fn SetSegmentFlags(&self, vertexflags: D2D1_PATH_SEGMENT);
@@ -539,5 +541,3 @@ impl ID2D1SimplifiedGeometrySink_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID2D1SimplifiedGeometrySink {}
-unsafe impl Send for ID2D1SimplifiedGeometrySink {}
-unsafe impl Sync for ID2D1SimplifiedGeometrySink {}

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct2D/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct2D/mod.rs
@@ -2579,6 +2579,8 @@ pub struct ID2D1AnalysisTransform_Vtbl {
     pub base__: windows_core::IUnknown_Vtbl,
     pub ProcessAnalysisResults: unsafe extern "system" fn(*mut core::ffi::c_void, *const u8, u32) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID2D1AnalysisTransform {}
+unsafe impl Sync for ID2D1AnalysisTransform {}
 pub trait ID2D1AnalysisTransform_Impl: windows_core::IUnknownImpl {
     fn ProcessAnalysisResults(&self, analysisdata: *const u8, analysisdatacount: u32) -> windows_core::Result<()>;
 }
@@ -2597,8 +2599,6 @@ impl ID2D1AnalysisTransform_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID2D1AnalysisTransform {}
-unsafe impl Send for ID2D1AnalysisTransform {}
-unsafe impl Sync for ID2D1AnalysisTransform {}
 windows_core::imp::define_interface!(ID2D1Bitmap, ID2D1Bitmap_Vtbl, 0xa2296057_ea42_4099_983b_539fb6505426);
 impl core::ops::Deref for ID2D1Bitmap {
     type Target = ID2D1Image;
@@ -2683,6 +2683,8 @@ pub struct ID2D1Bitmap_Vtbl {
     #[cfg(not(feature = "Win32_Graphics_Direct2D_Common"))]
     CopyFromMemory: usize,
 }
+unsafe impl Send for ID2D1Bitmap {}
+unsafe impl Sync for ID2D1Bitmap {}
 #[cfg(all(feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait ID2D1Bitmap_Impl: ID2D1Image_Impl {
     fn GetSize(&self) -> Common::D2D_SIZE_F;
@@ -2755,10 +2757,6 @@ impl ID2D1Bitmap_Vtbl {
 }
 #[cfg(all(feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_Dxgi_Common"))]
 impl windows_core::RuntimeName for ID2D1Bitmap {}
-#[cfg(all(feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_Dxgi_Common"))]
-unsafe impl Send for ID2D1Bitmap {}
-#[cfg(all(feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_Dxgi_Common"))]
-unsafe impl Sync for ID2D1Bitmap {}
 windows_core::imp::define_interface!(ID2D1Bitmap1, ID2D1Bitmap1_Vtbl, 0xa898a84c_3873_4588_b08b_ebbf978df041);
 impl core::ops::Deref for ID2D1Bitmap1 {
     type Target = ID2D1Bitmap;
@@ -2807,6 +2805,8 @@ pub struct ID2D1Bitmap1_Vtbl {
     pub Map: unsafe extern "system" fn(*mut core::ffi::c_void, D2D1_MAP_OPTIONS, *mut D2D1_MAPPED_RECT) -> windows_core::HRESULT,
     pub Unmap: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID2D1Bitmap1 {}
+unsafe impl Sync for ID2D1Bitmap1 {}
 #[cfg(all(feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait ID2D1Bitmap1_Impl: ID2D1Bitmap_Impl {
     fn GetColorContext(&self, colorcontext: windows_core::OutRef<'_, ID2D1ColorContext>);
@@ -2875,10 +2875,6 @@ impl ID2D1Bitmap1_Vtbl {
 }
 #[cfg(all(feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_Dxgi_Common"))]
 impl windows_core::RuntimeName for ID2D1Bitmap1 {}
-#[cfg(all(feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_Dxgi_Common"))]
-unsafe impl Send for ID2D1Bitmap1 {}
-#[cfg(all(feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_Dxgi_Common"))]
-unsafe impl Sync for ID2D1Bitmap1 {}
 windows_core::imp::define_interface!(ID2D1BitmapBrush, ID2D1BitmapBrush_Vtbl, 0x2cd906aa_12e2_11dc_9fed_001143a055f9);
 impl core::ops::Deref for ID2D1BitmapBrush {
     type Target = ID2D1Brush;
@@ -2932,6 +2928,8 @@ pub struct ID2D1BitmapBrush_Vtbl {
     pub GetInterpolationMode: unsafe extern "system" fn(*mut core::ffi::c_void) -> D2D1_BITMAP_INTERPOLATION_MODE,
     pub GetBitmap: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void),
 }
+unsafe impl Send for ID2D1BitmapBrush {}
+unsafe impl Sync for ID2D1BitmapBrush {}
 #[cfg(feature = "Foundation_Numerics")]
 pub trait ID2D1BitmapBrush_Impl: ID2D1Brush_Impl {
     fn SetExtendModeX(&self, extendmodex: D2D1_EXTEND_MODE);
@@ -3012,10 +3010,6 @@ impl ID2D1BitmapBrush_Vtbl {
 }
 #[cfg(feature = "Foundation_Numerics")]
 impl windows_core::RuntimeName for ID2D1BitmapBrush {}
-#[cfg(feature = "Foundation_Numerics")]
-unsafe impl Send for ID2D1BitmapBrush {}
-#[cfg(feature = "Foundation_Numerics")]
-unsafe impl Sync for ID2D1BitmapBrush {}
 windows_core::imp::define_interface!(ID2D1BitmapBrush1, ID2D1BitmapBrush1_Vtbl, 0x41343a53_e41a_49a2_91cd_21793bbb62e5);
 impl core::ops::Deref for ID2D1BitmapBrush1 {
     type Target = ID2D1BitmapBrush;
@@ -3038,6 +3032,8 @@ pub struct ID2D1BitmapBrush1_Vtbl {
     pub SetInterpolationMode1: unsafe extern "system" fn(*mut core::ffi::c_void, D2D1_INTERPOLATION_MODE),
     pub GetInterpolationMode1: unsafe extern "system" fn(*mut core::ffi::c_void) -> D2D1_INTERPOLATION_MODE,
 }
+unsafe impl Send for ID2D1BitmapBrush1 {}
+unsafe impl Sync for ID2D1BitmapBrush1 {}
 #[cfg(feature = "Foundation_Numerics")]
 pub trait ID2D1BitmapBrush1_Impl: ID2D1BitmapBrush_Impl {
     fn SetInterpolationMode1(&self, interpolationmode: D2D1_INTERPOLATION_MODE);
@@ -3070,10 +3066,6 @@ impl ID2D1BitmapBrush1_Vtbl {
 }
 #[cfg(feature = "Foundation_Numerics")]
 impl windows_core::RuntimeName for ID2D1BitmapBrush1 {}
-#[cfg(feature = "Foundation_Numerics")]
-unsafe impl Send for ID2D1BitmapBrush1 {}
-#[cfg(feature = "Foundation_Numerics")]
-unsafe impl Sync for ID2D1BitmapBrush1 {}
 windows_core::imp::define_interface!(ID2D1BitmapRenderTarget, ID2D1BitmapRenderTarget_Vtbl, 0x2cd90695_12e2_11dc_9fed_001143a055f9);
 impl core::ops::Deref for ID2D1BitmapRenderTarget {
     type Target = ID2D1RenderTarget;
@@ -3095,6 +3087,8 @@ pub struct ID2D1BitmapRenderTarget_Vtbl {
     pub base__: ID2D1RenderTarget_Vtbl,
     pub GetBitmap: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID2D1BitmapRenderTarget {}
+unsafe impl Sync for ID2D1BitmapRenderTarget {}
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging"))]
 pub trait ID2D1BitmapRenderTarget_Impl: ID2D1RenderTarget_Impl {
     fn GetBitmap(&self) -> windows_core::Result<ID2D1Bitmap>;
@@ -3122,10 +3116,6 @@ impl ID2D1BitmapRenderTarget_Vtbl {
 }
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging"))]
 impl windows_core::RuntimeName for ID2D1BitmapRenderTarget {}
-#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging"))]
-unsafe impl Send for ID2D1BitmapRenderTarget {}
-#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging"))]
-unsafe impl Sync for ID2D1BitmapRenderTarget {}
 windows_core::imp::define_interface!(ID2D1BlendTransform, ID2D1BlendTransform_Vtbl, 0x63ac0b32_ba44_450f_8806_7f4ca1ff2f1b);
 impl core::ops::Deref for ID2D1BlendTransform {
     type Target = ID2D1ConcreteTransform;
@@ -3148,6 +3138,8 @@ pub struct ID2D1BlendTransform_Vtbl {
     pub SetDescription: unsafe extern "system" fn(*mut core::ffi::c_void, *const D2D1_BLEND_DESCRIPTION),
     pub GetDescription: unsafe extern "system" fn(*mut core::ffi::c_void, *mut D2D1_BLEND_DESCRIPTION),
 }
+unsafe impl Send for ID2D1BlendTransform {}
+unsafe impl Sync for ID2D1BlendTransform {}
 pub trait ID2D1BlendTransform_Impl: ID2D1ConcreteTransform_Impl {
     fn SetDescription(&self, description: *const D2D1_BLEND_DESCRIPTION);
     fn GetDescription(&self, description: *mut D2D1_BLEND_DESCRIPTION);
@@ -3177,8 +3169,6 @@ impl ID2D1BlendTransform_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID2D1BlendTransform {}
-unsafe impl Send for ID2D1BlendTransform {}
-unsafe impl Sync for ID2D1BlendTransform {}
 windows_core::imp::define_interface!(ID2D1BorderTransform, ID2D1BorderTransform_Vtbl, 0x4998735c_3a19_473c_9781_656847e3a347);
 impl core::ops::Deref for ID2D1BorderTransform {
     type Target = ID2D1ConcreteTransform;
@@ -3209,6 +3199,8 @@ pub struct ID2D1BorderTransform_Vtbl {
     pub GetExtendModeX: unsafe extern "system" fn(*mut core::ffi::c_void) -> D2D1_EXTEND_MODE,
     pub GetExtendModeY: unsafe extern "system" fn(*mut core::ffi::c_void) -> D2D1_EXTEND_MODE,
 }
+unsafe impl Send for ID2D1BorderTransform {}
+unsafe impl Sync for ID2D1BorderTransform {}
 pub trait ID2D1BorderTransform_Impl: ID2D1ConcreteTransform_Impl {
     fn SetExtendModeX(&self, extendmode: D2D1_EXTEND_MODE);
     fn SetExtendModeY(&self, extendmode: D2D1_EXTEND_MODE);
@@ -3254,8 +3246,6 @@ impl ID2D1BorderTransform_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID2D1BorderTransform {}
-unsafe impl Send for ID2D1BorderTransform {}
-unsafe impl Sync for ID2D1BorderTransform {}
 windows_core::imp::define_interface!(ID2D1BoundsAdjustmentTransform, ID2D1BoundsAdjustmentTransform_Vtbl, 0x90f732e2_5092_4606_a819_8651970baccd);
 impl core::ops::Deref for ID2D1BoundsAdjustmentTransform {
     type Target = ID2D1TransformNode;
@@ -3282,6 +3272,8 @@ pub struct ID2D1BoundsAdjustmentTransform_Vtbl {
     pub SetOutputBounds: unsafe extern "system" fn(*mut core::ffi::c_void, *const super::super::Foundation::RECT),
     pub GetOutputBounds: unsafe extern "system" fn(*mut core::ffi::c_void, *mut super::super::Foundation::RECT),
 }
+unsafe impl Send for ID2D1BoundsAdjustmentTransform {}
+unsafe impl Sync for ID2D1BoundsAdjustmentTransform {}
 pub trait ID2D1BoundsAdjustmentTransform_Impl: ID2D1TransformNode_Impl {
     fn SetOutputBounds(&self, outputbounds: *const super::super::Foundation::RECT);
     fn GetOutputBounds(&self, outputbounds: *mut super::super::Foundation::RECT);
@@ -3311,8 +3303,6 @@ impl ID2D1BoundsAdjustmentTransform_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID2D1BoundsAdjustmentTransform {}
-unsafe impl Send for ID2D1BoundsAdjustmentTransform {}
-unsafe impl Sync for ID2D1BoundsAdjustmentTransform {}
 windows_core::imp::define_interface!(ID2D1Brush, ID2D1Brush_Vtbl, 0x2cd906a8_12e2_11dc_9fed_001143a055f9);
 impl core::ops::Deref for ID2D1Brush {
     type Target = ID2D1Resource;
@@ -3351,6 +3341,8 @@ pub struct ID2D1Brush_Vtbl {
     #[cfg(not(feature = "Foundation_Numerics"))]
     GetTransform: usize,
 }
+unsafe impl Send for ID2D1Brush {}
+unsafe impl Sync for ID2D1Brush {}
 #[cfg(feature = "Foundation_Numerics")]
 pub trait ID2D1Brush_Impl: ID2D1Resource_Impl {
     fn SetOpacity(&self, opacity: f32);
@@ -3399,10 +3391,6 @@ impl ID2D1Brush_Vtbl {
 }
 #[cfg(feature = "Foundation_Numerics")]
 impl windows_core::RuntimeName for ID2D1Brush {}
-#[cfg(feature = "Foundation_Numerics")]
-unsafe impl Send for ID2D1Brush {}
-#[cfg(feature = "Foundation_Numerics")]
-unsafe impl Sync for ID2D1Brush {}
 windows_core::imp::define_interface!(ID2D1ColorContext, ID2D1ColorContext_Vtbl, 0x1c4820bb_5771_4518_a581_2fe4dd0ec657);
 impl core::ops::Deref for ID2D1ColorContext {
     type Target = ID2D1Resource;
@@ -3429,6 +3417,8 @@ pub struct ID2D1ColorContext_Vtbl {
     pub GetProfileSize: unsafe extern "system" fn(*mut core::ffi::c_void) -> u32,
     pub GetProfile: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u8, u32) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID2D1ColorContext {}
+unsafe impl Sync for ID2D1ColorContext {}
 pub trait ID2D1ColorContext_Impl: ID2D1Resource_Impl {
     fn GetColorSpace(&self) -> D2D1_COLOR_SPACE;
     fn GetProfileSize(&self) -> u32;
@@ -3466,8 +3456,6 @@ impl ID2D1ColorContext_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID2D1ColorContext {}
-unsafe impl Send for ID2D1ColorContext {}
-unsafe impl Sync for ID2D1ColorContext {}
 windows_core::imp::define_interface!(ID2D1ColorContext1, ID2D1ColorContext1_Vtbl, 0x1ab42875_c57f_4be9_bd85_9cd78d6f55ee);
 impl core::ops::Deref for ID2D1ColorContext1 {
     type Target = ID2D1ColorContext;
@@ -3502,6 +3490,8 @@ pub struct ID2D1ColorContext1_Vtbl {
     #[cfg(not(feature = "Win32_Graphics_Direct2D_Common"))]
     GetSimpleColorProfile: usize,
 }
+unsafe impl Send for ID2D1ColorContext1 {}
+unsafe impl Sync for ID2D1ColorContext1 {}
 #[cfg(all(feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait ID2D1ColorContext1_Impl: ID2D1ColorContext_Impl {
     fn GetColorContextType(&self) -> D2D1_COLOR_CONTEXT_TYPE;
@@ -3542,10 +3532,6 @@ impl ID2D1ColorContext1_Vtbl {
 }
 #[cfg(all(feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_Dxgi_Common"))]
 impl windows_core::RuntimeName for ID2D1ColorContext1 {}
-#[cfg(all(feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_Dxgi_Common"))]
-unsafe impl Send for ID2D1ColorContext1 {}
-#[cfg(all(feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_Dxgi_Common"))]
-unsafe impl Sync for ID2D1ColorContext1 {}
 windows_core::imp::define_interface!(ID2D1CommandList, ID2D1CommandList_Vtbl, 0xb4f34a19_2383_4d76_94f6_ec343657c3dc);
 impl core::ops::Deref for ID2D1CommandList {
     type Target = ID2D1Image;
@@ -3571,6 +3557,8 @@ pub struct ID2D1CommandList_Vtbl {
     pub Stream: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
     pub Close: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID2D1CommandList {}
+unsafe impl Sync for ID2D1CommandList {}
 pub trait ID2D1CommandList_Impl: ID2D1Image_Impl {
     fn Stream(&self, sink: windows_core::Ref<ID2D1CommandSink>) -> windows_core::Result<()>;
     fn Close(&self) -> windows_core::Result<()>;
@@ -3596,8 +3584,6 @@ impl ID2D1CommandList_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID2D1CommandList {}
-unsafe impl Send for ID2D1CommandList {}
-unsafe impl Sync for ID2D1CommandList {}
 windows_core::imp::define_interface!(ID2D1CommandSink, ID2D1CommandSink_Vtbl, 0x54d7898a_a061_40a7_bec7_e465bcba2c4f);
 windows_core::imp::interface_hierarchy!(ID2D1CommandSink, windows_core::IUnknown);
 impl ID2D1CommandSink {
@@ -3805,6 +3791,8 @@ pub struct ID2D1CommandSink_Vtbl {
     pub PopAxisAlignedClip: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
     pub PopLayer: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID2D1CommandSink {}
+unsafe impl Sync for ID2D1CommandSink {}
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite"))]
 pub trait ID2D1CommandSink_Impl: windows_core::IUnknownImpl {
     fn BeginDraw(&self) -> windows_core::Result<()>;
@@ -4021,10 +4009,6 @@ impl ID2D1CommandSink_Vtbl {
 }
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite"))]
 impl windows_core::RuntimeName for ID2D1CommandSink {}
-#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite"))]
-unsafe impl Send for ID2D1CommandSink {}
-#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite"))]
-unsafe impl Sync for ID2D1CommandSink {}
 windows_core::imp::define_interface!(ID2D1CommandSink1, ID2D1CommandSink1_Vtbl, 0x9eb767fd_4269_4467_b8c2_eb30cb305743);
 impl core::ops::Deref for ID2D1CommandSink1 {
     type Target = ID2D1CommandSink;
@@ -4043,6 +4027,8 @@ pub struct ID2D1CommandSink1_Vtbl {
     pub base__: ID2D1CommandSink_Vtbl,
     pub SetPrimitiveBlend1: unsafe extern "system" fn(*mut core::ffi::c_void, D2D1_PRIMITIVE_BLEND) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID2D1CommandSink1 {}
+unsafe impl Sync for ID2D1CommandSink1 {}
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite"))]
 pub trait ID2D1CommandSink1_Impl: ID2D1CommandSink_Impl {
     fn SetPrimitiveBlend1(&self, primitiveblend: D2D1_PRIMITIVE_BLEND) -> windows_core::Result<()>;
@@ -4064,10 +4050,6 @@ impl ID2D1CommandSink1_Vtbl {
 }
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite"))]
 impl windows_core::RuntimeName for ID2D1CommandSink1 {}
-#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite"))]
-unsafe impl Send for ID2D1CommandSink1 {}
-#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite"))]
-unsafe impl Sync for ID2D1CommandSink1 {}
 windows_core::imp::define_interface!(ID2D1CommandSink2, ID2D1CommandSink2_Vtbl, 0x3bab440e_417e_47df_a2e2_bc0be6a00916);
 impl core::ops::Deref for ID2D1CommandSink2 {
     type Target = ID2D1CommandSink1;
@@ -4109,6 +4091,8 @@ pub struct ID2D1CommandSink2_Vtbl {
     #[cfg(not(feature = "Win32_Graphics_Direct2D_Common"))]
     DrawGdiMetafile: usize,
 }
+unsafe impl Send for ID2D1CommandSink2 {}
+unsafe impl Sync for ID2D1CommandSink2 {}
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite"))]
 pub trait ID2D1CommandSink2_Impl: ID2D1CommandSink1_Impl {
     fn DrawInk(&self, ink: windows_core::Ref<ID2D1Ink>, brush: windows_core::Ref<ID2D1Brush>, inkstyle: windows_core::Ref<ID2D1InkStyle>) -> windows_core::Result<()>;
@@ -4149,10 +4133,6 @@ impl ID2D1CommandSink2_Vtbl {
 }
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite"))]
 impl windows_core::RuntimeName for ID2D1CommandSink2 {}
-#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite"))]
-unsafe impl Send for ID2D1CommandSink2 {}
-#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite"))]
-unsafe impl Sync for ID2D1CommandSink2 {}
 windows_core::imp::define_interface!(ID2D1CommandSink3, ID2D1CommandSink3_Vtbl, 0x18079135_4cf3_4868_bc8e_06067e6d242d);
 impl core::ops::Deref for ID2D1CommandSink3 {
     type Target = ID2D1CommandSink2;
@@ -4175,6 +4155,8 @@ pub struct ID2D1CommandSink3_Vtbl {
     pub base__: ID2D1CommandSink2_Vtbl,
     pub DrawSpriteBatch: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, u32, u32, *mut core::ffi::c_void, D2D1_BITMAP_INTERPOLATION_MODE, D2D1_SPRITE_OPTIONS) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID2D1CommandSink3 {}
+unsafe impl Sync for ID2D1CommandSink3 {}
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite"))]
 pub trait ID2D1CommandSink3_Impl: ID2D1CommandSink2_Impl {
     fn DrawSpriteBatch(&self, spritebatch: windows_core::Ref<ID2D1SpriteBatch>, startindex: u32, spritecount: u32, bitmap: windows_core::Ref<ID2D1Bitmap>, interpolationmode: D2D1_BITMAP_INTERPOLATION_MODE, spriteoptions: D2D1_SPRITE_OPTIONS) -> windows_core::Result<()>;
@@ -4196,10 +4178,6 @@ impl ID2D1CommandSink3_Vtbl {
 }
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite"))]
 impl windows_core::RuntimeName for ID2D1CommandSink3 {}
-#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite"))]
-unsafe impl Send for ID2D1CommandSink3 {}
-#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite"))]
-unsafe impl Sync for ID2D1CommandSink3 {}
 windows_core::imp::define_interface!(ID2D1CommandSink4, ID2D1CommandSink4_Vtbl, 0xc78a6519_40d6_4218_b2de_beeeb744bb3e);
 impl core::ops::Deref for ID2D1CommandSink4 {
     type Target = ID2D1CommandSink3;
@@ -4218,6 +4196,8 @@ pub struct ID2D1CommandSink4_Vtbl {
     pub base__: ID2D1CommandSink3_Vtbl,
     pub SetPrimitiveBlend2: unsafe extern "system" fn(*mut core::ffi::c_void, D2D1_PRIMITIVE_BLEND) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID2D1CommandSink4 {}
+unsafe impl Sync for ID2D1CommandSink4 {}
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite"))]
 pub trait ID2D1CommandSink4_Impl: ID2D1CommandSink3_Impl {
     fn SetPrimitiveBlend2(&self, primitiveblend: D2D1_PRIMITIVE_BLEND) -> windows_core::Result<()>;
@@ -4239,10 +4219,6 @@ impl ID2D1CommandSink4_Vtbl {
 }
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite"))]
 impl windows_core::RuntimeName for ID2D1CommandSink4 {}
-#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite"))]
-unsafe impl Send for ID2D1CommandSink4 {}
-#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite"))]
-unsafe impl Sync for ID2D1CommandSink4 {}
 windows_core::imp::define_interface!(ID2D1CommandSink5, ID2D1CommandSink5_Vtbl, 0x7047dd26_b1e7_44a7_959a_8349e2144fa8);
 impl core::ops::Deref for ID2D1CommandSink5 {
     type Target = ID2D1CommandSink4;
@@ -4268,6 +4244,8 @@ pub struct ID2D1CommandSink5_Vtbl {
     #[cfg(not(feature = "Win32_Graphics_Direct2D_Common"))]
     BlendImage: usize,
 }
+unsafe impl Send for ID2D1CommandSink5 {}
+unsafe impl Sync for ID2D1CommandSink5 {}
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite"))]
 pub trait ID2D1CommandSink5_Impl: ID2D1CommandSink4_Impl {
     fn BlendImage(&self, image: windows_core::Ref<ID2D1Image>, blendmode: Common::D2D1_BLEND_MODE, targetoffset: *const Common::D2D_POINT_2F, imagerectangle: *const Common::D2D_RECT_F, interpolationmode: D2D1_INTERPOLATION_MODE) -> windows_core::Result<()>;
@@ -4289,10 +4267,6 @@ impl ID2D1CommandSink5_Vtbl {
 }
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite"))]
 impl windows_core::RuntimeName for ID2D1CommandSink5 {}
-#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite"))]
-unsafe impl Send for ID2D1CommandSink5 {}
-#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite"))]
-unsafe impl Sync for ID2D1CommandSink5 {}
 windows_core::imp::define_interface!(ID2D1ComputeInfo, ID2D1ComputeInfo_Vtbl, 0x5598b14b_9fd7_48b7_9bdb_8f0964eb38bc);
 impl core::ops::Deref for ID2D1ComputeInfo {
     type Target = ID2D1RenderInfo;
@@ -4322,6 +4296,8 @@ pub struct ID2D1ComputeInfo_Vtbl {
     pub SetComputeShader: unsafe extern "system" fn(*mut core::ffi::c_void, *const windows_core::GUID) -> windows_core::HRESULT,
     pub SetResourceTexture: unsafe extern "system" fn(*mut core::ffi::c_void, u32, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID2D1ComputeInfo {}
+unsafe impl Sync for ID2D1ComputeInfo {}
 pub trait ID2D1ComputeInfo_Impl: ID2D1RenderInfo_Impl {
     fn SetComputeShaderConstantBuffer(&self, buffer: *const u8, buffercount: u32) -> windows_core::Result<()>;
     fn SetComputeShader(&self, shaderid: *const windows_core::GUID) -> windows_core::Result<()>;
@@ -4359,8 +4335,6 @@ impl ID2D1ComputeInfo_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID2D1ComputeInfo {}
-unsafe impl Send for ID2D1ComputeInfo {}
-unsafe impl Sync for ID2D1ComputeInfo {}
 windows_core::imp::define_interface!(ID2D1ComputeTransform, ID2D1ComputeTransform_Vtbl, 0x0d85573c_01e3_4f7d_bfd9_0d60608bf3c3);
 impl core::ops::Deref for ID2D1ComputeTransform {
     type Target = ID2D1Transform;
@@ -4386,6 +4360,8 @@ pub struct ID2D1ComputeTransform_Vtbl {
     pub SetComputeInfo: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
     pub CalculateThreadgroups: unsafe extern "system" fn(*mut core::ffi::c_void, *const super::super::Foundation::RECT, *mut u32, *mut u32, *mut u32) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID2D1ComputeTransform {}
+unsafe impl Sync for ID2D1ComputeTransform {}
 pub trait ID2D1ComputeTransform_Impl: ID2D1Transform_Impl {
     fn SetComputeInfo(&self, computeinfo: windows_core::Ref<ID2D1ComputeInfo>) -> windows_core::Result<()>;
     fn CalculateThreadgroups(&self, outputrect: *const super::super::Foundation::RECT, dimensionx: *mut u32, dimensiony: *mut u32, dimensionz: *mut u32) -> windows_core::Result<()>;
@@ -4415,8 +4391,6 @@ impl ID2D1ComputeTransform_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID2D1ComputeTransform {}
-unsafe impl Send for ID2D1ComputeTransform {}
-unsafe impl Sync for ID2D1ComputeTransform {}
 windows_core::imp::define_interface!(ID2D1ConcreteTransform, ID2D1ConcreteTransform_Vtbl, 0x1a799d8a_69f7_4e4c_9fed_437ccc6684cc);
 impl core::ops::Deref for ID2D1ConcreteTransform {
     type Target = ID2D1TransformNode;
@@ -4439,6 +4413,8 @@ pub struct ID2D1ConcreteTransform_Vtbl {
     pub SetOutputBuffer: unsafe extern "system" fn(*mut core::ffi::c_void, D2D1_BUFFER_PRECISION, D2D1_CHANNEL_DEPTH) -> windows_core::HRESULT,
     pub SetCached: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::BOOL),
 }
+unsafe impl Send for ID2D1ConcreteTransform {}
+unsafe impl Sync for ID2D1ConcreteTransform {}
 pub trait ID2D1ConcreteTransform_Impl: ID2D1TransformNode_Impl {
     fn SetOutputBuffer(&self, bufferprecision: D2D1_BUFFER_PRECISION, channeldepth: D2D1_CHANNEL_DEPTH) -> windows_core::Result<()>;
     fn SetCached(&self, iscached: super::super::Foundation::BOOL);
@@ -4468,8 +4444,6 @@ impl ID2D1ConcreteTransform_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID2D1ConcreteTransform {}
-unsafe impl Send for ID2D1ConcreteTransform {}
-unsafe impl Sync for ID2D1ConcreteTransform {}
 windows_core::imp::define_interface!(ID2D1DCRenderTarget, ID2D1DCRenderTarget_Vtbl, 0x1c51bc64_de61_46fd_9899_63a5d8f03950);
 impl core::ops::Deref for ID2D1DCRenderTarget {
     type Target = ID2D1RenderTarget;
@@ -4492,6 +4466,8 @@ pub struct ID2D1DCRenderTarget_Vtbl {
     #[cfg(not(feature = "Win32_Graphics_Gdi"))]
     BindDC: usize,
 }
+unsafe impl Send for ID2D1DCRenderTarget {}
+unsafe impl Sync for ID2D1DCRenderTarget {}
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Gdi", feature = "Win32_Graphics_Imaging"))]
 pub trait ID2D1DCRenderTarget_Impl: ID2D1RenderTarget_Impl {
     fn BindDC(&self, hdc: super::Gdi::HDC, psubrect: *const super::super::Foundation::RECT) -> windows_core::Result<()>;
@@ -4513,10 +4489,6 @@ impl ID2D1DCRenderTarget_Vtbl {
 }
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Gdi", feature = "Win32_Graphics_Imaging"))]
 impl windows_core::RuntimeName for ID2D1DCRenderTarget {}
-#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Gdi", feature = "Win32_Graphics_Imaging"))]
-unsafe impl Send for ID2D1DCRenderTarget {}
-#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Gdi", feature = "Win32_Graphics_Imaging"))]
-unsafe impl Sync for ID2D1DCRenderTarget {}
 windows_core::imp::define_interface!(ID2D1Device, ID2D1Device_Vtbl, 0x47dd575d_ac05_4cdd_8049_9b02cd16f44c);
 impl core::ops::Deref for ID2D1Device {
     type Target = ID2D1Resource;
@@ -4565,6 +4537,8 @@ pub struct ID2D1Device_Vtbl {
     pub GetMaximumTextureMemory: unsafe extern "system" fn(*mut core::ffi::c_void) -> u64,
     pub ClearResources: unsafe extern "system" fn(*mut core::ffi::c_void, u32),
 }
+unsafe impl Send for ID2D1Device {}
+unsafe impl Sync for ID2D1Device {}
 #[cfg(all(feature = "Win32_Graphics_Imaging", feature = "Win32_Storage_Xps_Printing"))]
 pub trait ID2D1Device_Impl: ID2D1Resource_Impl {
     fn CreateDeviceContext(&self, options: D2D1_DEVICE_CONTEXT_OPTIONS) -> windows_core::Result<ID2D1DeviceContext>;
@@ -4633,10 +4607,6 @@ impl ID2D1Device_Vtbl {
 }
 #[cfg(all(feature = "Win32_Graphics_Imaging", feature = "Win32_Storage_Xps_Printing"))]
 impl windows_core::RuntimeName for ID2D1Device {}
-#[cfg(all(feature = "Win32_Graphics_Imaging", feature = "Win32_Storage_Xps_Printing"))]
-unsafe impl Send for ID2D1Device {}
-#[cfg(all(feature = "Win32_Graphics_Imaging", feature = "Win32_Storage_Xps_Printing"))]
-unsafe impl Sync for ID2D1Device {}
 windows_core::imp::define_interface!(ID2D1Device1, ID2D1Device1_Vtbl, 0xd21768e1_23a4_4823_a14b_7c3eba85d658);
 impl core::ops::Deref for ID2D1Device1 {
     type Target = ID2D1Device;
@@ -4666,6 +4636,8 @@ pub struct ID2D1Device1_Vtbl {
     pub SetRenderingPriority: unsafe extern "system" fn(*mut core::ffi::c_void, D2D1_RENDERING_PRIORITY),
     pub CreateDeviceContext: unsafe extern "system" fn(*mut core::ffi::c_void, D2D1_DEVICE_CONTEXT_OPTIONS, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID2D1Device1 {}
+unsafe impl Sync for ID2D1Device1 {}
 #[cfg(all(feature = "Win32_Graphics_Imaging", feature = "Win32_Storage_Xps_Printing"))]
 pub trait ID2D1Device1_Impl: ID2D1Device_Impl {
     fn GetRenderingPriority(&self) -> D2D1_RENDERING_PRIORITY;
@@ -4712,10 +4684,6 @@ impl ID2D1Device1_Vtbl {
 }
 #[cfg(all(feature = "Win32_Graphics_Imaging", feature = "Win32_Storage_Xps_Printing"))]
 impl windows_core::RuntimeName for ID2D1Device1 {}
-#[cfg(all(feature = "Win32_Graphics_Imaging", feature = "Win32_Storage_Xps_Printing"))]
-unsafe impl Send for ID2D1Device1 {}
-#[cfg(all(feature = "Win32_Graphics_Imaging", feature = "Win32_Storage_Xps_Printing"))]
-unsafe impl Sync for ID2D1Device1 {}
 windows_core::imp::define_interface!(ID2D1Device2, ID2D1Device2_Vtbl, 0xa44472e1_8dfb_4e60_8492_6e2861c9ca8b);
 impl core::ops::Deref for ID2D1Device2 {
     type Target = ID2D1Device1;
@@ -4755,6 +4723,8 @@ pub struct ID2D1Device2_Vtbl {
     #[cfg(not(feature = "Win32_Graphics_Dxgi"))]
     GetDxgiDevice: usize,
 }
+unsafe impl Send for ID2D1Device2 {}
+unsafe impl Sync for ID2D1Device2 {}
 #[cfg(all(feature = "Win32_Graphics_Dxgi", feature = "Win32_Graphics_Imaging", feature = "Win32_Storage_Xps_Printing"))]
 pub trait ID2D1Device2_Impl: ID2D1Device1_Impl {
     fn CreateDeviceContext(&self, options: D2D1_DEVICE_CONTEXT_OPTIONS) -> windows_core::Result<ID2D1DeviceContext2>;
@@ -4807,10 +4777,6 @@ impl ID2D1Device2_Vtbl {
 }
 #[cfg(all(feature = "Win32_Graphics_Dxgi", feature = "Win32_Graphics_Imaging", feature = "Win32_Storage_Xps_Printing"))]
 impl windows_core::RuntimeName for ID2D1Device2 {}
-#[cfg(all(feature = "Win32_Graphics_Dxgi", feature = "Win32_Graphics_Imaging", feature = "Win32_Storage_Xps_Printing"))]
-unsafe impl Send for ID2D1Device2 {}
-#[cfg(all(feature = "Win32_Graphics_Dxgi", feature = "Win32_Graphics_Imaging", feature = "Win32_Storage_Xps_Printing"))]
-unsafe impl Sync for ID2D1Device2 {}
 windows_core::imp::define_interface!(ID2D1Device3, ID2D1Device3_Vtbl, 0x852f2087_802c_4037_ab60_ff2e7ee6fc01);
 impl core::ops::Deref for ID2D1Device3 {
     type Target = ID2D1Device2;
@@ -4832,6 +4798,8 @@ pub struct ID2D1Device3_Vtbl {
     pub base__: ID2D1Device2_Vtbl,
     pub CreateDeviceContext: unsafe extern "system" fn(*mut core::ffi::c_void, D2D1_DEVICE_CONTEXT_OPTIONS, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID2D1Device3 {}
+unsafe impl Sync for ID2D1Device3 {}
 #[cfg(all(feature = "Win32_Graphics_Dxgi", feature = "Win32_Graphics_Imaging", feature = "Win32_Storage_Xps_Printing"))]
 pub trait ID2D1Device3_Impl: ID2D1Device2_Impl {
     fn CreateDeviceContext(&self, options: D2D1_DEVICE_CONTEXT_OPTIONS) -> windows_core::Result<ID2D1DeviceContext3>;
@@ -4859,10 +4827,6 @@ impl ID2D1Device3_Vtbl {
 }
 #[cfg(all(feature = "Win32_Graphics_Dxgi", feature = "Win32_Graphics_Imaging", feature = "Win32_Storage_Xps_Printing"))]
 impl windows_core::RuntimeName for ID2D1Device3 {}
-#[cfg(all(feature = "Win32_Graphics_Dxgi", feature = "Win32_Graphics_Imaging", feature = "Win32_Storage_Xps_Printing"))]
-unsafe impl Send for ID2D1Device3 {}
-#[cfg(all(feature = "Win32_Graphics_Dxgi", feature = "Win32_Graphics_Imaging", feature = "Win32_Storage_Xps_Printing"))]
-unsafe impl Sync for ID2D1Device3 {}
 windows_core::imp::define_interface!(ID2D1Device4, ID2D1Device4_Vtbl, 0xd7bdb159_5683_4a46_bc9c_72dc720b858b);
 impl core::ops::Deref for ID2D1Device4 {
     type Target = ID2D1Device3;
@@ -4892,6 +4856,8 @@ pub struct ID2D1Device4_Vtbl {
     pub SetMaximumColorGlyphCacheMemory: unsafe extern "system" fn(*mut core::ffi::c_void, u64),
     pub GetMaximumColorGlyphCacheMemory: unsafe extern "system" fn(*mut core::ffi::c_void) -> u64,
 }
+unsafe impl Send for ID2D1Device4 {}
+unsafe impl Sync for ID2D1Device4 {}
 #[cfg(all(feature = "Win32_Graphics_Dxgi", feature = "Win32_Graphics_Imaging", feature = "Win32_Storage_Xps_Printing"))]
 pub trait ID2D1Device4_Impl: ID2D1Device3_Impl {
     fn CreateDeviceContext(&self, options: D2D1_DEVICE_CONTEXT_OPTIONS) -> windows_core::Result<ID2D1DeviceContext4>;
@@ -4938,10 +4904,6 @@ impl ID2D1Device4_Vtbl {
 }
 #[cfg(all(feature = "Win32_Graphics_Dxgi", feature = "Win32_Graphics_Imaging", feature = "Win32_Storage_Xps_Printing"))]
 impl windows_core::RuntimeName for ID2D1Device4 {}
-#[cfg(all(feature = "Win32_Graphics_Dxgi", feature = "Win32_Graphics_Imaging", feature = "Win32_Storage_Xps_Printing"))]
-unsafe impl Send for ID2D1Device4 {}
-#[cfg(all(feature = "Win32_Graphics_Dxgi", feature = "Win32_Graphics_Imaging", feature = "Win32_Storage_Xps_Printing"))]
-unsafe impl Sync for ID2D1Device4 {}
 windows_core::imp::define_interface!(ID2D1Device5, ID2D1Device5_Vtbl, 0xd55ba0a4_6405_4694_aef5_08ee1a4358b4);
 impl core::ops::Deref for ID2D1Device5 {
     type Target = ID2D1Device4;
@@ -4963,6 +4925,8 @@ pub struct ID2D1Device5_Vtbl {
     pub base__: ID2D1Device4_Vtbl,
     pub CreateDeviceContext: unsafe extern "system" fn(*mut core::ffi::c_void, D2D1_DEVICE_CONTEXT_OPTIONS, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID2D1Device5 {}
+unsafe impl Sync for ID2D1Device5 {}
 #[cfg(all(feature = "Win32_Graphics_Dxgi", feature = "Win32_Graphics_Imaging", feature = "Win32_Storage_Xps_Printing"))]
 pub trait ID2D1Device5_Impl: ID2D1Device4_Impl {
     fn CreateDeviceContext(&self, options: D2D1_DEVICE_CONTEXT_OPTIONS) -> windows_core::Result<ID2D1DeviceContext5>;
@@ -4990,10 +4954,6 @@ impl ID2D1Device5_Vtbl {
 }
 #[cfg(all(feature = "Win32_Graphics_Dxgi", feature = "Win32_Graphics_Imaging", feature = "Win32_Storage_Xps_Printing"))]
 impl windows_core::RuntimeName for ID2D1Device5 {}
-#[cfg(all(feature = "Win32_Graphics_Dxgi", feature = "Win32_Graphics_Imaging", feature = "Win32_Storage_Xps_Printing"))]
-unsafe impl Send for ID2D1Device5 {}
-#[cfg(all(feature = "Win32_Graphics_Dxgi", feature = "Win32_Graphics_Imaging", feature = "Win32_Storage_Xps_Printing"))]
-unsafe impl Sync for ID2D1Device5 {}
 windows_core::imp::define_interface!(ID2D1Device6, ID2D1Device6_Vtbl, 0x7bfef914_2d75_4bad_be87_e18ddb077b6d);
 impl core::ops::Deref for ID2D1Device6 {
     type Target = ID2D1Device5;
@@ -5015,6 +4975,8 @@ pub struct ID2D1Device6_Vtbl {
     pub base__: ID2D1Device5_Vtbl,
     pub CreateDeviceContext: unsafe extern "system" fn(*mut core::ffi::c_void, D2D1_DEVICE_CONTEXT_OPTIONS, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID2D1Device6 {}
+unsafe impl Sync for ID2D1Device6 {}
 #[cfg(all(feature = "Win32_Graphics_Dxgi", feature = "Win32_Graphics_Imaging", feature = "Win32_Storage_Xps_Printing"))]
 pub trait ID2D1Device6_Impl: ID2D1Device5_Impl {
     fn CreateDeviceContext(&self, options: D2D1_DEVICE_CONTEXT_OPTIONS) -> windows_core::Result<ID2D1DeviceContext6>;
@@ -5042,10 +5004,6 @@ impl ID2D1Device6_Vtbl {
 }
 #[cfg(all(feature = "Win32_Graphics_Dxgi", feature = "Win32_Graphics_Imaging", feature = "Win32_Storage_Xps_Printing"))]
 impl windows_core::RuntimeName for ID2D1Device6 {}
-#[cfg(all(feature = "Win32_Graphics_Dxgi", feature = "Win32_Graphics_Imaging", feature = "Win32_Storage_Xps_Printing"))]
-unsafe impl Send for ID2D1Device6 {}
-#[cfg(all(feature = "Win32_Graphics_Dxgi", feature = "Win32_Graphics_Imaging", feature = "Win32_Storage_Xps_Printing"))]
-unsafe impl Sync for ID2D1Device6 {}
 windows_core::imp::define_interface!(ID2D1Device7, ID2D1Device7_Vtbl, 0xf07c8968_dd4e_4ba6_9cbd_eb6d3752dcbb);
 impl core::ops::Deref for ID2D1Device7 {
     type Target = ID2D1Device6;
@@ -5067,6 +5025,8 @@ pub struct ID2D1Device7_Vtbl {
     pub base__: ID2D1Device6_Vtbl,
     pub CreateDeviceContext: unsafe extern "system" fn(*mut core::ffi::c_void, D2D1_DEVICE_CONTEXT_OPTIONS, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID2D1Device7 {}
+unsafe impl Sync for ID2D1Device7 {}
 #[cfg(all(feature = "Win32_Graphics_Dxgi", feature = "Win32_Graphics_Imaging", feature = "Win32_Storage_Xps_Printing"))]
 pub trait ID2D1Device7_Impl: ID2D1Device6_Impl {
     fn CreateDeviceContext(&self, options: D2D1_DEVICE_CONTEXT_OPTIONS) -> windows_core::Result<ID2D1DeviceContext7>;
@@ -5094,10 +5054,6 @@ impl ID2D1Device7_Vtbl {
 }
 #[cfg(all(feature = "Win32_Graphics_Dxgi", feature = "Win32_Graphics_Imaging", feature = "Win32_Storage_Xps_Printing"))]
 impl windows_core::RuntimeName for ID2D1Device7 {}
-#[cfg(all(feature = "Win32_Graphics_Dxgi", feature = "Win32_Graphics_Imaging", feature = "Win32_Storage_Xps_Printing"))]
-unsafe impl Send for ID2D1Device7 {}
-#[cfg(all(feature = "Win32_Graphics_Dxgi", feature = "Win32_Graphics_Imaging", feature = "Win32_Storage_Xps_Printing"))]
-unsafe impl Sync for ID2D1Device7 {}
 windows_core::imp::define_interface!(ID2D1DeviceContext, ID2D1DeviceContext_Vtbl, 0xe8f7fe7a_191c_466d_ad95_975678bda998);
 impl core::ops::Deref for ID2D1DeviceContext {
     type Target = ID2D1RenderTarget;
@@ -5455,6 +5411,8 @@ pub struct ID2D1DeviceContext_Vtbl {
     #[cfg(not(feature = "Win32_Graphics_Direct2D_Common"))]
     FillOpacityMask: usize,
 }
+unsafe impl Send for ID2D1DeviceContext {}
+unsafe impl Sync for ID2D1DeviceContext {}
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging"))]
 pub trait ID2D1DeviceContext_Impl: ID2D1RenderTarget_Impl {
     fn CreateBitmap(&self, size: &Common::D2D_SIZE_U, sourcedata: *const core::ffi::c_void, pitch: u32, bitmapproperties: *const D2D1_BITMAP_PROPERTIES1) -> windows_core::Result<ID2D1Bitmap1>;
@@ -5841,10 +5799,6 @@ impl ID2D1DeviceContext_Vtbl {
 }
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging"))]
 impl windows_core::RuntimeName for ID2D1DeviceContext {}
-#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging"))]
-unsafe impl Send for ID2D1DeviceContext {}
-#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging"))]
-unsafe impl Sync for ID2D1DeviceContext {}
 windows_core::imp::define_interface!(ID2D1DeviceContext1, ID2D1DeviceContext1_Vtbl, 0xd37f57e4_6908_459f_a199_e72f24f79987);
 impl core::ops::Deref for ID2D1DeviceContext1 {
     type Target = ID2D1DeviceContext;
@@ -5888,6 +5842,8 @@ pub struct ID2D1DeviceContext1_Vtbl {
     pub CreateStrokedGeometryRealization: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, f32, f32, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
     pub DrawGeometryRealization: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut core::ffi::c_void),
 }
+unsafe impl Send for ID2D1DeviceContext1 {}
+unsafe impl Sync for ID2D1DeviceContext1 {}
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging"))]
 pub trait ID2D1DeviceContext1_Impl: ID2D1DeviceContext_Impl {
     fn CreateFilledGeometryRealization(&self, geometry: windows_core::Ref<ID2D1Geometry>, flatteningtolerance: f32) -> windows_core::Result<ID2D1GeometryRealization>;
@@ -5940,10 +5896,6 @@ impl ID2D1DeviceContext1_Vtbl {
 }
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging"))]
 impl windows_core::RuntimeName for ID2D1DeviceContext1 {}
-#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging"))]
-unsafe impl Send for ID2D1DeviceContext1 {}
-#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging"))]
-unsafe impl Sync for ID2D1DeviceContext1 {}
 windows_core::imp::define_interface!(ID2D1DeviceContext2, ID2D1DeviceContext2_Vtbl, 0x394ea6a3_0c34_4321_950b_6ca20f0be6c7);
 impl core::ops::Deref for ID2D1DeviceContext2 {
     type Target = ID2D1DeviceContext1;
@@ -6070,6 +6022,8 @@ pub struct ID2D1DeviceContext2_Vtbl {
     DrawGdiMetafile: usize,
     pub CreateTransformedImageSource: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *const D2D1_TRANSFORMED_IMAGE_SOURCE_PROPERTIES, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID2D1DeviceContext2 {}
+unsafe impl Sync for ID2D1DeviceContext2 {}
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging"))]
 pub trait ID2D1DeviceContext2_Impl: ID2D1DeviceContext1_Impl {
     fn CreateInk(&self, startpoint: *const D2D1_INK_POINT) -> windows_core::Result<ID2D1Ink>;
@@ -6222,10 +6176,6 @@ impl ID2D1DeviceContext2_Vtbl {
 }
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging"))]
 impl windows_core::RuntimeName for ID2D1DeviceContext2 {}
-#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging"))]
-unsafe impl Send for ID2D1DeviceContext2 {}
-#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging"))]
-unsafe impl Sync for ID2D1DeviceContext2 {}
 windows_core::imp::define_interface!(ID2D1DeviceContext3, ID2D1DeviceContext3_Vtbl, 0x235a7496_8351_414c_bcd4_6672ab2d8e00);
 impl core::ops::Deref for ID2D1DeviceContext3 {
     type Target = ID2D1DeviceContext2;
@@ -6255,6 +6205,8 @@ pub struct ID2D1DeviceContext3_Vtbl {
     pub CreateSpriteBatch: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
     pub DrawSpriteBatch: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, u32, u32, *mut core::ffi::c_void, D2D1_BITMAP_INTERPOLATION_MODE, D2D1_SPRITE_OPTIONS),
 }
+unsafe impl Send for ID2D1DeviceContext3 {}
+unsafe impl Sync for ID2D1DeviceContext3 {}
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging"))]
 pub trait ID2D1DeviceContext3_Impl: ID2D1DeviceContext2_Impl {
     fn CreateSpriteBatch(&self) -> windows_core::Result<ID2D1SpriteBatch>;
@@ -6293,10 +6245,6 @@ impl ID2D1DeviceContext3_Vtbl {
 }
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging"))]
 impl windows_core::RuntimeName for ID2D1DeviceContext3 {}
-#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging"))]
-unsafe impl Send for ID2D1DeviceContext3 {}
-#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging"))]
-unsafe impl Sync for ID2D1DeviceContext3 {}
 windows_core::imp::define_interface!(ID2D1DeviceContext4, ID2D1DeviceContext4_Vtbl, 0x8c427831_3d90_4476_b647_c4fae349e4db);
 impl core::ops::Deref for ID2D1DeviceContext4 {
     type Target = ID2D1DeviceContext3;
@@ -6388,6 +6336,8 @@ pub struct ID2D1DeviceContext4_Vtbl {
     #[cfg(not(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite")))]
     GetSvgGlyphImage: usize,
 }
+unsafe impl Send for ID2D1DeviceContext4 {}
+unsafe impl Sync for ID2D1DeviceContext4 {}
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging"))]
 pub trait ID2D1DeviceContext4_Impl: ID2D1DeviceContext3_Impl {
     fn CreateSvgGlyphStyle(&self) -> windows_core::Result<ID2D1SvgGlyphStyle>;
@@ -6466,10 +6416,6 @@ impl ID2D1DeviceContext4_Vtbl {
 }
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging"))]
 impl windows_core::RuntimeName for ID2D1DeviceContext4 {}
-#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging"))]
-unsafe impl Send for ID2D1DeviceContext4 {}
-#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging"))]
-unsafe impl Sync for ID2D1DeviceContext4 {}
 windows_core::imp::define_interface!(ID2D1DeviceContext5, ID2D1DeviceContext5_Vtbl, 0x7836d248_68cc_4df6_b9e8_de991bf62eb7);
 impl core::ops::Deref for ID2D1DeviceContext5 {
     type Target = ID2D1DeviceContext4;
@@ -6527,6 +6473,8 @@ pub struct ID2D1DeviceContext5_Vtbl {
     #[cfg(not(feature = "Win32_Graphics_Direct2D_Common"))]
     CreateColorContextFromSimpleColorProfile: usize,
 }
+unsafe impl Send for ID2D1DeviceContext5 {}
+unsafe impl Sync for ID2D1DeviceContext5 {}
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging", feature = "Win32_System_Com"))]
 pub trait ID2D1DeviceContext5_Impl: ID2D1DeviceContext4_Impl {
     fn CreateSvgDocument(&self, inputxmlstream: windows_core::Ref<super::super::System::Com::IStream>, viewportsize: &Common::D2D_SIZE_F) -> windows_core::Result<ID2D1SvgDocument>;
@@ -6593,10 +6541,6 @@ impl ID2D1DeviceContext5_Vtbl {
 }
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging", feature = "Win32_System_Com"))]
 impl windows_core::RuntimeName for ID2D1DeviceContext5 {}
-#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging", feature = "Win32_System_Com"))]
-unsafe impl Send for ID2D1DeviceContext5 {}
-#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging", feature = "Win32_System_Com"))]
-unsafe impl Sync for ID2D1DeviceContext5 {}
 windows_core::imp::define_interface!(ID2D1DeviceContext6, ID2D1DeviceContext6_Vtbl, 0x985f7e37_4ed0_4a19_98a3_15b0edfde306);
 impl core::ops::Deref for ID2D1DeviceContext6 {
     type Target = ID2D1DeviceContext5;
@@ -6622,6 +6566,8 @@ pub struct ID2D1DeviceContext6_Vtbl {
     #[cfg(not(feature = "Win32_Graphics_Direct2D_Common"))]
     BlendImage: usize,
 }
+unsafe impl Send for ID2D1DeviceContext6 {}
+unsafe impl Sync for ID2D1DeviceContext6 {}
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging", feature = "Win32_System_Com"))]
 pub trait ID2D1DeviceContext6_Impl: ID2D1DeviceContext5_Impl {
     fn BlendImage(&self, image: windows_core::Ref<ID2D1Image>, blendmode: Common::D2D1_BLEND_MODE, targetoffset: *const Common::D2D_POINT_2F, imagerectangle: *const Common::D2D_RECT_F, interpolationmode: D2D1_INTERPOLATION_MODE);
@@ -6643,10 +6589,6 @@ impl ID2D1DeviceContext6_Vtbl {
 }
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging", feature = "Win32_System_Com"))]
 impl windows_core::RuntimeName for ID2D1DeviceContext6 {}
-#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging", feature = "Win32_System_Com"))]
-unsafe impl Send for ID2D1DeviceContext6 {}
-#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging", feature = "Win32_System_Com"))]
-unsafe impl Sync for ID2D1DeviceContext6 {}
 windows_core::imp::define_interface!(ID2D1DeviceContext7, ID2D1DeviceContext7_Vtbl, 0xec891cf7_9b69_4851_9def_4e0915771e62);
 impl core::ops::Deref for ID2D1DeviceContext7 {
     type Target = ID2D1DeviceContext6;
@@ -6692,6 +6634,8 @@ pub struct ID2D1DeviceContext7_Vtbl {
     #[cfg(not(all(feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite")))]
     DrawGlyphRunWithColorSupport: usize,
 }
+unsafe impl Send for ID2D1DeviceContext7 {}
+unsafe impl Sync for ID2D1DeviceContext7 {}
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging", feature = "Win32_System_Com"))]
 pub trait ID2D1DeviceContext7_Impl: ID2D1DeviceContext6_Impl {
     fn GetPaintFeatureLevel(&self) -> super::DirectWrite::DWRITE_PAINT_FEATURE_LEVEL;
@@ -6732,10 +6676,6 @@ impl ID2D1DeviceContext7_Vtbl {
 }
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging", feature = "Win32_System_Com"))]
 impl windows_core::RuntimeName for ID2D1DeviceContext7 {}
-#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging", feature = "Win32_System_Com"))]
-unsafe impl Send for ID2D1DeviceContext7 {}
-#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging", feature = "Win32_System_Com"))]
-unsafe impl Sync for ID2D1DeviceContext7 {}
 windows_core::imp::define_interface!(ID2D1DrawInfo, ID2D1DrawInfo_Vtbl, 0x693ce632_7f2f_45de_93fe_18d88b37aa21);
 impl core::ops::Deref for ID2D1DrawInfo {
     type Target = ID2D1RenderInfo;
@@ -6776,6 +6716,8 @@ pub struct ID2D1DrawInfo_Vtbl {
     pub SetPixelShader: unsafe extern "system" fn(*mut core::ffi::c_void, *const windows_core::GUID, D2D1_PIXEL_OPTIONS) -> windows_core::HRESULT,
     pub SetVertexProcessing: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, D2D1_VERTEX_OPTIONS, *const D2D1_BLEND_DESCRIPTION, *const D2D1_VERTEX_RANGE, *const windows_core::GUID) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID2D1DrawInfo {}
+unsafe impl Sync for ID2D1DrawInfo {}
 pub trait ID2D1DrawInfo_Impl: ID2D1RenderInfo_Impl {
     fn SetPixelShaderConstantBuffer(&self, buffer: *const u8, buffercount: u32) -> windows_core::Result<()>;
     fn SetResourceTexture(&self, textureindex: u32, resourcetexture: windows_core::Ref<ID2D1ResourceTexture>) -> windows_core::Result<()>;
@@ -6829,8 +6771,6 @@ impl ID2D1DrawInfo_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID2D1DrawInfo {}
-unsafe impl Send for ID2D1DrawInfo {}
-unsafe impl Sync for ID2D1DrawInfo {}
 windows_core::imp::define_interface!(ID2D1DrawTransform, ID2D1DrawTransform_Vtbl, 0x36bfdcb6_9739_435d_a30d_a653beff6a6f);
 impl core::ops::Deref for ID2D1DrawTransform {
     type Target = ID2D1Transform;
@@ -6852,6 +6792,8 @@ pub struct ID2D1DrawTransform_Vtbl {
     pub base__: ID2D1Transform_Vtbl,
     pub SetDrawInfo: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID2D1DrawTransform {}
+unsafe impl Sync for ID2D1DrawTransform {}
 pub trait ID2D1DrawTransform_Impl: ID2D1Transform_Impl {
     fn SetDrawInfo(&self, drawinfo: windows_core::Ref<ID2D1DrawInfo>) -> windows_core::Result<()>;
 }
@@ -6870,8 +6812,6 @@ impl ID2D1DrawTransform_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID2D1DrawTransform {}
-unsafe impl Send for ID2D1DrawTransform {}
-unsafe impl Sync for ID2D1DrawTransform {}
 windows_core::imp::define_interface!(ID2D1DrawingStateBlock, ID2D1DrawingStateBlock_Vtbl, 0x28506e39_ebf6_46a1_bb47_fd85565ab957);
 impl core::ops::Deref for ID2D1DrawingStateBlock {
     type Target = ID2D1Resource;
@@ -6925,6 +6865,8 @@ pub struct ID2D1DrawingStateBlock_Vtbl {
     #[cfg(not(feature = "Win32_Graphics_DirectWrite"))]
     GetTextRenderingParams: usize,
 }
+unsafe impl Send for ID2D1DrawingStateBlock {}
+unsafe impl Sync for ID2D1DrawingStateBlock {}
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_DirectWrite"))]
 pub trait ID2D1DrawingStateBlock_Impl: ID2D1Resource_Impl {
     fn GetDescription(&self, statedescription: *mut D2D1_DRAWING_STATE_DESCRIPTION);
@@ -6973,10 +6915,6 @@ impl ID2D1DrawingStateBlock_Vtbl {
 }
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_DirectWrite"))]
 impl windows_core::RuntimeName for ID2D1DrawingStateBlock {}
-#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_DirectWrite"))]
-unsafe impl Send for ID2D1DrawingStateBlock {}
-#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_DirectWrite"))]
-unsafe impl Sync for ID2D1DrawingStateBlock {}
 windows_core::imp::define_interface!(ID2D1DrawingStateBlock1, ID2D1DrawingStateBlock1_Vtbl, 0x689f1f85_c72e_4e33_8f19_85754efd5ace);
 impl core::ops::Deref for ID2D1DrawingStateBlock1 {
     type Target = ID2D1DrawingStateBlock;
@@ -7007,6 +6945,8 @@ pub struct ID2D1DrawingStateBlock1_Vtbl {
     #[cfg(not(feature = "Foundation_Numerics"))]
     SetDescription: usize,
 }
+unsafe impl Send for ID2D1DrawingStateBlock1 {}
+unsafe impl Sync for ID2D1DrawingStateBlock1 {}
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_DirectWrite"))]
 pub trait ID2D1DrawingStateBlock1_Impl: ID2D1DrawingStateBlock_Impl {
     fn GetDescription(&self, statedescription: *mut D2D1_DRAWING_STATE_DESCRIPTION1);
@@ -7039,10 +6979,6 @@ impl ID2D1DrawingStateBlock1_Vtbl {
 }
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_DirectWrite"))]
 impl windows_core::RuntimeName for ID2D1DrawingStateBlock1 {}
-#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_DirectWrite"))]
-unsafe impl Send for ID2D1DrawingStateBlock1 {}
-#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_DirectWrite"))]
-unsafe impl Sync for ID2D1DrawingStateBlock1 {}
 windows_core::imp::define_interface!(ID2D1Effect, ID2D1Effect_Vtbl, 0x28211a43_7d89_476f_8181_2d6159b220ad);
 impl core::ops::Deref for ID2D1Effect {
     type Target = ID2D1Properties;
@@ -7088,6 +7024,8 @@ pub struct ID2D1Effect_Vtbl {
     pub GetInputCount: unsafe extern "system" fn(*mut core::ffi::c_void) -> u32,
     pub GetOutput: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void),
 }
+unsafe impl Send for ID2D1Effect {}
+unsafe impl Sync for ID2D1Effect {}
 pub trait ID2D1Effect_Impl: ID2D1Properties_Impl {
     fn SetInput(&self, index: u32, input: windows_core::Ref<ID2D1Image>, invalidate: super::super::Foundation::BOOL);
     fn SetInputCount(&self, inputcount: u32) -> windows_core::Result<()>;
@@ -7141,8 +7079,6 @@ impl ID2D1Effect_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID2D1Effect {}
-unsafe impl Send for ID2D1Effect {}
-unsafe impl Sync for ID2D1Effect {}
 windows_core::imp::define_interface!(ID2D1EffectContext, ID2D1EffectContext_Vtbl, 0x3d9f916b_27dc_4ad7_b4f1_64945340f563);
 windows_core::imp::interface_hierarchy!(ID2D1EffectContext, windows_core::IUnknown);
 impl ID2D1EffectContext {
@@ -7298,6 +7234,8 @@ pub struct ID2D1EffectContext_Vtbl {
     pub CheckFeatureSupport: unsafe extern "system" fn(*mut core::ffi::c_void, D2D1_FEATURE, *mut core::ffi::c_void, u32) -> windows_core::HRESULT,
     pub IsBufferPrecisionSupported: unsafe extern "system" fn(*mut core::ffi::c_void, D2D1_BUFFER_PRECISION) -> super::super::Foundation::BOOL,
 }
+unsafe impl Send for ID2D1EffectContext {}
+unsafe impl Sync for ID2D1EffectContext {}
 #[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging"))]
 pub trait ID2D1EffectContext_Impl: windows_core::IUnknownImpl {
     fn GetDpi(&self, dpix: *mut f32, dpiy: *mut f32);
@@ -7566,10 +7504,6 @@ impl ID2D1EffectContext_Vtbl {
 }
 #[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging"))]
 impl windows_core::RuntimeName for ID2D1EffectContext {}
-#[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging"))]
-unsafe impl Send for ID2D1EffectContext {}
-#[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging"))]
-unsafe impl Sync for ID2D1EffectContext {}
 windows_core::imp::define_interface!(ID2D1EffectContext1, ID2D1EffectContext1_Vtbl, 0x84ab595a_fc81_4546_bacd_e8ef4d8abe7a);
 impl core::ops::Deref for ID2D1EffectContext1 {
     type Target = ID2D1EffectContext;
@@ -7591,6 +7525,8 @@ pub struct ID2D1EffectContext1_Vtbl {
     pub base__: ID2D1EffectContext_Vtbl,
     pub CreateLookupTable3D: unsafe extern "system" fn(*mut core::ffi::c_void, D2D1_BUFFER_PRECISION, *const u32, *const u8, u32, *const u32, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID2D1EffectContext1 {}
+unsafe impl Sync for ID2D1EffectContext1 {}
 #[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging"))]
 pub trait ID2D1EffectContext1_Impl: ID2D1EffectContext_Impl {
     fn CreateLookupTable3D(&self, precision: D2D1_BUFFER_PRECISION, extents: *const u32, data: *const u8, datacount: u32, strides: *const u32) -> windows_core::Result<ID2D1LookupTable3D>;
@@ -7618,10 +7554,6 @@ impl ID2D1EffectContext1_Vtbl {
 }
 #[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging"))]
 impl windows_core::RuntimeName for ID2D1EffectContext1 {}
-#[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging"))]
-unsafe impl Send for ID2D1EffectContext1 {}
-#[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging"))]
-unsafe impl Sync for ID2D1EffectContext1 {}
 windows_core::imp::define_interface!(ID2D1EffectContext2, ID2D1EffectContext2_Vtbl, 0x577ad2a0_9fc7_4dda_8b18_dab810140052);
 impl core::ops::Deref for ID2D1EffectContext2 {
     type Target = ID2D1EffectContext1;
@@ -7658,6 +7590,8 @@ pub struct ID2D1EffectContext2_Vtbl {
     #[cfg(not(feature = "Win32_Graphics_Direct2D_Common"))]
     CreateColorContextFromSimpleColorProfile: usize,
 }
+unsafe impl Send for ID2D1EffectContext2 {}
+unsafe impl Sync for ID2D1EffectContext2 {}
 #[cfg(all(feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging"))]
 pub trait ID2D1EffectContext2_Impl: ID2D1EffectContext1_Impl {
     fn CreateColorContextFromDxgiColorSpace(&self, colorspace: super::Dxgi::Common::DXGI_COLOR_SPACE_TYPE) -> windows_core::Result<ID2D1ColorContext1>;
@@ -7702,10 +7636,6 @@ impl ID2D1EffectContext2_Vtbl {
 }
 #[cfg(all(feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging"))]
 impl windows_core::RuntimeName for ID2D1EffectContext2 {}
-#[cfg(all(feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging"))]
-unsafe impl Send for ID2D1EffectContext2 {}
-#[cfg(all(feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging"))]
-unsafe impl Sync for ID2D1EffectContext2 {}
 windows_core::imp::define_interface!(ID2D1EffectImpl, ID2D1EffectImpl_Vtbl, 0xa248fd3f_3e6c_4e63_9f03_7f68ecc91db9);
 windows_core::imp::interface_hierarchy!(ID2D1EffectImpl, windows_core::IUnknown);
 impl ID2D1EffectImpl {
@@ -7733,6 +7663,8 @@ pub struct ID2D1EffectImpl_Vtbl {
     pub PrepareForRender: unsafe extern "system" fn(*mut core::ffi::c_void, D2D1_CHANGE_TYPE) -> windows_core::HRESULT,
     pub SetGraph: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID2D1EffectImpl {}
+unsafe impl Sync for ID2D1EffectImpl {}
 pub trait ID2D1EffectImpl_Impl: windows_core::IUnknownImpl {
     fn Initialize(&self, effectcontext: windows_core::Ref<ID2D1EffectContext>, transformgraph: windows_core::Ref<ID2D1TransformGraph>) -> windows_core::Result<()>;
     fn PrepareForRender(&self, changetype: D2D1_CHANGE_TYPE) -> windows_core::Result<()>;
@@ -7770,8 +7702,6 @@ impl ID2D1EffectImpl_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID2D1EffectImpl {}
-unsafe impl Send for ID2D1EffectImpl {}
-unsafe impl Sync for ID2D1EffectImpl {}
 windows_core::imp::define_interface!(ID2D1EllipseGeometry, ID2D1EllipseGeometry_Vtbl, 0x2cd906a4_12e2_11dc_9fed_001143a055f9);
 impl core::ops::Deref for ID2D1EllipseGeometry {
     type Target = ID2D1Geometry;
@@ -7798,6 +7728,8 @@ pub struct ID2D1EllipseGeometry_Vtbl {
     #[cfg(not(feature = "Win32_Graphics_Direct2D_Common"))]
     GetEllipse: usize,
 }
+unsafe impl Send for ID2D1EllipseGeometry {}
+unsafe impl Sync for ID2D1EllipseGeometry {}
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common"))]
 pub trait ID2D1EllipseGeometry_Impl: ID2D1Geometry_Impl {
     fn GetEllipse(&self, ellipse: *mut D2D1_ELLIPSE);
@@ -7819,10 +7751,6 @@ impl ID2D1EllipseGeometry_Vtbl {
 }
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common"))]
 impl windows_core::RuntimeName for ID2D1EllipseGeometry {}
-#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common"))]
-unsafe impl Send for ID2D1EllipseGeometry {}
-#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common"))]
-unsafe impl Sync for ID2D1EllipseGeometry {}
 windows_core::imp::define_interface!(ID2D1Factory, ID2D1Factory_Vtbl, 0x06152247_6f50_465a_9245_118bfd3b6007);
 windows_core::imp::interface_hierarchy!(ID2D1Factory, windows_core::IUnknown);
 impl ID2D1Factory {
@@ -7975,6 +7903,8 @@ pub struct ID2D1Factory_Vtbl {
     #[cfg(not(all(feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_Dxgi_Common")))]
     CreateDCRenderTarget: usize,
 }
+unsafe impl Send for ID2D1Factory {}
+unsafe impl Sync for ID2D1Factory {}
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging"))]
 pub trait ID2D1Factory_Impl: windows_core::IUnknownImpl {
     fn ReloadSystemMetrics(&self) -> windows_core::Result<()>;
@@ -8175,10 +8105,6 @@ impl ID2D1Factory_Vtbl {
 }
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging"))]
 impl windows_core::RuntimeName for ID2D1Factory {}
-#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging"))]
-unsafe impl Send for ID2D1Factory {}
-#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging"))]
-unsafe impl Sync for ID2D1Factory {}
 windows_core::imp::define_interface!(ID2D1Factory1, ID2D1Factory1_Vtbl, 0xbb12d362_daee_4b9a_aa1d_14ba401cfa1f);
 impl core::ops::Deref for ID2D1Factory1 {
     type Target = ID2D1Factory;
@@ -8282,6 +8208,8 @@ pub struct ID2D1Factory1_Vtbl {
     pub GetRegisteredEffects: unsafe extern "system" fn(*mut core::ffi::c_void, *mut windows_core::GUID, u32, *mut u32, *mut u32) -> windows_core::HRESULT,
     pub GetEffectProperties: unsafe extern "system" fn(*mut core::ffi::c_void, *const windows_core::GUID, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID2D1Factory1 {}
+unsafe impl Sync for ID2D1Factory1 {}
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging", feature = "Win32_System_Com"))]
 pub trait ID2D1Factory1_Impl: ID2D1Factory_Impl {
     fn CreateDevice(&self, dxgidevice: windows_core::Ref<super::Dxgi::IDXGIDevice>) -> windows_core::Result<ID2D1Device>;
@@ -8414,10 +8342,6 @@ impl ID2D1Factory1_Vtbl {
 }
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging", feature = "Win32_System_Com"))]
 impl windows_core::RuntimeName for ID2D1Factory1 {}
-#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging", feature = "Win32_System_Com"))]
-unsafe impl Send for ID2D1Factory1 {}
-#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging", feature = "Win32_System_Com"))]
-unsafe impl Sync for ID2D1Factory1 {}
 windows_core::imp::define_interface!(ID2D1Factory2, ID2D1Factory2_Vtbl, 0x94f81a73_9212_4376_9c58_b16a3a0d3992);
 impl core::ops::Deref for ID2D1Factory2 {
     type Target = ID2D1Factory1;
@@ -8446,6 +8370,8 @@ pub struct ID2D1Factory2_Vtbl {
     #[cfg(not(feature = "Win32_Graphics_Dxgi"))]
     CreateDevice: usize,
 }
+unsafe impl Send for ID2D1Factory2 {}
+unsafe impl Sync for ID2D1Factory2 {}
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging", feature = "Win32_System_Com"))]
 pub trait ID2D1Factory2_Impl: ID2D1Factory1_Impl {
     fn CreateDevice(&self, dxgidevice: windows_core::Ref<super::Dxgi::IDXGIDevice>) -> windows_core::Result<ID2D1Device1>;
@@ -8473,10 +8399,6 @@ impl ID2D1Factory2_Vtbl {
 }
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging", feature = "Win32_System_Com"))]
 impl windows_core::RuntimeName for ID2D1Factory2 {}
-#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging", feature = "Win32_System_Com"))]
-unsafe impl Send for ID2D1Factory2 {}
-#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging", feature = "Win32_System_Com"))]
-unsafe impl Sync for ID2D1Factory2 {}
 windows_core::imp::define_interface!(ID2D1Factory3, ID2D1Factory3_Vtbl, 0x0869759f_4f00_413f_b03e_2bda45404d0f);
 impl core::ops::Deref for ID2D1Factory3 {
     type Target = ID2D1Factory2;
@@ -8505,6 +8427,8 @@ pub struct ID2D1Factory3_Vtbl {
     #[cfg(not(feature = "Win32_Graphics_Dxgi"))]
     CreateDevice: usize,
 }
+unsafe impl Send for ID2D1Factory3 {}
+unsafe impl Sync for ID2D1Factory3 {}
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging", feature = "Win32_System_Com"))]
 pub trait ID2D1Factory3_Impl: ID2D1Factory2_Impl {
     fn CreateDevice(&self, dxgidevice: windows_core::Ref<super::Dxgi::IDXGIDevice>) -> windows_core::Result<ID2D1Device2>;
@@ -8532,10 +8456,6 @@ impl ID2D1Factory3_Vtbl {
 }
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging", feature = "Win32_System_Com"))]
 impl windows_core::RuntimeName for ID2D1Factory3 {}
-#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging", feature = "Win32_System_Com"))]
-unsafe impl Send for ID2D1Factory3 {}
-#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging", feature = "Win32_System_Com"))]
-unsafe impl Sync for ID2D1Factory3 {}
 windows_core::imp::define_interface!(ID2D1Factory4, ID2D1Factory4_Vtbl, 0xbd4ec2d2_0662_4bee_ba8e_6f29f032e096);
 impl core::ops::Deref for ID2D1Factory4 {
     type Target = ID2D1Factory3;
@@ -8564,6 +8484,8 @@ pub struct ID2D1Factory4_Vtbl {
     #[cfg(not(feature = "Win32_Graphics_Dxgi"))]
     CreateDevice: usize,
 }
+unsafe impl Send for ID2D1Factory4 {}
+unsafe impl Sync for ID2D1Factory4 {}
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging", feature = "Win32_System_Com"))]
 pub trait ID2D1Factory4_Impl: ID2D1Factory3_Impl {
     fn CreateDevice(&self, dxgidevice: windows_core::Ref<super::Dxgi::IDXGIDevice>) -> windows_core::Result<ID2D1Device3>;
@@ -8591,10 +8513,6 @@ impl ID2D1Factory4_Vtbl {
 }
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging", feature = "Win32_System_Com"))]
 impl windows_core::RuntimeName for ID2D1Factory4 {}
-#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging", feature = "Win32_System_Com"))]
-unsafe impl Send for ID2D1Factory4 {}
-#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging", feature = "Win32_System_Com"))]
-unsafe impl Sync for ID2D1Factory4 {}
 windows_core::imp::define_interface!(ID2D1Factory5, ID2D1Factory5_Vtbl, 0xc4349994_838e_4b0f_8cab_44997d9eeacc);
 impl core::ops::Deref for ID2D1Factory5 {
     type Target = ID2D1Factory4;
@@ -8623,6 +8541,8 @@ pub struct ID2D1Factory5_Vtbl {
     #[cfg(not(feature = "Win32_Graphics_Dxgi"))]
     CreateDevice: usize,
 }
+unsafe impl Send for ID2D1Factory5 {}
+unsafe impl Sync for ID2D1Factory5 {}
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging", feature = "Win32_System_Com"))]
 pub trait ID2D1Factory5_Impl: ID2D1Factory4_Impl {
     fn CreateDevice(&self, dxgidevice: windows_core::Ref<super::Dxgi::IDXGIDevice>) -> windows_core::Result<ID2D1Device4>;
@@ -8650,10 +8570,6 @@ impl ID2D1Factory5_Vtbl {
 }
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging", feature = "Win32_System_Com"))]
 impl windows_core::RuntimeName for ID2D1Factory5 {}
-#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging", feature = "Win32_System_Com"))]
-unsafe impl Send for ID2D1Factory5 {}
-#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging", feature = "Win32_System_Com"))]
-unsafe impl Sync for ID2D1Factory5 {}
 windows_core::imp::define_interface!(ID2D1Factory6, ID2D1Factory6_Vtbl, 0xf9976f46_f642_44c1_97ca_da32ea2a2635);
 impl core::ops::Deref for ID2D1Factory6 {
     type Target = ID2D1Factory5;
@@ -8682,6 +8598,8 @@ pub struct ID2D1Factory6_Vtbl {
     #[cfg(not(feature = "Win32_Graphics_Dxgi"))]
     CreateDevice: usize,
 }
+unsafe impl Send for ID2D1Factory6 {}
+unsafe impl Sync for ID2D1Factory6 {}
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging", feature = "Win32_System_Com"))]
 pub trait ID2D1Factory6_Impl: ID2D1Factory5_Impl {
     fn CreateDevice(&self, dxgidevice: windows_core::Ref<super::Dxgi::IDXGIDevice>) -> windows_core::Result<ID2D1Device5>;
@@ -8709,10 +8627,6 @@ impl ID2D1Factory6_Vtbl {
 }
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging", feature = "Win32_System_Com"))]
 impl windows_core::RuntimeName for ID2D1Factory6 {}
-#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging", feature = "Win32_System_Com"))]
-unsafe impl Send for ID2D1Factory6 {}
-#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging", feature = "Win32_System_Com"))]
-unsafe impl Sync for ID2D1Factory6 {}
 windows_core::imp::define_interface!(ID2D1Factory7, ID2D1Factory7_Vtbl, 0xbdc2bdd3_b96c_4de6_bdf7_99d4745454de);
 impl core::ops::Deref for ID2D1Factory7 {
     type Target = ID2D1Factory6;
@@ -8741,6 +8655,8 @@ pub struct ID2D1Factory7_Vtbl {
     #[cfg(not(feature = "Win32_Graphics_Dxgi"))]
     CreateDevice: usize,
 }
+unsafe impl Send for ID2D1Factory7 {}
+unsafe impl Sync for ID2D1Factory7 {}
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging", feature = "Win32_System_Com"))]
 pub trait ID2D1Factory7_Impl: ID2D1Factory6_Impl {
     fn CreateDevice(&self, dxgidevice: windows_core::Ref<super::Dxgi::IDXGIDevice>) -> windows_core::Result<ID2D1Device6>;
@@ -8768,10 +8684,6 @@ impl ID2D1Factory7_Vtbl {
 }
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging", feature = "Win32_System_Com"))]
 impl windows_core::RuntimeName for ID2D1Factory7 {}
-#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging", feature = "Win32_System_Com"))]
-unsafe impl Send for ID2D1Factory7 {}
-#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging", feature = "Win32_System_Com"))]
-unsafe impl Sync for ID2D1Factory7 {}
 windows_core::imp::define_interface!(ID2D1Factory8, ID2D1Factory8_Vtbl, 0x677c9311_f36d_4b1f_ae86_86d1223ffd3a);
 impl core::ops::Deref for ID2D1Factory8 {
     type Target = ID2D1Factory7;
@@ -8800,6 +8712,8 @@ pub struct ID2D1Factory8_Vtbl {
     #[cfg(not(feature = "Win32_Graphics_Dxgi"))]
     CreateDevice: usize,
 }
+unsafe impl Send for ID2D1Factory8 {}
+unsafe impl Sync for ID2D1Factory8 {}
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging", feature = "Win32_System_Com"))]
 pub trait ID2D1Factory8_Impl: ID2D1Factory7_Impl {
     fn CreateDevice(&self, dxgidevice: windows_core::Ref<super::Dxgi::IDXGIDevice>) -> windows_core::Result<ID2D1Device7>;
@@ -8827,10 +8741,6 @@ impl ID2D1Factory8_Vtbl {
 }
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging", feature = "Win32_System_Com"))]
 impl windows_core::RuntimeName for ID2D1Factory8 {}
-#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging", feature = "Win32_System_Com"))]
-unsafe impl Send for ID2D1Factory8 {}
-#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging", feature = "Win32_System_Com"))]
-unsafe impl Sync for ID2D1Factory8 {}
 windows_core::imp::define_interface!(ID2D1GdiInteropRenderTarget, ID2D1GdiInteropRenderTarget_Vtbl, 0xe0db51c3_6f77_4bae_b3d5_e47509b35838);
 windows_core::imp::interface_hierarchy!(ID2D1GdiInteropRenderTarget, windows_core::IUnknown);
 impl ID2D1GdiInteropRenderTarget {
@@ -8854,6 +8764,8 @@ pub struct ID2D1GdiInteropRenderTarget_Vtbl {
     GetDC: usize,
     pub ReleaseDC: unsafe extern "system" fn(*mut core::ffi::c_void, *const super::super::Foundation::RECT) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID2D1GdiInteropRenderTarget {}
+unsafe impl Sync for ID2D1GdiInteropRenderTarget {}
 #[cfg(feature = "Win32_Graphics_Gdi")]
 pub trait ID2D1GdiInteropRenderTarget_Impl: windows_core::IUnknownImpl {
     fn GetDC(&self, mode: D2D1_DC_INITIALIZE_MODE) -> windows_core::Result<super::Gdi::HDC>;
@@ -8888,10 +8800,6 @@ impl ID2D1GdiInteropRenderTarget_Vtbl {
 }
 #[cfg(feature = "Win32_Graphics_Gdi")]
 impl windows_core::RuntimeName for ID2D1GdiInteropRenderTarget {}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-unsafe impl Send for ID2D1GdiInteropRenderTarget {}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-unsafe impl Sync for ID2D1GdiInteropRenderTarget {}
 windows_core::imp::define_interface!(ID2D1GdiMetafile, ID2D1GdiMetafile_Vtbl, 0x2f543dc3_cfc1_4211_864f_cfd91c6f3395);
 impl core::ops::Deref for ID2D1GdiMetafile {
     type Target = ID2D1Resource;
@@ -8924,6 +8832,8 @@ pub struct ID2D1GdiMetafile_Vtbl {
     #[cfg(not(feature = "Win32_Graphics_Direct2D_Common"))]
     GetBounds: usize,
 }
+unsafe impl Send for ID2D1GdiMetafile {}
+unsafe impl Sync for ID2D1GdiMetafile {}
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
 pub trait ID2D1GdiMetafile_Impl: ID2D1Resource_Impl {
     fn Stream(&self, sink: windows_core::Ref<ID2D1GdiMetafileSink>) -> windows_core::Result<()>;
@@ -8958,10 +8868,6 @@ impl ID2D1GdiMetafile_Vtbl {
 }
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
 impl windows_core::RuntimeName for ID2D1GdiMetafile {}
-#[cfg(feature = "Win32_Graphics_Direct2D_Common")]
-unsafe impl Send for ID2D1GdiMetafile {}
-#[cfg(feature = "Win32_Graphics_Direct2D_Common")]
-unsafe impl Sync for ID2D1GdiMetafile {}
 windows_core::imp::define_interface!(ID2D1GdiMetafile1, ID2D1GdiMetafile1_Vtbl, 0x2e69f9e8_dd3f_4bf9_95ba_c04f49d788df);
 impl core::ops::Deref for ID2D1GdiMetafile1 {
     type Target = ID2D1GdiMetafile;
@@ -8991,6 +8897,8 @@ pub struct ID2D1GdiMetafile1_Vtbl {
     #[cfg(not(feature = "Win32_Graphics_Direct2D_Common"))]
     GetSourceBounds: usize,
 }
+unsafe impl Send for ID2D1GdiMetafile1 {}
+unsafe impl Sync for ID2D1GdiMetafile1 {}
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
 pub trait ID2D1GdiMetafile1_Impl: ID2D1GdiMetafile_Impl {
     fn GetDpi(&self, dpix: *mut f32, dpiy: *mut f32) -> windows_core::Result<()>;
@@ -9029,10 +8937,6 @@ impl ID2D1GdiMetafile1_Vtbl {
 }
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
 impl windows_core::RuntimeName for ID2D1GdiMetafile1 {}
-#[cfg(feature = "Win32_Graphics_Direct2D_Common")]
-unsafe impl Send for ID2D1GdiMetafile1 {}
-#[cfg(feature = "Win32_Graphics_Direct2D_Common")]
-unsafe impl Sync for ID2D1GdiMetafile1 {}
 windows_core::imp::define_interface!(ID2D1GdiMetafileSink, ID2D1GdiMetafileSink_Vtbl, 0x82237326_8111_4f7c_bcf4_b5c1175564fe);
 windows_core::imp::interface_hierarchy!(ID2D1GdiMetafileSink, windows_core::IUnknown);
 impl ID2D1GdiMetafileSink {
@@ -9045,6 +8949,8 @@ pub struct ID2D1GdiMetafileSink_Vtbl {
     pub base__: windows_core::IUnknown_Vtbl,
     pub ProcessRecord: unsafe extern "system" fn(*mut core::ffi::c_void, u32, *const core::ffi::c_void, u32) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID2D1GdiMetafileSink {}
+unsafe impl Sync for ID2D1GdiMetafileSink {}
 pub trait ID2D1GdiMetafileSink_Impl: windows_core::IUnknownImpl {
     fn ProcessRecord(&self, recordtype: u32, recorddata: *const core::ffi::c_void, recorddatasize: u32) -> windows_core::Result<()>;
 }
@@ -9063,8 +8969,6 @@ impl ID2D1GdiMetafileSink_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID2D1GdiMetafileSink {}
-unsafe impl Send for ID2D1GdiMetafileSink {}
-unsafe impl Sync for ID2D1GdiMetafileSink {}
 windows_core::imp::define_interface!(ID2D1GdiMetafileSink1, ID2D1GdiMetafileSink1_Vtbl, 0xfd0ecb6b_91e6_411e_8655_395e760f91b4);
 impl core::ops::Deref for ID2D1GdiMetafileSink1 {
     type Target = ID2D1GdiMetafileSink;
@@ -9083,6 +8987,8 @@ pub struct ID2D1GdiMetafileSink1_Vtbl {
     pub base__: ID2D1GdiMetafileSink_Vtbl,
     pub ProcessRecord: unsafe extern "system" fn(*mut core::ffi::c_void, u32, *const core::ffi::c_void, u32, u32) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID2D1GdiMetafileSink1 {}
+unsafe impl Sync for ID2D1GdiMetafileSink1 {}
 pub trait ID2D1GdiMetafileSink1_Impl: ID2D1GdiMetafileSink_Impl {
     fn ProcessRecord(&self, recordtype: u32, recorddata: *const core::ffi::c_void, recorddatasize: u32, flags: u32) -> windows_core::Result<()>;
 }
@@ -9101,8 +9007,6 @@ impl ID2D1GdiMetafileSink1_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID2D1GdiMetafileSink1 {}
-unsafe impl Send for ID2D1GdiMetafileSink1 {}
-unsafe impl Sync for ID2D1GdiMetafileSink1 {}
 windows_core::imp::define_interface!(ID2D1Geometry, ID2D1Geometry_Vtbl, 0x2cd906a1_12e2_11dc_9fed_001143a055f9);
 impl core::ops::Deref for ID2D1Geometry {
     type Target = ID2D1Resource;
@@ -9268,6 +9172,8 @@ pub struct ID2D1Geometry_Vtbl {
     #[cfg(not(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common")))]
     Widen: usize,
 }
+unsafe impl Send for ID2D1Geometry {}
+unsafe impl Sync for ID2D1Geometry {}
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common"))]
 pub trait ID2D1Geometry_Impl: ID2D1Resource_Impl {
     fn GetBounds(&self, worldtransform: *const super::super::super::Foundation::Numerics::Matrix3x2) -> windows_core::Result<Common::D2D_RECT_F>;
@@ -9430,10 +9336,6 @@ impl ID2D1Geometry_Vtbl {
 }
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common"))]
 impl windows_core::RuntimeName for ID2D1Geometry {}
-#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common"))]
-unsafe impl Send for ID2D1Geometry {}
-#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common"))]
-unsafe impl Sync for ID2D1Geometry {}
 windows_core::imp::define_interface!(ID2D1GeometryGroup, ID2D1GeometryGroup_Vtbl, 0x2cd906a6_12e2_11dc_9fed_001143a055f9);
 impl core::ops::Deref for ID2D1GeometryGroup {
     type Target = ID2D1Geometry;
@@ -9464,6 +9366,8 @@ pub struct ID2D1GeometryGroup_Vtbl {
     pub GetSourceGeometryCount: unsafe extern "system" fn(*mut core::ffi::c_void) -> u32,
     pub GetSourceGeometries: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void, u32),
 }
+unsafe impl Send for ID2D1GeometryGroup {}
+unsafe impl Sync for ID2D1GeometryGroup {}
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common"))]
 pub trait ID2D1GeometryGroup_Impl: ID2D1Geometry_Impl {
     fn GetFillMode(&self) -> Common::D2D1_FILL_MODE;
@@ -9504,10 +9408,6 @@ impl ID2D1GeometryGroup_Vtbl {
 }
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common"))]
 impl windows_core::RuntimeName for ID2D1GeometryGroup {}
-#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common"))]
-unsafe impl Send for ID2D1GeometryGroup {}
-#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common"))]
-unsafe impl Sync for ID2D1GeometryGroup {}
 windows_core::imp::define_interface!(ID2D1GeometryRealization, ID2D1GeometryRealization_Vtbl, 0xa16907d7_bc02_4801_99e8_8cf7f485f774);
 impl core::ops::Deref for ID2D1GeometryRealization {
     type Target = ID2D1Resource;
@@ -9520,6 +9420,8 @@ windows_core::imp::interface_hierarchy!(ID2D1GeometryRealization, windows_core::
 pub struct ID2D1GeometryRealization_Vtbl {
     pub base__: ID2D1Resource_Vtbl,
 }
+unsafe impl Send for ID2D1GeometryRealization {}
+unsafe impl Sync for ID2D1GeometryRealization {}
 pub trait ID2D1GeometryRealization_Impl: ID2D1Resource_Impl {}
 impl ID2D1GeometryRealization_Vtbl {
     pub const fn new<Identity: ID2D1GeometryRealization_Impl, const OFFSET: isize>() -> Self {
@@ -9530,8 +9432,6 @@ impl ID2D1GeometryRealization_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID2D1GeometryRealization {}
-unsafe impl Send for ID2D1GeometryRealization {}
-unsafe impl Sync for ID2D1GeometryRealization {}
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
 windows_core::imp::define_interface!(ID2D1GeometrySink, ID2D1GeometrySink_Vtbl, 0x2cd9069f_12e2_11dc_9fed_001143a055f9);
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
@@ -9571,6 +9471,10 @@ pub struct ID2D1GeometrySink_Vtbl {
     pub AddQuadraticBeziers: unsafe extern "system" fn(*mut core::ffi::c_void, *const D2D1_QUADRATIC_BEZIER_SEGMENT, u32),
     pub AddArc: unsafe extern "system" fn(*mut core::ffi::c_void, *const D2D1_ARC_SEGMENT),
 }
+#[cfg(feature = "Win32_Graphics_Direct2D_Common")]
+unsafe impl Send for ID2D1GeometrySink {}
+#[cfg(feature = "Win32_Graphics_Direct2D_Common")]
+unsafe impl Sync for ID2D1GeometrySink {}
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
 pub trait ID2D1GeometrySink_Impl: Common::ID2D1SimplifiedGeometrySink_Impl {
     fn AddLine(&self, point: &Common::D2D_POINT_2F);
@@ -9627,10 +9531,6 @@ impl ID2D1GeometrySink_Vtbl {
 }
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
 impl windows_core::RuntimeName for ID2D1GeometrySink {}
-#[cfg(feature = "Win32_Graphics_Direct2D_Common")]
-unsafe impl Send for ID2D1GeometrySink {}
-#[cfg(feature = "Win32_Graphics_Direct2D_Common")]
-unsafe impl Sync for ID2D1GeometrySink {}
 windows_core::imp::define_interface!(ID2D1GradientMesh, ID2D1GradientMesh_Vtbl, 0xf292e401_c050_4cde_83d7_04962d3b23c2);
 impl core::ops::Deref for ID2D1GradientMesh {
     type Target = ID2D1Resource;
@@ -9657,6 +9557,8 @@ pub struct ID2D1GradientMesh_Vtbl {
     #[cfg(not(feature = "Win32_Graphics_Direct2D_Common"))]
     GetPatches: usize,
 }
+unsafe impl Send for ID2D1GradientMesh {}
+unsafe impl Sync for ID2D1GradientMesh {}
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
 pub trait ID2D1GradientMesh_Impl: ID2D1Resource_Impl {
     fn GetPatchCount(&self) -> u32;
@@ -9689,10 +9591,6 @@ impl ID2D1GradientMesh_Vtbl {
 }
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
 impl windows_core::RuntimeName for ID2D1GradientMesh {}
-#[cfg(feature = "Win32_Graphics_Direct2D_Common")]
-unsafe impl Send for ID2D1GradientMesh {}
-#[cfg(feature = "Win32_Graphics_Direct2D_Common")]
-unsafe impl Sync for ID2D1GradientMesh {}
 windows_core::imp::define_interface!(ID2D1GradientStopCollection, ID2D1GradientStopCollection_Vtbl, 0x2cd906a7_12e2_11dc_9fed_001143a055f9);
 impl core::ops::Deref for ID2D1GradientStopCollection {
     type Target = ID2D1Resource;
@@ -9727,6 +9625,8 @@ pub struct ID2D1GradientStopCollection_Vtbl {
     pub GetColorInterpolationGamma: unsafe extern "system" fn(*mut core::ffi::c_void) -> D2D1_GAMMA,
     pub GetExtendMode: unsafe extern "system" fn(*mut core::ffi::c_void) -> D2D1_EXTEND_MODE,
 }
+unsafe impl Send for ID2D1GradientStopCollection {}
+unsafe impl Sync for ID2D1GradientStopCollection {}
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
 pub trait ID2D1GradientStopCollection_Impl: ID2D1Resource_Impl {
     fn GetGradientStopCount(&self) -> u32;
@@ -9775,10 +9675,6 @@ impl ID2D1GradientStopCollection_Vtbl {
 }
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
 impl windows_core::RuntimeName for ID2D1GradientStopCollection {}
-#[cfg(feature = "Win32_Graphics_Direct2D_Common")]
-unsafe impl Send for ID2D1GradientStopCollection {}
-#[cfg(feature = "Win32_Graphics_Direct2D_Common")]
-unsafe impl Sync for ID2D1GradientStopCollection {}
 windows_core::imp::define_interface!(ID2D1GradientStopCollection1, ID2D1GradientStopCollection1_Vtbl, 0xae1572f4_5dd0_4777_998b_9279472ae63b);
 impl core::ops::Deref for ID2D1GradientStopCollection1 {
     type Target = ID2D1GradientStopCollection;
@@ -9817,6 +9713,8 @@ pub struct ID2D1GradientStopCollection1_Vtbl {
     pub GetBufferPrecision: unsafe extern "system" fn(*mut core::ffi::c_void) -> D2D1_BUFFER_PRECISION,
     pub GetColorInterpolationMode: unsafe extern "system" fn(*mut core::ffi::c_void) -> D2D1_COLOR_INTERPOLATION_MODE,
 }
+unsafe impl Send for ID2D1GradientStopCollection1 {}
+unsafe impl Sync for ID2D1GradientStopCollection1 {}
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
 pub trait ID2D1GradientStopCollection1_Impl: ID2D1GradientStopCollection_Impl {
     fn GetGradientStops1(&self, gradientstops: *mut Common::D2D1_GRADIENT_STOP, gradientstopscount: u32);
@@ -9873,10 +9771,6 @@ impl ID2D1GradientStopCollection1_Vtbl {
 }
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
 impl windows_core::RuntimeName for ID2D1GradientStopCollection1 {}
-#[cfg(feature = "Win32_Graphics_Direct2D_Common")]
-unsafe impl Send for ID2D1GradientStopCollection1 {}
-#[cfg(feature = "Win32_Graphics_Direct2D_Common")]
-unsafe impl Sync for ID2D1GradientStopCollection1 {}
 windows_core::imp::define_interface!(ID2D1HwndRenderTarget, ID2D1HwndRenderTarget_Vtbl, 0x2cd90698_12e2_11dc_9fed_001143a055f9);
 impl core::ops::Deref for ID2D1HwndRenderTarget {
     type Target = ID2D1RenderTarget;
@@ -9907,6 +9801,8 @@ pub struct ID2D1HwndRenderTarget_Vtbl {
     Resize: usize,
     pub GetHwnd: unsafe extern "system" fn(*mut core::ffi::c_void) -> super::super::Foundation::HWND,
 }
+unsafe impl Send for ID2D1HwndRenderTarget {}
+unsafe impl Sync for ID2D1HwndRenderTarget {}
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging"))]
 pub trait ID2D1HwndRenderTarget_Impl: ID2D1RenderTarget_Impl {
     fn CheckWindowState(&self) -> D2D1_WINDOW_STATE;
@@ -9947,10 +9843,6 @@ impl ID2D1HwndRenderTarget_Vtbl {
 }
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging"))]
 impl windows_core::RuntimeName for ID2D1HwndRenderTarget {}
-#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging"))]
-unsafe impl Send for ID2D1HwndRenderTarget {}
-#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging"))]
-unsafe impl Sync for ID2D1HwndRenderTarget {}
 windows_core::imp::define_interface!(ID2D1Image, ID2D1Image_Vtbl, 0x65019f75_8da2_497c_b32c_dfa34e48ede6);
 impl core::ops::Deref for ID2D1Image {
     type Target = ID2D1Resource;
@@ -9963,6 +9855,8 @@ windows_core::imp::interface_hierarchy!(ID2D1Image, windows_core::IUnknown, ID2D
 pub struct ID2D1Image_Vtbl {
     pub base__: ID2D1Resource_Vtbl,
 }
+unsafe impl Send for ID2D1Image {}
+unsafe impl Sync for ID2D1Image {}
 pub trait ID2D1Image_Impl: ID2D1Resource_Impl {}
 impl ID2D1Image_Vtbl {
     pub const fn new<Identity: ID2D1Image_Impl, const OFFSET: isize>() -> Self {
@@ -9973,8 +9867,6 @@ impl ID2D1Image_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID2D1Image {}
-unsafe impl Send for ID2D1Image {}
-unsafe impl Sync for ID2D1Image {}
 windows_core::imp::define_interface!(ID2D1ImageBrush, ID2D1ImageBrush_Vtbl, 0xfe9e984d_3f95_407c_b5db_cb94d4e8f87c);
 impl core::ops::Deref for ID2D1ImageBrush {
     type Target = ID2D1Brush;
@@ -10048,6 +9940,8 @@ pub struct ID2D1ImageBrush_Vtbl {
     #[cfg(not(feature = "Win32_Graphics_Direct2D_Common"))]
     GetSourceRectangle: usize,
 }
+unsafe impl Send for ID2D1ImageBrush {}
+unsafe impl Sync for ID2D1ImageBrush {}
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common"))]
 pub trait ID2D1ImageBrush_Impl: ID2D1Brush_Impl {
     fn SetImage(&self, image: windows_core::Ref<ID2D1Image>);
@@ -10144,10 +10038,6 @@ impl ID2D1ImageBrush_Vtbl {
 }
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common"))]
 impl windows_core::RuntimeName for ID2D1ImageBrush {}
-#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common"))]
-unsafe impl Send for ID2D1ImageBrush {}
-#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common"))]
-unsafe impl Sync for ID2D1ImageBrush {}
 windows_core::imp::define_interface!(ID2D1ImageSource, ID2D1ImageSource_Vtbl, 0xc9b664e5_74a1_4378_9ac2_eefc37a3f4d8);
 impl core::ops::Deref for ID2D1ImageSource {
     type Target = ID2D1Image;
@@ -10173,6 +10063,8 @@ pub struct ID2D1ImageSource_Vtbl {
     pub OfferResources: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
     pub TryReclaimResources: unsafe extern "system" fn(*mut core::ffi::c_void, *mut super::super::Foundation::BOOL) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID2D1ImageSource {}
+unsafe impl Sync for ID2D1ImageSource {}
 pub trait ID2D1ImageSource_Impl: ID2D1Image_Impl {
     fn OfferResources(&self) -> windows_core::Result<()>;
     fn TryReclaimResources(&self) -> windows_core::Result<super::super::Foundation::BOOL>;
@@ -10208,8 +10100,6 @@ impl ID2D1ImageSource_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID2D1ImageSource {}
-unsafe impl Send for ID2D1ImageSource {}
-unsafe impl Sync for ID2D1ImageSource {}
 windows_core::imp::define_interface!(ID2D1ImageSourceFromWic, ID2D1ImageSourceFromWic_Vtbl, 0x77395441_1c8f_4555_8683_f50dab0fe792);
 impl core::ops::Deref for ID2D1ImageSourceFromWic {
     type Target = ID2D1ImageSource;
@@ -10252,6 +10142,8 @@ pub struct ID2D1ImageSourceFromWic_Vtbl {
     #[cfg(not(feature = "Win32_Graphics_Imaging"))]
     GetSource: usize,
 }
+unsafe impl Send for ID2D1ImageSourceFromWic {}
+unsafe impl Sync for ID2D1ImageSourceFromWic {}
 #[cfg(all(feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_Imaging"))]
 pub trait ID2D1ImageSourceFromWic_Impl: ID2D1ImageSource_Impl {
     fn EnsureCached(&self, rectangletofill: *const Common::D2D_RECT_U) -> windows_core::Result<()>;
@@ -10292,10 +10184,6 @@ impl ID2D1ImageSourceFromWic_Vtbl {
 }
 #[cfg(all(feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_Imaging"))]
 impl windows_core::RuntimeName for ID2D1ImageSourceFromWic {}
-#[cfg(all(feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_Imaging"))]
-unsafe impl Send for ID2D1ImageSourceFromWic {}
-#[cfg(all(feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_Imaging"))]
-unsafe impl Sync for ID2D1ImageSourceFromWic {}
 windows_core::imp::define_interface!(ID2D1Ink, ID2D1Ink_Vtbl, 0xb499923b_7029_478f_a8b3_432c7c5f5312);
 impl core::ops::Deref for ID2D1Ink {
     type Target = ID2D1Resource;
@@ -10372,6 +10260,8 @@ pub struct ID2D1Ink_Vtbl {
     #[cfg(not(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common")))]
     GetBounds: usize,
 }
+unsafe impl Send for ID2D1Ink {}
+unsafe impl Sync for ID2D1Ink {}
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common"))]
 pub trait ID2D1Ink_Impl: ID2D1Resource_Impl {
     fn SetStartPoint(&self, startpoint: *const D2D1_INK_POINT);
@@ -10474,10 +10364,6 @@ impl ID2D1Ink_Vtbl {
 }
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common"))]
 impl windows_core::RuntimeName for ID2D1Ink {}
-#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common"))]
-unsafe impl Send for ID2D1Ink {}
-#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common"))]
-unsafe impl Sync for ID2D1Ink {}
 windows_core::imp::define_interface!(ID2D1InkStyle, ID2D1InkStyle_Vtbl, 0xbae8b344_23fc_4071_8cb5_d05d6f073848);
 impl core::ops::Deref for ID2D1InkStyle {
     type Target = ID2D1Resource;
@@ -10516,6 +10402,8 @@ pub struct ID2D1InkStyle_Vtbl {
     pub SetNibShape: unsafe extern "system" fn(*mut core::ffi::c_void, D2D1_INK_NIB_SHAPE),
     pub GetNibShape: unsafe extern "system" fn(*mut core::ffi::c_void) -> D2D1_INK_NIB_SHAPE,
 }
+unsafe impl Send for ID2D1InkStyle {}
+unsafe impl Sync for ID2D1InkStyle {}
 #[cfg(feature = "Foundation_Numerics")]
 pub trait ID2D1InkStyle_Impl: ID2D1Resource_Impl {
     fn SetNibTransform(&self, transform: *const super::super::super::Foundation::Numerics::Matrix3x2);
@@ -10564,10 +10452,6 @@ impl ID2D1InkStyle_Vtbl {
 }
 #[cfg(feature = "Foundation_Numerics")]
 impl windows_core::RuntimeName for ID2D1InkStyle {}
-#[cfg(feature = "Foundation_Numerics")]
-unsafe impl Send for ID2D1InkStyle {}
-#[cfg(feature = "Foundation_Numerics")]
-unsafe impl Sync for ID2D1InkStyle {}
 windows_core::imp::define_interface!(ID2D1Layer, ID2D1Layer_Vtbl, 0x2cd9069b_12e2_11dc_9fed_001143a055f9);
 impl core::ops::Deref for ID2D1Layer {
     type Target = ID2D1Resource;
@@ -10594,6 +10478,8 @@ pub struct ID2D1Layer_Vtbl {
     #[cfg(not(feature = "Win32_Graphics_Direct2D_Common"))]
     GetSize: usize,
 }
+unsafe impl Send for ID2D1Layer {}
+unsafe impl Sync for ID2D1Layer {}
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
 pub trait ID2D1Layer_Impl: ID2D1Resource_Impl {
     fn GetSize(&self) -> Common::D2D_SIZE_F;
@@ -10615,10 +10501,6 @@ impl ID2D1Layer_Vtbl {
 }
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
 impl windows_core::RuntimeName for ID2D1Layer {}
-#[cfg(feature = "Win32_Graphics_Direct2D_Common")]
-unsafe impl Send for ID2D1Layer {}
-#[cfg(feature = "Win32_Graphics_Direct2D_Common")]
-unsafe impl Sync for ID2D1Layer {}
 windows_core::imp::define_interface!(ID2D1LinearGradientBrush, ID2D1LinearGradientBrush_Vtbl, 0x2cd906ab_12e2_11dc_9fed_001143a055f9);
 impl core::ops::Deref for ID2D1LinearGradientBrush {
     type Target = ID2D1Brush;
@@ -10681,6 +10563,8 @@ pub struct ID2D1LinearGradientBrush_Vtbl {
     GetEndPoint: usize,
     pub GetGradientStopCollection: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void),
 }
+unsafe impl Send for ID2D1LinearGradientBrush {}
+unsafe impl Sync for ID2D1LinearGradientBrush {}
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common"))]
 pub trait ID2D1LinearGradientBrush_Impl: ID2D1Brush_Impl {
     fn SetStartPoint(&self, startpoint: &Common::D2D_POINT_2F);
@@ -10737,10 +10621,6 @@ impl ID2D1LinearGradientBrush_Vtbl {
 }
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common"))]
 impl windows_core::RuntimeName for ID2D1LinearGradientBrush {}
-#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common"))]
-unsafe impl Send for ID2D1LinearGradientBrush {}
-#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common"))]
-unsafe impl Sync for ID2D1LinearGradientBrush {}
 windows_core::imp::define_interface!(ID2D1LookupTable3D, ID2D1LookupTable3D_Vtbl, 0x53dd9855_a3b0_4d5b_82e1_26e25c5e5797);
 impl core::ops::Deref for ID2D1LookupTable3D {
     type Target = ID2D1Resource;
@@ -10753,6 +10633,8 @@ windows_core::imp::interface_hierarchy!(ID2D1LookupTable3D, windows_core::IUnkno
 pub struct ID2D1LookupTable3D_Vtbl {
     pub base__: ID2D1Resource_Vtbl,
 }
+unsafe impl Send for ID2D1LookupTable3D {}
+unsafe impl Sync for ID2D1LookupTable3D {}
 pub trait ID2D1LookupTable3D_Impl: ID2D1Resource_Impl {}
 impl ID2D1LookupTable3D_Vtbl {
     pub const fn new<Identity: ID2D1LookupTable3D_Impl, const OFFSET: isize>() -> Self {
@@ -10763,8 +10645,6 @@ impl ID2D1LookupTable3D_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID2D1LookupTable3D {}
-unsafe impl Send for ID2D1LookupTable3D {}
-unsafe impl Sync for ID2D1LookupTable3D {}
 windows_core::imp::define_interface!(ID2D1Mesh, ID2D1Mesh_Vtbl, 0x2cd906c2_12e2_11dc_9fed_001143a055f9);
 impl core::ops::Deref for ID2D1Mesh {
     type Target = ID2D1Resource;
@@ -10786,6 +10666,8 @@ pub struct ID2D1Mesh_Vtbl {
     pub base__: ID2D1Resource_Vtbl,
     pub Open: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID2D1Mesh {}
+unsafe impl Sync for ID2D1Mesh {}
 pub trait ID2D1Mesh_Impl: ID2D1Resource_Impl {
     fn Open(&self) -> windows_core::Result<ID2D1TessellationSink>;
 }
@@ -10810,8 +10692,6 @@ impl ID2D1Mesh_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID2D1Mesh {}
-unsafe impl Send for ID2D1Mesh {}
-unsafe impl Sync for ID2D1Mesh {}
 windows_core::imp::define_interface!(ID2D1Multithread, ID2D1Multithread_Vtbl, 0x31e6e7bc_e0ff_4d46_8c64_a0a8c41c15d3);
 windows_core::imp::interface_hierarchy!(ID2D1Multithread, windows_core::IUnknown);
 impl ID2D1Multithread {
@@ -10832,6 +10712,8 @@ pub struct ID2D1Multithread_Vtbl {
     pub Enter: unsafe extern "system" fn(*mut core::ffi::c_void),
     pub Leave: unsafe extern "system" fn(*mut core::ffi::c_void),
 }
+unsafe impl Send for ID2D1Multithread {}
+unsafe impl Sync for ID2D1Multithread {}
 pub trait ID2D1Multithread_Impl: windows_core::IUnknownImpl {
     fn GetMultithreadProtected(&self) -> super::super::Foundation::BOOL;
     fn Enter(&self);
@@ -10869,8 +10751,6 @@ impl ID2D1Multithread_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID2D1Multithread {}
-unsafe impl Send for ID2D1Multithread {}
-unsafe impl Sync for ID2D1Multithread {}
 windows_core::imp::define_interface!(ID2D1OffsetTransform, ID2D1OffsetTransform_Vtbl, 0x3fe6adea_7643_4f53_bd14_a0ce63f24042);
 impl core::ops::Deref for ID2D1OffsetTransform {
     type Target = ID2D1TransformNode;
@@ -10897,6 +10777,8 @@ pub struct ID2D1OffsetTransform_Vtbl {
     pub SetOffset: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::POINT),
     pub GetOffset: unsafe extern "system" fn(*mut core::ffi::c_void, *mut super::super::Foundation::POINT),
 }
+unsafe impl Send for ID2D1OffsetTransform {}
+unsafe impl Sync for ID2D1OffsetTransform {}
 pub trait ID2D1OffsetTransform_Impl: ID2D1TransformNode_Impl {
     fn SetOffset(&self, offset: &super::super::Foundation::POINT);
     fn GetOffset(&self) -> super::super::Foundation::POINT;
@@ -10922,8 +10804,6 @@ impl ID2D1OffsetTransform_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID2D1OffsetTransform {}
-unsafe impl Send for ID2D1OffsetTransform {}
-unsafe impl Sync for ID2D1OffsetTransform {}
 windows_core::imp::define_interface!(ID2D1PathGeometry, ID2D1PathGeometry_Vtbl, 0x2cd906a5_12e2_11dc_9fed_001143a055f9);
 impl core::ops::Deref for ID2D1PathGeometry {
     type Target = ID2D1Geometry;
@@ -10974,6 +10854,8 @@ pub struct ID2D1PathGeometry_Vtbl {
     pub GetSegmentCount: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u32) -> windows_core::HRESULT,
     pub GetFigureCount: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u32) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID2D1PathGeometry {}
+unsafe impl Sync for ID2D1PathGeometry {}
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common"))]
 pub trait ID2D1PathGeometry_Impl: ID2D1Geometry_Impl {
     fn Open(&self) -> windows_core::Result<ID2D1GeometrySink>;
@@ -11040,10 +10922,6 @@ impl ID2D1PathGeometry_Vtbl {
 }
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common"))]
 impl windows_core::RuntimeName for ID2D1PathGeometry {}
-#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common"))]
-unsafe impl Send for ID2D1PathGeometry {}
-#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common"))]
-unsafe impl Sync for ID2D1PathGeometry {}
 windows_core::imp::define_interface!(ID2D1PathGeometry1, ID2D1PathGeometry1_Vtbl, 0x62baa2d2_ab54_41b7_b872_787e0106a421);
 impl core::ops::Deref for ID2D1PathGeometry1 {
     type Target = ID2D1PathGeometry;
@@ -11066,6 +10944,8 @@ pub struct ID2D1PathGeometry1_Vtbl {
     #[cfg(not(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common")))]
     ComputePointAndSegmentAtLength: usize,
 }
+unsafe impl Send for ID2D1PathGeometry1 {}
+unsafe impl Sync for ID2D1PathGeometry1 {}
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common"))]
 pub trait ID2D1PathGeometry1_Impl: ID2D1PathGeometry_Impl {
     fn ComputePointAndSegmentAtLength(&self, length: f32, startsegment: u32, worldtransform: *const super::super::super::Foundation::Numerics::Matrix3x2, flatteningtolerance: f32, pointdescription: *mut D2D1_POINT_DESCRIPTION) -> windows_core::Result<()>;
@@ -11087,10 +10967,6 @@ impl ID2D1PathGeometry1_Vtbl {
 }
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common"))]
 impl windows_core::RuntimeName for ID2D1PathGeometry1 {}
-#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common"))]
-unsafe impl Send for ID2D1PathGeometry1 {}
-#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common"))]
-unsafe impl Sync for ID2D1PathGeometry1 {}
 windows_core::imp::define_interface!(ID2D1PrintControl, ID2D1PrintControl_Vtbl, 0x2c1d867d_c290_41c8_ae7e_34a98702e9a5);
 windows_core::imp::interface_hierarchy!(ID2D1PrintControl, windows_core::IUnknown);
 impl ID2D1PrintControl {
@@ -11115,6 +10991,8 @@ pub struct ID2D1PrintControl_Vtbl {
     AddPage: usize,
     pub Close: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID2D1PrintControl {}
+unsafe impl Sync for ID2D1PrintControl {}
 #[cfg(all(feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_System_Com"))]
 pub trait ID2D1PrintControl_Impl: windows_core::IUnknownImpl {
     fn AddPage(&self, commandlist: windows_core::Ref<ID2D1CommandList>, pagesize: &Common::D2D_SIZE_F, pageprintticketstream: windows_core::Ref<super::super::System::Com::IStream>, tag1: *mut u64, tag2: *mut u64) -> windows_core::Result<()>;
@@ -11143,10 +11021,6 @@ impl ID2D1PrintControl_Vtbl {
 }
 #[cfg(all(feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_System_Com"))]
 impl windows_core::RuntimeName for ID2D1PrintControl {}
-#[cfg(all(feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_System_Com"))]
-unsafe impl Send for ID2D1PrintControl {}
-#[cfg(all(feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_System_Com"))]
-unsafe impl Sync for ID2D1PrintControl {}
 windows_core::imp::define_interface!(ID2D1Properties, ID2D1Properties_Vtbl, 0x483473d7_cd46_4f9d_9d3a_3112aa80159d);
 windows_core::imp::interface_hierarchy!(ID2D1Properties, windows_core::IUnknown);
 impl ID2D1Properties {
@@ -11211,6 +11085,8 @@ pub struct ID2D1Properties_Vtbl {
     pub GetValueSize: unsafe extern "system" fn(*mut core::ffi::c_void, u32) -> u32,
     pub GetSubProperties: unsafe extern "system" fn(*mut core::ffi::c_void, u32, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID2D1Properties {}
+unsafe impl Sync for ID2D1Properties {}
 pub trait ID2D1Properties_Impl: windows_core::IUnknownImpl {
     fn GetPropertyCount(&self) -> u32;
     fn GetPropertyName(&self, index: u32, name: windows_core::PWSTR, namecount: u32) -> windows_core::Result<()>;
@@ -11318,8 +11194,6 @@ impl ID2D1Properties_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID2D1Properties {}
-unsafe impl Send for ID2D1Properties {}
-unsafe impl Sync for ID2D1Properties {}
 windows_core::imp::define_interface!(ID2D1RadialGradientBrush, ID2D1RadialGradientBrush_Vtbl, 0x2cd906ac_12e2_11dc_9fed_001143a055f9);
 impl core::ops::Deref for ID2D1RadialGradientBrush {
     type Target = ID2D1Brush;
@@ -11398,6 +11272,8 @@ pub struct ID2D1RadialGradientBrush_Vtbl {
     pub GetRadiusY: unsafe extern "system" fn(*mut core::ffi::c_void) -> f32,
     pub GetGradientStopCollection: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void),
 }
+unsafe impl Send for ID2D1RadialGradientBrush {}
+unsafe impl Sync for ID2D1RadialGradientBrush {}
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common"))]
 pub trait ID2D1RadialGradientBrush_Impl: ID2D1Brush_Impl {
     fn SetCenter(&self, center: &Common::D2D_POINT_2F);
@@ -11486,10 +11362,6 @@ impl ID2D1RadialGradientBrush_Vtbl {
 }
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common"))]
 impl windows_core::RuntimeName for ID2D1RadialGradientBrush {}
-#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common"))]
-unsafe impl Send for ID2D1RadialGradientBrush {}
-#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common"))]
-unsafe impl Sync for ID2D1RadialGradientBrush {}
 windows_core::imp::define_interface!(ID2D1RectangleGeometry, ID2D1RectangleGeometry_Vtbl, 0x2cd906a2_12e2_11dc_9fed_001143a055f9);
 impl core::ops::Deref for ID2D1RectangleGeometry {
     type Target = ID2D1Geometry;
@@ -11516,6 +11388,8 @@ pub struct ID2D1RectangleGeometry_Vtbl {
     #[cfg(not(feature = "Win32_Graphics_Direct2D_Common"))]
     GetRect: usize,
 }
+unsafe impl Send for ID2D1RectangleGeometry {}
+unsafe impl Sync for ID2D1RectangleGeometry {}
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common"))]
 pub trait ID2D1RectangleGeometry_Impl: ID2D1Geometry_Impl {
     fn GetRect(&self, rect: *mut Common::D2D_RECT_F);
@@ -11537,10 +11411,6 @@ impl ID2D1RectangleGeometry_Vtbl {
 }
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common"))]
 impl windows_core::RuntimeName for ID2D1RectangleGeometry {}
-#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common"))]
-unsafe impl Send for ID2D1RectangleGeometry {}
-#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common"))]
-unsafe impl Sync for ID2D1RectangleGeometry {}
 windows_core::imp::define_interface!(ID2D1RenderInfo, ID2D1RenderInfo_Vtbl, 0x519ae1bd_d19a_420d_b849_364f594776b7);
 windows_core::imp::interface_hierarchy!(ID2D1RenderInfo, windows_core::IUnknown);
 impl ID2D1RenderInfo {
@@ -11565,6 +11435,8 @@ pub struct ID2D1RenderInfo_Vtbl {
     pub SetCached: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::BOOL),
     pub SetInstructionCountHint: unsafe extern "system" fn(*mut core::ffi::c_void, u32),
 }
+unsafe impl Send for ID2D1RenderInfo {}
+unsafe impl Sync for ID2D1RenderInfo {}
 pub trait ID2D1RenderInfo_Impl: windows_core::IUnknownImpl {
     fn SetInputDescription(&self, inputindex: u32, inputdescription: &D2D1_INPUT_DESCRIPTION) -> windows_core::Result<()>;
     fn SetOutputBuffer(&self, bufferprecision: D2D1_BUFFER_PRECISION, channeldepth: D2D1_CHANNEL_DEPTH) -> windows_core::Result<()>;
@@ -11610,8 +11482,6 @@ impl ID2D1RenderInfo_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID2D1RenderInfo {}
-unsafe impl Send for ID2D1RenderInfo {}
-unsafe impl Sync for ID2D1RenderInfo {}
 windows_core::imp::define_interface!(ID2D1RenderTarget, ID2D1RenderTarget_Vtbl, 0x2cd90694_12e2_11dc_9fed_001143a055f9);
 impl core::ops::Deref for ID2D1RenderTarget {
     type Target = ID2D1Resource;
@@ -12097,6 +11967,8 @@ pub struct ID2D1RenderTarget_Vtbl {
     #[cfg(not(all(feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_Dxgi_Common")))]
     IsSupported: usize,
 }
+unsafe impl Send for ID2D1RenderTarget {}
+unsafe impl Sync for ID2D1RenderTarget {}
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging"))]
 pub trait ID2D1RenderTarget_Impl: ID2D1Resource_Impl {
     fn CreateBitmap(&self, size: &Common::D2D_SIZE_U, srcdata: *const core::ffi::c_void, pitch: u32, bitmapproperties: *const D2D1_BITMAP_PROPERTIES) -> windows_core::Result<ID2D1Bitmap>;
@@ -12597,10 +12469,6 @@ impl ID2D1RenderTarget_Vtbl {
 }
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging"))]
 impl windows_core::RuntimeName for ID2D1RenderTarget {}
-#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging"))]
-unsafe impl Send for ID2D1RenderTarget {}
-#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging"))]
-unsafe impl Sync for ID2D1RenderTarget {}
 windows_core::imp::define_interface!(ID2D1Resource, ID2D1Resource_Vtbl, 0x2cd90691_12e2_11dc_9fed_001143a055f9);
 windows_core::imp::interface_hierarchy!(ID2D1Resource, windows_core::IUnknown);
 impl ID2D1Resource {
@@ -12617,6 +12485,8 @@ pub struct ID2D1Resource_Vtbl {
     pub base__: windows_core::IUnknown_Vtbl,
     pub GetFactory: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void),
 }
+unsafe impl Send for ID2D1Resource {}
+unsafe impl Sync for ID2D1Resource {}
 pub trait ID2D1Resource_Impl: windows_core::IUnknownImpl {
     fn GetFactory(&self, factory: windows_core::OutRef<'_, ID2D1Factory>);
 }
@@ -12635,8 +12505,6 @@ impl ID2D1Resource_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID2D1Resource {}
-unsafe impl Send for ID2D1Resource {}
-unsafe impl Sync for ID2D1Resource {}
 windows_core::imp::define_interface!(ID2D1ResourceTexture, ID2D1ResourceTexture_Vtbl, 0x688d15c3_02b0_438d_b13a_d1b44c32c39a);
 windows_core::imp::interface_hierarchy!(ID2D1ResourceTexture, windows_core::IUnknown);
 impl ID2D1ResourceTexture {
@@ -12649,6 +12517,8 @@ pub struct ID2D1ResourceTexture_Vtbl {
     pub base__: windows_core::IUnknown_Vtbl,
     pub Update: unsafe extern "system" fn(*mut core::ffi::c_void, *const u32, *const u32, *const u32, u32, *const u8, u32) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID2D1ResourceTexture {}
+unsafe impl Sync for ID2D1ResourceTexture {}
 pub trait ID2D1ResourceTexture_Impl: windows_core::IUnknownImpl {
     fn Update(&self, minimumextents: *const u32, maximimumextents: *const u32, strides: *const u32, dimensions: u32, data: *const u8, datacount: u32) -> windows_core::Result<()>;
 }
@@ -12667,8 +12537,6 @@ impl ID2D1ResourceTexture_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID2D1ResourceTexture {}
-unsafe impl Send for ID2D1ResourceTexture {}
-unsafe impl Sync for ID2D1ResourceTexture {}
 windows_core::imp::define_interface!(ID2D1RoundedRectangleGeometry, ID2D1RoundedRectangleGeometry_Vtbl, 0x2cd906a3_12e2_11dc_9fed_001143a055f9);
 impl core::ops::Deref for ID2D1RoundedRectangleGeometry {
     type Target = ID2D1Geometry;
@@ -12691,6 +12559,8 @@ pub struct ID2D1RoundedRectangleGeometry_Vtbl {
     #[cfg(not(feature = "Win32_Graphics_Direct2D_Common"))]
     GetRoundedRect: usize,
 }
+unsafe impl Send for ID2D1RoundedRectangleGeometry {}
+unsafe impl Sync for ID2D1RoundedRectangleGeometry {}
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common"))]
 pub trait ID2D1RoundedRectangleGeometry_Impl: ID2D1Geometry_Impl {
     fn GetRoundedRect(&self, roundedrect: *mut D2D1_ROUNDED_RECT);
@@ -12712,10 +12582,6 @@ impl ID2D1RoundedRectangleGeometry_Vtbl {
 }
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common"))]
 impl windows_core::RuntimeName for ID2D1RoundedRectangleGeometry {}
-#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common"))]
-unsafe impl Send for ID2D1RoundedRectangleGeometry {}
-#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common"))]
-unsafe impl Sync for ID2D1RoundedRectangleGeometry {}
 windows_core::imp::define_interface!(ID2D1SolidColorBrush, ID2D1SolidColorBrush_Vtbl, 0x2cd906a9_12e2_11dc_9fed_001143a055f9);
 impl core::ops::Deref for ID2D1SolidColorBrush {
     type Target = ID2D1Brush;
@@ -12750,6 +12616,8 @@ pub struct ID2D1SolidColorBrush_Vtbl {
     #[cfg(not(feature = "Win32_Graphics_Direct2D_Common"))]
     GetColor: usize,
 }
+unsafe impl Send for ID2D1SolidColorBrush {}
+unsafe impl Sync for ID2D1SolidColorBrush {}
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common"))]
 pub trait ID2D1SolidColorBrush_Impl: ID2D1Brush_Impl {
     fn SetColor(&self, color: *const Common::D2D1_COLOR_F);
@@ -12778,10 +12646,6 @@ impl ID2D1SolidColorBrush_Vtbl {
 }
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common"))]
 impl windows_core::RuntimeName for ID2D1SolidColorBrush {}
-#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common"))]
-unsafe impl Send for ID2D1SolidColorBrush {}
-#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common"))]
-unsafe impl Sync for ID2D1SolidColorBrush {}
 windows_core::imp::define_interface!(ID2D1SourceTransform, ID2D1SourceTransform_Vtbl, 0xdb1800dd_0c34_4cf9_be90_31cc0a5653e1);
 impl core::ops::Deref for ID2D1SourceTransform {
     type Target = ID2D1Transform;
@@ -12814,6 +12678,8 @@ pub struct ID2D1SourceTransform_Vtbl {
     #[cfg(not(feature = "Win32_Graphics_Direct2D_Common"))]
     Draw: usize,
 }
+unsafe impl Send for ID2D1SourceTransform {}
+unsafe impl Sync for ID2D1SourceTransform {}
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
 pub trait ID2D1SourceTransform_Impl: ID2D1Transform_Impl {
     fn SetRenderInfo(&self, renderinfo: windows_core::Ref<ID2D1RenderInfo>) -> windows_core::Result<()>;
@@ -12842,10 +12708,6 @@ impl ID2D1SourceTransform_Vtbl {
 }
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
 impl windows_core::RuntimeName for ID2D1SourceTransform {}
-#[cfg(feature = "Win32_Graphics_Direct2D_Common")]
-unsafe impl Send for ID2D1SourceTransform {}
-#[cfg(feature = "Win32_Graphics_Direct2D_Common")]
-unsafe impl Sync for ID2D1SourceTransform {}
 windows_core::imp::define_interface!(ID2D1SpriteBatch, ID2D1SpriteBatch_Vtbl, 0x4dc583bf_3a10_438a_8722_e9765224f1f1);
 impl core::ops::Deref for ID2D1SpriteBatch {
     type Target = ID2D1Resource;
@@ -12892,6 +12754,8 @@ pub struct ID2D1SpriteBatch_Vtbl {
     pub GetSpriteCount: unsafe extern "system" fn(*mut core::ffi::c_void) -> u32,
     pub Clear: unsafe extern "system" fn(*mut core::ffi::c_void),
 }
+unsafe impl Send for ID2D1SpriteBatch {}
+unsafe impl Sync for ID2D1SpriteBatch {}
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common"))]
 pub trait ID2D1SpriteBatch_Impl: ID2D1Resource_Impl {
     fn AddSprites(&self, spritecount: u32, destinationrectangles: *const Common::D2D_RECT_F, sourcerectangles: *const Common::D2D_RECT_U, colors: *const Common::D2D1_COLOR_F, transforms: *const super::super::super::Foundation::Numerics::Matrix3x2, destinationrectanglesstride: u32, sourcerectanglesstride: u32, colorsstride: u32, transformsstride: u32) -> windows_core::Result<()>;
@@ -12948,10 +12812,6 @@ impl ID2D1SpriteBatch_Vtbl {
 }
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common"))]
 impl windows_core::RuntimeName for ID2D1SpriteBatch {}
-#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common"))]
-unsafe impl Send for ID2D1SpriteBatch {}
-#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common"))]
-unsafe impl Sync for ID2D1SpriteBatch {}
 windows_core::imp::define_interface!(ID2D1StrokeStyle, ID2D1StrokeStyle_Vtbl, 0x2cd9069d_12e2_11dc_9fed_001143a055f9);
 impl core::ops::Deref for ID2D1StrokeStyle {
     type Target = ID2D1Resource;
@@ -13002,6 +12862,8 @@ pub struct ID2D1StrokeStyle_Vtbl {
     pub GetDashesCount: unsafe extern "system" fn(*mut core::ffi::c_void) -> u32,
     pub GetDashes: unsafe extern "system" fn(*mut core::ffi::c_void, *mut f32, u32),
 }
+unsafe impl Send for ID2D1StrokeStyle {}
+unsafe impl Sync for ID2D1StrokeStyle {}
 pub trait ID2D1StrokeStyle_Impl: ID2D1Resource_Impl {
     fn GetStartCap(&self) -> D2D1_CAP_STYLE;
     fn GetEndCap(&self) -> D2D1_CAP_STYLE;
@@ -13087,8 +12949,6 @@ impl ID2D1StrokeStyle_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID2D1StrokeStyle {}
-unsafe impl Send for ID2D1StrokeStyle {}
-unsafe impl Sync for ID2D1StrokeStyle {}
 windows_core::imp::define_interface!(ID2D1StrokeStyle1, ID2D1StrokeStyle1_Vtbl, 0x10a72a66_e91c_43f4_993f_ddf4b82b0b4a);
 impl core::ops::Deref for ID2D1StrokeStyle1 {
     type Target = ID2D1StrokeStyle;
@@ -13107,6 +12967,8 @@ pub struct ID2D1StrokeStyle1_Vtbl {
     pub base__: ID2D1StrokeStyle_Vtbl,
     pub GetStrokeTransformType: unsafe extern "system" fn(*mut core::ffi::c_void) -> D2D1_STROKE_TRANSFORM_TYPE,
 }
+unsafe impl Send for ID2D1StrokeStyle1 {}
+unsafe impl Sync for ID2D1StrokeStyle1 {}
 pub trait ID2D1StrokeStyle1_Impl: ID2D1StrokeStyle_Impl {
     fn GetStrokeTransformType(&self) -> D2D1_STROKE_TRANSFORM_TYPE;
 }
@@ -13125,8 +12987,6 @@ impl ID2D1StrokeStyle1_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID2D1StrokeStyle1 {}
-unsafe impl Send for ID2D1StrokeStyle1 {}
-unsafe impl Sync for ID2D1StrokeStyle1 {}
 windows_core::imp::define_interface!(ID2D1SvgAttribute, ID2D1SvgAttribute_Vtbl, 0xc9cdb0dd_f8c9_4e70_b7c2_301c80292c5e);
 impl core::ops::Deref for ID2D1SvgAttribute {
     type Target = ID2D1Resource;
@@ -13156,6 +13016,8 @@ pub struct ID2D1SvgAttribute_Vtbl {
     pub GetElement: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void),
     pub Clone: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID2D1SvgAttribute {}
+unsafe impl Sync for ID2D1SvgAttribute {}
 pub trait ID2D1SvgAttribute_Impl: ID2D1Resource_Impl {
     fn GetElement(&self, element: windows_core::OutRef<'_, ID2D1SvgElement>);
     fn Clone(&self) -> windows_core::Result<ID2D1SvgAttribute>;
@@ -13187,8 +13049,6 @@ impl ID2D1SvgAttribute_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID2D1SvgAttribute {}
-unsafe impl Send for ID2D1SvgAttribute {}
-unsafe impl Sync for ID2D1SvgAttribute {}
 windows_core::imp::define_interface!(ID2D1SvgDocument, ID2D1SvgDocument_Vtbl, 0x86b88e4d_afa4_4d7b_88e4_68a51c4a0aec);
 impl core::ops::Deref for ID2D1SvgDocument {
     type Target = ID2D1Resource;
@@ -13313,6 +13173,8 @@ pub struct ID2D1SvgDocument_Vtbl {
     CreatePointCollection: usize,
     pub CreatePathData: unsafe extern "system" fn(*mut core::ffi::c_void, *const f32, u32, *const D2D1_SVG_PATH_COMMAND, u32, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID2D1SvgDocument {}
+unsafe impl Sync for ID2D1SvgDocument {}
 #[cfg(all(feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_System_Com"))]
 pub trait ID2D1SvgDocument_Impl: ID2D1Resource_Impl {
     fn SetViewportSize(&self, viewportsize: &Common::D2D_SIZE_F) -> windows_core::Result<()>;
@@ -13453,10 +13315,6 @@ impl ID2D1SvgDocument_Vtbl {
 }
 #[cfg(all(feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_System_Com"))]
 impl windows_core::RuntimeName for ID2D1SvgDocument {}
-#[cfg(all(feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_System_Com"))]
-unsafe impl Send for ID2D1SvgDocument {}
-#[cfg(all(feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_System_Com"))]
-unsafe impl Sync for ID2D1SvgDocument {}
 windows_core::imp::define_interface!(ID2D1SvgElement, ID2D1SvgElement_Vtbl, 0xac7b67a6_183e_49c1_a823_0ebe40b0db29);
 impl core::ops::Deref for ID2D1SvgElement {
     type Target = ID2D1Resource;
@@ -13673,6 +13531,8 @@ pub struct ID2D1SvgElement_Vtbl {
     pub GetAttributeValue3: unsafe extern "system" fn(*mut core::ffi::c_void, windows_core::PCWSTR, D2D1_SVG_ATTRIBUTE_STRING_TYPE, windows_core::PWSTR, u32) -> windows_core::HRESULT,
     pub GetAttributeValueLength: unsafe extern "system" fn(*mut core::ffi::c_void, windows_core::PCWSTR, D2D1_SVG_ATTRIBUTE_STRING_TYPE, *mut u32) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID2D1SvgElement {}
+unsafe impl Sync for ID2D1SvgElement {}
 pub trait ID2D1SvgElement_Impl: ID2D1Resource_Impl {
     fn GetDocument(&self, document: windows_core::OutRef<'_, ID2D1SvgDocument>);
     fn GetTagName(&self, name: windows_core::PWSTR, namecount: u32) -> windows_core::Result<()>;
@@ -13950,8 +13810,6 @@ impl ID2D1SvgElement_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID2D1SvgElement {}
-unsafe impl Send for ID2D1SvgElement {}
-unsafe impl Sync for ID2D1SvgElement {}
 windows_core::imp::define_interface!(ID2D1SvgGlyphStyle, ID2D1SvgGlyphStyle_Vtbl, 0xaf671749_d241_4db8_8e41_dcc2e5c1a438);
 impl core::ops::Deref for ID2D1SvgGlyphStyle {
     type Target = ID2D1Resource;
@@ -13996,6 +13854,8 @@ pub struct ID2D1SvgGlyphStyle_Vtbl {
     pub GetStrokeDashesCount: unsafe extern "system" fn(*mut core::ffi::c_void) -> u32,
     pub GetStroke: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void, *mut f32, *mut f32, u32, *mut f32),
 }
+unsafe impl Send for ID2D1SvgGlyphStyle {}
+unsafe impl Sync for ID2D1SvgGlyphStyle {}
 pub trait ID2D1SvgGlyphStyle_Impl: ID2D1Resource_Impl {
     fn SetFill(&self, brush: windows_core::Ref<ID2D1Brush>) -> windows_core::Result<()>;
     fn GetFill(&self, brush: windows_core::OutRef<'_, ID2D1Brush>);
@@ -14049,8 +13909,6 @@ impl ID2D1SvgGlyphStyle_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID2D1SvgGlyphStyle {}
-unsafe impl Send for ID2D1SvgGlyphStyle {}
-unsafe impl Sync for ID2D1SvgGlyphStyle {}
 windows_core::imp::define_interface!(ID2D1SvgPaint, ID2D1SvgPaint_Vtbl, 0xd59bab0a_68a2_455b_a5dc_9eb2854e2490);
 impl core::ops::Deref for ID2D1SvgPaint {
     type Target = ID2D1SvgAttribute;
@@ -14108,6 +13966,8 @@ pub struct ID2D1SvgPaint_Vtbl {
     pub GetId: unsafe extern "system" fn(*mut core::ffi::c_void, windows_core::PWSTR, u32) -> windows_core::HRESULT,
     pub GetIdLength: unsafe extern "system" fn(*mut core::ffi::c_void) -> u32,
 }
+unsafe impl Send for ID2D1SvgPaint {}
+unsafe impl Sync for ID2D1SvgPaint {}
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
 pub trait ID2D1SvgPaint_Impl: ID2D1SvgAttribute_Impl {
     fn SetPaintType(&self, painttype: D2D1_SVG_PAINT_TYPE) -> windows_core::Result<()>;
@@ -14180,10 +14040,6 @@ impl ID2D1SvgPaint_Vtbl {
 }
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
 impl windows_core::RuntimeName for ID2D1SvgPaint {}
-#[cfg(feature = "Win32_Graphics_Direct2D_Common")]
-unsafe impl Send for ID2D1SvgPaint {}
-#[cfg(feature = "Win32_Graphics_Direct2D_Common")]
-unsafe impl Sync for ID2D1SvgPaint {}
 windows_core::imp::define_interface!(ID2D1SvgPathData, ID2D1SvgPathData_Vtbl, 0xc095e4f4_bb98_43d6_9745_4d1b84ec9888);
 impl core::ops::Deref for ID2D1SvgPathData {
     type Target = ID2D1SvgAttribute;
@@ -14241,6 +14097,8 @@ pub struct ID2D1SvgPathData_Vtbl {
     #[cfg(not(feature = "Win32_Graphics_Direct2D_Common"))]
     CreatePathGeometry: usize,
 }
+unsafe impl Send for ID2D1SvgPathData {}
+unsafe impl Sync for ID2D1SvgPathData {}
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
 pub trait ID2D1SvgPathData_Impl: ID2D1SvgAttribute_Impl {
     fn RemoveSegmentDataAtEnd(&self, datacount: u32) -> windows_core::Result<()>;
@@ -14335,10 +14193,6 @@ impl ID2D1SvgPathData_Vtbl {
 }
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
 impl windows_core::RuntimeName for ID2D1SvgPathData {}
-#[cfg(feature = "Win32_Graphics_Direct2D_Common")]
-unsafe impl Send for ID2D1SvgPathData {}
-#[cfg(feature = "Win32_Graphics_Direct2D_Common")]
-unsafe impl Sync for ID2D1SvgPathData {}
 windows_core::imp::define_interface!(ID2D1SvgPointCollection, ID2D1SvgPointCollection_Vtbl, 0x9dbe4c0d_3572_4dd9_9825_5530813bb712);
 impl core::ops::Deref for ID2D1SvgPointCollection {
     type Target = ID2D1SvgAttribute;
@@ -14377,6 +14231,8 @@ pub struct ID2D1SvgPointCollection_Vtbl {
     GetPoints: usize,
     pub GetPointsCount: unsafe extern "system" fn(*mut core::ffi::c_void) -> u32,
 }
+unsafe impl Send for ID2D1SvgPointCollection {}
+unsafe impl Sync for ID2D1SvgPointCollection {}
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
 pub trait ID2D1SvgPointCollection_Impl: ID2D1SvgAttribute_Impl {
     fn RemovePointsAtEnd(&self, pointscount: u32) -> windows_core::Result<()>;
@@ -14425,10 +14281,6 @@ impl ID2D1SvgPointCollection_Vtbl {
 }
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
 impl windows_core::RuntimeName for ID2D1SvgPointCollection {}
-#[cfg(feature = "Win32_Graphics_Direct2D_Common")]
-unsafe impl Send for ID2D1SvgPointCollection {}
-#[cfg(feature = "Win32_Graphics_Direct2D_Common")]
-unsafe impl Sync for ID2D1SvgPointCollection {}
 windows_core::imp::define_interface!(ID2D1SvgStrokeDashArray, ID2D1SvgStrokeDashArray_Vtbl, 0xf1c0ca52_92a3_4f00_b4ce_f35691efd9d9);
 impl core::ops::Deref for ID2D1SvgStrokeDashArray {
     type Target = ID2D1SvgAttribute;
@@ -14467,6 +14319,8 @@ pub struct ID2D1SvgStrokeDashArray_Vtbl {
     pub GetDashes2: unsafe extern "system" fn(*mut core::ffi::c_void, *mut f32, u32, u32) -> windows_core::HRESULT,
     pub GetDashesCount: unsafe extern "system" fn(*mut core::ffi::c_void) -> u32,
 }
+unsafe impl Send for ID2D1SvgStrokeDashArray {}
+unsafe impl Sync for ID2D1SvgStrokeDashArray {}
 pub trait ID2D1SvgStrokeDashArray_Impl: ID2D1SvgAttribute_Impl {
     fn RemoveDashesAtEnd(&self, dashescount: u32) -> windows_core::Result<()>;
     fn UpdateDashes(&self, dashes: *const D2D1_SVG_LENGTH, dashescount: u32, startindex: u32) -> windows_core::Result<()>;
@@ -14528,8 +14382,6 @@ impl ID2D1SvgStrokeDashArray_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID2D1SvgStrokeDashArray {}
-unsafe impl Send for ID2D1SvgStrokeDashArray {}
-unsafe impl Sync for ID2D1SvgStrokeDashArray {}
 windows_core::imp::define_interface!(ID2D1TessellationSink, ID2D1TessellationSink_Vtbl, 0x2cd906c1_12e2_11dc_9fed_001143a055f9);
 windows_core::imp::interface_hierarchy!(ID2D1TessellationSink, windows_core::IUnknown);
 impl ID2D1TessellationSink {
@@ -14550,6 +14402,8 @@ pub struct ID2D1TessellationSink_Vtbl {
     AddTriangles: usize,
     pub Close: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID2D1TessellationSink {}
+unsafe impl Sync for ID2D1TessellationSink {}
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
 pub trait ID2D1TessellationSink_Impl: windows_core::IUnknownImpl {
     fn AddTriangles(&self, triangles: *const D2D1_TRIANGLE, trianglescount: u32);
@@ -14578,10 +14432,6 @@ impl ID2D1TessellationSink_Vtbl {
 }
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
 impl windows_core::RuntimeName for ID2D1TessellationSink {}
-#[cfg(feature = "Win32_Graphics_Direct2D_Common")]
-unsafe impl Send for ID2D1TessellationSink {}
-#[cfg(feature = "Win32_Graphics_Direct2D_Common")]
-unsafe impl Sync for ID2D1TessellationSink {}
 windows_core::imp::define_interface!(ID2D1Transform, ID2D1Transform_Vtbl, 0xef1a287d_342a_4f76_8fdb_da0d6ea9f92b);
 impl core::ops::Deref for ID2D1Transform {
     type Target = ID2D1TransformNode;
@@ -14611,6 +14461,8 @@ pub struct ID2D1Transform_Vtbl {
     pub MapInputRectsToOutputRect: unsafe extern "system" fn(*mut core::ffi::c_void, *const super::super::Foundation::RECT, *const super::super::Foundation::RECT, u32, *mut super::super::Foundation::RECT, *mut super::super::Foundation::RECT) -> windows_core::HRESULT,
     pub MapInvalidRect: unsafe extern "system" fn(*mut core::ffi::c_void, u32, super::super::Foundation::RECT, *mut super::super::Foundation::RECT) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID2D1Transform {}
+unsafe impl Sync for ID2D1Transform {}
 pub trait ID2D1Transform_Impl: ID2D1TransformNode_Impl {
     fn MapOutputRectToInputRects(&self, outputrect: *const super::super::Foundation::RECT, inputrects: *mut super::super::Foundation::RECT, inputrectscount: u32) -> windows_core::Result<()>;
     fn MapInputRectsToOutputRect(&self, inputrects: *const super::super::Foundation::RECT, inputopaquesubrects: *const super::super::Foundation::RECT, inputrectcount: u32, outputrect: *mut super::super::Foundation::RECT, outputopaquesubrect: *mut super::super::Foundation::RECT) -> windows_core::Result<()>;
@@ -14654,8 +14506,6 @@ impl ID2D1Transform_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID2D1Transform {}
-unsafe impl Send for ID2D1Transform {}
-unsafe impl Sync for ID2D1Transform {}
 windows_core::imp::define_interface!(ID2D1TransformGraph, ID2D1TransformGraph_Vtbl, 0x13d29038_c3e6_4034_9081_13b53a417992);
 windows_core::imp::interface_hierarchy!(ID2D1TransformGraph, windows_core::IUnknown);
 impl ID2D1TransformGraph {
@@ -14719,6 +14569,8 @@ pub struct ID2D1TransformGraph_Vtbl {
     pub Clear: unsafe extern "system" fn(*mut core::ffi::c_void),
     pub SetPassthroughGraph: unsafe extern "system" fn(*mut core::ffi::c_void, u32) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID2D1TransformGraph {}
+unsafe impl Sync for ID2D1TransformGraph {}
 pub trait ID2D1TransformGraph_Impl: windows_core::IUnknownImpl {
     fn GetInputCount(&self) -> u32;
     fn SetSingleTransformNode(&self, node: windows_core::Ref<ID2D1TransformNode>) -> windows_core::Result<()>;
@@ -14804,8 +14656,6 @@ impl ID2D1TransformGraph_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID2D1TransformGraph {}
-unsafe impl Send for ID2D1TransformGraph {}
-unsafe impl Sync for ID2D1TransformGraph {}
 windows_core::imp::define_interface!(ID2D1TransformNode, ID2D1TransformNode_Vtbl, 0xb2efe1e7_729f_4102_949f_505fa21bf666);
 windows_core::imp::interface_hierarchy!(ID2D1TransformNode, windows_core::IUnknown);
 impl ID2D1TransformNode {
@@ -14818,6 +14668,8 @@ pub struct ID2D1TransformNode_Vtbl {
     pub base__: windows_core::IUnknown_Vtbl,
     pub GetInputCount: unsafe extern "system" fn(*mut core::ffi::c_void) -> u32,
 }
+unsafe impl Send for ID2D1TransformNode {}
+unsafe impl Sync for ID2D1TransformNode {}
 pub trait ID2D1TransformNode_Impl: windows_core::IUnknownImpl {
     fn GetInputCount(&self) -> u32;
 }
@@ -14836,8 +14688,6 @@ impl ID2D1TransformNode_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID2D1TransformNode {}
-unsafe impl Send for ID2D1TransformNode {}
-unsafe impl Sync for ID2D1TransformNode {}
 windows_core::imp::define_interface!(ID2D1TransformedGeometry, ID2D1TransformedGeometry_Vtbl, 0x2cd906bb_12e2_11dc_9fed_001143a055f9);
 impl core::ops::Deref for ID2D1TransformedGeometry {
     type Target = ID2D1Geometry;
@@ -14868,6 +14718,8 @@ pub struct ID2D1TransformedGeometry_Vtbl {
     #[cfg(not(feature = "Foundation_Numerics"))]
     GetTransform: usize,
 }
+unsafe impl Send for ID2D1TransformedGeometry {}
+unsafe impl Sync for ID2D1TransformedGeometry {}
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common"))]
 pub trait ID2D1TransformedGeometry_Impl: ID2D1Geometry_Impl {
     fn GetSourceGeometry(&self, sourcegeometry: windows_core::OutRef<'_, ID2D1Geometry>);
@@ -14900,10 +14752,6 @@ impl ID2D1TransformedGeometry_Vtbl {
 }
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common"))]
 impl windows_core::RuntimeName for ID2D1TransformedGeometry {}
-#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common"))]
-unsafe impl Send for ID2D1TransformedGeometry {}
-#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common"))]
-unsafe impl Sync for ID2D1TransformedGeometry {}
 windows_core::imp::define_interface!(ID2D1TransformedImageSource, ID2D1TransformedImageSource_Vtbl, 0x7f1f79e5_2796_416c_8f55_700f911445e5);
 impl core::ops::Deref for ID2D1TransformedImageSource {
     type Target = ID2D1Image;
@@ -14930,6 +14778,8 @@ pub struct ID2D1TransformedImageSource_Vtbl {
     pub GetSource: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void),
     pub GetProperties: unsafe extern "system" fn(*mut core::ffi::c_void, *mut D2D1_TRANSFORMED_IMAGE_SOURCE_PROPERTIES),
 }
+unsafe impl Send for ID2D1TransformedImageSource {}
+unsafe impl Sync for ID2D1TransformedImageSource {}
 pub trait ID2D1TransformedImageSource_Impl: ID2D1Image_Impl {
     fn GetSource(&self, imagesource: windows_core::OutRef<'_, ID2D1ImageSource>);
     fn GetProperties(&self, properties: *mut D2D1_TRANSFORMED_IMAGE_SOURCE_PROPERTIES);
@@ -14955,8 +14805,6 @@ impl ID2D1TransformedImageSource_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID2D1TransformedImageSource {}
-unsafe impl Send for ID2D1TransformedImageSource {}
-unsafe impl Sync for ID2D1TransformedImageSource {}
 windows_core::imp::define_interface!(ID2D1VertexBuffer, ID2D1VertexBuffer_Vtbl, 0x9b8b1336_00a5_4668_92b7_ced5d8bf9b7b);
 windows_core::imp::interface_hierarchy!(ID2D1VertexBuffer, windows_core::IUnknown);
 impl ID2D1VertexBuffer {
@@ -14973,6 +14821,8 @@ pub struct ID2D1VertexBuffer_Vtbl {
     pub Map: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut u8, u32) -> windows_core::HRESULT,
     pub Unmap: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID2D1VertexBuffer {}
+unsafe impl Sync for ID2D1VertexBuffer {}
 pub trait ID2D1VertexBuffer_Impl: windows_core::IUnknownImpl {
     fn Map(&self, data: *mut *mut u8, buffersize: u32) -> windows_core::Result<()>;
     fn Unmap(&self) -> windows_core::Result<()>;
@@ -14998,8 +14848,6 @@ impl ID2D1VertexBuffer_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID2D1VertexBuffer {}
-unsafe impl Send for ID2D1VertexBuffer {}
-unsafe impl Sync for ID2D1VertexBuffer {}
 pub type PD2D1_EFFECT_FACTORY = Option<unsafe extern "system" fn(effectimpl: *mut Option<windows_core::IUnknown>) -> windows_core::HRESULT>;
 pub type PD2D1_PROPERTY_GET_FUNCTION = Option<unsafe extern "system" fn(effect: Option<windows_core::IUnknown>, data: *mut u8, datasize: u32, actualsize: *mut u32) -> windows_core::HRESULT>;
 pub type PD2D1_PROPERTY_SET_FUNCTION = Option<unsafe extern "system" fn(effect: Option<windows_core::IUnknown>, data: *const u8, datasize: u32) -> windows_core::HRESULT>;

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D/mod.rs
@@ -767,6 +767,8 @@ pub struct ID3DBlob_Vtbl {
     pub GetBufferPointer: unsafe extern "system" fn(*mut core::ffi::c_void) -> *mut core::ffi::c_void,
     pub GetBufferSize: unsafe extern "system" fn(*mut core::ffi::c_void) -> usize,
 }
+unsafe impl Send for ID3DBlob {}
+unsafe impl Sync for ID3DBlob {}
 pub trait ID3DBlob_Impl: windows_core::IUnknownImpl {
     fn GetBufferPointer(&self) -> *mut core::ffi::c_void;
     fn GetBufferSize(&self) -> usize;
@@ -796,8 +798,6 @@ impl ID3DBlob_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3DBlob {}
-unsafe impl Send for ID3DBlob {}
-unsafe impl Sync for ID3DBlob {}
 windows_core::imp::define_interface!(ID3DDestructionNotifier, ID3DDestructionNotifier_Vtbl, 0xa06eb39a_50da_425b_8c31_4eecd6c270f3);
 windows_core::imp::interface_hierarchy!(ID3DDestructionNotifier, windows_core::IUnknown);
 impl ID3DDestructionNotifier {
@@ -817,6 +817,8 @@ pub struct ID3DDestructionNotifier_Vtbl {
     pub RegisterDestructionCallback: unsafe extern "system" fn(*mut core::ffi::c_void, PFN_DESTRUCTION_CALLBACK, *const core::ffi::c_void, *mut u32) -> windows_core::HRESULT,
     pub UnregisterDestructionCallback: unsafe extern "system" fn(*mut core::ffi::c_void, u32) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID3DDestructionNotifier {}
+unsafe impl Sync for ID3DDestructionNotifier {}
 pub trait ID3DDestructionNotifier_Impl: windows_core::IUnknownImpl {
     fn RegisterDestructionCallback(&self, callbackfn: PFN_DESTRUCTION_CALLBACK, pdata: *const core::ffi::c_void) -> windows_core::Result<u32>;
     fn UnregisterDestructionCallback(&self, callbackid: u32) -> windows_core::Result<()>;
@@ -852,8 +854,6 @@ impl ID3DDestructionNotifier_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3DDestructionNotifier {}
-unsafe impl Send for ID3DDestructionNotifier {}
-unsafe impl Sync for ID3DDestructionNotifier {}
 windows_core::imp::define_interface!(ID3DInclude, ID3DInclude_Vtbl);
 impl ID3DInclude {
     pub unsafe fn Open<P1>(&self, includetype: D3D_INCLUDE_TYPE, pfilename: P1, pparentdata: *const core::ffi::c_void, ppdata: *mut *mut core::ffi::c_void, pbytes: *mut u32) -> windows_core::Result<()>
@@ -871,6 +871,8 @@ pub struct ID3DInclude_Vtbl {
     pub Open: unsafe extern "system" fn(*mut core::ffi::c_void, D3D_INCLUDE_TYPE, windows_core::PCSTR, *const core::ffi::c_void, *mut *mut core::ffi::c_void, *mut u32) -> windows_core::HRESULT,
     pub Close: unsafe extern "system" fn(*mut core::ffi::c_void, *const core::ffi::c_void) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID3DInclude {}
+unsafe impl Sync for ID3DInclude {}
 pub trait ID3DInclude_Impl {
     fn Open(&self, includetype: D3D_INCLUDE_TYPE, pfilename: &windows_core::PCSTR, pparentdata: *const core::ffi::c_void, ppdata: *mut *mut core::ffi::c_void, pbytes: *mut u32) -> windows_core::Result<()>;
     fn Close(&self, pdata: *const core::ffi::c_void) -> windows_core::Result<()>;
@@ -905,8 +907,6 @@ impl ID3DInclude {
         unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
     }
 }
-unsafe impl Send for ID3DInclude {}
-unsafe impl Sync for ID3DInclude {}
 pub type PFN_DESTRUCTION_CALLBACK = Option<unsafe extern "system" fn(pdata: *mut core::ffi::c_void)>;
 pub const WKPDID_CommentStringW: windows_core::GUID = windows_core::GUID::from_u128(0xd0149dc0_90e8_4ec8_8144_e900ad266bb2);
 pub const WKPDID_D3D12UniqueObjectId: windows_core::GUID = windows_core::GUID::from_u128(0x1b39de15_ec04_4bae_ba4d_8cef79fc04c1);

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D10/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D10/mod.rs
@@ -2760,6 +2760,8 @@ pub struct ID3D10Asynchronous_Vtbl {
     pub GetData: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, u32, u32) -> windows_core::HRESULT,
     pub GetDataSize: unsafe extern "system" fn(*mut core::ffi::c_void) -> u32,
 }
+unsafe impl Send for ID3D10Asynchronous {}
+unsafe impl Sync for ID3D10Asynchronous {}
 pub trait ID3D10Asynchronous_Impl: ID3D10DeviceChild_Impl {
     fn Begin(&self);
     fn End(&self);
@@ -2805,8 +2807,6 @@ impl ID3D10Asynchronous_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D10Asynchronous {}
-unsafe impl Send for ID3D10Asynchronous {}
-unsafe impl Sync for ID3D10Asynchronous {}
 windows_core::imp::define_interface!(ID3D10BlendState, ID3D10BlendState_Vtbl, 0xedad8d19_8a35_4d6d_8566_2ea276cde161);
 impl core::ops::Deref for ID3D10BlendState {
     type Target = ID3D10DeviceChild;
@@ -2825,6 +2825,8 @@ pub struct ID3D10BlendState_Vtbl {
     pub base__: ID3D10DeviceChild_Vtbl,
     pub GetDesc: unsafe extern "system" fn(*mut core::ffi::c_void, *mut D3D10_BLEND_DESC),
 }
+unsafe impl Send for ID3D10BlendState {}
+unsafe impl Sync for ID3D10BlendState {}
 pub trait ID3D10BlendState_Impl: ID3D10DeviceChild_Impl {
     fn GetDesc(&self, pdesc: *mut D3D10_BLEND_DESC);
 }
@@ -2843,8 +2845,6 @@ impl ID3D10BlendState_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D10BlendState {}
-unsafe impl Send for ID3D10BlendState {}
-unsafe impl Sync for ID3D10BlendState {}
 windows_core::imp::define_interface!(ID3D10BlendState1, ID3D10BlendState1_Vtbl, 0xedad8d99_8a35_4d6d_8566_2ea276cde161);
 impl core::ops::Deref for ID3D10BlendState1 {
     type Target = ID3D10BlendState;
@@ -2863,6 +2863,8 @@ pub struct ID3D10BlendState1_Vtbl {
     pub base__: ID3D10BlendState_Vtbl,
     pub GetDesc1: unsafe extern "system" fn(*mut core::ffi::c_void, *mut D3D10_BLEND_DESC1),
 }
+unsafe impl Send for ID3D10BlendState1 {}
+unsafe impl Sync for ID3D10BlendState1 {}
 pub trait ID3D10BlendState1_Impl: ID3D10BlendState_Impl {
     fn GetDesc1(&self, pdesc: *mut D3D10_BLEND_DESC1);
 }
@@ -2881,8 +2883,6 @@ impl ID3D10BlendState1_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D10BlendState1 {}
-unsafe impl Send for ID3D10BlendState1 {}
-unsafe impl Sync for ID3D10BlendState1 {}
 windows_core::imp::define_interface!(ID3D10Buffer, ID3D10Buffer_Vtbl, 0x9b7e4c02_342c_4106_a19f_4f2704f689f0);
 impl core::ops::Deref for ID3D10Buffer {
     type Target = ID3D10Resource;
@@ -2909,6 +2909,8 @@ pub struct ID3D10Buffer_Vtbl {
     pub Unmap: unsafe extern "system" fn(*mut core::ffi::c_void),
     pub GetDesc: unsafe extern "system" fn(*mut core::ffi::c_void, *mut D3D10_BUFFER_DESC),
 }
+unsafe impl Send for ID3D10Buffer {}
+unsafe impl Sync for ID3D10Buffer {}
 pub trait ID3D10Buffer_Impl: ID3D10Resource_Impl {
     fn Map(&self, maptype: D3D10_MAP, mapflags: u32, ppdata: *mut *mut core::ffi::c_void) -> windows_core::Result<()>;
     fn Unmap(&self);
@@ -2946,8 +2948,6 @@ impl ID3D10Buffer_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D10Buffer {}
-unsafe impl Send for ID3D10Buffer {}
-unsafe impl Sync for ID3D10Buffer {}
 windows_core::imp::define_interface!(ID3D10Counter, ID3D10Counter_Vtbl, 0x9b7e4c11_342c_4106_a19f_4f2704f689f0);
 impl core::ops::Deref for ID3D10Counter {
     type Target = ID3D10Asynchronous;
@@ -2970,6 +2970,8 @@ pub struct ID3D10Counter_Vtbl {
     pub base__: ID3D10Asynchronous_Vtbl,
     pub GetDesc: unsafe extern "system" fn(*mut core::ffi::c_void, *mut D3D10_COUNTER_DESC),
 }
+unsafe impl Send for ID3D10Counter {}
+unsafe impl Sync for ID3D10Counter {}
 pub trait ID3D10Counter_Impl: ID3D10Asynchronous_Impl {
     fn GetDesc(&self, pdesc: *mut D3D10_COUNTER_DESC);
 }
@@ -2988,8 +2990,6 @@ impl ID3D10Counter_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D10Counter {}
-unsafe impl Send for ID3D10Counter {}
-unsafe impl Sync for ID3D10Counter {}
 windows_core::imp::define_interface!(ID3D10Debug, ID3D10Debug_Vtbl, 0x9b7e4e01_342c_4106_a19f_4f2704f689f0);
 windows_core::imp::interface_hierarchy!(ID3D10Debug, windows_core::IUnknown);
 impl ID3D10Debug {
@@ -3040,6 +3040,8 @@ pub struct ID3D10Debug_Vtbl {
     GetSwapChain: usize,
     pub Validate: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID3D10Debug {}
+unsafe impl Sync for ID3D10Debug {}
 #[cfg(feature = "Win32_Graphics_Dxgi")]
 pub trait ID3D10Debug_Impl: windows_core::IUnknownImpl {
     fn SetFeatureMask(&self, mask: u32) -> windows_core::Result<()>;
@@ -3118,10 +3120,6 @@ impl ID3D10Debug_Vtbl {
 }
 #[cfg(feature = "Win32_Graphics_Dxgi")]
 impl windows_core::RuntimeName for ID3D10Debug {}
-#[cfg(feature = "Win32_Graphics_Dxgi")]
-unsafe impl Send for ID3D10Debug {}
-#[cfg(feature = "Win32_Graphics_Dxgi")]
-unsafe impl Sync for ID3D10Debug {}
 windows_core::imp::define_interface!(ID3D10DepthStencilState, ID3D10DepthStencilState_Vtbl, 0x2b4b1cc8_a4ad_41f8_8322_ca86fc3ec675);
 impl core::ops::Deref for ID3D10DepthStencilState {
     type Target = ID3D10DeviceChild;
@@ -3140,6 +3138,8 @@ pub struct ID3D10DepthStencilState_Vtbl {
     pub base__: ID3D10DeviceChild_Vtbl,
     pub GetDesc: unsafe extern "system" fn(*mut core::ffi::c_void, *mut D3D10_DEPTH_STENCIL_DESC),
 }
+unsafe impl Send for ID3D10DepthStencilState {}
+unsafe impl Sync for ID3D10DepthStencilState {}
 pub trait ID3D10DepthStencilState_Impl: ID3D10DeviceChild_Impl {
     fn GetDesc(&self, pdesc: *mut D3D10_DEPTH_STENCIL_DESC);
 }
@@ -3158,8 +3158,6 @@ impl ID3D10DepthStencilState_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D10DepthStencilState {}
-unsafe impl Send for ID3D10DepthStencilState {}
-unsafe impl Sync for ID3D10DepthStencilState {}
 windows_core::imp::define_interface!(ID3D10DepthStencilView, ID3D10DepthStencilView_Vtbl, 0x9b7e4c09_342c_4106_a19f_4f2704f689f0);
 impl core::ops::Deref for ID3D10DepthStencilView {
     type Target = ID3D10View;
@@ -3182,6 +3180,8 @@ pub struct ID3D10DepthStencilView_Vtbl {
     #[cfg(not(feature = "Win32_Graphics_Dxgi_Common"))]
     GetDesc: usize,
 }
+unsafe impl Send for ID3D10DepthStencilView {}
+unsafe impl Sync for ID3D10DepthStencilView {}
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 pub trait ID3D10DepthStencilView_Impl: ID3D10View_Impl {
     fn GetDesc(&self, pdesc: *mut D3D10_DEPTH_STENCIL_VIEW_DESC);
@@ -3203,10 +3203,6 @@ impl ID3D10DepthStencilView_Vtbl {
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl windows_core::RuntimeName for ID3D10DepthStencilView {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-unsafe impl Send for ID3D10DepthStencilView {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-unsafe impl Sync for ID3D10DepthStencilView {}
 windows_core::imp::define_interface!(ID3D10Device, ID3D10Device_Vtbl, 0x9b7e4c0f_342c_4106_a19f_4f2704f689f0);
 windows_core::imp::interface_hierarchy!(ID3D10Device, windows_core::IUnknown);
 impl ID3D10Device {
@@ -3760,6 +3756,8 @@ pub struct ID3D10Device_Vtbl {
     pub SetTextFilterSize: unsafe extern "system" fn(*mut core::ffi::c_void, u32, u32),
     pub GetTextFilterSize: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u32, *mut u32),
 }
+unsafe impl Send for ID3D10Device {}
+unsafe impl Sync for ID3D10Device {}
 #[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait ID3D10Device_Impl: windows_core::IUnknownImpl {
     fn VSSetConstantBuffers(&self, startslot: u32, numbuffers: u32, ppconstantbuffers: *const Option<ID3D10Buffer>);
@@ -4566,10 +4564,6 @@ impl ID3D10Device_Vtbl {
 }
 #[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
 impl windows_core::RuntimeName for ID3D10Device {}
-#[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
-unsafe impl Send for ID3D10Device {}
-#[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
-unsafe impl Sync for ID3D10Device {}
 windows_core::imp::define_interface!(ID3D10Device1, ID3D10Device1_Vtbl, 0x9b7e4c8f_342c_4106_a19f_4f2704f689f0);
 impl core::ops::Deref for ID3D10Device1 {
     type Target = ID3D10Device;
@@ -4603,6 +4597,8 @@ pub struct ID3D10Device1_Vtbl {
     pub CreateBlendState1: unsafe extern "system" fn(*mut core::ffi::c_void, *const D3D10_BLEND_DESC1, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
     pub GetFeatureLevel: unsafe extern "system" fn(*mut core::ffi::c_void) -> D3D10_FEATURE_LEVEL1,
 }
+unsafe impl Send for ID3D10Device1 {}
+unsafe impl Sync for ID3D10Device1 {}
 #[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait ID3D10Device1_Impl: ID3D10Device_Impl {
     fn CreateShaderResourceView1(&self, presource: windows_core::Ref<ID3D10Resource>, pdesc: *const D3D10_SHADER_RESOURCE_VIEW_DESC1, ppsrview: windows_core::OutRef<'_, ID3D10ShaderResourceView1>) -> windows_core::Result<()>;
@@ -4643,10 +4639,6 @@ impl ID3D10Device1_Vtbl {
 }
 #[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
 impl windows_core::RuntimeName for ID3D10Device1 {}
-#[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
-unsafe impl Send for ID3D10Device1 {}
-#[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
-unsafe impl Sync for ID3D10Device1 {}
 windows_core::imp::define_interface!(ID3D10DeviceChild, ID3D10DeviceChild_Vtbl, 0x9b7e4c00_342c_4106_a19f_4f2704f689f0);
 windows_core::imp::interface_hierarchy!(ID3D10DeviceChild, windows_core::IUnknown);
 impl ID3D10DeviceChild {
@@ -4678,6 +4670,8 @@ pub struct ID3D10DeviceChild_Vtbl {
     pub SetPrivateData: unsafe extern "system" fn(*mut core::ffi::c_void, *const windows_core::GUID, u32, *const core::ffi::c_void) -> windows_core::HRESULT,
     pub SetPrivateDataInterface: unsafe extern "system" fn(*mut core::ffi::c_void, *const windows_core::GUID, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID3D10DeviceChild {}
+unsafe impl Sync for ID3D10DeviceChild {}
 pub trait ID3D10DeviceChild_Impl: windows_core::IUnknownImpl {
     fn GetDevice(&self, ppdevice: windows_core::OutRef<'_, ID3D10Device>);
     fn GetPrivateData(&self, guid: *const windows_core::GUID, pdatasize: *mut u32, pdata: *mut core::ffi::c_void) -> windows_core::Result<()>;
@@ -4723,8 +4717,6 @@ impl ID3D10DeviceChild_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D10DeviceChild {}
-unsafe impl Send for ID3D10DeviceChild {}
-unsafe impl Sync for ID3D10DeviceChild {}
 windows_core::imp::define_interface!(ID3D10Effect, ID3D10Effect_Vtbl, 0x51b0ca8b_ec0b_4519_870d_8ee1cb5017c7);
 windows_core::imp::interface_hierarchy!(ID3D10Effect, windows_core::IUnknown);
 impl ID3D10Effect {
@@ -4800,6 +4792,8 @@ pub struct ID3D10Effect_Vtbl {
     pub Optimize: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
     pub IsOptimized: unsafe extern "system" fn(*mut core::ffi::c_void) -> super::super::Foundation::BOOL,
 }
+unsafe impl Send for ID3D10Effect {}
+unsafe impl Sync for ID3D10Effect {}
 pub trait ID3D10Effect_Impl: windows_core::IUnknownImpl {
     fn IsValid(&self) -> super::super::Foundation::BOOL;
     fn IsPool(&self) -> super::super::Foundation::BOOL;
@@ -4923,8 +4917,6 @@ impl ID3D10Effect_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D10Effect {}
-unsafe impl Send for ID3D10Effect {}
-unsafe impl Sync for ID3D10Effect {}
 windows_core::imp::define_interface!(ID3D10EffectBlendVariable, ID3D10EffectBlendVariable_Vtbl);
 impl core::ops::Deref for ID3D10EffectBlendVariable {
     type Target = ID3D10EffectVariable;
@@ -4950,6 +4942,8 @@ pub struct ID3D10EffectBlendVariable_Vtbl {
     pub GetBlendState: unsafe extern "system" fn(*mut core::ffi::c_void, u32, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
     pub GetBackingStore: unsafe extern "system" fn(*mut core::ffi::c_void, u32, *mut D3D10_BLEND_DESC) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID3D10EffectBlendVariable {}
+unsafe impl Sync for ID3D10EffectBlendVariable {}
 pub trait ID3D10EffectBlendVariable_Impl: ID3D10EffectVariable_Impl {
     fn GetBlendState(&self, index: u32) -> windows_core::Result<ID3D10BlendState>;
     fn GetBackingStore(&self, index: u32, pblenddesc: *mut D3D10_BLEND_DESC) -> windows_core::Result<()>;
@@ -4990,8 +4984,6 @@ impl ID3D10EffectBlendVariable {
         unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
     }
 }
-unsafe impl Send for ID3D10EffectBlendVariable {}
-unsafe impl Sync for ID3D10EffectBlendVariable {}
 windows_core::imp::define_interface!(ID3D10EffectConstantBuffer, ID3D10EffectConstantBuffer_Vtbl);
 impl core::ops::Deref for ID3D10EffectConstantBuffer {
     type Target = ID3D10EffectVariable;
@@ -5034,6 +5026,8 @@ pub struct ID3D10EffectConstantBuffer_Vtbl {
     pub SetTextureBuffer: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
     pub GetTextureBuffer: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID3D10EffectConstantBuffer {}
+unsafe impl Sync for ID3D10EffectConstantBuffer {}
 pub trait ID3D10EffectConstantBuffer_Impl: ID3D10EffectVariable_Impl {
     fn SetConstantBuffer(&self, pconstantbuffer: windows_core::Ref<ID3D10Buffer>) -> windows_core::Result<()>;
     fn GetConstantBuffer(&self) -> windows_core::Result<ID3D10Buffer>;
@@ -5102,8 +5096,6 @@ impl ID3D10EffectConstantBuffer {
         unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
     }
 }
-unsafe impl Send for ID3D10EffectConstantBuffer {}
-unsafe impl Sync for ID3D10EffectConstantBuffer {}
 windows_core::imp::define_interface!(ID3D10EffectDepthStencilVariable, ID3D10EffectDepthStencilVariable_Vtbl);
 impl core::ops::Deref for ID3D10EffectDepthStencilVariable {
     type Target = ID3D10EffectVariable;
@@ -5129,6 +5121,8 @@ pub struct ID3D10EffectDepthStencilVariable_Vtbl {
     pub GetDepthStencilState: unsafe extern "system" fn(*mut core::ffi::c_void, u32, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
     pub GetBackingStore: unsafe extern "system" fn(*mut core::ffi::c_void, u32, *mut D3D10_DEPTH_STENCIL_DESC) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID3D10EffectDepthStencilVariable {}
+unsafe impl Sync for ID3D10EffectDepthStencilVariable {}
 pub trait ID3D10EffectDepthStencilVariable_Impl: ID3D10EffectVariable_Impl {
     fn GetDepthStencilState(&self, index: u32) -> windows_core::Result<ID3D10DepthStencilState>;
     fn GetBackingStore(&self, index: u32, pdepthstencildesc: *mut D3D10_DEPTH_STENCIL_DESC) -> windows_core::Result<()>;
@@ -5173,8 +5167,6 @@ impl ID3D10EffectDepthStencilVariable {
         unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
     }
 }
-unsafe impl Send for ID3D10EffectDepthStencilVariable {}
-unsafe impl Sync for ID3D10EffectDepthStencilVariable {}
 windows_core::imp::define_interface!(ID3D10EffectDepthStencilViewVariable, ID3D10EffectDepthStencilViewVariable_Vtbl);
 impl core::ops::Deref for ID3D10EffectDepthStencilViewVariable {
     type Target = ID3D10EffectVariable;
@@ -5211,6 +5203,8 @@ pub struct ID3D10EffectDepthStencilViewVariable_Vtbl {
     pub SetDepthStencilArray: unsafe extern "system" fn(*mut core::ffi::c_void, *const *mut core::ffi::c_void, u32, u32) -> windows_core::HRESULT,
     pub GetDepthStencilArray: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void, u32, u32) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID3D10EffectDepthStencilViewVariable {}
+unsafe impl Sync for ID3D10EffectDepthStencilViewVariable {}
 pub trait ID3D10EffectDepthStencilViewVariable_Impl: ID3D10EffectVariable_Impl {
     fn SetDepthStencil(&self, presource: windows_core::Ref<ID3D10DepthStencilView>) -> windows_core::Result<()>;
     fn GetDepthStencil(&self) -> windows_core::Result<ID3D10DepthStencilView>;
@@ -5273,8 +5267,6 @@ impl ID3D10EffectDepthStencilViewVariable {
         unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
     }
 }
-unsafe impl Send for ID3D10EffectDepthStencilViewVariable {}
-unsafe impl Sync for ID3D10EffectDepthStencilViewVariable {}
 windows_core::imp::define_interface!(ID3D10EffectMatrixVariable, ID3D10EffectMatrixVariable_Vtbl);
 impl core::ops::Deref for ID3D10EffectMatrixVariable {
     type Target = ID3D10EffectVariable;
@@ -5321,6 +5313,8 @@ pub struct ID3D10EffectMatrixVariable_Vtbl {
     pub SetMatrixTransposeArray: unsafe extern "system" fn(*mut core::ffi::c_void, *mut f32, u32, u32) -> windows_core::HRESULT,
     pub GetMatrixTransposeArray: unsafe extern "system" fn(*mut core::ffi::c_void, *mut f32, u32, u32) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID3D10EffectMatrixVariable {}
+unsafe impl Sync for ID3D10EffectMatrixVariable {}
 pub trait ID3D10EffectMatrixVariable_Impl: ID3D10EffectVariable_Impl {
     fn SetMatrix(&self, pdata: *mut f32) -> windows_core::Result<()>;
     fn GetMatrix(&self, pdata: *mut f32) -> windows_core::Result<()>;
@@ -5413,8 +5407,6 @@ impl ID3D10EffectMatrixVariable {
         unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
     }
 }
-unsafe impl Send for ID3D10EffectMatrixVariable {}
-unsafe impl Sync for ID3D10EffectMatrixVariable {}
 windows_core::imp::define_interface!(ID3D10EffectPass, ID3D10EffectPass_Vtbl);
 impl ID3D10EffectPass {
     pub unsafe fn IsValid(&self) -> super::super::Foundation::BOOL {
@@ -5460,6 +5452,8 @@ pub struct ID3D10EffectPass_Vtbl {
     pub Apply: unsafe extern "system" fn(*mut core::ffi::c_void, u32) -> windows_core::HRESULT,
     pub ComputeStateBlockMask: unsafe extern "system" fn(*mut core::ffi::c_void, *mut D3D10_STATE_BLOCK_MASK) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID3D10EffectPass {}
+unsafe impl Sync for ID3D10EffectPass {}
 pub trait ID3D10EffectPass_Impl {
     fn IsValid(&self) -> super::super::Foundation::BOOL;
     fn GetDesc(&self, pdesc: *mut D3D10_PASS_DESC) -> windows_core::Result<()>;
@@ -5560,8 +5554,6 @@ impl ID3D10EffectPass {
         unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
     }
 }
-unsafe impl Send for ID3D10EffectPass {}
-unsafe impl Sync for ID3D10EffectPass {}
 windows_core::imp::define_interface!(ID3D10EffectPool, ID3D10EffectPool_Vtbl, 0x9537ab04_3250_412e_8213_fcd2f8677933);
 windows_core::imp::interface_hierarchy!(ID3D10EffectPool, windows_core::IUnknown);
 impl ID3D10EffectPool {
@@ -5574,6 +5566,8 @@ pub struct ID3D10EffectPool_Vtbl {
     pub base__: windows_core::IUnknown_Vtbl,
     pub AsEffect: unsafe extern "system" fn(*mut core::ffi::c_void) -> Option<ID3D10Effect>,
 }
+unsafe impl Send for ID3D10EffectPool {}
+unsafe impl Sync for ID3D10EffectPool {}
 pub trait ID3D10EffectPool_Impl: windows_core::IUnknownImpl {
     fn AsEffect(&self) -> Option<ID3D10Effect>;
 }
@@ -5592,8 +5586,6 @@ impl ID3D10EffectPool_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D10EffectPool {}
-unsafe impl Send for ID3D10EffectPool {}
-unsafe impl Sync for ID3D10EffectPool {}
 windows_core::imp::define_interface!(ID3D10EffectRasterizerVariable, ID3D10EffectRasterizerVariable_Vtbl);
 impl core::ops::Deref for ID3D10EffectRasterizerVariable {
     type Target = ID3D10EffectVariable;
@@ -5619,6 +5611,8 @@ pub struct ID3D10EffectRasterizerVariable_Vtbl {
     pub GetRasterizerState: unsafe extern "system" fn(*mut core::ffi::c_void, u32, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
     pub GetBackingStore: unsafe extern "system" fn(*mut core::ffi::c_void, u32, *mut D3D10_RASTERIZER_DESC) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID3D10EffectRasterizerVariable {}
+unsafe impl Sync for ID3D10EffectRasterizerVariable {}
 pub trait ID3D10EffectRasterizerVariable_Impl: ID3D10EffectVariable_Impl {
     fn GetRasterizerState(&self, index: u32) -> windows_core::Result<ID3D10RasterizerState>;
     fn GetBackingStore(&self, index: u32, prasterizerdesc: *mut D3D10_RASTERIZER_DESC) -> windows_core::Result<()>;
@@ -5663,8 +5657,6 @@ impl ID3D10EffectRasterizerVariable {
         unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
     }
 }
-unsafe impl Send for ID3D10EffectRasterizerVariable {}
-unsafe impl Sync for ID3D10EffectRasterizerVariable {}
 windows_core::imp::define_interface!(ID3D10EffectRenderTargetViewVariable, ID3D10EffectRenderTargetViewVariable_Vtbl);
 impl core::ops::Deref for ID3D10EffectRenderTargetViewVariable {
     type Target = ID3D10EffectVariable;
@@ -5701,6 +5693,8 @@ pub struct ID3D10EffectRenderTargetViewVariable_Vtbl {
     pub SetRenderTargetArray: unsafe extern "system" fn(*mut core::ffi::c_void, *const *mut core::ffi::c_void, u32, u32) -> windows_core::HRESULT,
     pub GetRenderTargetArray: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void, u32, u32) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID3D10EffectRenderTargetViewVariable {}
+unsafe impl Sync for ID3D10EffectRenderTargetViewVariable {}
 pub trait ID3D10EffectRenderTargetViewVariable_Impl: ID3D10EffectVariable_Impl {
     fn SetRenderTarget(&self, presource: windows_core::Ref<ID3D10RenderTargetView>) -> windows_core::Result<()>;
     fn GetRenderTarget(&self) -> windows_core::Result<ID3D10RenderTargetView>;
@@ -5763,8 +5757,6 @@ impl ID3D10EffectRenderTargetViewVariable {
         unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
     }
 }
-unsafe impl Send for ID3D10EffectRenderTargetViewVariable {}
-unsafe impl Sync for ID3D10EffectRenderTargetViewVariable {}
 windows_core::imp::define_interface!(ID3D10EffectSamplerVariable, ID3D10EffectSamplerVariable_Vtbl);
 impl core::ops::Deref for ID3D10EffectSamplerVariable {
     type Target = ID3D10EffectVariable;
@@ -5790,6 +5782,8 @@ pub struct ID3D10EffectSamplerVariable_Vtbl {
     pub GetSampler: unsafe extern "system" fn(*mut core::ffi::c_void, u32, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
     pub GetBackingStore: unsafe extern "system" fn(*mut core::ffi::c_void, u32, *mut D3D10_SAMPLER_DESC) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID3D10EffectSamplerVariable {}
+unsafe impl Sync for ID3D10EffectSamplerVariable {}
 pub trait ID3D10EffectSamplerVariable_Impl: ID3D10EffectVariable_Impl {
     fn GetSampler(&self, index: u32) -> windows_core::Result<ID3D10SamplerState>;
     fn GetBackingStore(&self, index: u32, psamplerdesc: *mut D3D10_SAMPLER_DESC) -> windows_core::Result<()>;
@@ -5830,8 +5824,6 @@ impl ID3D10EffectSamplerVariable {
         unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
     }
 }
-unsafe impl Send for ID3D10EffectSamplerVariable {}
-unsafe impl Sync for ID3D10EffectSamplerVariable {}
 windows_core::imp::define_interface!(ID3D10EffectScalarVariable, ID3D10EffectScalarVariable_Vtbl);
 impl core::ops::Deref for ID3D10EffectScalarVariable {
     type Target = ID3D10EffectVariable;
@@ -5903,6 +5895,8 @@ pub struct ID3D10EffectScalarVariable_Vtbl {
     pub SetBoolArray: unsafe extern "system" fn(*mut core::ffi::c_void, *const super::super::Foundation::BOOL, u32, u32) -> windows_core::HRESULT,
     pub GetBoolArray: unsafe extern "system" fn(*mut core::ffi::c_void, *mut super::super::Foundation::BOOL, u32, u32) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID3D10EffectScalarVariable {}
+unsafe impl Sync for ID3D10EffectScalarVariable {}
 pub trait ID3D10EffectScalarVariable_Impl: ID3D10EffectVariable_Impl {
     fn SetFloat(&self, value: f32) -> windows_core::Result<()>;
     fn GetFloat(&self) -> windows_core::Result<f32>;
@@ -6049,8 +6043,6 @@ impl ID3D10EffectScalarVariable {
         unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
     }
 }
-unsafe impl Send for ID3D10EffectScalarVariable {}
-unsafe impl Sync for ID3D10EffectScalarVariable {}
 windows_core::imp::define_interface!(ID3D10EffectShaderResourceVariable, ID3D10EffectShaderResourceVariable_Vtbl);
 impl core::ops::Deref for ID3D10EffectShaderResourceVariable {
     type Target = ID3D10EffectVariable;
@@ -6087,6 +6079,8 @@ pub struct ID3D10EffectShaderResourceVariable_Vtbl {
     pub SetResourceArray: unsafe extern "system" fn(*mut core::ffi::c_void, *const *mut core::ffi::c_void, u32, u32) -> windows_core::HRESULT,
     pub GetResourceArray: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void, u32, u32) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID3D10EffectShaderResourceVariable {}
+unsafe impl Sync for ID3D10EffectShaderResourceVariable {}
 pub trait ID3D10EffectShaderResourceVariable_Impl: ID3D10EffectVariable_Impl {
     fn SetResource(&self, presource: windows_core::Ref<ID3D10ShaderResourceView>) -> windows_core::Result<()>;
     fn GetResource(&self) -> windows_core::Result<ID3D10ShaderResourceView>;
@@ -6149,8 +6143,6 @@ impl ID3D10EffectShaderResourceVariable {
         unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
     }
 }
-unsafe impl Send for ID3D10EffectShaderResourceVariable {}
-unsafe impl Sync for ID3D10EffectShaderResourceVariable {}
 windows_core::imp::define_interface!(ID3D10EffectShaderVariable, ID3D10EffectShaderVariable_Vtbl);
 impl core::ops::Deref for ID3D10EffectShaderVariable {
     type Target = ID3D10EffectVariable;
@@ -6206,6 +6198,8 @@ pub struct ID3D10EffectShaderVariable_Vtbl {
     #[cfg(not(feature = "Win32_Graphics_Direct3D"))]
     GetOutputSignatureElementDesc: usize,
 }
+unsafe impl Send for ID3D10EffectShaderVariable {}
+unsafe impl Sync for ID3D10EffectShaderVariable {}
 #[cfg(feature = "Win32_Graphics_Direct3D")]
 pub trait ID3D10EffectShaderVariable_Impl: ID3D10EffectVariable_Impl {
     fn GetShaderDesc(&self, shaderindex: u32, pdesc: *mut D3D10_EFFECT_SHADER_DESC) -> windows_core::Result<()>;
@@ -6303,10 +6297,6 @@ impl ID3D10EffectShaderVariable {
         unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
     }
 }
-#[cfg(feature = "Win32_Graphics_Direct3D")]
-unsafe impl Send for ID3D10EffectShaderVariable {}
-#[cfg(feature = "Win32_Graphics_Direct3D")]
-unsafe impl Sync for ID3D10EffectShaderVariable {}
 windows_core::imp::define_interface!(ID3D10EffectStringVariable, ID3D10EffectStringVariable_Vtbl);
 impl core::ops::Deref for ID3D10EffectStringVariable {
     type Target = ID3D10EffectVariable;
@@ -6332,6 +6322,8 @@ pub struct ID3D10EffectStringVariable_Vtbl {
     pub GetString: unsafe extern "system" fn(*mut core::ffi::c_void, *mut windows_core::PCSTR) -> windows_core::HRESULT,
     pub GetStringArray: unsafe extern "system" fn(*mut core::ffi::c_void, *mut windows_core::PCSTR, u32, u32) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID3D10EffectStringVariable {}
+unsafe impl Sync for ID3D10EffectStringVariable {}
 pub trait ID3D10EffectStringVariable_Impl: ID3D10EffectVariable_Impl {
     fn GetString(&self) -> windows_core::Result<windows_core::PCSTR>;
     fn GetStringArray(&self, ppstrings: *mut windows_core::PCSTR, offset: u32, count: u32) -> windows_core::Result<()>;
@@ -6372,8 +6364,6 @@ impl ID3D10EffectStringVariable {
         unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
     }
 }
-unsafe impl Send for ID3D10EffectStringVariable {}
-unsafe impl Sync for ID3D10EffectStringVariable {}
 windows_core::imp::define_interface!(ID3D10EffectTechnique, ID3D10EffectTechnique_Vtbl);
 impl ID3D10EffectTechnique {
     pub unsafe fn IsValid(&self) -> super::super::Foundation::BOOL {
@@ -6414,6 +6404,8 @@ pub struct ID3D10EffectTechnique_Vtbl {
     pub GetPassByName: unsafe extern "system" fn(*mut core::ffi::c_void, windows_core::PCSTR) -> Option<ID3D10EffectPass>,
     pub ComputeStateBlockMask: unsafe extern "system" fn(*mut core::ffi::c_void, *mut D3D10_STATE_BLOCK_MASK) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID3D10EffectTechnique {}
+unsafe impl Sync for ID3D10EffectTechnique {}
 pub trait ID3D10EffectTechnique_Impl {
     fn IsValid(&self) -> super::super::Foundation::BOOL;
     fn GetDesc(&self, pdesc: *mut D3D10_TECHNIQUE_DESC) -> windows_core::Result<()>;
@@ -6496,8 +6488,6 @@ impl ID3D10EffectTechnique {
         unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
     }
 }
-unsafe impl Send for ID3D10EffectTechnique {}
-unsafe impl Sync for ID3D10EffectTechnique {}
 windows_core::imp::define_interface!(ID3D10EffectType, ID3D10EffectType_Vtbl);
 impl ID3D10EffectType {
     pub unsafe fn IsValid(&self) -> super::super::Foundation::BOOL {
@@ -6542,6 +6532,8 @@ pub struct ID3D10EffectType_Vtbl {
     pub GetMemberName: unsafe extern "system" fn(*mut core::ffi::c_void, u32) -> windows_core::PCSTR,
     pub GetMemberSemantic: unsafe extern "system" fn(*mut core::ffi::c_void, u32) -> windows_core::PCSTR,
 }
+unsafe impl Send for ID3D10EffectType {}
+unsafe impl Sync for ID3D10EffectType {}
 #[cfg(feature = "Win32_Graphics_Direct3D")]
 pub trait ID3D10EffectType_Impl {
     fn IsValid(&self) -> super::super::Foundation::BOOL;
@@ -6629,10 +6621,6 @@ impl ID3D10EffectType {
         unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
     }
 }
-#[cfg(feature = "Win32_Graphics_Direct3D")]
-unsafe impl Send for ID3D10EffectType {}
-#[cfg(feature = "Win32_Graphics_Direct3D")]
-unsafe impl Sync for ID3D10EffectType {}
 windows_core::imp::define_interface!(ID3D10EffectVariable, ID3D10EffectVariable_Vtbl);
 impl ID3D10EffectVariable {
     pub unsafe fn IsValid(&self) -> super::super::Foundation::BOOL {
@@ -6748,6 +6736,8 @@ pub struct ID3D10EffectVariable_Vtbl {
     pub SetRawValue: unsafe extern "system" fn(*mut core::ffi::c_void, *const core::ffi::c_void, u32, u32) -> windows_core::HRESULT,
     pub GetRawValue: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, u32, u32) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID3D10EffectVariable {}
+unsafe impl Sync for ID3D10EffectVariable {}
 pub trait ID3D10EffectVariable_Impl {
     fn IsValid(&self) -> super::super::Foundation::BOOL;
     fn GetType(&self) -> Option<ID3D10EffectType>;
@@ -6992,8 +6982,6 @@ impl ID3D10EffectVariable {
         unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
     }
 }
-unsafe impl Send for ID3D10EffectVariable {}
-unsafe impl Sync for ID3D10EffectVariable {}
 windows_core::imp::define_interface!(ID3D10EffectVectorVariable, ID3D10EffectVectorVariable_Vtbl);
 impl core::ops::Deref for ID3D10EffectVectorVariable {
     type Target = ID3D10EffectVariable;
@@ -7056,6 +7044,8 @@ pub struct ID3D10EffectVectorVariable_Vtbl {
     pub GetIntVectorArray: unsafe extern "system" fn(*mut core::ffi::c_void, *mut i32, u32, u32) -> windows_core::HRESULT,
     pub GetFloatVectorArray: unsafe extern "system" fn(*mut core::ffi::c_void, *mut f32, u32, u32) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID3D10EffectVectorVariable {}
+unsafe impl Sync for ID3D10EffectVectorVariable {}
 pub trait ID3D10EffectVectorVariable_Impl: ID3D10EffectVariable_Impl {
     fn SetBoolVector(&self, pdata: *mut super::super::Foundation::BOOL) -> windows_core::Result<()>;
     fn SetIntVector(&self, pdata: *mut i32) -> windows_core::Result<()>;
@@ -7184,8 +7174,6 @@ impl ID3D10EffectVectorVariable {
         unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
     }
 }
-unsafe impl Send for ID3D10EffectVectorVariable {}
-unsafe impl Sync for ID3D10EffectVectorVariable {}
 windows_core::imp::define_interface!(ID3D10GeometryShader, ID3D10GeometryShader_Vtbl, 0x6316be88_54cd_4040_ab44_20461bc81f68);
 impl core::ops::Deref for ID3D10GeometryShader {
     type Target = ID3D10DeviceChild;
@@ -7198,6 +7186,8 @@ windows_core::imp::interface_hierarchy!(ID3D10GeometryShader, windows_core::IUnk
 pub struct ID3D10GeometryShader_Vtbl {
     pub base__: ID3D10DeviceChild_Vtbl,
 }
+unsafe impl Send for ID3D10GeometryShader {}
+unsafe impl Sync for ID3D10GeometryShader {}
 pub trait ID3D10GeometryShader_Impl: ID3D10DeviceChild_Impl {}
 impl ID3D10GeometryShader_Vtbl {
     pub const fn new<Identity: ID3D10GeometryShader_Impl, const OFFSET: isize>() -> Self {
@@ -7208,8 +7198,6 @@ impl ID3D10GeometryShader_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D10GeometryShader {}
-unsafe impl Send for ID3D10GeometryShader {}
-unsafe impl Sync for ID3D10GeometryShader {}
 windows_core::imp::define_interface!(ID3D10InfoQueue, ID3D10InfoQueue_Vtbl, 0x1b940b17_2642_4d1f_ab1f_b99bad0c395f);
 windows_core::imp::interface_hierarchy!(ID3D10InfoQueue, windows_core::IUnknown);
 impl ID3D10InfoQueue {
@@ -7364,6 +7352,8 @@ pub struct ID3D10InfoQueue_Vtbl {
     pub SetMuteDebugOutput: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::BOOL),
     pub GetMuteDebugOutput: unsafe extern "system" fn(*mut core::ffi::c_void) -> super::super::Foundation::BOOL,
 }
+unsafe impl Send for ID3D10InfoQueue {}
+unsafe impl Sync for ID3D10InfoQueue {}
 pub trait ID3D10InfoQueue_Impl: windows_core::IUnknownImpl {
     fn SetMessageCountLimit(&self, messagecountlimit: u64) -> windows_core::Result<()>;
     fn ClearStoredMessages(&self);
@@ -7657,8 +7647,6 @@ impl ID3D10InfoQueue_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D10InfoQueue {}
-unsafe impl Send for ID3D10InfoQueue {}
-unsafe impl Sync for ID3D10InfoQueue {}
 windows_core::imp::define_interface!(ID3D10InputLayout, ID3D10InputLayout_Vtbl, 0x9b7e4c0b_342c_4106_a19f_4f2704f689f0);
 impl core::ops::Deref for ID3D10InputLayout {
     type Target = ID3D10DeviceChild;
@@ -7671,6 +7659,8 @@ windows_core::imp::interface_hierarchy!(ID3D10InputLayout, windows_core::IUnknow
 pub struct ID3D10InputLayout_Vtbl {
     pub base__: ID3D10DeviceChild_Vtbl,
 }
+unsafe impl Send for ID3D10InputLayout {}
+unsafe impl Sync for ID3D10InputLayout {}
 pub trait ID3D10InputLayout_Impl: ID3D10DeviceChild_Impl {}
 impl ID3D10InputLayout_Vtbl {
     pub const fn new<Identity: ID3D10InputLayout_Impl, const OFFSET: isize>() -> Self {
@@ -7681,8 +7671,6 @@ impl ID3D10InputLayout_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D10InputLayout {}
-unsafe impl Send for ID3D10InputLayout {}
-unsafe impl Sync for ID3D10InputLayout {}
 windows_core::imp::define_interface!(ID3D10Multithread, ID3D10Multithread_Vtbl, 0x9b7e4e00_342c_4106_a19f_4f2704f689f0);
 windows_core::imp::interface_hierarchy!(ID3D10Multithread, windows_core::IUnknown);
 impl ID3D10Multithread {
@@ -7707,6 +7695,8 @@ pub struct ID3D10Multithread_Vtbl {
     pub SetMultithreadProtected: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::BOOL) -> super::super::Foundation::BOOL,
     pub GetMultithreadProtected: unsafe extern "system" fn(*mut core::ffi::c_void) -> super::super::Foundation::BOOL,
 }
+unsafe impl Send for ID3D10Multithread {}
+unsafe impl Sync for ID3D10Multithread {}
 pub trait ID3D10Multithread_Impl: windows_core::IUnknownImpl {
     fn Enter(&self);
     fn Leave(&self);
@@ -7752,8 +7742,6 @@ impl ID3D10Multithread_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D10Multithread {}
-unsafe impl Send for ID3D10Multithread {}
-unsafe impl Sync for ID3D10Multithread {}
 windows_core::imp::define_interface!(ID3D10PixelShader, ID3D10PixelShader_Vtbl, 0x4968b601_9d00_4cde_8346_8e7f675819b6);
 impl core::ops::Deref for ID3D10PixelShader {
     type Target = ID3D10DeviceChild;
@@ -7766,6 +7754,8 @@ windows_core::imp::interface_hierarchy!(ID3D10PixelShader, windows_core::IUnknow
 pub struct ID3D10PixelShader_Vtbl {
     pub base__: ID3D10DeviceChild_Vtbl,
 }
+unsafe impl Send for ID3D10PixelShader {}
+unsafe impl Sync for ID3D10PixelShader {}
 pub trait ID3D10PixelShader_Impl: ID3D10DeviceChild_Impl {}
 impl ID3D10PixelShader_Vtbl {
     pub const fn new<Identity: ID3D10PixelShader_Impl, const OFFSET: isize>() -> Self {
@@ -7776,8 +7766,6 @@ impl ID3D10PixelShader_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D10PixelShader {}
-unsafe impl Send for ID3D10PixelShader {}
-unsafe impl Sync for ID3D10PixelShader {}
 windows_core::imp::define_interface!(ID3D10Predicate, ID3D10Predicate_Vtbl, 0x9b7e4c10_342c_4106_a19f_4f2704f689f0);
 impl core::ops::Deref for ID3D10Predicate {
     type Target = ID3D10Query;
@@ -7790,6 +7778,8 @@ windows_core::imp::interface_hierarchy!(ID3D10Predicate, windows_core::IUnknown,
 pub struct ID3D10Predicate_Vtbl {
     pub base__: ID3D10Query_Vtbl,
 }
+unsafe impl Send for ID3D10Predicate {}
+unsafe impl Sync for ID3D10Predicate {}
 pub trait ID3D10Predicate_Impl: ID3D10Query_Impl {}
 impl ID3D10Predicate_Vtbl {
     pub const fn new<Identity: ID3D10Predicate_Impl, const OFFSET: isize>() -> Self {
@@ -7800,8 +7790,6 @@ impl ID3D10Predicate_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D10Predicate {}
-unsafe impl Send for ID3D10Predicate {}
-unsafe impl Sync for ID3D10Predicate {}
 windows_core::imp::define_interface!(ID3D10Query, ID3D10Query_Vtbl, 0x9b7e4c0e_342c_4106_a19f_4f2704f689f0);
 impl core::ops::Deref for ID3D10Query {
     type Target = ID3D10Asynchronous;
@@ -7824,6 +7812,8 @@ pub struct ID3D10Query_Vtbl {
     pub base__: ID3D10Asynchronous_Vtbl,
     pub GetDesc: unsafe extern "system" fn(*mut core::ffi::c_void, *mut D3D10_QUERY_DESC),
 }
+unsafe impl Send for ID3D10Query {}
+unsafe impl Sync for ID3D10Query {}
 pub trait ID3D10Query_Impl: ID3D10Asynchronous_Impl {
     fn GetDesc(&self, pdesc: *mut D3D10_QUERY_DESC);
 }
@@ -7842,8 +7832,6 @@ impl ID3D10Query_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D10Query {}
-unsafe impl Send for ID3D10Query {}
-unsafe impl Sync for ID3D10Query {}
 windows_core::imp::define_interface!(ID3D10RasterizerState, ID3D10RasterizerState_Vtbl, 0xa2a07292_89af_4345_be2e_c53d9fbb6e9f);
 impl core::ops::Deref for ID3D10RasterizerState {
     type Target = ID3D10DeviceChild;
@@ -7862,6 +7850,8 @@ pub struct ID3D10RasterizerState_Vtbl {
     pub base__: ID3D10DeviceChild_Vtbl,
     pub GetDesc: unsafe extern "system" fn(*mut core::ffi::c_void, *mut D3D10_RASTERIZER_DESC),
 }
+unsafe impl Send for ID3D10RasterizerState {}
+unsafe impl Sync for ID3D10RasterizerState {}
 pub trait ID3D10RasterizerState_Impl: ID3D10DeviceChild_Impl {
     fn GetDesc(&self, pdesc: *mut D3D10_RASTERIZER_DESC);
 }
@@ -7880,8 +7870,6 @@ impl ID3D10RasterizerState_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D10RasterizerState {}
-unsafe impl Send for ID3D10RasterizerState {}
-unsafe impl Sync for ID3D10RasterizerState {}
 windows_core::imp::define_interface!(ID3D10RenderTargetView, ID3D10RenderTargetView_Vtbl, 0x9b7e4c08_342c_4106_a19f_4f2704f689f0);
 impl core::ops::Deref for ID3D10RenderTargetView {
     type Target = ID3D10View;
@@ -7904,6 +7892,8 @@ pub struct ID3D10RenderTargetView_Vtbl {
     #[cfg(not(feature = "Win32_Graphics_Dxgi_Common"))]
     GetDesc: usize,
 }
+unsafe impl Send for ID3D10RenderTargetView {}
+unsafe impl Sync for ID3D10RenderTargetView {}
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 pub trait ID3D10RenderTargetView_Impl: ID3D10View_Impl {
     fn GetDesc(&self, pdesc: *mut D3D10_RENDER_TARGET_VIEW_DESC);
@@ -7925,10 +7915,6 @@ impl ID3D10RenderTargetView_Vtbl {
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl windows_core::RuntimeName for ID3D10RenderTargetView {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-unsafe impl Send for ID3D10RenderTargetView {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-unsafe impl Sync for ID3D10RenderTargetView {}
 windows_core::imp::define_interface!(ID3D10Resource, ID3D10Resource_Vtbl, 0x9b7e4c01_342c_4106_a19f_4f2704f689f0);
 impl core::ops::Deref for ID3D10Resource {
     type Target = ID3D10DeviceChild;
@@ -7959,6 +7945,8 @@ pub struct ID3D10Resource_Vtbl {
     pub SetEvictionPriority: unsafe extern "system" fn(*mut core::ffi::c_void, u32),
     pub GetEvictionPriority: unsafe extern "system" fn(*mut core::ffi::c_void) -> u32,
 }
+unsafe impl Send for ID3D10Resource {}
+unsafe impl Sync for ID3D10Resource {}
 pub trait ID3D10Resource_Impl: ID3D10DeviceChild_Impl {
     fn GetType(&self, rtype: *mut D3D10_RESOURCE_DIMENSION);
     fn SetEvictionPriority(&self, evictionpriority: u32);
@@ -7996,8 +7984,6 @@ impl ID3D10Resource_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D10Resource {}
-unsafe impl Send for ID3D10Resource {}
-unsafe impl Sync for ID3D10Resource {}
 windows_core::imp::define_interface!(ID3D10SamplerState, ID3D10SamplerState_Vtbl, 0x9b7e4c0c_342c_4106_a19f_4f2704f689f0);
 impl core::ops::Deref for ID3D10SamplerState {
     type Target = ID3D10DeviceChild;
@@ -8016,6 +8002,8 @@ pub struct ID3D10SamplerState_Vtbl {
     pub base__: ID3D10DeviceChild_Vtbl,
     pub GetDesc: unsafe extern "system" fn(*mut core::ffi::c_void, *mut D3D10_SAMPLER_DESC),
 }
+unsafe impl Send for ID3D10SamplerState {}
+unsafe impl Sync for ID3D10SamplerState {}
 pub trait ID3D10SamplerState_Impl: ID3D10DeviceChild_Impl {
     fn GetDesc(&self, pdesc: *mut D3D10_SAMPLER_DESC);
 }
@@ -8034,8 +8022,6 @@ impl ID3D10SamplerState_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D10SamplerState {}
-unsafe impl Send for ID3D10SamplerState {}
-unsafe impl Sync for ID3D10SamplerState {}
 windows_core::imp::define_interface!(ID3D10ShaderReflection, ID3D10ShaderReflection_Vtbl, 0xd40e20b6_f8f7_42ad_ab20_4baf8f15dfaa);
 windows_core::imp::interface_hierarchy!(ID3D10ShaderReflection, windows_core::IUnknown);
 impl ID3D10ShaderReflection {
@@ -8087,6 +8073,8 @@ pub struct ID3D10ShaderReflection_Vtbl {
     #[cfg(not(feature = "Win32_Graphics_Direct3D"))]
     GetOutputParameterDesc: usize,
 }
+unsafe impl Send for ID3D10ShaderReflection {}
+unsafe impl Sync for ID3D10ShaderReflection {}
 #[cfg(feature = "Win32_Graphics_Direct3D")]
 pub trait ID3D10ShaderReflection_Impl: windows_core::IUnknownImpl {
     fn GetDesc(&self, pdesc: *mut D3D10_SHADER_DESC) -> windows_core::Result<()>;
@@ -8151,10 +8139,6 @@ impl ID3D10ShaderReflection_Vtbl {
 }
 #[cfg(feature = "Win32_Graphics_Direct3D")]
 impl windows_core::RuntimeName for ID3D10ShaderReflection {}
-#[cfg(feature = "Win32_Graphics_Direct3D")]
-unsafe impl Send for ID3D10ShaderReflection {}
-#[cfg(feature = "Win32_Graphics_Direct3D")]
-unsafe impl Sync for ID3D10ShaderReflection {}
 windows_core::imp::define_interface!(ID3D10ShaderReflection1, ID3D10ShaderReflection1_Vtbl, 0xc3457783_a846_47ce_9520_cea6f66e7447);
 windows_core::imp::interface_hierarchy!(ID3D10ShaderReflection1, windows_core::IUnknown);
 impl ID3D10ShaderReflection1 {
@@ -8277,6 +8261,8 @@ pub struct ID3D10ShaderReflection1_Vtbl {
     pub IsLevel9Shader: unsafe extern "system" fn(*mut core::ffi::c_void, *mut super::super::Foundation::BOOL) -> windows_core::HRESULT,
     pub IsSampleFrequencyShader: unsafe extern "system" fn(*mut core::ffi::c_void, *mut super::super::Foundation::BOOL) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID3D10ShaderReflection1 {}
+unsafe impl Sync for ID3D10ShaderReflection1 {}
 #[cfg(feature = "Win32_Graphics_Direct3D")]
 pub trait ID3D10ShaderReflection1_Impl: windows_core::IUnknownImpl {
     fn GetDesc(&self, pdesc: *mut D3D10_SHADER_DESC) -> windows_core::Result<()>;
@@ -8455,10 +8441,6 @@ impl ID3D10ShaderReflection1_Vtbl {
 }
 #[cfg(feature = "Win32_Graphics_Direct3D")]
 impl windows_core::RuntimeName for ID3D10ShaderReflection1 {}
-#[cfg(feature = "Win32_Graphics_Direct3D")]
-unsafe impl Send for ID3D10ShaderReflection1 {}
-#[cfg(feature = "Win32_Graphics_Direct3D")]
-unsafe impl Sync for ID3D10ShaderReflection1 {}
 windows_core::imp::define_interface!(ID3D10ShaderReflectionConstantBuffer, ID3D10ShaderReflectionConstantBuffer_Vtbl);
 impl ID3D10ShaderReflectionConstantBuffer {
     #[cfg(feature = "Win32_Graphics_Direct3D")]
@@ -8484,6 +8466,8 @@ pub struct ID3D10ShaderReflectionConstantBuffer_Vtbl {
     pub GetVariableByIndex: unsafe extern "system" fn(*mut core::ffi::c_void, u32) -> Option<ID3D10ShaderReflectionVariable>,
     pub GetVariableByName: unsafe extern "system" fn(*mut core::ffi::c_void, windows_core::PCSTR) -> Option<ID3D10ShaderReflectionVariable>,
 }
+unsafe impl Send for ID3D10ShaderReflectionConstantBuffer {}
+unsafe impl Sync for ID3D10ShaderReflectionConstantBuffer {}
 #[cfg(feature = "Win32_Graphics_Direct3D")]
 pub trait ID3D10ShaderReflectionConstantBuffer_Impl {
     fn GetDesc(&self, pdesc: *mut D3D10_SHADER_BUFFER_DESC) -> windows_core::Result<()>;
@@ -8531,10 +8515,6 @@ impl ID3D10ShaderReflectionConstantBuffer {
         unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
     }
 }
-#[cfg(feature = "Win32_Graphics_Direct3D")]
-unsafe impl Send for ID3D10ShaderReflectionConstantBuffer {}
-#[cfg(feature = "Win32_Graphics_Direct3D")]
-unsafe impl Sync for ID3D10ShaderReflectionConstantBuffer {}
 windows_core::imp::define_interface!(ID3D10ShaderReflectionType, ID3D10ShaderReflectionType_Vtbl);
 impl ID3D10ShaderReflectionType {
     #[cfg(feature = "Win32_Graphics_Direct3D")]
@@ -8564,6 +8544,8 @@ pub struct ID3D10ShaderReflectionType_Vtbl {
     pub GetMemberTypeByName: unsafe extern "system" fn(*mut core::ffi::c_void, windows_core::PCSTR) -> Option<ID3D10ShaderReflectionType>,
     pub GetMemberTypeName: unsafe extern "system" fn(*mut core::ffi::c_void, u32) -> windows_core::PCSTR,
 }
+unsafe impl Send for ID3D10ShaderReflectionType {}
+unsafe impl Sync for ID3D10ShaderReflectionType {}
 #[cfg(feature = "Win32_Graphics_Direct3D")]
 pub trait ID3D10ShaderReflectionType_Impl {
     fn GetDesc(&self, pdesc: *mut D3D10_SHADER_TYPE_DESC) -> windows_core::Result<()>;
@@ -8624,10 +8606,6 @@ impl ID3D10ShaderReflectionType {
         unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
     }
 }
-#[cfg(feature = "Win32_Graphics_Direct3D")]
-unsafe impl Send for ID3D10ShaderReflectionType {}
-#[cfg(feature = "Win32_Graphics_Direct3D")]
-unsafe impl Sync for ID3D10ShaderReflectionType {}
 windows_core::imp::define_interface!(ID3D10ShaderReflectionVariable, ID3D10ShaderReflectionVariable_Vtbl);
 impl ID3D10ShaderReflectionVariable {
     pub unsafe fn GetDesc(&self, pdesc: *mut D3D10_SHADER_VARIABLE_DESC) -> windows_core::Result<()> {
@@ -8642,6 +8620,8 @@ pub struct ID3D10ShaderReflectionVariable_Vtbl {
     pub GetDesc: unsafe extern "system" fn(*mut core::ffi::c_void, *mut D3D10_SHADER_VARIABLE_DESC) -> windows_core::HRESULT,
     pub GetType: unsafe extern "system" fn(*mut core::ffi::c_void) -> Option<ID3D10ShaderReflectionType>,
 }
+unsafe impl Send for ID3D10ShaderReflectionVariable {}
+unsafe impl Sync for ID3D10ShaderReflectionVariable {}
 pub trait ID3D10ShaderReflectionVariable_Impl {
     fn GetDesc(&self, pdesc: *mut D3D10_SHADER_VARIABLE_DESC) -> windows_core::Result<()>;
     fn GetType(&self) -> Option<ID3D10ShaderReflectionType>;
@@ -8676,8 +8656,6 @@ impl ID3D10ShaderReflectionVariable {
         unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
     }
 }
-unsafe impl Send for ID3D10ShaderReflectionVariable {}
-unsafe impl Sync for ID3D10ShaderReflectionVariable {}
 windows_core::imp::define_interface!(ID3D10ShaderResourceView, ID3D10ShaderResourceView_Vtbl, 0x9b7e4c07_342c_4106_a19f_4f2704f689f0);
 impl core::ops::Deref for ID3D10ShaderResourceView {
     type Target = ID3D10View;
@@ -8700,6 +8678,8 @@ pub struct ID3D10ShaderResourceView_Vtbl {
     #[cfg(not(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common")))]
     GetDesc: usize,
 }
+unsafe impl Send for ID3D10ShaderResourceView {}
+unsafe impl Sync for ID3D10ShaderResourceView {}
 #[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait ID3D10ShaderResourceView_Impl: ID3D10View_Impl {
     fn GetDesc(&self, pdesc: *mut D3D10_SHADER_RESOURCE_VIEW_DESC);
@@ -8721,10 +8701,6 @@ impl ID3D10ShaderResourceView_Vtbl {
 }
 #[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
 impl windows_core::RuntimeName for ID3D10ShaderResourceView {}
-#[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
-unsafe impl Send for ID3D10ShaderResourceView {}
-#[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
-unsafe impl Sync for ID3D10ShaderResourceView {}
 windows_core::imp::define_interface!(ID3D10ShaderResourceView1, ID3D10ShaderResourceView1_Vtbl, 0x9b7e4c87_342c_4106_a19f_4f2704f689f0);
 impl core::ops::Deref for ID3D10ShaderResourceView1 {
     type Target = ID3D10ShaderResourceView;
@@ -8747,6 +8723,8 @@ pub struct ID3D10ShaderResourceView1_Vtbl {
     #[cfg(not(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common")))]
     GetDesc1: usize,
 }
+unsafe impl Send for ID3D10ShaderResourceView1 {}
+unsafe impl Sync for ID3D10ShaderResourceView1 {}
 #[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait ID3D10ShaderResourceView1_Impl: ID3D10ShaderResourceView_Impl {
     fn GetDesc1(&self, pdesc: *mut D3D10_SHADER_RESOURCE_VIEW_DESC1);
@@ -8768,10 +8746,6 @@ impl ID3D10ShaderResourceView1_Vtbl {
 }
 #[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
 impl windows_core::RuntimeName for ID3D10ShaderResourceView1 {}
-#[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
-unsafe impl Send for ID3D10ShaderResourceView1 {}
-#[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
-unsafe impl Sync for ID3D10ShaderResourceView1 {}
 windows_core::imp::define_interface!(ID3D10StateBlock, ID3D10StateBlock_Vtbl, 0x0803425a_57f5_4dd6_9465_a87570834a08);
 windows_core::imp::interface_hierarchy!(ID3D10StateBlock, windows_core::IUnknown);
 impl ID3D10StateBlock {
@@ -8799,6 +8773,8 @@ pub struct ID3D10StateBlock_Vtbl {
     pub ReleaseAllDeviceObjects: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
     pub GetDevice: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID3D10StateBlock {}
+unsafe impl Sync for ID3D10StateBlock {}
 pub trait ID3D10StateBlock_Impl: windows_core::IUnknownImpl {
     fn Capture(&self) -> windows_core::Result<()>;
     fn Apply(&self) -> windows_core::Result<()>;
@@ -8850,8 +8826,6 @@ impl ID3D10StateBlock_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D10StateBlock {}
-unsafe impl Send for ID3D10StateBlock {}
-unsafe impl Sync for ID3D10StateBlock {}
 windows_core::imp::define_interface!(ID3D10SwitchToRef, ID3D10SwitchToRef_Vtbl, 0x9b7e4e02_342c_4106_a19f_4f2704f689f0);
 windows_core::imp::interface_hierarchy!(ID3D10SwitchToRef, windows_core::IUnknown);
 impl ID3D10SwitchToRef {
@@ -8868,6 +8842,8 @@ pub struct ID3D10SwitchToRef_Vtbl {
     pub SetUseRef: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::BOOL) -> super::super::Foundation::BOOL,
     pub GetUseRef: unsafe extern "system" fn(*mut core::ffi::c_void) -> super::super::Foundation::BOOL,
 }
+unsafe impl Send for ID3D10SwitchToRef {}
+unsafe impl Sync for ID3D10SwitchToRef {}
 pub trait ID3D10SwitchToRef_Impl: windows_core::IUnknownImpl {
     fn SetUseRef(&self, useref: super::super::Foundation::BOOL) -> super::super::Foundation::BOOL;
     fn GetUseRef(&self) -> super::super::Foundation::BOOL;
@@ -8897,8 +8873,6 @@ impl ID3D10SwitchToRef_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D10SwitchToRef {}
-unsafe impl Send for ID3D10SwitchToRef {}
-unsafe impl Sync for ID3D10SwitchToRef {}
 windows_core::imp::define_interface!(ID3D10Texture1D, ID3D10Texture1D_Vtbl, 0x9b7e4c03_342c_4106_a19f_4f2704f689f0);
 impl core::ops::Deref for ID3D10Texture1D {
     type Target = ID3D10Resource;
@@ -8929,6 +8903,8 @@ pub struct ID3D10Texture1D_Vtbl {
     #[cfg(not(feature = "Win32_Graphics_Dxgi_Common"))]
     GetDesc: usize,
 }
+unsafe impl Send for ID3D10Texture1D {}
+unsafe impl Sync for ID3D10Texture1D {}
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 pub trait ID3D10Texture1D_Impl: ID3D10Resource_Impl {
     fn Map(&self, subresource: u32, maptype: D3D10_MAP, mapflags: u32, ppdata: *mut *mut core::ffi::c_void) -> windows_core::Result<()>;
@@ -8969,10 +8945,6 @@ impl ID3D10Texture1D_Vtbl {
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl windows_core::RuntimeName for ID3D10Texture1D {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-unsafe impl Send for ID3D10Texture1D {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-unsafe impl Sync for ID3D10Texture1D {}
 windows_core::imp::define_interface!(ID3D10Texture2D, ID3D10Texture2D_Vtbl, 0x9b7e4c04_342c_4106_a19f_4f2704f689f0);
 impl core::ops::Deref for ID3D10Texture2D {
     type Target = ID3D10Resource;
@@ -9006,6 +8978,8 @@ pub struct ID3D10Texture2D_Vtbl {
     #[cfg(not(feature = "Win32_Graphics_Dxgi_Common"))]
     GetDesc: usize,
 }
+unsafe impl Send for ID3D10Texture2D {}
+unsafe impl Sync for ID3D10Texture2D {}
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 pub trait ID3D10Texture2D_Impl: ID3D10Resource_Impl {
     fn Map(&self, subresource: u32, maptype: D3D10_MAP, mapflags: u32) -> windows_core::Result<D3D10_MAPPED_TEXTURE2D>;
@@ -9052,10 +9026,6 @@ impl ID3D10Texture2D_Vtbl {
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl windows_core::RuntimeName for ID3D10Texture2D {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-unsafe impl Send for ID3D10Texture2D {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-unsafe impl Sync for ID3D10Texture2D {}
 windows_core::imp::define_interface!(ID3D10Texture3D, ID3D10Texture3D_Vtbl, 0x9b7e4c05_342c_4106_a19f_4f2704f689f0);
 impl core::ops::Deref for ID3D10Texture3D {
     type Target = ID3D10Resource;
@@ -9089,6 +9059,8 @@ pub struct ID3D10Texture3D_Vtbl {
     #[cfg(not(feature = "Win32_Graphics_Dxgi_Common"))]
     GetDesc: usize,
 }
+unsafe impl Send for ID3D10Texture3D {}
+unsafe impl Sync for ID3D10Texture3D {}
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 pub trait ID3D10Texture3D_Impl: ID3D10Resource_Impl {
     fn Map(&self, subresource: u32, maptype: D3D10_MAP, mapflags: u32) -> windows_core::Result<D3D10_MAPPED_TEXTURE3D>;
@@ -9135,10 +9107,6 @@ impl ID3D10Texture3D_Vtbl {
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl windows_core::RuntimeName for ID3D10Texture3D {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-unsafe impl Send for ID3D10Texture3D {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-unsafe impl Sync for ID3D10Texture3D {}
 windows_core::imp::define_interface!(ID3D10VertexShader, ID3D10VertexShader_Vtbl, 0x9b7e4c0a_342c_4106_a19f_4f2704f689f0);
 impl core::ops::Deref for ID3D10VertexShader {
     type Target = ID3D10DeviceChild;
@@ -9151,6 +9119,8 @@ windows_core::imp::interface_hierarchy!(ID3D10VertexShader, windows_core::IUnkno
 pub struct ID3D10VertexShader_Vtbl {
     pub base__: ID3D10DeviceChild_Vtbl,
 }
+unsafe impl Send for ID3D10VertexShader {}
+unsafe impl Sync for ID3D10VertexShader {}
 pub trait ID3D10VertexShader_Impl: ID3D10DeviceChild_Impl {}
 impl ID3D10VertexShader_Vtbl {
     pub const fn new<Identity: ID3D10VertexShader_Impl, const OFFSET: isize>() -> Self {
@@ -9161,8 +9131,6 @@ impl ID3D10VertexShader_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D10VertexShader {}
-unsafe impl Send for ID3D10VertexShader {}
-unsafe impl Sync for ID3D10VertexShader {}
 windows_core::imp::define_interface!(ID3D10View, ID3D10View_Vtbl, 0xc902b03f_60a7_49ba_9936_2a3ab37a7e33);
 impl core::ops::Deref for ID3D10View {
     type Target = ID3D10DeviceChild;
@@ -9185,6 +9153,8 @@ pub struct ID3D10View_Vtbl {
     pub base__: ID3D10DeviceChild_Vtbl,
     pub GetResource: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void),
 }
+unsafe impl Send for ID3D10View {}
+unsafe impl Sync for ID3D10View {}
 pub trait ID3D10View_Impl: ID3D10DeviceChild_Impl {
     fn GetResource(&self, ppresource: windows_core::OutRef<'_, ID3D10Resource>);
 }
@@ -9203,8 +9173,6 @@ impl ID3D10View_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D10View {}
-unsafe impl Send for ID3D10View {}
-unsafe impl Sync for ID3D10View {}
 #[cfg(feature = "Win32_Graphics_Dxgi")]
 pub type PFN_D3D10_CREATE_DEVICE1 = Option<unsafe extern "system" fn(param0: Option<super::Dxgi::IDXGIAdapter>, param1: D3D10_DRIVER_TYPE, param2: super::super::Foundation::HMODULE, param3: u32, param4: D3D10_FEATURE_LEVEL1, param5: u32, param6: *mut Option<ID3D10Device1>) -> windows_core::HRESULT>;
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D11/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D11/mod.rs
@@ -6085,6 +6085,8 @@ pub struct ID3D11Asynchronous_Vtbl {
     pub base__: ID3D11DeviceChild_Vtbl,
     pub GetDataSize: unsafe extern "system" fn(*mut core::ffi::c_void) -> u32,
 }
+unsafe impl Send for ID3D11Asynchronous {}
+unsafe impl Sync for ID3D11Asynchronous {}
 pub trait ID3D11Asynchronous_Impl: ID3D11DeviceChild_Impl {
     fn GetDataSize(&self) -> u32;
 }
@@ -6103,8 +6105,6 @@ impl ID3D11Asynchronous_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D11Asynchronous {}
-unsafe impl Send for ID3D11Asynchronous {}
-unsafe impl Sync for ID3D11Asynchronous {}
 windows_core::imp::define_interface!(ID3D11AuthenticatedChannel, ID3D11AuthenticatedChannel_Vtbl, 0x3015a308_dcbd_47aa_a747_192486d14d4a);
 impl core::ops::Deref for ID3D11AuthenticatedChannel {
     type Target = ID3D11DeviceChild;
@@ -6138,6 +6138,8 @@ pub struct ID3D11AuthenticatedChannel_Vtbl {
     pub GetCertificate: unsafe extern "system" fn(*mut core::ffi::c_void, u32, *mut u8) -> windows_core::HRESULT,
     pub GetChannelHandle: unsafe extern "system" fn(*mut core::ffi::c_void, *mut super::super::Foundation::HANDLE),
 }
+unsafe impl Send for ID3D11AuthenticatedChannel {}
+unsafe impl Sync for ID3D11AuthenticatedChannel {}
 pub trait ID3D11AuthenticatedChannel_Impl: ID3D11DeviceChild_Impl {
     fn GetCertificateSize(&self) -> windows_core::Result<u32>;
     fn GetCertificate(&self, certificatesize: u32, pcertificate: *mut u8) -> windows_core::Result<()>;
@@ -6181,8 +6183,6 @@ impl ID3D11AuthenticatedChannel_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D11AuthenticatedChannel {}
-unsafe impl Send for ID3D11AuthenticatedChannel {}
-unsafe impl Sync for ID3D11AuthenticatedChannel {}
 windows_core::imp::define_interface!(ID3D11BlendState, ID3D11BlendState_Vtbl, 0x75b68faa_347d_4159_8f45_a0640f01cd9a);
 impl core::ops::Deref for ID3D11BlendState {
     type Target = ID3D11DeviceChild;
@@ -6201,6 +6201,8 @@ pub struct ID3D11BlendState_Vtbl {
     pub base__: ID3D11DeviceChild_Vtbl,
     pub GetDesc: unsafe extern "system" fn(*mut core::ffi::c_void, *mut D3D11_BLEND_DESC),
 }
+unsafe impl Send for ID3D11BlendState {}
+unsafe impl Sync for ID3D11BlendState {}
 pub trait ID3D11BlendState_Impl: ID3D11DeviceChild_Impl {
     fn GetDesc(&self, pdesc: *mut D3D11_BLEND_DESC);
 }
@@ -6219,8 +6221,6 @@ impl ID3D11BlendState_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D11BlendState {}
-unsafe impl Send for ID3D11BlendState {}
-unsafe impl Sync for ID3D11BlendState {}
 windows_core::imp::define_interface!(ID3D11BlendState1, ID3D11BlendState1_Vtbl, 0xcc86fabe_da55_401d_85e7_e3c9de2877e9);
 impl core::ops::Deref for ID3D11BlendState1 {
     type Target = ID3D11BlendState;
@@ -6239,6 +6239,8 @@ pub struct ID3D11BlendState1_Vtbl {
     pub base__: ID3D11BlendState_Vtbl,
     pub GetDesc1: unsafe extern "system" fn(*mut core::ffi::c_void, *mut D3D11_BLEND_DESC1),
 }
+unsafe impl Send for ID3D11BlendState1 {}
+unsafe impl Sync for ID3D11BlendState1 {}
 pub trait ID3D11BlendState1_Impl: ID3D11BlendState_Impl {
     fn GetDesc1(&self, pdesc: *mut D3D11_BLEND_DESC1);
 }
@@ -6257,8 +6259,6 @@ impl ID3D11BlendState1_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D11BlendState1 {}
-unsafe impl Send for ID3D11BlendState1 {}
-unsafe impl Sync for ID3D11BlendState1 {}
 windows_core::imp::define_interface!(ID3D11Buffer, ID3D11Buffer_Vtbl, 0x48570b85_d1ee_4fcd_a250_eb350722b037);
 impl core::ops::Deref for ID3D11Buffer {
     type Target = ID3D11Resource;
@@ -6277,6 +6277,8 @@ pub struct ID3D11Buffer_Vtbl {
     pub base__: ID3D11Resource_Vtbl,
     pub GetDesc: unsafe extern "system" fn(*mut core::ffi::c_void, *mut D3D11_BUFFER_DESC),
 }
+unsafe impl Send for ID3D11Buffer {}
+unsafe impl Sync for ID3D11Buffer {}
 pub trait ID3D11Buffer_Impl: ID3D11Resource_Impl {
     fn GetDesc(&self, pdesc: *mut D3D11_BUFFER_DESC);
 }
@@ -6295,8 +6297,6 @@ impl ID3D11Buffer_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D11Buffer {}
-unsafe impl Send for ID3D11Buffer {}
-unsafe impl Sync for ID3D11Buffer {}
 windows_core::imp::define_interface!(ID3D11ClassInstance, ID3D11ClassInstance_Vtbl, 0xa6cd7faa_b0b7_4a2f_9436_8662a65797cb);
 impl core::ops::Deref for ID3D11ClassInstance {
     type Target = ID3D11DeviceChild;
@@ -6331,6 +6331,8 @@ pub struct ID3D11ClassInstance_Vtbl {
     pub GetInstanceName: unsafe extern "system" fn(*mut core::ffi::c_void, windows_core::PSTR, *mut usize),
     pub GetTypeName: unsafe extern "system" fn(*mut core::ffi::c_void, windows_core::PSTR, *mut usize),
 }
+unsafe impl Send for ID3D11ClassInstance {}
+unsafe impl Sync for ID3D11ClassInstance {}
 pub trait ID3D11ClassInstance_Impl: ID3D11DeviceChild_Impl {
     fn GetClassLinkage(&self, pplinkage: windows_core::OutRef<'_, ID3D11ClassLinkage>);
     fn GetDesc(&self, pdesc: *mut D3D11_CLASS_INSTANCE_DESC);
@@ -6376,8 +6378,6 @@ impl ID3D11ClassInstance_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D11ClassInstance {}
-unsafe impl Send for ID3D11ClassInstance {}
-unsafe impl Sync for ID3D11ClassInstance {}
 windows_core::imp::define_interface!(ID3D11ClassLinkage, ID3D11ClassLinkage_Vtbl, 0xddf57cba_9543_46e4_a12b_f207a0fe7fed);
 impl core::ops::Deref for ID3D11ClassLinkage {
     type Target = ID3D11DeviceChild;
@@ -6412,6 +6412,8 @@ pub struct ID3D11ClassLinkage_Vtbl {
     pub GetClassInstance: unsafe extern "system" fn(*mut core::ffi::c_void, windows_core::PCSTR, u32, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
     pub CreateClassInstance: unsafe extern "system" fn(*mut core::ffi::c_void, windows_core::PCSTR, u32, u32, u32, u32, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID3D11ClassLinkage {}
+unsafe impl Sync for ID3D11ClassLinkage {}
 pub trait ID3D11ClassLinkage_Impl: ID3D11DeviceChild_Impl {
     fn GetClassInstance(&self, pclassinstancename: &windows_core::PCSTR, instanceindex: u32) -> windows_core::Result<ID3D11ClassInstance>;
     fn CreateClassInstance(&self, pclasstypename: &windows_core::PCSTR, constantbufferoffset: u32, constantvectoroffset: u32, textureoffset: u32, sampleroffset: u32) -> windows_core::Result<ID3D11ClassInstance>;
@@ -6453,8 +6455,6 @@ impl ID3D11ClassLinkage_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D11ClassLinkage {}
-unsafe impl Send for ID3D11ClassLinkage {}
-unsafe impl Sync for ID3D11ClassLinkage {}
 windows_core::imp::define_interface!(ID3D11CommandList, ID3D11CommandList_Vtbl, 0xa24bc4d1_769e_43f7_8013_98ff566c18e2);
 impl core::ops::Deref for ID3D11CommandList {
     type Target = ID3D11DeviceChild;
@@ -6473,6 +6473,8 @@ pub struct ID3D11CommandList_Vtbl {
     pub base__: ID3D11DeviceChild_Vtbl,
     pub GetContextFlags: unsafe extern "system" fn(*mut core::ffi::c_void) -> u32,
 }
+unsafe impl Send for ID3D11CommandList {}
+unsafe impl Sync for ID3D11CommandList {}
 pub trait ID3D11CommandList_Impl: ID3D11DeviceChild_Impl {
     fn GetContextFlags(&self) -> u32;
 }
@@ -6491,8 +6493,6 @@ impl ID3D11CommandList_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D11CommandList {}
-unsafe impl Send for ID3D11CommandList {}
-unsafe impl Sync for ID3D11CommandList {}
 windows_core::imp::define_interface!(ID3D11ComputeShader, ID3D11ComputeShader_Vtbl, 0x4f5b196e_c2bd_495e_bd01_1fded38e4969);
 impl core::ops::Deref for ID3D11ComputeShader {
     type Target = ID3D11DeviceChild;
@@ -6505,6 +6505,8 @@ windows_core::imp::interface_hierarchy!(ID3D11ComputeShader, windows_core::IUnkn
 pub struct ID3D11ComputeShader_Vtbl {
     pub base__: ID3D11DeviceChild_Vtbl,
 }
+unsafe impl Send for ID3D11ComputeShader {}
+unsafe impl Sync for ID3D11ComputeShader {}
 pub trait ID3D11ComputeShader_Impl: ID3D11DeviceChild_Impl {}
 impl ID3D11ComputeShader_Vtbl {
     pub const fn new<Identity: ID3D11ComputeShader_Impl, const OFFSET: isize>() -> Self {
@@ -6515,8 +6517,6 @@ impl ID3D11ComputeShader_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D11ComputeShader {}
-unsafe impl Send for ID3D11ComputeShader {}
-unsafe impl Sync for ID3D11ComputeShader {}
 windows_core::imp::define_interface!(ID3D11Counter, ID3D11Counter_Vtbl, 0x6e8c49fb_a371_4770_b440_29086022b741);
 impl core::ops::Deref for ID3D11Counter {
     type Target = ID3D11Asynchronous;
@@ -6539,6 +6539,8 @@ pub struct ID3D11Counter_Vtbl {
     pub base__: ID3D11Asynchronous_Vtbl,
     pub GetDesc: unsafe extern "system" fn(*mut core::ffi::c_void, *mut D3D11_COUNTER_DESC),
 }
+unsafe impl Send for ID3D11Counter {}
+unsafe impl Sync for ID3D11Counter {}
 pub trait ID3D11Counter_Impl: ID3D11Asynchronous_Impl {
     fn GetDesc(&self, pdesc: *mut D3D11_COUNTER_DESC);
 }
@@ -6557,8 +6559,6 @@ impl ID3D11Counter_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D11Counter {}
-unsafe impl Send for ID3D11Counter {}
-unsafe impl Sync for ID3D11Counter {}
 windows_core::imp::define_interface!(ID3D11CryptoSession, ID3D11CryptoSession_Vtbl, 0x9b32f9ad_bdcc_40a6_a39d_d5c865845720);
 impl core::ops::Deref for ID3D11CryptoSession {
     type Target = ID3D11DeviceChild;
@@ -6608,6 +6608,8 @@ pub struct ID3D11CryptoSession_Vtbl {
     pub GetCertificate: unsafe extern "system" fn(*mut core::ffi::c_void, u32, *mut u8) -> windows_core::HRESULT,
     pub GetCryptoSessionHandle: unsafe extern "system" fn(*mut core::ffi::c_void, *mut super::super::Foundation::HANDLE),
 }
+unsafe impl Send for ID3D11CryptoSession {}
+unsafe impl Sync for ID3D11CryptoSession {}
 pub trait ID3D11CryptoSession_Impl: ID3D11DeviceChild_Impl {
     fn GetCryptoType(&self, pcryptotype: *mut windows_core::GUID);
     fn GetDecoderProfile(&self, pdecoderprofile: *mut windows_core::GUID);
@@ -6667,8 +6669,6 @@ impl ID3D11CryptoSession_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D11CryptoSession {}
-unsafe impl Send for ID3D11CryptoSession {}
-unsafe impl Sync for ID3D11CryptoSession {}
 windows_core::imp::define_interface!(ID3D11Debug, ID3D11Debug_Vtbl, 0x79cf2233_7536_4948_9d36_1e4692dc5760);
 windows_core::imp::interface_hierarchy!(ID3D11Debug, windows_core::IUnknown);
 impl ID3D11Debug {
@@ -6733,6 +6733,8 @@ pub struct ID3D11Debug_Vtbl {
     pub ReportLiveDeviceObjects: unsafe extern "system" fn(*mut core::ffi::c_void, D3D11_RLDO_FLAGS) -> windows_core::HRESULT,
     pub ValidateContextForDispatch: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID3D11Debug {}
+unsafe impl Sync for ID3D11Debug {}
 #[cfg(feature = "Win32_Graphics_Dxgi")]
 pub trait ID3D11Debug_Impl: windows_core::IUnknownImpl {
     fn SetFeatureMask(&self, mask: u32) -> windows_core::Result<()>;
@@ -6827,10 +6829,6 @@ impl ID3D11Debug_Vtbl {
 }
 #[cfg(feature = "Win32_Graphics_Dxgi")]
 impl windows_core::RuntimeName for ID3D11Debug {}
-#[cfg(feature = "Win32_Graphics_Dxgi")]
-unsafe impl Send for ID3D11Debug {}
-#[cfg(feature = "Win32_Graphics_Dxgi")]
-unsafe impl Sync for ID3D11Debug {}
 windows_core::imp::define_interface!(ID3D11DepthStencilState, ID3D11DepthStencilState_Vtbl, 0x03823efb_8d8f_4e1c_9aa2_f64bb2cbfdf1);
 impl core::ops::Deref for ID3D11DepthStencilState {
     type Target = ID3D11DeviceChild;
@@ -6849,6 +6847,8 @@ pub struct ID3D11DepthStencilState_Vtbl {
     pub base__: ID3D11DeviceChild_Vtbl,
     pub GetDesc: unsafe extern "system" fn(*mut core::ffi::c_void, *mut D3D11_DEPTH_STENCIL_DESC),
 }
+unsafe impl Send for ID3D11DepthStencilState {}
+unsafe impl Sync for ID3D11DepthStencilState {}
 pub trait ID3D11DepthStencilState_Impl: ID3D11DeviceChild_Impl {
     fn GetDesc(&self, pdesc: *mut D3D11_DEPTH_STENCIL_DESC);
 }
@@ -6867,8 +6867,6 @@ impl ID3D11DepthStencilState_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D11DepthStencilState {}
-unsafe impl Send for ID3D11DepthStencilState {}
-unsafe impl Sync for ID3D11DepthStencilState {}
 windows_core::imp::define_interface!(ID3D11DepthStencilView, ID3D11DepthStencilView_Vtbl, 0x9fdac92a_1876_48c3_afad_25b94f84a9b6);
 impl core::ops::Deref for ID3D11DepthStencilView {
     type Target = ID3D11View;
@@ -6891,6 +6889,8 @@ pub struct ID3D11DepthStencilView_Vtbl {
     #[cfg(not(feature = "Win32_Graphics_Dxgi_Common"))]
     GetDesc: usize,
 }
+unsafe impl Send for ID3D11DepthStencilView {}
+unsafe impl Sync for ID3D11DepthStencilView {}
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 pub trait ID3D11DepthStencilView_Impl: ID3D11View_Impl {
     fn GetDesc(&self, pdesc: *mut D3D11_DEPTH_STENCIL_VIEW_DESC);
@@ -6912,10 +6912,6 @@ impl ID3D11DepthStencilView_Vtbl {
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl windows_core::RuntimeName for ID3D11DepthStencilView {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-unsafe impl Send for ID3D11DepthStencilView {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-unsafe impl Sync for ID3D11DepthStencilView {}
 windows_core::imp::define_interface!(ID3D11Device, ID3D11Device_Vtbl, 0xdb6f6ddb_ac77_4e88_8253_819df9bbf140);
 windows_core::imp::interface_hierarchy!(ID3D11Device, windows_core::IUnknown);
 impl ID3D11Device {
@@ -7198,6 +7194,8 @@ pub struct ID3D11Device_Vtbl {
     pub SetExceptionMode: unsafe extern "system" fn(*mut core::ffi::c_void, u32) -> windows_core::HRESULT,
     pub GetExceptionMode: unsafe extern "system" fn(*mut core::ffi::c_void) -> u32,
 }
+unsafe impl Send for ID3D11Device {}
+unsafe impl Sync for ID3D11Device {}
 #[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait ID3D11Device_Impl: windows_core::IUnknownImpl {
     fn CreateBuffer(&self, pdesc: *const D3D11_BUFFER_DESC, pinitialdata: *const D3D11_SUBRESOURCE_DATA, ppbuffer: windows_core::OutRef<'_, ID3D11Buffer>) -> windows_core::Result<()>;
@@ -7552,10 +7550,6 @@ impl ID3D11Device_Vtbl {
 }
 #[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
 impl windows_core::RuntimeName for ID3D11Device {}
-#[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
-unsafe impl Send for ID3D11Device {}
-#[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
-unsafe impl Sync for ID3D11Device {}
 windows_core::imp::define_interface!(ID3D11Device1, ID3D11Device1_Vtbl, 0xa04bfb29_08ef_43d6_a49c_a9bdbdcbe686);
 impl core::ops::Deref for ID3D11Device1 {
     type Target = ID3D11Device;
@@ -7615,6 +7609,8 @@ pub struct ID3D11Device1_Vtbl {
     pub OpenSharedResource1: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::HANDLE, *const windows_core::GUID, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
     pub OpenSharedResourceByName: unsafe extern "system" fn(*mut core::ffi::c_void, windows_core::PCWSTR, u32, *const windows_core::GUID, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID3D11Device1 {}
+unsafe impl Sync for ID3D11Device1 {}
 #[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait ID3D11Device1_Impl: ID3D11Device_Impl {
     fn GetImmediateContext1(&self, ppimmediatecontext: windows_core::OutRef<'_, ID3D11DeviceContext1>);
@@ -7687,10 +7683,6 @@ impl ID3D11Device1_Vtbl {
 }
 #[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
 impl windows_core::RuntimeName for ID3D11Device1 {}
-#[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
-unsafe impl Send for ID3D11Device1 {}
-#[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
-unsafe impl Sync for ID3D11Device1 {}
 windows_core::imp::define_interface!(ID3D11Device2, ID3D11Device2_Vtbl, 0x9d06dffa_d1e5_4d07_83a8_1bb123f2f841);
 impl core::ops::Deref for ID3D11Device2 {
     type Target = ID3D11Device1;
@@ -7735,6 +7727,8 @@ pub struct ID3D11Device2_Vtbl {
     #[cfg(not(feature = "Win32_Graphics_Dxgi_Common"))]
     CheckMultisampleQualityLevels1: usize,
 }
+unsafe impl Send for ID3D11Device2 {}
+unsafe impl Sync for ID3D11Device2 {}
 #[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait ID3D11Device2_Impl: ID3D11Device1_Impl {
     fn GetImmediateContext2(&self, ppimmediatecontext: windows_core::OutRef<'_, ID3D11DeviceContext2>);
@@ -7789,10 +7783,6 @@ impl ID3D11Device2_Vtbl {
 }
 #[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
 impl windows_core::RuntimeName for ID3D11Device2 {}
-#[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
-unsafe impl Send for ID3D11Device2 {}
-#[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
-unsafe impl Sync for ID3D11Device2 {}
 windows_core::imp::define_interface!(ID3D11Device3, ID3D11Device3_Vtbl, 0xa05c8c37_d2c6_4732_b3a0_9ce0b0dc9ae6);
 impl core::ops::Deref for ID3D11Device3 {
     type Target = ID3D11Device2;
@@ -7890,6 +7880,8 @@ pub struct ID3D11Device3_Vtbl {
     pub WriteToSubresource: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, u32, *const D3D11_BOX, *const core::ffi::c_void, u32, u32),
     pub ReadFromSubresource: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, u32, u32, *mut core::ffi::c_void, u32, *const D3D11_BOX),
 }
+unsafe impl Send for ID3D11Device3 {}
+unsafe impl Sync for ID3D11Device3 {}
 #[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait ID3D11Device3_Impl: ID3D11Device2_Impl {
     fn CreateTexture2D1(&self, pdesc1: *const D3D11_TEXTURE2D_DESC1, pinitialdata: *const D3D11_SUBRESOURCE_DATA, pptexture2d: windows_core::OutRef<'_, ID3D11Texture2D1>) -> windows_core::Result<()>;
@@ -7994,10 +7986,6 @@ impl ID3D11Device3_Vtbl {
 }
 #[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
 impl windows_core::RuntimeName for ID3D11Device3 {}
-#[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
-unsafe impl Send for ID3D11Device3 {}
-#[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
-unsafe impl Sync for ID3D11Device3 {}
 windows_core::imp::define_interface!(ID3D11Device4, ID3D11Device4_Vtbl, 0x8992ab71_02e6_4b8d_ba48_b056dcda42c4);
 impl core::ops::Deref for ID3D11Device4 {
     type Target = ID3D11Device3;
@@ -8023,6 +8011,8 @@ pub struct ID3D11Device4_Vtbl {
     pub RegisterDeviceRemovedEvent: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::HANDLE, *mut u32) -> windows_core::HRESULT,
     pub UnregisterDeviceRemoved: unsafe extern "system" fn(*mut core::ffi::c_void, u32),
 }
+unsafe impl Send for ID3D11Device4 {}
+unsafe impl Sync for ID3D11Device4 {}
 #[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait ID3D11Device4_Impl: ID3D11Device3_Impl {
     fn RegisterDeviceRemovedEvent(&self, hevent: super::super::Foundation::HANDLE) -> windows_core::Result<u32>;
@@ -8061,10 +8051,6 @@ impl ID3D11Device4_Vtbl {
 }
 #[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
 impl windows_core::RuntimeName for ID3D11Device4 {}
-#[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
-unsafe impl Send for ID3D11Device4 {}
-#[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
-unsafe impl Sync for ID3D11Device4 {}
 windows_core::imp::define_interface!(ID3D11Device5, ID3D11Device5_Vtbl, 0x8ffde202_a0e7_45df_9e01_e837801b5ea0);
 impl core::ops::Deref for ID3D11Device5 {
     type Target = ID3D11Device4;
@@ -8093,6 +8079,8 @@ pub struct ID3D11Device5_Vtbl {
     pub OpenSharedFence: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::HANDLE, *const windows_core::GUID, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
     pub CreateFence: unsafe extern "system" fn(*mut core::ffi::c_void, u64, D3D11_FENCE_FLAG, *const windows_core::GUID, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID3D11Device5 {}
+unsafe impl Sync for ID3D11Device5 {}
 #[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait ID3D11Device5_Impl: ID3D11Device4_Impl {
     fn OpenSharedFence(&self, hfence: super::super::Foundation::HANDLE, returnedinterface: *const windows_core::GUID, ppfence: *mut *mut core::ffi::c_void) -> windows_core::Result<()>;
@@ -8125,10 +8113,6 @@ impl ID3D11Device5_Vtbl {
 }
 #[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
 impl windows_core::RuntimeName for ID3D11Device5 {}
-#[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
-unsafe impl Send for ID3D11Device5 {}
-#[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
-unsafe impl Sync for ID3D11Device5 {}
 windows_core::imp::define_interface!(ID3D11DeviceChild, ID3D11DeviceChild_Vtbl, 0x1841e5c8_16b0_489b_bcc8_44cfb0d5deae);
 windows_core::imp::interface_hierarchy!(ID3D11DeviceChild, windows_core::IUnknown);
 impl ID3D11DeviceChild {
@@ -8160,6 +8144,8 @@ pub struct ID3D11DeviceChild_Vtbl {
     pub SetPrivateData: unsafe extern "system" fn(*mut core::ffi::c_void, *const windows_core::GUID, u32, *const core::ffi::c_void) -> windows_core::HRESULT,
     pub SetPrivateDataInterface: unsafe extern "system" fn(*mut core::ffi::c_void, *const windows_core::GUID, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID3D11DeviceChild {}
+unsafe impl Sync for ID3D11DeviceChild {}
 pub trait ID3D11DeviceChild_Impl: windows_core::IUnknownImpl {
     fn GetDevice(&self, ppdevice: windows_core::OutRef<'_, ID3D11Device>);
     fn GetPrivateData(&self, guid: *const windows_core::GUID, pdatasize: *mut u32, pdata: *mut core::ffi::c_void) -> windows_core::Result<()>;
@@ -8205,8 +8191,6 @@ impl ID3D11DeviceChild_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D11DeviceChild {}
-unsafe impl Send for ID3D11DeviceChild {}
-unsafe impl Sync for ID3D11DeviceChild {}
 windows_core::imp::define_interface!(ID3D11DeviceContext, ID3D11DeviceContext_Vtbl, 0xc0bfa96c_e089_44fb_8eaf_26f8796190da);
 impl core::ops::Deref for ID3D11DeviceContext {
     type Target = ID3D11DeviceChild;
@@ -8804,6 +8788,8 @@ pub struct ID3D11DeviceContext_Vtbl {
     pub GetContextFlags: unsafe extern "system" fn(*mut core::ffi::c_void) -> u32,
     pub FinishCommandList: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::BOOL, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID3D11DeviceContext {}
+unsafe impl Sync for ID3D11DeviceContext {}
 #[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait ID3D11DeviceContext_Impl: ID3D11DeviceChild_Impl {
     fn VSSetConstantBuffers(&self, startslot: u32, numbuffers: u32, ppconstantbuffers: *const Option<ID3D11Buffer>);
@@ -9684,10 +9670,6 @@ impl ID3D11DeviceContext_Vtbl {
 }
 #[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
 impl windows_core::RuntimeName for ID3D11DeviceContext {}
-#[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
-unsafe impl Send for ID3D11DeviceContext {}
-#[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
-unsafe impl Sync for ID3D11DeviceContext {}
 windows_core::imp::define_interface!(ID3D11DeviceContext1, ID3D11DeviceContext1_Vtbl, 0xbb2c6faa_b5fb_4082_8e6b_388b8cfa90e1);
 impl core::ops::Deref for ID3D11DeviceContext1 {
     type Target = ID3D11DeviceContext;
@@ -9800,6 +9782,8 @@ pub struct ID3D11DeviceContext1_Vtbl {
     pub ClearView: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *const f32, *const super::super::Foundation::RECT, u32),
     pub DiscardView1: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *const super::super::Foundation::RECT, u32),
 }
+unsafe impl Send for ID3D11DeviceContext1 {}
+unsafe impl Sync for ID3D11DeviceContext1 {}
 #[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait ID3D11DeviceContext1_Impl: ID3D11DeviceContext_Impl {
     fn CopySubresourceRegion1(&self, pdstresource: windows_core::Ref<ID3D11Resource>, dstsubresource: u32, dstx: u32, dsty: u32, dstz: u32, psrcresource: windows_core::Ref<ID3D11Resource>, srcsubresource: u32, psrcbox: *const D3D11_BOX, copyflags: u32);
@@ -9968,10 +9952,6 @@ impl ID3D11DeviceContext1_Vtbl {
 }
 #[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
 impl windows_core::RuntimeName for ID3D11DeviceContext1 {}
-#[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
-unsafe impl Send for ID3D11DeviceContext1 {}
-#[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
-unsafe impl Sync for ID3D11DeviceContext1 {}
 windows_core::imp::define_interface!(ID3D11DeviceContext2, ID3D11DeviceContext2_Vtbl, 0x420d5b32_b90c_4da4_bef0_359f6a24a83a);
 impl core::ops::Deref for ID3D11DeviceContext2 {
     type Target = ID3D11DeviceContext1;
@@ -10054,6 +10034,8 @@ pub struct ID3D11DeviceContext2_Vtbl {
     pub BeginEventInt: unsafe extern "system" fn(*mut core::ffi::c_void, windows_core::PCWSTR, i32),
     pub EndEvent: unsafe extern "system" fn(*mut core::ffi::c_void),
 }
+unsafe impl Send for ID3D11DeviceContext2 {}
+unsafe impl Sync for ID3D11DeviceContext2 {}
 #[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait ID3D11DeviceContext2_Impl: ID3D11DeviceContext1_Impl {
     fn UpdateTileMappings(&self, ptiledresource: windows_core::Ref<ID3D11Resource>, numtiledresourceregions: u32, ptiledresourceregionstartcoordinates: *const D3D11_TILED_RESOURCE_COORDINATE, ptiledresourceregionsizes: *const D3D11_TILE_REGION_SIZE, ptilepool: windows_core::Ref<ID3D11Buffer>, numranges: u32, prangeflags: *const u32, ptilepoolstartoffsets: *const u32, prangetilecounts: *const u32, flags: u32) -> windows_core::Result<()>;
@@ -10150,10 +10132,6 @@ impl ID3D11DeviceContext2_Vtbl {
 }
 #[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
 impl windows_core::RuntimeName for ID3D11DeviceContext2 {}
-#[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
-unsafe impl Send for ID3D11DeviceContext2 {}
-#[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
-unsafe impl Sync for ID3D11DeviceContext2 {}
 windows_core::imp::define_interface!(ID3D11DeviceContext3, ID3D11DeviceContext3_Vtbl, 0xb4e3c01d_e79e_4637_91b2_510e9f4c9b8f);
 impl core::ops::Deref for ID3D11DeviceContext3 {
     type Target = ID3D11DeviceContext2;
@@ -10184,6 +10162,8 @@ pub struct ID3D11DeviceContext3_Vtbl {
     pub SetHardwareProtectionState: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::BOOL),
     pub GetHardwareProtectionState: unsafe extern "system" fn(*mut core::ffi::c_void, *mut super::super::Foundation::BOOL),
 }
+unsafe impl Send for ID3D11DeviceContext3 {}
+unsafe impl Sync for ID3D11DeviceContext3 {}
 #[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait ID3D11DeviceContext3_Impl: ID3D11DeviceContext2_Impl {
     fn Flush1(&self, contexttype: D3D11_CONTEXT_TYPE, hevent: super::super::Foundation::HANDLE);
@@ -10224,10 +10204,6 @@ impl ID3D11DeviceContext3_Vtbl {
 }
 #[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
 impl windows_core::RuntimeName for ID3D11DeviceContext3 {}
-#[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
-unsafe impl Send for ID3D11DeviceContext3 {}
-#[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
-unsafe impl Sync for ID3D11DeviceContext3 {}
 windows_core::imp::define_interface!(ID3D11DeviceContext4, ID3D11DeviceContext4_Vtbl, 0x917600da_f58c_4c33_98d8_3e15b390fa24);
 impl core::ops::Deref for ID3D11DeviceContext4 {
     type Target = ID3D11DeviceContext3;
@@ -10256,6 +10232,8 @@ pub struct ID3D11DeviceContext4_Vtbl {
     pub Signal: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, u64) -> windows_core::HRESULT,
     pub Wait: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, u64) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID3D11DeviceContext4 {}
+unsafe impl Sync for ID3D11DeviceContext4 {}
 #[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait ID3D11DeviceContext4_Impl: ID3D11DeviceContext3_Impl {
     fn Signal(&self, pfence: windows_core::Ref<ID3D11Fence>, value: u64) -> windows_core::Result<()>;
@@ -10284,10 +10262,6 @@ impl ID3D11DeviceContext4_Vtbl {
 }
 #[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
 impl windows_core::RuntimeName for ID3D11DeviceContext4 {}
-#[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
-unsafe impl Send for ID3D11DeviceContext4 {}
-#[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
-unsafe impl Sync for ID3D11DeviceContext4 {}
 windows_core::imp::define_interface!(ID3D11DomainShader, ID3D11DomainShader_Vtbl, 0xf582c508_0f36_490c_9977_31eece268cfa);
 impl core::ops::Deref for ID3D11DomainShader {
     type Target = ID3D11DeviceChild;
@@ -10300,6 +10274,8 @@ windows_core::imp::interface_hierarchy!(ID3D11DomainShader, windows_core::IUnkno
 pub struct ID3D11DomainShader_Vtbl {
     pub base__: ID3D11DeviceChild_Vtbl,
 }
+unsafe impl Send for ID3D11DomainShader {}
+unsafe impl Sync for ID3D11DomainShader {}
 pub trait ID3D11DomainShader_Impl: ID3D11DeviceChild_Impl {}
 impl ID3D11DomainShader_Vtbl {
     pub const fn new<Identity: ID3D11DomainShader_Impl, const OFFSET: isize>() -> Self {
@@ -10310,8 +10286,6 @@ impl ID3D11DomainShader_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D11DomainShader {}
-unsafe impl Send for ID3D11DomainShader {}
-unsafe impl Sync for ID3D11DomainShader {}
 windows_core::imp::define_interface!(ID3D11Fence, ID3D11Fence_Vtbl, 0xaffde9d1_1df7_4bb7_8a34_0f46251dab80);
 impl core::ops::Deref for ID3D11Fence {
     type Target = ID3D11DeviceChild;
@@ -10348,6 +10322,8 @@ pub struct ID3D11Fence_Vtbl {
     pub GetCompletedValue: unsafe extern "system" fn(*mut core::ffi::c_void) -> u64,
     pub SetEventOnCompletion: unsafe extern "system" fn(*mut core::ffi::c_void, u64, super::super::Foundation::HANDLE) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID3D11Fence {}
+unsafe impl Sync for ID3D11Fence {}
 #[cfg(feature = "Win32_Security")]
 pub trait ID3D11Fence_Impl: ID3D11DeviceChild_Impl {
     fn CreateSharedHandle(&self, pattributes: *const super::super::Security::SECURITY_ATTRIBUTES, dwaccess: u32, lpname: &windows_core::PCWSTR) -> windows_core::Result<super::super::Foundation::HANDLE>;
@@ -10394,10 +10370,6 @@ impl ID3D11Fence_Vtbl {
 }
 #[cfg(feature = "Win32_Security")]
 impl windows_core::RuntimeName for ID3D11Fence {}
-#[cfg(feature = "Win32_Security")]
-unsafe impl Send for ID3D11Fence {}
-#[cfg(feature = "Win32_Security")]
-unsafe impl Sync for ID3D11Fence {}
 windows_core::imp::define_interface!(ID3D11FunctionLinkingGraph, ID3D11FunctionLinkingGraph_Vtbl, 0x54133220_1ce8_43d3_8236_9855c5ceecff);
 windows_core::imp::interface_hierarchy!(ID3D11FunctionLinkingGraph, windows_core::IUnknown);
 impl ID3D11FunctionLinkingGraph {
@@ -10485,6 +10457,8 @@ pub struct ID3D11FunctionLinkingGraph_Vtbl {
     #[cfg(not(feature = "Win32_Graphics_Direct3D"))]
     GenerateHlsl: usize,
 }
+unsafe impl Send for ID3D11FunctionLinkingGraph {}
+unsafe impl Sync for ID3D11FunctionLinkingGraph {}
 #[cfg(feature = "Win32_Graphics_Direct3D")]
 pub trait ID3D11FunctionLinkingGraph_Impl: windows_core::IUnknownImpl {
     fn CreateModuleInstance(&self, ppmoduleinstance: windows_core::OutRef<'_, ID3D11ModuleInstance>, pperrorbuffer: windows_core::OutRef<'_, super::Direct3D::ID3DBlob>) -> windows_core::Result<()>;
@@ -10589,10 +10563,6 @@ impl ID3D11FunctionLinkingGraph_Vtbl {
 }
 #[cfg(feature = "Win32_Graphics_Direct3D")]
 impl windows_core::RuntimeName for ID3D11FunctionLinkingGraph {}
-#[cfg(feature = "Win32_Graphics_Direct3D")]
-unsafe impl Send for ID3D11FunctionLinkingGraph {}
-#[cfg(feature = "Win32_Graphics_Direct3D")]
-unsafe impl Sync for ID3D11FunctionLinkingGraph {}
 windows_core::imp::define_interface!(ID3D11FunctionParameterReflection, ID3D11FunctionParameterReflection_Vtbl);
 impl ID3D11FunctionParameterReflection {
     #[cfg(feature = "Win32_Graphics_Direct3D")]
@@ -10607,6 +10577,8 @@ pub struct ID3D11FunctionParameterReflection_Vtbl {
     #[cfg(not(feature = "Win32_Graphics_Direct3D"))]
     GetDesc: usize,
 }
+unsafe impl Send for ID3D11FunctionParameterReflection {}
+unsafe impl Sync for ID3D11FunctionParameterReflection {}
 #[cfg(feature = "Win32_Graphics_Direct3D")]
 pub trait ID3D11FunctionParameterReflection_Impl {
     fn GetDesc(&self, pdesc: *mut D3D11_PARAMETER_DESC) -> windows_core::Result<()>;
@@ -10638,10 +10610,6 @@ impl ID3D11FunctionParameterReflection {
         unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
     }
 }
-#[cfg(feature = "Win32_Graphics_Direct3D")]
-unsafe impl Send for ID3D11FunctionParameterReflection {}
-#[cfg(feature = "Win32_Graphics_Direct3D")]
-unsafe impl Sync for ID3D11FunctionParameterReflection {}
 windows_core::imp::define_interface!(ID3D11FunctionReflection, ID3D11FunctionReflection_Vtbl);
 impl ID3D11FunctionReflection {
     #[cfg(feature = "Win32_Graphics_Direct3D")]
@@ -10697,6 +10665,8 @@ pub struct ID3D11FunctionReflection_Vtbl {
     GetResourceBindingDescByName: usize,
     pub GetFunctionParameter: unsafe extern "system" fn(*mut core::ffi::c_void, i32) -> Option<ID3D11FunctionParameterReflection>,
 }
+unsafe impl Send for ID3D11FunctionReflection {}
+unsafe impl Sync for ID3D11FunctionReflection {}
 #[cfg(feature = "Win32_Graphics_Direct3D")]
 pub trait ID3D11FunctionReflection_Impl {
     fn GetDesc(&self, pdesc: *mut D3D11_FUNCTION_DESC) -> windows_core::Result<()>;
@@ -10784,10 +10754,6 @@ impl ID3D11FunctionReflection {
         unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
     }
 }
-#[cfg(feature = "Win32_Graphics_Direct3D")]
-unsafe impl Send for ID3D11FunctionReflection {}
-#[cfg(feature = "Win32_Graphics_Direct3D")]
-unsafe impl Sync for ID3D11FunctionReflection {}
 windows_core::imp::define_interface!(ID3D11GeometryShader, ID3D11GeometryShader_Vtbl, 0x38325b96_effb_4022_ba02_2e795b70275c);
 impl core::ops::Deref for ID3D11GeometryShader {
     type Target = ID3D11DeviceChild;
@@ -10800,6 +10766,8 @@ windows_core::imp::interface_hierarchy!(ID3D11GeometryShader, windows_core::IUnk
 pub struct ID3D11GeometryShader_Vtbl {
     pub base__: ID3D11DeviceChild_Vtbl,
 }
+unsafe impl Send for ID3D11GeometryShader {}
+unsafe impl Sync for ID3D11GeometryShader {}
 pub trait ID3D11GeometryShader_Impl: ID3D11DeviceChild_Impl {}
 impl ID3D11GeometryShader_Vtbl {
     pub const fn new<Identity: ID3D11GeometryShader_Impl, const OFFSET: isize>() -> Self {
@@ -10810,8 +10778,6 @@ impl ID3D11GeometryShader_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D11GeometryShader {}
-unsafe impl Send for ID3D11GeometryShader {}
-unsafe impl Sync for ID3D11GeometryShader {}
 windows_core::imp::define_interface!(ID3D11HullShader, ID3D11HullShader_Vtbl, 0x8e5c6061_628a_4c8e_8264_bbe45cb3d5dd);
 impl core::ops::Deref for ID3D11HullShader {
     type Target = ID3D11DeviceChild;
@@ -10824,6 +10790,8 @@ windows_core::imp::interface_hierarchy!(ID3D11HullShader, windows_core::IUnknown
 pub struct ID3D11HullShader_Vtbl {
     pub base__: ID3D11DeviceChild_Vtbl,
 }
+unsafe impl Send for ID3D11HullShader {}
+unsafe impl Sync for ID3D11HullShader {}
 pub trait ID3D11HullShader_Impl: ID3D11DeviceChild_Impl {}
 impl ID3D11HullShader_Vtbl {
     pub const fn new<Identity: ID3D11HullShader_Impl, const OFFSET: isize>() -> Self {
@@ -10834,8 +10802,6 @@ impl ID3D11HullShader_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D11HullShader {}
-unsafe impl Send for ID3D11HullShader {}
-unsafe impl Sync for ID3D11HullShader {}
 windows_core::imp::define_interface!(ID3D11InfoQueue, ID3D11InfoQueue_Vtbl, 0x6543dbb6_1b48_42f5_ab82_e97ec74326f6);
 windows_core::imp::interface_hierarchy!(ID3D11InfoQueue, windows_core::IUnknown);
 impl ID3D11InfoQueue {
@@ -10990,6 +10956,8 @@ pub struct ID3D11InfoQueue_Vtbl {
     pub SetMuteDebugOutput: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::BOOL),
     pub GetMuteDebugOutput: unsafe extern "system" fn(*mut core::ffi::c_void) -> super::super::Foundation::BOOL,
 }
+unsafe impl Send for ID3D11InfoQueue {}
+unsafe impl Sync for ID3D11InfoQueue {}
 pub trait ID3D11InfoQueue_Impl: windows_core::IUnknownImpl {
     fn SetMessageCountLimit(&self, messagecountlimit: u64) -> windows_core::Result<()>;
     fn ClearStoredMessages(&self);
@@ -11283,8 +11251,6 @@ impl ID3D11InfoQueue_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D11InfoQueue {}
-unsafe impl Send for ID3D11InfoQueue {}
-unsafe impl Sync for ID3D11InfoQueue {}
 windows_core::imp::define_interface!(ID3D11InputLayout, ID3D11InputLayout_Vtbl, 0xe4819ddc_4cf0_4025_bd26_5de82a3e07b7);
 impl core::ops::Deref for ID3D11InputLayout {
     type Target = ID3D11DeviceChild;
@@ -11297,6 +11263,8 @@ windows_core::imp::interface_hierarchy!(ID3D11InputLayout, windows_core::IUnknow
 pub struct ID3D11InputLayout_Vtbl {
     pub base__: ID3D11DeviceChild_Vtbl,
 }
+unsafe impl Send for ID3D11InputLayout {}
+unsafe impl Sync for ID3D11InputLayout {}
 pub trait ID3D11InputLayout_Impl: ID3D11DeviceChild_Impl {}
 impl ID3D11InputLayout_Vtbl {
     pub const fn new<Identity: ID3D11InputLayout_Impl, const OFFSET: isize>() -> Self {
@@ -11307,8 +11275,6 @@ impl ID3D11InputLayout_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D11InputLayout {}
-unsafe impl Send for ID3D11InputLayout {}
-unsafe impl Sync for ID3D11InputLayout {}
 windows_core::imp::define_interface!(ID3D11LibraryReflection, ID3D11LibraryReflection_Vtbl, 0x54384f1b_5b3e_4bb7_ae01_60ba3097cbb6);
 windows_core::imp::interface_hierarchy!(ID3D11LibraryReflection, windows_core::IUnknown);
 impl ID3D11LibraryReflection {
@@ -11328,6 +11294,8 @@ pub struct ID3D11LibraryReflection_Vtbl {
     pub GetDesc: unsafe extern "system" fn(*mut core::ffi::c_void, *mut D3D11_LIBRARY_DESC) -> windows_core::HRESULT,
     pub GetFunctionByIndex: unsafe extern "system" fn(*mut core::ffi::c_void, i32) -> Option<ID3D11FunctionReflection>,
 }
+unsafe impl Send for ID3D11LibraryReflection {}
+unsafe impl Sync for ID3D11LibraryReflection {}
 pub trait ID3D11LibraryReflection_Impl: windows_core::IUnknownImpl {
     fn GetDesc(&self) -> windows_core::Result<D3D11_LIBRARY_DESC>;
     fn GetFunctionByIndex(&self, functionindex: i32) -> Option<ID3D11FunctionReflection>;
@@ -11363,8 +11331,6 @@ impl ID3D11LibraryReflection_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D11LibraryReflection {}
-unsafe impl Send for ID3D11LibraryReflection {}
-unsafe impl Sync for ID3D11LibraryReflection {}
 windows_core::imp::define_interface!(ID3D11Linker, ID3D11Linker_Vtbl, 0x59a6cd0e_e10d_4c1f_88c0_63aba1daf30e);
 windows_core::imp::interface_hierarchy!(ID3D11Linker, windows_core::IUnknown);
 impl ID3D11Linker {
@@ -11397,6 +11363,8 @@ pub struct ID3D11Linker_Vtbl {
     pub UseLibrary: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
     pub AddClipPlaneFromCBuffer: unsafe extern "system" fn(*mut core::ffi::c_void, u32, u32) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID3D11Linker {}
+unsafe impl Sync for ID3D11Linker {}
 #[cfg(feature = "Win32_Graphics_Direct3D")]
 pub trait ID3D11Linker_Impl: windows_core::IUnknownImpl {
     fn Link(&self, pentry: windows_core::Ref<ID3D11ModuleInstance>, pentryname: &windows_core::PCSTR, ptargetname: &windows_core::PCSTR, uflags: u32, ppshaderblob: windows_core::OutRef<'_, super::Direct3D::ID3DBlob>, pperrorbuffer: windows_core::OutRef<'_, super::Direct3D::ID3DBlob>) -> windows_core::Result<()>;
@@ -11437,16 +11405,14 @@ impl ID3D11Linker_Vtbl {
 }
 #[cfg(feature = "Win32_Graphics_Direct3D")]
 impl windows_core::RuntimeName for ID3D11Linker {}
-#[cfg(feature = "Win32_Graphics_Direct3D")]
-unsafe impl Send for ID3D11Linker {}
-#[cfg(feature = "Win32_Graphics_Direct3D")]
-unsafe impl Sync for ID3D11Linker {}
 windows_core::imp::define_interface!(ID3D11LinkingNode, ID3D11LinkingNode_Vtbl, 0xd80dd70c_8d2f_4751_94a1_03c79b3556db);
 windows_core::imp::interface_hierarchy!(ID3D11LinkingNode, windows_core::IUnknown);
 #[repr(C)]
 pub struct ID3D11LinkingNode_Vtbl {
     pub base__: windows_core::IUnknown_Vtbl,
 }
+unsafe impl Send for ID3D11LinkingNode {}
+unsafe impl Sync for ID3D11LinkingNode {}
 pub trait ID3D11LinkingNode_Impl: windows_core::IUnknownImpl {}
 impl ID3D11LinkingNode_Vtbl {
     pub const fn new<Identity: ID3D11LinkingNode_Impl, const OFFSET: isize>() -> Self {
@@ -11457,8 +11423,6 @@ impl ID3D11LinkingNode_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D11LinkingNode {}
-unsafe impl Send for ID3D11LinkingNode {}
-unsafe impl Sync for ID3D11LinkingNode {}
 windows_core::imp::define_interface!(ID3D11Module, ID3D11Module_Vtbl, 0xcac701ee_80fc_4122_8242_10b39c8cec34);
 windows_core::imp::interface_hierarchy!(ID3D11Module, windows_core::IUnknown);
 impl ID3D11Module {
@@ -11477,6 +11441,8 @@ pub struct ID3D11Module_Vtbl {
     pub base__: windows_core::IUnknown_Vtbl,
     pub CreateInstance: unsafe extern "system" fn(*mut core::ffi::c_void, windows_core::PCSTR, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID3D11Module {}
+unsafe impl Sync for ID3D11Module {}
 pub trait ID3D11Module_Impl: windows_core::IUnknownImpl {
     fn CreateInstance(&self, pnamespace: &windows_core::PCSTR) -> windows_core::Result<ID3D11ModuleInstance>;
 }
@@ -11501,8 +11467,6 @@ impl ID3D11Module_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D11Module {}
-unsafe impl Send for ID3D11Module {}
-unsafe impl Sync for ID3D11Module {}
 windows_core::imp::define_interface!(ID3D11ModuleInstance, ID3D11ModuleInstance_Vtbl, 0x469e07f7_045a_48d5_aa12_68a478cdf75d);
 windows_core::imp::interface_hierarchy!(ID3D11ModuleInstance, windows_core::IUnknown);
 impl ID3D11ModuleInstance {
@@ -11566,6 +11530,8 @@ pub struct ID3D11ModuleInstance_Vtbl {
     pub BindResourceAsUnorderedAccessView: unsafe extern "system" fn(*mut core::ffi::c_void, u32, u32, u32) -> windows_core::HRESULT,
     pub BindResourceAsUnorderedAccessViewByName: unsafe extern "system" fn(*mut core::ffi::c_void, windows_core::PCSTR, u32, u32) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID3D11ModuleInstance {}
+unsafe impl Sync for ID3D11ModuleInstance {}
 pub trait ID3D11ModuleInstance_Impl: windows_core::IUnknownImpl {
     fn BindConstantBuffer(&self, usrcslot: u32, udstslot: u32, cbdstoffset: u32) -> windows_core::Result<()>;
     fn BindConstantBufferByName(&self, pname: &windows_core::PCSTR, udstslot: u32, cbdstoffset: u32) -> windows_core::Result<()>;
@@ -11659,8 +11625,6 @@ impl ID3D11ModuleInstance_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D11ModuleInstance {}
-unsafe impl Send for ID3D11ModuleInstance {}
-unsafe impl Sync for ID3D11ModuleInstance {}
 windows_core::imp::define_interface!(ID3D11Multithread, ID3D11Multithread_Vtbl, 0x9b7e4e00_342c_4106_a19f_4f2704f689f0);
 windows_core::imp::interface_hierarchy!(ID3D11Multithread, windows_core::IUnknown);
 impl ID3D11Multithread {
@@ -11685,6 +11649,8 @@ pub struct ID3D11Multithread_Vtbl {
     pub SetMultithreadProtected: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::BOOL) -> super::super::Foundation::BOOL,
     pub GetMultithreadProtected: unsafe extern "system" fn(*mut core::ffi::c_void) -> super::super::Foundation::BOOL,
 }
+unsafe impl Send for ID3D11Multithread {}
+unsafe impl Sync for ID3D11Multithread {}
 pub trait ID3D11Multithread_Impl: windows_core::IUnknownImpl {
     fn Enter(&self);
     fn Leave(&self);
@@ -11730,8 +11696,6 @@ impl ID3D11Multithread_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D11Multithread {}
-unsafe impl Send for ID3D11Multithread {}
-unsafe impl Sync for ID3D11Multithread {}
 windows_core::imp::define_interface!(ID3D11PixelShader, ID3D11PixelShader_Vtbl, 0xea82e40d_51dc_4f33_93d4_db7c9125ae8c);
 impl core::ops::Deref for ID3D11PixelShader {
     type Target = ID3D11DeviceChild;
@@ -11744,6 +11708,8 @@ windows_core::imp::interface_hierarchy!(ID3D11PixelShader, windows_core::IUnknow
 pub struct ID3D11PixelShader_Vtbl {
     pub base__: ID3D11DeviceChild_Vtbl,
 }
+unsafe impl Send for ID3D11PixelShader {}
+unsafe impl Sync for ID3D11PixelShader {}
 pub trait ID3D11PixelShader_Impl: ID3D11DeviceChild_Impl {}
 impl ID3D11PixelShader_Vtbl {
     pub const fn new<Identity: ID3D11PixelShader_Impl, const OFFSET: isize>() -> Self {
@@ -11754,8 +11720,6 @@ impl ID3D11PixelShader_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D11PixelShader {}
-unsafe impl Send for ID3D11PixelShader {}
-unsafe impl Sync for ID3D11PixelShader {}
 windows_core::imp::define_interface!(ID3D11Predicate, ID3D11Predicate_Vtbl, 0x9eb576dd_9f77_4d86_81aa_8bab5fe490e2);
 impl core::ops::Deref for ID3D11Predicate {
     type Target = ID3D11Query;
@@ -11768,6 +11732,8 @@ windows_core::imp::interface_hierarchy!(ID3D11Predicate, windows_core::IUnknown,
 pub struct ID3D11Predicate_Vtbl {
     pub base__: ID3D11Query_Vtbl,
 }
+unsafe impl Send for ID3D11Predicate {}
+unsafe impl Sync for ID3D11Predicate {}
 pub trait ID3D11Predicate_Impl: ID3D11Query_Impl {}
 impl ID3D11Predicate_Vtbl {
     pub const fn new<Identity: ID3D11Predicate_Impl, const OFFSET: isize>() -> Self {
@@ -11778,8 +11744,6 @@ impl ID3D11Predicate_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D11Predicate {}
-unsafe impl Send for ID3D11Predicate {}
-unsafe impl Sync for ID3D11Predicate {}
 windows_core::imp::define_interface!(ID3D11Query, ID3D11Query_Vtbl, 0xd6c00747_87b7_425e_b84d_44d108560afd);
 impl core::ops::Deref for ID3D11Query {
     type Target = ID3D11Asynchronous;
@@ -11802,6 +11766,8 @@ pub struct ID3D11Query_Vtbl {
     pub base__: ID3D11Asynchronous_Vtbl,
     pub GetDesc: unsafe extern "system" fn(*mut core::ffi::c_void, *mut D3D11_QUERY_DESC),
 }
+unsafe impl Send for ID3D11Query {}
+unsafe impl Sync for ID3D11Query {}
 pub trait ID3D11Query_Impl: ID3D11Asynchronous_Impl {
     fn GetDesc(&self, pdesc: *mut D3D11_QUERY_DESC);
 }
@@ -11820,8 +11786,6 @@ impl ID3D11Query_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D11Query {}
-unsafe impl Send for ID3D11Query {}
-unsafe impl Sync for ID3D11Query {}
 windows_core::imp::define_interface!(ID3D11Query1, ID3D11Query1_Vtbl, 0x631b4766_36dc_461d_8db6_c47e13e60916);
 impl core::ops::Deref for ID3D11Query1 {
     type Target = ID3D11Query;
@@ -11844,6 +11808,8 @@ pub struct ID3D11Query1_Vtbl {
     pub base__: ID3D11Query_Vtbl,
     pub GetDesc1: unsafe extern "system" fn(*mut core::ffi::c_void, *mut D3D11_QUERY_DESC1),
 }
+unsafe impl Send for ID3D11Query1 {}
+unsafe impl Sync for ID3D11Query1 {}
 pub trait ID3D11Query1_Impl: ID3D11Query_Impl {
     fn GetDesc1(&self, pdesc1: *mut D3D11_QUERY_DESC1);
 }
@@ -11862,8 +11828,6 @@ impl ID3D11Query1_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D11Query1 {}
-unsafe impl Send for ID3D11Query1 {}
-unsafe impl Sync for ID3D11Query1 {}
 windows_core::imp::define_interface!(ID3D11RasterizerState, ID3D11RasterizerState_Vtbl, 0x9bb4ab81_ab1a_4d8f_b506_fc04200b6ee7);
 impl core::ops::Deref for ID3D11RasterizerState {
     type Target = ID3D11DeviceChild;
@@ -11882,6 +11846,8 @@ pub struct ID3D11RasterizerState_Vtbl {
     pub base__: ID3D11DeviceChild_Vtbl,
     pub GetDesc: unsafe extern "system" fn(*mut core::ffi::c_void, *mut D3D11_RASTERIZER_DESC),
 }
+unsafe impl Send for ID3D11RasterizerState {}
+unsafe impl Sync for ID3D11RasterizerState {}
 pub trait ID3D11RasterizerState_Impl: ID3D11DeviceChild_Impl {
     fn GetDesc(&self, pdesc: *mut D3D11_RASTERIZER_DESC);
 }
@@ -11900,8 +11866,6 @@ impl ID3D11RasterizerState_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D11RasterizerState {}
-unsafe impl Send for ID3D11RasterizerState {}
-unsafe impl Sync for ID3D11RasterizerState {}
 windows_core::imp::define_interface!(ID3D11RasterizerState1, ID3D11RasterizerState1_Vtbl, 0x1217d7a6_5039_418c_b042_9cbe256afd6e);
 impl core::ops::Deref for ID3D11RasterizerState1 {
     type Target = ID3D11RasterizerState;
@@ -11920,6 +11884,8 @@ pub struct ID3D11RasterizerState1_Vtbl {
     pub base__: ID3D11RasterizerState_Vtbl,
     pub GetDesc1: unsafe extern "system" fn(*mut core::ffi::c_void, *mut D3D11_RASTERIZER_DESC1),
 }
+unsafe impl Send for ID3D11RasterizerState1 {}
+unsafe impl Sync for ID3D11RasterizerState1 {}
 pub trait ID3D11RasterizerState1_Impl: ID3D11RasterizerState_Impl {
     fn GetDesc1(&self, pdesc: *mut D3D11_RASTERIZER_DESC1);
 }
@@ -11938,8 +11904,6 @@ impl ID3D11RasterizerState1_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D11RasterizerState1 {}
-unsafe impl Send for ID3D11RasterizerState1 {}
-unsafe impl Sync for ID3D11RasterizerState1 {}
 windows_core::imp::define_interface!(ID3D11RasterizerState2, ID3D11RasterizerState2_Vtbl, 0x6fbd02fb_209f_46c4_b059_2ed15586a6ac);
 impl core::ops::Deref for ID3D11RasterizerState2 {
     type Target = ID3D11RasterizerState1;
@@ -11958,6 +11922,8 @@ pub struct ID3D11RasterizerState2_Vtbl {
     pub base__: ID3D11RasterizerState1_Vtbl,
     pub GetDesc2: unsafe extern "system" fn(*mut core::ffi::c_void, *mut D3D11_RASTERIZER_DESC2),
 }
+unsafe impl Send for ID3D11RasterizerState2 {}
+unsafe impl Sync for ID3D11RasterizerState2 {}
 pub trait ID3D11RasterizerState2_Impl: ID3D11RasterizerState1_Impl {
     fn GetDesc2(&self, pdesc: *mut D3D11_RASTERIZER_DESC2);
 }
@@ -11976,8 +11942,6 @@ impl ID3D11RasterizerState2_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D11RasterizerState2 {}
-unsafe impl Send for ID3D11RasterizerState2 {}
-unsafe impl Sync for ID3D11RasterizerState2 {}
 windows_core::imp::define_interface!(ID3D11RefDefaultTrackingOptions, ID3D11RefDefaultTrackingOptions_Vtbl, 0x03916615_c644_418c_9bf4_75db5be63ca0);
 windows_core::imp::interface_hierarchy!(ID3D11RefDefaultTrackingOptions, windows_core::IUnknown);
 impl ID3D11RefDefaultTrackingOptions {
@@ -11990,6 +11954,8 @@ pub struct ID3D11RefDefaultTrackingOptions_Vtbl {
     pub base__: windows_core::IUnknown_Vtbl,
     pub SetTrackingOptions: unsafe extern "system" fn(*mut core::ffi::c_void, u32, u32) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID3D11RefDefaultTrackingOptions {}
+unsafe impl Sync for ID3D11RefDefaultTrackingOptions {}
 pub trait ID3D11RefDefaultTrackingOptions_Impl: windows_core::IUnknownImpl {
     fn SetTrackingOptions(&self, resourcetypeflags: u32, options: u32) -> windows_core::Result<()>;
 }
@@ -12008,8 +11974,6 @@ impl ID3D11RefDefaultTrackingOptions_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D11RefDefaultTrackingOptions {}
-unsafe impl Send for ID3D11RefDefaultTrackingOptions {}
-unsafe impl Sync for ID3D11RefDefaultTrackingOptions {}
 windows_core::imp::define_interface!(ID3D11RefTrackingOptions, ID3D11RefTrackingOptions_Vtbl, 0x193dacdf_0db2_4c05_a55c_ef06cac56fd9);
 windows_core::imp::interface_hierarchy!(ID3D11RefTrackingOptions, windows_core::IUnknown);
 impl ID3D11RefTrackingOptions {
@@ -12022,6 +11986,8 @@ pub struct ID3D11RefTrackingOptions_Vtbl {
     pub base__: windows_core::IUnknown_Vtbl,
     pub SetTrackingOptions: unsafe extern "system" fn(*mut core::ffi::c_void, u32) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID3D11RefTrackingOptions {}
+unsafe impl Sync for ID3D11RefTrackingOptions {}
 pub trait ID3D11RefTrackingOptions_Impl: windows_core::IUnknownImpl {
     fn SetTrackingOptions(&self, uoptions: u32) -> windows_core::Result<()>;
 }
@@ -12040,8 +12006,6 @@ impl ID3D11RefTrackingOptions_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D11RefTrackingOptions {}
-unsafe impl Send for ID3D11RefTrackingOptions {}
-unsafe impl Sync for ID3D11RefTrackingOptions {}
 windows_core::imp::define_interface!(ID3D11RenderTargetView, ID3D11RenderTargetView_Vtbl, 0xdfdba067_0b8d_4865_875b_d7b4516cc164);
 impl core::ops::Deref for ID3D11RenderTargetView {
     type Target = ID3D11View;
@@ -12064,6 +12028,8 @@ pub struct ID3D11RenderTargetView_Vtbl {
     #[cfg(not(feature = "Win32_Graphics_Dxgi_Common"))]
     GetDesc: usize,
 }
+unsafe impl Send for ID3D11RenderTargetView {}
+unsafe impl Sync for ID3D11RenderTargetView {}
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 pub trait ID3D11RenderTargetView_Impl: ID3D11View_Impl {
     fn GetDesc(&self, pdesc: *mut D3D11_RENDER_TARGET_VIEW_DESC);
@@ -12085,10 +12051,6 @@ impl ID3D11RenderTargetView_Vtbl {
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl windows_core::RuntimeName for ID3D11RenderTargetView {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-unsafe impl Send for ID3D11RenderTargetView {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-unsafe impl Sync for ID3D11RenderTargetView {}
 windows_core::imp::define_interface!(ID3D11RenderTargetView1, ID3D11RenderTargetView1_Vtbl, 0xffbe2e23_f011_418a_ac56_5ceed7c5b94b);
 impl core::ops::Deref for ID3D11RenderTargetView1 {
     type Target = ID3D11RenderTargetView;
@@ -12111,6 +12073,8 @@ pub struct ID3D11RenderTargetView1_Vtbl {
     #[cfg(not(feature = "Win32_Graphics_Dxgi_Common"))]
     GetDesc1: usize,
 }
+unsafe impl Send for ID3D11RenderTargetView1 {}
+unsafe impl Sync for ID3D11RenderTargetView1 {}
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 pub trait ID3D11RenderTargetView1_Impl: ID3D11RenderTargetView_Impl {
     fn GetDesc1(&self, pdesc1: *mut D3D11_RENDER_TARGET_VIEW_DESC1);
@@ -12132,10 +12096,6 @@ impl ID3D11RenderTargetView1_Vtbl {
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl windows_core::RuntimeName for ID3D11RenderTargetView1 {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-unsafe impl Send for ID3D11RenderTargetView1 {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-unsafe impl Sync for ID3D11RenderTargetView1 {}
 windows_core::imp::define_interface!(ID3D11Resource, ID3D11Resource_Vtbl, 0xdc8e63f3_d12b_4952_b47b_5e45026a862d);
 impl core::ops::Deref for ID3D11Resource {
     type Target = ID3D11DeviceChild;
@@ -12166,6 +12126,8 @@ pub struct ID3D11Resource_Vtbl {
     pub SetEvictionPriority: unsafe extern "system" fn(*mut core::ffi::c_void, u32),
     pub GetEvictionPriority: unsafe extern "system" fn(*mut core::ffi::c_void) -> u32,
 }
+unsafe impl Send for ID3D11Resource {}
+unsafe impl Sync for ID3D11Resource {}
 pub trait ID3D11Resource_Impl: ID3D11DeviceChild_Impl {
     fn GetType(&self, presourcedimension: *mut D3D11_RESOURCE_DIMENSION);
     fn SetEvictionPriority(&self, evictionpriority: u32);
@@ -12203,8 +12165,6 @@ impl ID3D11Resource_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D11Resource {}
-unsafe impl Send for ID3D11Resource {}
-unsafe impl Sync for ID3D11Resource {}
 windows_core::imp::define_interface!(ID3D11SamplerState, ID3D11SamplerState_Vtbl, 0xda6fea51_564c_4487_9810_f0d0f9b4e3a5);
 impl core::ops::Deref for ID3D11SamplerState {
     type Target = ID3D11DeviceChild;
@@ -12223,6 +12183,8 @@ pub struct ID3D11SamplerState_Vtbl {
     pub base__: ID3D11DeviceChild_Vtbl,
     pub GetDesc: unsafe extern "system" fn(*mut core::ffi::c_void, *mut D3D11_SAMPLER_DESC),
 }
+unsafe impl Send for ID3D11SamplerState {}
+unsafe impl Sync for ID3D11SamplerState {}
 pub trait ID3D11SamplerState_Impl: ID3D11DeviceChild_Impl {
     fn GetDesc(&self, pdesc: *mut D3D11_SAMPLER_DESC);
 }
@@ -12241,8 +12203,6 @@ impl ID3D11SamplerState_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D11SamplerState {}
-unsafe impl Send for ID3D11SamplerState {}
-unsafe impl Sync for ID3D11SamplerState {}
 windows_core::imp::define_interface!(ID3D11ShaderReflection, ID3D11ShaderReflection_Vtbl, 0x8d536ca1_0cca_4956_a837_786963755584);
 windows_core::imp::interface_hierarchy!(ID3D11ShaderReflection, windows_core::IUnknown);
 impl ID3D11ShaderReflection {
@@ -12371,6 +12331,8 @@ pub struct ID3D11ShaderReflection_Vtbl {
     pub GetThreadGroupSize: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u32, *mut u32, *mut u32) -> u32,
     pub GetRequiresFlags: unsafe extern "system" fn(*mut core::ffi::c_void) -> u64,
 }
+unsafe impl Send for ID3D11ShaderReflection {}
+unsafe impl Sync for ID3D11ShaderReflection {}
 #[cfg(feature = "Win32_Graphics_Direct3D")]
 pub trait ID3D11ShaderReflection_Impl: windows_core::IUnknownImpl {
     fn GetDesc(&self, pdesc: *mut D3D11_SHADER_DESC) -> windows_core::Result<()>;
@@ -12545,10 +12507,6 @@ impl ID3D11ShaderReflection_Vtbl {
 }
 #[cfg(feature = "Win32_Graphics_Direct3D")]
 impl windows_core::RuntimeName for ID3D11ShaderReflection {}
-#[cfg(feature = "Win32_Graphics_Direct3D")]
-unsafe impl Send for ID3D11ShaderReflection {}
-#[cfg(feature = "Win32_Graphics_Direct3D")]
-unsafe impl Sync for ID3D11ShaderReflection {}
 windows_core::imp::define_interface!(ID3D11ShaderReflectionConstantBuffer, ID3D11ShaderReflectionConstantBuffer_Vtbl);
 impl ID3D11ShaderReflectionConstantBuffer {
     #[cfg(feature = "Win32_Graphics_Direct3D")]
@@ -12574,6 +12532,8 @@ pub struct ID3D11ShaderReflectionConstantBuffer_Vtbl {
     pub GetVariableByIndex: unsafe extern "system" fn(*mut core::ffi::c_void, u32) -> Option<ID3D11ShaderReflectionVariable>,
     pub GetVariableByName: unsafe extern "system" fn(*mut core::ffi::c_void, windows_core::PCSTR) -> Option<ID3D11ShaderReflectionVariable>,
 }
+unsafe impl Send for ID3D11ShaderReflectionConstantBuffer {}
+unsafe impl Sync for ID3D11ShaderReflectionConstantBuffer {}
 #[cfg(feature = "Win32_Graphics_Direct3D")]
 pub trait ID3D11ShaderReflectionConstantBuffer_Impl {
     fn GetDesc(&self, pdesc: *mut D3D11_SHADER_BUFFER_DESC) -> windows_core::Result<()>;
@@ -12621,10 +12581,6 @@ impl ID3D11ShaderReflectionConstantBuffer {
         unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
     }
 }
-#[cfg(feature = "Win32_Graphics_Direct3D")]
-unsafe impl Send for ID3D11ShaderReflectionConstantBuffer {}
-#[cfg(feature = "Win32_Graphics_Direct3D")]
-unsafe impl Sync for ID3D11ShaderReflectionConstantBuffer {}
 windows_core::imp::define_interface!(ID3D11ShaderReflectionType, ID3D11ShaderReflectionType_Vtbl);
 impl ID3D11ShaderReflectionType {
     #[cfg(feature = "Win32_Graphics_Direct3D")]
@@ -12691,6 +12647,8 @@ pub struct ID3D11ShaderReflectionType_Vtbl {
     pub IsOfType: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
     pub ImplementsInterface: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID3D11ShaderReflectionType {}
+unsafe impl Sync for ID3D11ShaderReflectionType {}
 #[cfg(feature = "Win32_Graphics_Direct3D")]
 pub trait ID3D11ShaderReflectionType_Impl {
     fn GetDesc(&self, pdesc: *mut D3D11_SHADER_TYPE_DESC) -> windows_core::Result<()>;
@@ -12814,10 +12772,6 @@ impl ID3D11ShaderReflectionType {
         unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
     }
 }
-#[cfg(feature = "Win32_Graphics_Direct3D")]
-unsafe impl Send for ID3D11ShaderReflectionType {}
-#[cfg(feature = "Win32_Graphics_Direct3D")]
-unsafe impl Sync for ID3D11ShaderReflectionType {}
 windows_core::imp::define_interface!(ID3D11ShaderReflectionVariable, ID3D11ShaderReflectionVariable_Vtbl);
 impl ID3D11ShaderReflectionVariable {
     pub unsafe fn GetDesc(&self, pdesc: *mut D3D11_SHADER_VARIABLE_DESC) -> windows_core::Result<()> {
@@ -12840,6 +12794,8 @@ pub struct ID3D11ShaderReflectionVariable_Vtbl {
     pub GetBuffer: unsafe extern "system" fn(*mut core::ffi::c_void) -> Option<ID3D11ShaderReflectionConstantBuffer>,
     pub GetInterfaceSlot: unsafe extern "system" fn(*mut core::ffi::c_void, u32) -> u32,
 }
+unsafe impl Send for ID3D11ShaderReflectionVariable {}
+unsafe impl Sync for ID3D11ShaderReflectionVariable {}
 pub trait ID3D11ShaderReflectionVariable_Impl {
     fn GetDesc(&self, pdesc: *mut D3D11_SHADER_VARIABLE_DESC) -> windows_core::Result<()>;
     fn GetType(&self) -> Option<ID3D11ShaderReflectionType>;
@@ -12890,8 +12846,6 @@ impl ID3D11ShaderReflectionVariable {
         unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
     }
 }
-unsafe impl Send for ID3D11ShaderReflectionVariable {}
-unsafe impl Sync for ID3D11ShaderReflectionVariable {}
 windows_core::imp::define_interface!(ID3D11ShaderResourceView, ID3D11ShaderResourceView_Vtbl, 0xb0e06fe0_8192_4e1a_b1ca_36d7414710b2);
 impl core::ops::Deref for ID3D11ShaderResourceView {
     type Target = ID3D11View;
@@ -12914,6 +12868,8 @@ pub struct ID3D11ShaderResourceView_Vtbl {
     #[cfg(not(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common")))]
     GetDesc: usize,
 }
+unsafe impl Send for ID3D11ShaderResourceView {}
+unsafe impl Sync for ID3D11ShaderResourceView {}
 #[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait ID3D11ShaderResourceView_Impl: ID3D11View_Impl {
     fn GetDesc(&self, pdesc: *mut D3D11_SHADER_RESOURCE_VIEW_DESC);
@@ -12935,10 +12891,6 @@ impl ID3D11ShaderResourceView_Vtbl {
 }
 #[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
 impl windows_core::RuntimeName for ID3D11ShaderResourceView {}
-#[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
-unsafe impl Send for ID3D11ShaderResourceView {}
-#[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
-unsafe impl Sync for ID3D11ShaderResourceView {}
 windows_core::imp::define_interface!(ID3D11ShaderResourceView1, ID3D11ShaderResourceView1_Vtbl, 0x91308b87_9040_411d_8c67_c39253ce3802);
 impl core::ops::Deref for ID3D11ShaderResourceView1 {
     type Target = ID3D11ShaderResourceView;
@@ -12961,6 +12913,8 @@ pub struct ID3D11ShaderResourceView1_Vtbl {
     #[cfg(not(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common")))]
     GetDesc1: usize,
 }
+unsafe impl Send for ID3D11ShaderResourceView1 {}
+unsafe impl Sync for ID3D11ShaderResourceView1 {}
 #[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait ID3D11ShaderResourceView1_Impl: ID3D11ShaderResourceView_Impl {
     fn GetDesc1(&self, pdesc1: *mut D3D11_SHADER_RESOURCE_VIEW_DESC1);
@@ -12982,10 +12936,6 @@ impl ID3D11ShaderResourceView1_Vtbl {
 }
 #[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
 impl windows_core::RuntimeName for ID3D11ShaderResourceView1 {}
-#[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
-unsafe impl Send for ID3D11ShaderResourceView1 {}
-#[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
-unsafe impl Sync for ID3D11ShaderResourceView1 {}
 windows_core::imp::define_interface!(ID3D11ShaderTrace, ID3D11ShaderTrace_Vtbl, 0x36b013e6_2811_4845_baa7_d623fe0df104);
 windows_core::imp::interface_hierarchy!(ID3D11ShaderTrace, windows_core::IUnknown);
 impl ID3D11ShaderTrace {
@@ -13026,6 +12976,8 @@ pub struct ID3D11ShaderTrace_Vtbl {
     pub GetWrittenRegister: unsafe extern "system" fn(*mut core::ffi::c_void, u32, u32, *mut D3D11_TRACE_REGISTER, *mut D3D11_TRACE_VALUE) -> windows_core::HRESULT,
     pub GetReadRegister: unsafe extern "system" fn(*mut core::ffi::c_void, u32, u32, *mut D3D11_TRACE_REGISTER, *mut D3D11_TRACE_VALUE) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID3D11ShaderTrace {}
+unsafe impl Sync for ID3D11ShaderTrace {}
 pub trait ID3D11ShaderTrace_Impl: windows_core::IUnknownImpl {
     fn TraceReady(&self, ptestcount: *mut u64) -> windows_core::Result<()>;
     fn ResetTrace(&self);
@@ -13103,8 +13055,6 @@ impl ID3D11ShaderTrace_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D11ShaderTrace {}
-unsafe impl Send for ID3D11ShaderTrace {}
-unsafe impl Sync for ID3D11ShaderTrace {}
 windows_core::imp::define_interface!(ID3D11ShaderTraceFactory, ID3D11ShaderTraceFactory_Vtbl, 0x1fbad429_66ab_41cc_9617_667ac10e4459);
 windows_core::imp::interface_hierarchy!(ID3D11ShaderTraceFactory, windows_core::IUnknown);
 impl ID3D11ShaderTraceFactory {
@@ -13123,6 +13073,8 @@ pub struct ID3D11ShaderTraceFactory_Vtbl {
     pub base__: windows_core::IUnknown_Vtbl,
     pub CreateShaderTrace: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *const D3D11_SHADER_TRACE_DESC, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID3D11ShaderTraceFactory {}
+unsafe impl Sync for ID3D11ShaderTraceFactory {}
 pub trait ID3D11ShaderTraceFactory_Impl: windows_core::IUnknownImpl {
     fn CreateShaderTrace(&self, pshader: windows_core::Ref<windows_core::IUnknown>, ptracedesc: *const D3D11_SHADER_TRACE_DESC) -> windows_core::Result<ID3D11ShaderTrace>;
 }
@@ -13147,8 +13099,6 @@ impl ID3D11ShaderTraceFactory_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D11ShaderTraceFactory {}
-unsafe impl Send for ID3D11ShaderTraceFactory {}
-unsafe impl Sync for ID3D11ShaderTraceFactory {}
 windows_core::imp::define_interface!(ID3D11SwitchToRef, ID3D11SwitchToRef_Vtbl, 0x1ef337e3_58e7_4f83_a692_db221f5ed47e);
 windows_core::imp::interface_hierarchy!(ID3D11SwitchToRef, windows_core::IUnknown);
 impl ID3D11SwitchToRef {
@@ -13165,6 +13115,8 @@ pub struct ID3D11SwitchToRef_Vtbl {
     pub SetUseRef: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::BOOL) -> super::super::Foundation::BOOL,
     pub GetUseRef: unsafe extern "system" fn(*mut core::ffi::c_void) -> super::super::Foundation::BOOL,
 }
+unsafe impl Send for ID3D11SwitchToRef {}
+unsafe impl Sync for ID3D11SwitchToRef {}
 pub trait ID3D11SwitchToRef_Impl: windows_core::IUnknownImpl {
     fn SetUseRef(&self, useref: super::super::Foundation::BOOL) -> super::super::Foundation::BOOL;
     fn GetUseRef(&self) -> super::super::Foundation::BOOL;
@@ -13194,8 +13146,6 @@ impl ID3D11SwitchToRef_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D11SwitchToRef {}
-unsafe impl Send for ID3D11SwitchToRef {}
-unsafe impl Sync for ID3D11SwitchToRef {}
 windows_core::imp::define_interface!(ID3D11Texture1D, ID3D11Texture1D_Vtbl, 0xf8fb5c27_c6b3_4f75_a4c8_439af2ef564c);
 impl core::ops::Deref for ID3D11Texture1D {
     type Target = ID3D11Resource;
@@ -13218,6 +13168,8 @@ pub struct ID3D11Texture1D_Vtbl {
     #[cfg(not(feature = "Win32_Graphics_Dxgi_Common"))]
     GetDesc: usize,
 }
+unsafe impl Send for ID3D11Texture1D {}
+unsafe impl Sync for ID3D11Texture1D {}
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 pub trait ID3D11Texture1D_Impl: ID3D11Resource_Impl {
     fn GetDesc(&self, pdesc: *mut D3D11_TEXTURE1D_DESC);
@@ -13239,10 +13191,6 @@ impl ID3D11Texture1D_Vtbl {
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl windows_core::RuntimeName for ID3D11Texture1D {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-unsafe impl Send for ID3D11Texture1D {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-unsafe impl Sync for ID3D11Texture1D {}
 windows_core::imp::define_interface!(ID3D11Texture2D, ID3D11Texture2D_Vtbl, 0x6f15aaf2_d208_4e89_9ab4_489535d34f9c);
 impl core::ops::Deref for ID3D11Texture2D {
     type Target = ID3D11Resource;
@@ -13265,6 +13213,8 @@ pub struct ID3D11Texture2D_Vtbl {
     #[cfg(not(feature = "Win32_Graphics_Dxgi_Common"))]
     GetDesc: usize,
 }
+unsafe impl Send for ID3D11Texture2D {}
+unsafe impl Sync for ID3D11Texture2D {}
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 pub trait ID3D11Texture2D_Impl: ID3D11Resource_Impl {
     fn GetDesc(&self, pdesc: *mut D3D11_TEXTURE2D_DESC);
@@ -13286,10 +13236,6 @@ impl ID3D11Texture2D_Vtbl {
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl windows_core::RuntimeName for ID3D11Texture2D {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-unsafe impl Send for ID3D11Texture2D {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-unsafe impl Sync for ID3D11Texture2D {}
 windows_core::imp::define_interface!(ID3D11Texture2D1, ID3D11Texture2D1_Vtbl, 0x51218251_1e33_4617_9ccb_4d3a4367e7bb);
 impl core::ops::Deref for ID3D11Texture2D1 {
     type Target = ID3D11Texture2D;
@@ -13312,6 +13258,8 @@ pub struct ID3D11Texture2D1_Vtbl {
     #[cfg(not(feature = "Win32_Graphics_Dxgi_Common"))]
     GetDesc1: usize,
 }
+unsafe impl Send for ID3D11Texture2D1 {}
+unsafe impl Sync for ID3D11Texture2D1 {}
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 pub trait ID3D11Texture2D1_Impl: ID3D11Texture2D_Impl {
     fn GetDesc1(&self, pdesc: *mut D3D11_TEXTURE2D_DESC1);
@@ -13333,10 +13281,6 @@ impl ID3D11Texture2D1_Vtbl {
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl windows_core::RuntimeName for ID3D11Texture2D1 {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-unsafe impl Send for ID3D11Texture2D1 {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-unsafe impl Sync for ID3D11Texture2D1 {}
 windows_core::imp::define_interface!(ID3D11Texture3D, ID3D11Texture3D_Vtbl, 0x037e866e_f56d_4357_a8af_9dabbe6e250e);
 impl core::ops::Deref for ID3D11Texture3D {
     type Target = ID3D11Resource;
@@ -13359,6 +13303,8 @@ pub struct ID3D11Texture3D_Vtbl {
     #[cfg(not(feature = "Win32_Graphics_Dxgi_Common"))]
     GetDesc: usize,
 }
+unsafe impl Send for ID3D11Texture3D {}
+unsafe impl Sync for ID3D11Texture3D {}
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 pub trait ID3D11Texture3D_Impl: ID3D11Resource_Impl {
     fn GetDesc(&self, pdesc: *mut D3D11_TEXTURE3D_DESC);
@@ -13380,10 +13326,6 @@ impl ID3D11Texture3D_Vtbl {
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl windows_core::RuntimeName for ID3D11Texture3D {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-unsafe impl Send for ID3D11Texture3D {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-unsafe impl Sync for ID3D11Texture3D {}
 windows_core::imp::define_interface!(ID3D11Texture3D1, ID3D11Texture3D1_Vtbl, 0x0c711683_2853_4846_9bb0_f3e60639e46a);
 impl core::ops::Deref for ID3D11Texture3D1 {
     type Target = ID3D11Texture3D;
@@ -13406,6 +13348,8 @@ pub struct ID3D11Texture3D1_Vtbl {
     #[cfg(not(feature = "Win32_Graphics_Dxgi_Common"))]
     GetDesc1: usize,
 }
+unsafe impl Send for ID3D11Texture3D1 {}
+unsafe impl Sync for ID3D11Texture3D1 {}
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 pub trait ID3D11Texture3D1_Impl: ID3D11Texture3D_Impl {
     fn GetDesc1(&self, pdesc: *mut D3D11_TEXTURE3D_DESC1);
@@ -13427,10 +13371,6 @@ impl ID3D11Texture3D1_Vtbl {
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl windows_core::RuntimeName for ID3D11Texture3D1 {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-unsafe impl Send for ID3D11Texture3D1 {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-unsafe impl Sync for ID3D11Texture3D1 {}
 windows_core::imp::define_interface!(ID3D11TracingDevice, ID3D11TracingDevice_Vtbl, 0x1911c771_1587_413e_a7e0_fb26c3de0268);
 windows_core::imp::interface_hierarchy!(ID3D11TracingDevice, windows_core::IUnknown);
 impl ID3D11TracingDevice {
@@ -13450,6 +13390,8 @@ pub struct ID3D11TracingDevice_Vtbl {
     pub SetShaderTrackingOptionsByType: unsafe extern "system" fn(*mut core::ffi::c_void, u32, u32) -> windows_core::HRESULT,
     pub SetShaderTrackingOptions: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, u32) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID3D11TracingDevice {}
+unsafe impl Sync for ID3D11TracingDevice {}
 pub trait ID3D11TracingDevice_Impl: windows_core::IUnknownImpl {
     fn SetShaderTrackingOptionsByType(&self, resourcetypeflags: u32, options: u32) -> windows_core::Result<()>;
     fn SetShaderTrackingOptions(&self, pshader: windows_core::Ref<windows_core::IUnknown>, options: u32) -> windows_core::Result<()>;
@@ -13479,8 +13421,6 @@ impl ID3D11TracingDevice_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D11TracingDevice {}
-unsafe impl Send for ID3D11TracingDevice {}
-unsafe impl Sync for ID3D11TracingDevice {}
 windows_core::imp::define_interface!(ID3D11UnorderedAccessView, ID3D11UnorderedAccessView_Vtbl, 0x28acf509_7f5c_48f6_8611_f316010a6380);
 impl core::ops::Deref for ID3D11UnorderedAccessView {
     type Target = ID3D11View;
@@ -13503,6 +13443,8 @@ pub struct ID3D11UnorderedAccessView_Vtbl {
     #[cfg(not(feature = "Win32_Graphics_Dxgi_Common"))]
     GetDesc: usize,
 }
+unsafe impl Send for ID3D11UnorderedAccessView {}
+unsafe impl Sync for ID3D11UnorderedAccessView {}
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 pub trait ID3D11UnorderedAccessView_Impl: ID3D11View_Impl {
     fn GetDesc(&self, pdesc: *mut D3D11_UNORDERED_ACCESS_VIEW_DESC);
@@ -13524,10 +13466,6 @@ impl ID3D11UnorderedAccessView_Vtbl {
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl windows_core::RuntimeName for ID3D11UnorderedAccessView {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-unsafe impl Send for ID3D11UnorderedAccessView {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-unsafe impl Sync for ID3D11UnorderedAccessView {}
 windows_core::imp::define_interface!(ID3D11UnorderedAccessView1, ID3D11UnorderedAccessView1_Vtbl, 0x7b3b6153_a886_4544_ab37_6537c8500403);
 impl core::ops::Deref for ID3D11UnorderedAccessView1 {
     type Target = ID3D11UnorderedAccessView;
@@ -13550,6 +13488,8 @@ pub struct ID3D11UnorderedAccessView1_Vtbl {
     #[cfg(not(feature = "Win32_Graphics_Dxgi_Common"))]
     GetDesc1: usize,
 }
+unsafe impl Send for ID3D11UnorderedAccessView1 {}
+unsafe impl Sync for ID3D11UnorderedAccessView1 {}
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 pub trait ID3D11UnorderedAccessView1_Impl: ID3D11UnorderedAccessView_Impl {
     fn GetDesc1(&self, pdesc1: *mut D3D11_UNORDERED_ACCESS_VIEW_DESC1);
@@ -13571,10 +13511,6 @@ impl ID3D11UnorderedAccessView1_Vtbl {
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl windows_core::RuntimeName for ID3D11UnorderedAccessView1 {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-unsafe impl Send for ID3D11UnorderedAccessView1 {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-unsafe impl Sync for ID3D11UnorderedAccessView1 {}
 windows_core::imp::define_interface!(ID3D11VertexShader, ID3D11VertexShader_Vtbl, 0x3b301d64_d678_4289_8897_22f8928b72f3);
 impl core::ops::Deref for ID3D11VertexShader {
     type Target = ID3D11DeviceChild;
@@ -13587,6 +13523,8 @@ windows_core::imp::interface_hierarchy!(ID3D11VertexShader, windows_core::IUnkno
 pub struct ID3D11VertexShader_Vtbl {
     pub base__: ID3D11DeviceChild_Vtbl,
 }
+unsafe impl Send for ID3D11VertexShader {}
+unsafe impl Sync for ID3D11VertexShader {}
 pub trait ID3D11VertexShader_Impl: ID3D11DeviceChild_Impl {}
 impl ID3D11VertexShader_Vtbl {
     pub const fn new<Identity: ID3D11VertexShader_Impl, const OFFSET: isize>() -> Self {
@@ -13597,8 +13535,6 @@ impl ID3D11VertexShader_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D11VertexShader {}
-unsafe impl Send for ID3D11VertexShader {}
-unsafe impl Sync for ID3D11VertexShader {}
 windows_core::imp::define_interface!(ID3D11VideoContext, ID3D11VideoContext_Vtbl, 0x61f21c45_3c0e_4a74_9cea_67100d9ad5e4);
 impl core::ops::Deref for ID3D11VideoContext {
     type Target = ID3D11DeviceChild;
@@ -14061,6 +13997,8 @@ pub struct ID3D11VideoContext_Vtbl {
     pub VideoProcessorSetStreamRotation: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, u32, super::super::Foundation::BOOL, D3D11_VIDEO_PROCESSOR_ROTATION),
     pub VideoProcessorGetStreamRotation: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, u32, *mut super::super::Foundation::BOOL, *mut D3D11_VIDEO_PROCESSOR_ROTATION),
 }
+unsafe impl Send for ID3D11VideoContext {}
+unsafe impl Sync for ID3D11VideoContext {}
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 pub trait ID3D11VideoContext_Impl: ID3D11DeviceChild_Impl {
     fn GetDecoderBuffer(&self, pdecoder: windows_core::Ref<ID3D11VideoDecoder>, r#type: D3D11_VIDEO_DECODER_BUFFER_TYPE, pbuffersize: *mut u32, ppbuffer: *mut *mut core::ffi::c_void) -> windows_core::Result<()>;
@@ -14541,10 +14479,6 @@ impl ID3D11VideoContext_Vtbl {
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl windows_core::RuntimeName for ID3D11VideoContext {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-unsafe impl Send for ID3D11VideoContext {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-unsafe impl Sync for ID3D11VideoContext {}
 windows_core::imp::define_interface!(ID3D11VideoContext1, ID3D11VideoContext1_Vtbl, 0xa7f026da_a5f8_4487_a564_15e34357651e);
 impl core::ops::Deref for ID3D11VideoContext1 {
     type Target = ID3D11VideoContext;
@@ -14706,6 +14640,8 @@ pub struct ID3D11VideoContext1_Vtbl {
     #[cfg(not(feature = "Win32_Graphics_Dxgi_Common"))]
     VideoProcessorGetBehaviorHints: usize,
 }
+unsafe impl Send for ID3D11VideoContext1 {}
+unsafe impl Sync for ID3D11VideoContext1 {}
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 pub trait ID3D11VideoContext1_Impl: ID3D11VideoContext_Impl {
     fn SubmitDecoderBuffers1(&self, pdecoder: windows_core::Ref<ID3D11VideoDecoder>, numbuffers: u32, pbufferdesc: *const D3D11_VIDEO_DECODER_BUFFER_DESC1) -> windows_core::Result<()>;
@@ -14852,10 +14788,6 @@ impl ID3D11VideoContext1_Vtbl {
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl windows_core::RuntimeName for ID3D11VideoContext1 {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-unsafe impl Send for ID3D11VideoContext1 {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-unsafe impl Sync for ID3D11VideoContext1 {}
 windows_core::imp::define_interface!(ID3D11VideoContext2, ID3D11VideoContext2_Vtbl, 0xc4e7374c_6243_4d1b_ae87_52b4f740e261);
 impl core::ops::Deref for ID3D11VideoContext2 {
     type Target = ID3D11VideoContext1;
@@ -14914,6 +14846,8 @@ pub struct ID3D11VideoContext2_Vtbl {
     #[cfg(not(feature = "Win32_Graphics_Dxgi"))]
     VideoProcessorGetStreamHDRMetaData: usize,
 }
+unsafe impl Send for ID3D11VideoContext2 {}
+unsafe impl Sync for ID3D11VideoContext2 {}
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 pub trait ID3D11VideoContext2_Impl: ID3D11VideoContext1_Impl {
     fn VideoProcessorSetOutputHDRMetaData(&self, pvideoprocessor: windows_core::Ref<ID3D11VideoProcessor>, r#type: super::Dxgi::DXGI_HDR_METADATA_TYPE, size: u32, phdrmetadata: *const core::ffi::c_void);
@@ -14962,10 +14896,6 @@ impl ID3D11VideoContext2_Vtbl {
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl windows_core::RuntimeName for ID3D11VideoContext2 {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-unsafe impl Send for ID3D11VideoContext2 {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-unsafe impl Sync for ID3D11VideoContext2 {}
 windows_core::imp::define_interface!(ID3D11VideoContext3, ID3D11VideoContext3_Vtbl, 0xa9e2faa0_cb39_418f_a0b7_d8aad4de672e);
 impl core::ops::Deref for ID3D11VideoContext3 {
     type Target = ID3D11VideoContext2;
@@ -14995,6 +14925,8 @@ pub struct ID3D11VideoContext3_Vtbl {
     pub DecoderBeginFrame1: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut core::ffi::c_void, u32, *const core::ffi::c_void, u32, *const u32, *const *mut core::ffi::c_void) -> windows_core::HRESULT,
     pub SubmitDecoderBuffers2: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, u32, *const D3D11_VIDEO_DECODER_BUFFER_DESC2) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID3D11VideoContext3 {}
+unsafe impl Sync for ID3D11VideoContext3 {}
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 pub trait ID3D11VideoContext3_Impl: ID3D11VideoContext2_Impl {
     fn DecoderBeginFrame1(&self, pdecoder: windows_core::Ref<ID3D11VideoDecoder>, pview: windows_core::Ref<ID3D11VideoDecoderOutputView>, contentkeysize: u32, pcontentkey: *const core::ffi::c_void, numcomponenthistograms: u32, phistogramoffsets: *const u32, pphistogrambuffers: *const Option<ID3D11Buffer>) -> windows_core::Result<()>;
@@ -15027,10 +14959,6 @@ impl ID3D11VideoContext3_Vtbl {
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl windows_core::RuntimeName for ID3D11VideoContext3 {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-unsafe impl Send for ID3D11VideoContext3 {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-unsafe impl Sync for ID3D11VideoContext3 {}
 windows_core::imp::define_interface!(ID3D11VideoDecoder, ID3D11VideoDecoder_Vtbl, 0x3c9c5b51_995d_48d1_9b8d_fa5caeded65c);
 impl core::ops::Deref for ID3D11VideoDecoder {
     type Target = ID3D11DeviceChild;
@@ -15060,6 +14988,8 @@ pub struct ID3D11VideoDecoder_Vtbl {
     GetCreationParameters: usize,
     pub GetDriverHandle: unsafe extern "system" fn(*mut core::ffi::c_void, *mut super::super::Foundation::HANDLE) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID3D11VideoDecoder {}
+unsafe impl Sync for ID3D11VideoDecoder {}
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 pub trait ID3D11VideoDecoder_Impl: ID3D11DeviceChild_Impl {
     fn GetCreationParameters(&self, pvideodesc: *mut D3D11_VIDEO_DECODER_DESC, pconfig: *mut D3D11_VIDEO_DECODER_CONFIG) -> windows_core::Result<()>;
@@ -15098,10 +15028,6 @@ impl ID3D11VideoDecoder_Vtbl {
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl windows_core::RuntimeName for ID3D11VideoDecoder {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-unsafe impl Send for ID3D11VideoDecoder {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-unsafe impl Sync for ID3D11VideoDecoder {}
 windows_core::imp::define_interface!(ID3D11VideoDecoderOutputView, ID3D11VideoDecoderOutputView_Vtbl, 0xc2931aea_2a85_4f20_860f_fba1fd256e18);
 impl core::ops::Deref for ID3D11VideoDecoderOutputView {
     type Target = ID3D11View;
@@ -15120,6 +15046,8 @@ pub struct ID3D11VideoDecoderOutputView_Vtbl {
     pub base__: ID3D11View_Vtbl,
     pub GetDesc: unsafe extern "system" fn(*mut core::ffi::c_void, *mut D3D11_VIDEO_DECODER_OUTPUT_VIEW_DESC),
 }
+unsafe impl Send for ID3D11VideoDecoderOutputView {}
+unsafe impl Sync for ID3D11VideoDecoderOutputView {}
 pub trait ID3D11VideoDecoderOutputView_Impl: ID3D11View_Impl {
     fn GetDesc(&self, pdesc: *mut D3D11_VIDEO_DECODER_OUTPUT_VIEW_DESC);
 }
@@ -15138,8 +15066,6 @@ impl ID3D11VideoDecoderOutputView_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D11VideoDecoderOutputView {}
-unsafe impl Send for ID3D11VideoDecoderOutputView {}
-unsafe impl Sync for ID3D11VideoDecoderOutputView {}
 windows_core::imp::define_interface!(ID3D11VideoDevice, ID3D11VideoDevice_Vtbl, 0x10ec4d5b_975a_4689_b9e4_d0aac30fe333);
 windows_core::imp::interface_hierarchy!(ID3D11VideoDevice, windows_core::IUnknown);
 impl ID3D11VideoDevice {
@@ -15280,6 +15206,8 @@ pub struct ID3D11VideoDevice_Vtbl {
     pub SetPrivateData: unsafe extern "system" fn(*mut core::ffi::c_void, *const windows_core::GUID, u32, *const core::ffi::c_void) -> windows_core::HRESULT,
     pub SetPrivateDataInterface: unsafe extern "system" fn(*mut core::ffi::c_void, *const windows_core::GUID, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID3D11VideoDevice {}
+unsafe impl Sync for ID3D11VideoDevice {}
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 pub trait ID3D11VideoDevice_Impl: windows_core::IUnknownImpl {
     fn CreateVideoDecoder(&self, pvideodesc: *const D3D11_VIDEO_DECODER_DESC, pconfig: *const D3D11_VIDEO_DECODER_CONFIG) -> windows_core::Result<ID3D11VideoDecoder>;
@@ -15486,10 +15414,6 @@ impl ID3D11VideoDevice_Vtbl {
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl windows_core::RuntimeName for ID3D11VideoDevice {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-unsafe impl Send for ID3D11VideoDevice {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-unsafe impl Sync for ID3D11VideoDevice {}
 windows_core::imp::define_interface!(ID3D11VideoDevice1, ID3D11VideoDevice1_Vtbl, 0x29da1d51_1321_4454_804b_f5fc9f861f0f);
 impl core::ops::Deref for ID3D11VideoDevice1 {
     type Target = ID3D11VideoDevice;
@@ -15538,6 +15462,8 @@ pub struct ID3D11VideoDevice1_Vtbl {
     #[cfg(not(feature = "Win32_Graphics_Dxgi_Common"))]
     RecommendVideoDecoderDownsampleParameters: usize,
 }
+unsafe impl Send for ID3D11VideoDevice1 {}
+unsafe impl Sync for ID3D11VideoDevice1 {}
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 pub trait ID3D11VideoDevice1_Impl: ID3D11VideoDevice_Impl {
     fn GetCryptoSessionPrivateDataSize(&self, pcryptotype: *const windows_core::GUID, pdecoderprofile: *const windows_core::GUID, pkeyexchangetype: *const windows_core::GUID, pprivateinputsize: *mut u32, pprivateoutputsize: *mut u32) -> windows_core::Result<()>;
@@ -15598,10 +15524,6 @@ impl ID3D11VideoDevice1_Vtbl {
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl windows_core::RuntimeName for ID3D11VideoDevice1 {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-unsafe impl Send for ID3D11VideoDevice1 {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-unsafe impl Sync for ID3D11VideoDevice1 {}
 windows_core::imp::define_interface!(ID3D11VideoDevice2, ID3D11VideoDevice2_Vtbl, 0x59c0cb01_35f0_4a70_8f67_87905c906a53);
 impl core::ops::Deref for ID3D11VideoDevice2 {
     type Target = ID3D11VideoDevice1;
@@ -15627,6 +15549,8 @@ pub struct ID3D11VideoDevice2_Vtbl {
     pub CheckFeatureSupport: unsafe extern "system" fn(*mut core::ffi::c_void, D3D11_FEATURE_VIDEO, *mut core::ffi::c_void, u32) -> windows_core::HRESULT,
     pub NegotiateCryptoSessionKeyExchangeMT: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, D3D11_CRYPTO_SESSION_KEY_EXCHANGE_FLAGS, u32, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID3D11VideoDevice2 {}
+unsafe impl Sync for ID3D11VideoDevice2 {}
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 pub trait ID3D11VideoDevice2_Impl: ID3D11VideoDevice1_Impl {
     fn CheckFeatureSupport(&self, feature: D3D11_FEATURE_VIDEO, pfeaturesupportdata: *mut core::ffi::c_void, featuresupportdatasize: u32) -> windows_core::Result<()>;
@@ -15659,10 +15583,6 @@ impl ID3D11VideoDevice2_Vtbl {
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl windows_core::RuntimeName for ID3D11VideoDevice2 {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-unsafe impl Send for ID3D11VideoDevice2 {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-unsafe impl Sync for ID3D11VideoDevice2 {}
 windows_core::imp::define_interface!(ID3D11VideoProcessor, ID3D11VideoProcessor_Vtbl, 0x1d7b0652_185f_41c6_85ce_0c5be3d4ae6c);
 impl core::ops::Deref for ID3D11VideoProcessor {
     type Target = ID3D11DeviceChild;
@@ -15689,6 +15609,8 @@ pub struct ID3D11VideoProcessor_Vtbl {
     GetContentDesc: usize,
     pub GetRateConversionCaps: unsafe extern "system" fn(*mut core::ffi::c_void, *mut D3D11_VIDEO_PROCESSOR_RATE_CONVERSION_CAPS),
 }
+unsafe impl Send for ID3D11VideoProcessor {}
+unsafe impl Sync for ID3D11VideoProcessor {}
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 pub trait ID3D11VideoProcessor_Impl: ID3D11DeviceChild_Impl {
     fn GetContentDesc(&self, pdesc: *mut D3D11_VIDEO_PROCESSOR_CONTENT_DESC);
@@ -15721,10 +15643,6 @@ impl ID3D11VideoProcessor_Vtbl {
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl windows_core::RuntimeName for ID3D11VideoProcessor {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-unsafe impl Send for ID3D11VideoProcessor {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-unsafe impl Sync for ID3D11VideoProcessor {}
 windows_core::imp::define_interface!(ID3D11VideoProcessorEnumerator, ID3D11VideoProcessorEnumerator_Vtbl, 0x31627037_53ab_4200_9061_05faa9ab45f9);
 impl core::ops::Deref for ID3D11VideoProcessorEnumerator {
     type Target = ID3D11DeviceChild;
@@ -15781,6 +15699,8 @@ pub struct ID3D11VideoProcessorEnumerator_Vtbl {
     GetVideoProcessorCustomRate: usize,
     pub GetVideoProcessorFilterRange: unsafe extern "system" fn(*mut core::ffi::c_void, D3D11_VIDEO_PROCESSOR_FILTER, *mut D3D11_VIDEO_PROCESSOR_FILTER_RANGE) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID3D11VideoProcessorEnumerator {}
+unsafe impl Sync for ID3D11VideoProcessorEnumerator {}
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 pub trait ID3D11VideoProcessorEnumerator_Impl: ID3D11DeviceChild_Impl {
     fn GetVideoProcessorContentDesc(&self, pcontentdesc: *mut D3D11_VIDEO_PROCESSOR_CONTENT_DESC) -> windows_core::Result<()>;
@@ -15857,10 +15777,6 @@ impl ID3D11VideoProcessorEnumerator_Vtbl {
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl windows_core::RuntimeName for ID3D11VideoProcessorEnumerator {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-unsafe impl Send for ID3D11VideoProcessorEnumerator {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-unsafe impl Sync for ID3D11VideoProcessorEnumerator {}
 windows_core::imp::define_interface!(ID3D11VideoProcessorEnumerator1, ID3D11VideoProcessorEnumerator1_Vtbl, 0x465217f2_5568_43cf_b5b9_f61d54531ca1);
 impl core::ops::Deref for ID3D11VideoProcessorEnumerator1 {
     type Target = ID3D11VideoProcessorEnumerator;
@@ -15886,6 +15802,8 @@ pub struct ID3D11VideoProcessorEnumerator1_Vtbl {
     #[cfg(not(feature = "Win32_Graphics_Dxgi_Common"))]
     CheckVideoProcessorFormatConversion: usize,
 }
+unsafe impl Send for ID3D11VideoProcessorEnumerator1 {}
+unsafe impl Sync for ID3D11VideoProcessorEnumerator1 {}
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 pub trait ID3D11VideoProcessorEnumerator1_Impl: ID3D11VideoProcessorEnumerator_Impl {
     fn CheckVideoProcessorFormatConversion(&self, inputformat: super::Dxgi::Common::DXGI_FORMAT, inputcolorspace: super::Dxgi::Common::DXGI_COLOR_SPACE_TYPE, outputformat: super::Dxgi::Common::DXGI_FORMAT, outputcolorspace: super::Dxgi::Common::DXGI_COLOR_SPACE_TYPE) -> windows_core::Result<super::super::Foundation::BOOL>;
@@ -15916,10 +15834,6 @@ impl ID3D11VideoProcessorEnumerator1_Vtbl {
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl windows_core::RuntimeName for ID3D11VideoProcessorEnumerator1 {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-unsafe impl Send for ID3D11VideoProcessorEnumerator1 {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-unsafe impl Sync for ID3D11VideoProcessorEnumerator1 {}
 windows_core::imp::define_interface!(ID3D11VideoProcessorInputView, ID3D11VideoProcessorInputView_Vtbl, 0x11ec5a5f_51dc_4945_ab34_6e8c21300ea5);
 impl core::ops::Deref for ID3D11VideoProcessorInputView {
     type Target = ID3D11View;
@@ -15942,6 +15856,8 @@ pub struct ID3D11VideoProcessorInputView_Vtbl {
     pub base__: ID3D11View_Vtbl,
     pub GetDesc: unsafe extern "system" fn(*mut core::ffi::c_void, *mut D3D11_VIDEO_PROCESSOR_INPUT_VIEW_DESC),
 }
+unsafe impl Send for ID3D11VideoProcessorInputView {}
+unsafe impl Sync for ID3D11VideoProcessorInputView {}
 pub trait ID3D11VideoProcessorInputView_Impl: ID3D11View_Impl {
     fn GetDesc(&self, pdesc: *mut D3D11_VIDEO_PROCESSOR_INPUT_VIEW_DESC);
 }
@@ -15960,8 +15876,6 @@ impl ID3D11VideoProcessorInputView_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D11VideoProcessorInputView {}
-unsafe impl Send for ID3D11VideoProcessorInputView {}
-unsafe impl Sync for ID3D11VideoProcessorInputView {}
 windows_core::imp::define_interface!(ID3D11VideoProcessorOutputView, ID3D11VideoProcessorOutputView_Vtbl, 0xa048285e_25a9_4527_bd93_d68b68c44254);
 impl core::ops::Deref for ID3D11VideoProcessorOutputView {
     type Target = ID3D11View;
@@ -15984,6 +15898,8 @@ pub struct ID3D11VideoProcessorOutputView_Vtbl {
     pub base__: ID3D11View_Vtbl,
     pub GetDesc: unsafe extern "system" fn(*mut core::ffi::c_void, *mut D3D11_VIDEO_PROCESSOR_OUTPUT_VIEW_DESC),
 }
+unsafe impl Send for ID3D11VideoProcessorOutputView {}
+unsafe impl Sync for ID3D11VideoProcessorOutputView {}
 pub trait ID3D11VideoProcessorOutputView_Impl: ID3D11View_Impl {
     fn GetDesc(&self, pdesc: *mut D3D11_VIDEO_PROCESSOR_OUTPUT_VIEW_DESC);
 }
@@ -16002,8 +15918,6 @@ impl ID3D11VideoProcessorOutputView_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D11VideoProcessorOutputView {}
-unsafe impl Send for ID3D11VideoProcessorOutputView {}
-unsafe impl Sync for ID3D11VideoProcessorOutputView {}
 windows_core::imp::define_interface!(ID3D11View, ID3D11View_Vtbl, 0x839d1216_bb2e_412b_b7f4_a9dbebe08ed1);
 impl core::ops::Deref for ID3D11View {
     type Target = ID3D11DeviceChild;
@@ -16026,6 +15940,8 @@ pub struct ID3D11View_Vtbl {
     pub base__: ID3D11DeviceChild_Vtbl,
     pub GetResource: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void),
 }
+unsafe impl Send for ID3D11View {}
+unsafe impl Sync for ID3D11View {}
 pub trait ID3D11View_Impl: ID3D11DeviceChild_Impl {
     fn GetResource(&self, ppresource: windows_core::OutRef<'_, ID3D11Resource>);
 }
@@ -16044,8 +15960,6 @@ impl ID3D11View_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D11View {}
-unsafe impl Send for ID3D11View {}
-unsafe impl Sync for ID3D11View {}
 windows_core::imp::define_interface!(ID3DDeviceContextState, ID3DDeviceContextState_Vtbl, 0x5c1e0d8a_7c23_48f9_8c59_a92958ceff11);
 impl core::ops::Deref for ID3DDeviceContextState {
     type Target = ID3D11DeviceChild;
@@ -16058,6 +15972,8 @@ windows_core::imp::interface_hierarchy!(ID3DDeviceContextState, windows_core::IU
 pub struct ID3DDeviceContextState_Vtbl {
     pub base__: ID3D11DeviceChild_Vtbl,
 }
+unsafe impl Send for ID3DDeviceContextState {}
+unsafe impl Sync for ID3DDeviceContextState {}
 pub trait ID3DDeviceContextState_Impl: ID3D11DeviceChild_Impl {}
 impl ID3DDeviceContextState_Vtbl {
     pub const fn new<Identity: ID3DDeviceContextState_Impl, const OFFSET: isize>() -> Self {
@@ -16068,8 +15984,6 @@ impl ID3DDeviceContextState_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3DDeviceContextState {}
-unsafe impl Send for ID3DDeviceContextState {}
-unsafe impl Sync for ID3DDeviceContextState {}
 windows_core::imp::define_interface!(ID3DUserDefinedAnnotation, ID3DUserDefinedAnnotation_Vtbl, 0xb2daad8b_03d4_4dbf_95eb_32ab4b63d0ab);
 windows_core::imp::interface_hierarchy!(ID3DUserDefinedAnnotation, windows_core::IUnknown);
 impl ID3DUserDefinedAnnotation {
@@ -16100,6 +16014,8 @@ pub struct ID3DUserDefinedAnnotation_Vtbl {
     pub SetMarker: unsafe extern "system" fn(*mut core::ffi::c_void, windows_core::PCWSTR),
     pub GetStatus: unsafe extern "system" fn(*mut core::ffi::c_void) -> super::super::Foundation::BOOL,
 }
+unsafe impl Send for ID3DUserDefinedAnnotation {}
+unsafe impl Sync for ID3DUserDefinedAnnotation {}
 pub trait ID3DUserDefinedAnnotation_Impl: windows_core::IUnknownImpl {
     fn BeginEvent(&self, name: &windows_core::PCWSTR) -> i32;
     fn EndEvent(&self) -> i32;
@@ -16145,8 +16061,6 @@ impl ID3DUserDefinedAnnotation_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3DUserDefinedAnnotation {}
-unsafe impl Send for ID3DUserDefinedAnnotation {}
-unsafe impl Sync for ID3DUserDefinedAnnotation {}
 windows_core::imp::define_interface!(ID3DX11FFT, ID3DX11FFT_Vtbl, 0xb3f7a938_4c93_4310_a675_b30d6de50553);
 windows_core::imp::interface_hierarchy!(ID3DX11FFT, windows_core::IUnknown);
 impl ID3DX11FFT {
@@ -16189,6 +16103,8 @@ pub struct ID3DX11FFT_Vtbl {
     pub ForwardTransform: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
     pub InverseTransform: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID3DX11FFT {}
+unsafe impl Sync for ID3DX11FFT {}
 pub trait ID3DX11FFT_Impl: windows_core::IUnknownImpl {
     fn SetForwardScale(&self, forwardscale: f32) -> windows_core::Result<()>;
     fn GetForwardScale(&self) -> f32;
@@ -16258,8 +16174,6 @@ impl ID3DX11FFT_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3DX11FFT {}
-unsafe impl Send for ID3DX11FFT {}
-unsafe impl Sync for ID3DX11FFT {}
 windows_core::imp::define_interface!(ID3DX11Scan, ID3DX11Scan_Vtbl, 0x5089b68f_e71d_4d38_be8e_f363b95a9405);
 windows_core::imp::interface_hierarchy!(ID3DX11Scan, windows_core::IUnknown);
 impl ID3DX11Scan {
@@ -16288,6 +16202,8 @@ pub struct ID3DX11Scan_Vtbl {
     pub Scan: unsafe extern "system" fn(*mut core::ffi::c_void, D3DX11_SCAN_DATA_TYPE, D3DX11_SCAN_OPCODE, u32, *mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
     pub Multiscan: unsafe extern "system" fn(*mut core::ffi::c_void, D3DX11_SCAN_DATA_TYPE, D3DX11_SCAN_OPCODE, u32, u32, u32, *mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID3DX11Scan {}
+unsafe impl Sync for ID3DX11Scan {}
 pub trait ID3DX11Scan_Impl: windows_core::IUnknownImpl {
     fn SetScanDirection(&self, direction: D3DX11_SCAN_DIRECTION) -> windows_core::Result<()>;
     fn Scan(&self, elementtype: D3DX11_SCAN_DATA_TYPE, opcode: D3DX11_SCAN_OPCODE, elementscansize: u32, psrc: windows_core::Ref<ID3D11UnorderedAccessView>, pdst: windows_core::Ref<ID3D11UnorderedAccessView>) -> windows_core::Result<()>;
@@ -16325,8 +16241,6 @@ impl ID3DX11Scan_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3DX11Scan {}
-unsafe impl Send for ID3DX11Scan {}
-unsafe impl Sync for ID3DX11Scan {}
 windows_core::imp::define_interface!(ID3DX11SegmentedScan, ID3DX11SegmentedScan_Vtbl, 0xa915128c_d954_4c79_bfe1_64db923194d6);
 windows_core::imp::interface_hierarchy!(ID3DX11SegmentedScan, windows_core::IUnknown);
 impl ID3DX11SegmentedScan {
@@ -16348,6 +16262,8 @@ pub struct ID3DX11SegmentedScan_Vtbl {
     pub SetScanDirection: unsafe extern "system" fn(*mut core::ffi::c_void, D3DX11_SCAN_DIRECTION) -> windows_core::HRESULT,
     pub SegScan: unsafe extern "system" fn(*mut core::ffi::c_void, D3DX11_SCAN_DATA_TYPE, D3DX11_SCAN_OPCODE, u32, *mut core::ffi::c_void, *mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID3DX11SegmentedScan {}
+unsafe impl Sync for ID3DX11SegmentedScan {}
 pub trait ID3DX11SegmentedScan_Impl: windows_core::IUnknownImpl {
     fn SetScanDirection(&self, direction: D3DX11_SCAN_DIRECTION) -> windows_core::Result<()>;
     fn SegScan(&self, elementtype: D3DX11_SCAN_DATA_TYPE, opcode: D3DX11_SCAN_OPCODE, elementscansize: u32, psrc: windows_core::Ref<ID3D11UnorderedAccessView>, psrcelementflags: windows_core::Ref<ID3D11UnorderedAccessView>, pdst: windows_core::Ref<ID3D11UnorderedAccessView>) -> windows_core::Result<()>;
@@ -16377,8 +16293,6 @@ impl ID3DX11SegmentedScan_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3DX11SegmentedScan {}
-unsafe impl Send for ID3DX11SegmentedScan {}
-unsafe impl Sync for ID3DX11SegmentedScan {}
 #[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi"))]
 pub type PFN_D3D11_CREATE_DEVICE = Option<unsafe extern "system" fn(param0: Option<super::Dxgi::IDXGIAdapter>, param1: super::Direct3D::D3D_DRIVER_TYPE, param2: super::super::Foundation::HMODULE, param3: u32, param4: *const super::Direct3D::D3D_FEATURE_LEVEL, featurelevels: u32, param6: u32, param7: *mut Option<ID3D11Device>, param8: *mut super::Direct3D::D3D_FEATURE_LEVEL, param9: *mut Option<ID3D11DeviceContext>) -> windows_core::HRESULT>;
 #[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D11on12/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D11on12/mod.rs
@@ -70,6 +70,8 @@ pub struct ID3D11On12Device_Vtbl {
     #[cfg(not(feature = "Win32_Graphics_Direct3D11"))]
     AcquireWrappedResources: usize,
 }
+unsafe impl Send for ID3D11On12Device {}
+unsafe impl Sync for ID3D11On12Device {}
 #[cfg(all(feature = "Win32_Graphics_Direct3D11", feature = "Win32_Graphics_Direct3D12"))]
 pub trait ID3D11On12Device_Impl: windows_core::IUnknownImpl {
     fn CreateWrappedResource(&self, presource12: windows_core::Ref<windows_core::IUnknown>, pflags11: *const D3D11_RESOURCE_FLAGS, instate: super::Direct3D12::D3D12_RESOURCE_STATES, outstate: super::Direct3D12::D3D12_RESOURCE_STATES, riid: *const windows_core::GUID, ppresource11: *mut *mut core::ffi::c_void) -> windows_core::Result<()>;
@@ -110,10 +112,6 @@ impl ID3D11On12Device_Vtbl {
 }
 #[cfg(all(feature = "Win32_Graphics_Direct3D11", feature = "Win32_Graphics_Direct3D12"))]
 impl windows_core::RuntimeName for ID3D11On12Device {}
-#[cfg(all(feature = "Win32_Graphics_Direct3D11", feature = "Win32_Graphics_Direct3D12"))]
-unsafe impl Send for ID3D11On12Device {}
-#[cfg(all(feature = "Win32_Graphics_Direct3D11", feature = "Win32_Graphics_Direct3D12"))]
-unsafe impl Sync for ID3D11On12Device {}
 windows_core::imp::define_interface!(ID3D11On12Device1, ID3D11On12Device1_Vtbl, 0xbdb64df4_ea2f_4c70_b861_aaab1258bb5d);
 impl core::ops::Deref for ID3D11On12Device1 {
     type Target = ID3D11On12Device;
@@ -136,6 +134,8 @@ pub struct ID3D11On12Device1_Vtbl {
     pub base__: ID3D11On12Device_Vtbl,
     pub GetD3D12Device: unsafe extern "system" fn(*mut core::ffi::c_void, *const windows_core::GUID, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID3D11On12Device1 {}
+unsafe impl Sync for ID3D11On12Device1 {}
 #[cfg(all(feature = "Win32_Graphics_Direct3D11", feature = "Win32_Graphics_Direct3D12"))]
 pub trait ID3D11On12Device1_Impl: ID3D11On12Device_Impl {
     fn GetD3D12Device(&self, riid: *const windows_core::GUID, ppvdevice: *mut *mut core::ffi::c_void) -> windows_core::Result<()>;
@@ -157,10 +157,6 @@ impl ID3D11On12Device1_Vtbl {
 }
 #[cfg(all(feature = "Win32_Graphics_Direct3D11", feature = "Win32_Graphics_Direct3D12"))]
 impl windows_core::RuntimeName for ID3D11On12Device1 {}
-#[cfg(all(feature = "Win32_Graphics_Direct3D11", feature = "Win32_Graphics_Direct3D12"))]
-unsafe impl Send for ID3D11On12Device1 {}
-#[cfg(all(feature = "Win32_Graphics_Direct3D11", feature = "Win32_Graphics_Direct3D12"))]
-unsafe impl Sync for ID3D11On12Device1 {}
 windows_core::imp::define_interface!(ID3D11On12Device2, ID3D11On12Device2_Vtbl, 0xdc90f331_4740_43fa_866e_67f12cb58223);
 impl core::ops::Deref for ID3D11On12Device2 {
     type Target = ID3D11On12Device1;
@@ -200,6 +196,8 @@ pub struct ID3D11On12Device2_Vtbl {
     #[cfg(not(all(feature = "Win32_Graphics_Direct3D11", feature = "Win32_Graphics_Direct3D12")))]
     ReturnUnderlyingResource: usize,
 }
+unsafe impl Send for ID3D11On12Device2 {}
+unsafe impl Sync for ID3D11On12Device2 {}
 #[cfg(all(feature = "Win32_Graphics_Direct3D11", feature = "Win32_Graphics_Direct3D12"))]
 pub trait ID3D11On12Device2_Impl: ID3D11On12Device1_Impl {
     fn UnwrapUnderlyingResource(&self, presource11: windows_core::Ref<super::Direct3D11::ID3D11Resource>, pcommandqueue: windows_core::Ref<super::Direct3D12::ID3D12CommandQueue>, riid: *const windows_core::GUID, ppvresource12: *mut *mut core::ffi::c_void) -> windows_core::Result<()>;
@@ -232,9 +230,5 @@ impl ID3D11On12Device2_Vtbl {
 }
 #[cfg(all(feature = "Win32_Graphics_Direct3D11", feature = "Win32_Graphics_Direct3D12"))]
 impl windows_core::RuntimeName for ID3D11On12Device2 {}
-#[cfg(all(feature = "Win32_Graphics_Direct3D11", feature = "Win32_Graphics_Direct3D12"))]
-unsafe impl Send for ID3D11On12Device2 {}
-#[cfg(all(feature = "Win32_Graphics_Direct3D11", feature = "Win32_Graphics_Direct3D12"))]
-unsafe impl Sync for ID3D11On12Device2 {}
 #[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Direct3D11"))]
 pub type PFN_D3D11ON12_CREATE_DEVICE = Option<unsafe extern "system" fn(param0: Option<windows_core::IUnknown>, param1: u32, param2: *const super::Direct3D::D3D_FEATURE_LEVEL, featurelevels: u32, param4: *const Option<windows_core::IUnknown>, numqueues: u32, param6: u32, param7: *mut Option<super::Direct3D11::ID3D11Device>, param8: *mut Option<super::Direct3D11::ID3D11DeviceContext>, param9: *mut super::Direct3D::D3D_FEATURE_LEVEL) -> windows_core::HRESULT>;

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D12/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D12/mod.rs
@@ -9189,6 +9189,8 @@ pub struct ID3D12CommandAllocator_Vtbl {
     pub base__: ID3D12Pageable_Vtbl,
     pub Reset: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID3D12CommandAllocator {}
+unsafe impl Sync for ID3D12CommandAllocator {}
 pub trait ID3D12CommandAllocator_Impl: ID3D12Pageable_Impl {
     fn Reset(&self) -> windows_core::Result<()>;
 }
@@ -9207,8 +9209,6 @@ impl ID3D12CommandAllocator_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D12CommandAllocator {}
-unsafe impl Send for ID3D12CommandAllocator {}
-unsafe impl Sync for ID3D12CommandAllocator {}
 windows_core::imp::define_interface!(ID3D12CommandList, ID3D12CommandList_Vtbl, 0x7116d91c_e7e4_47ce_b8c6_ec8168f437e5);
 impl core::ops::Deref for ID3D12CommandList {
     type Target = ID3D12DeviceChild;
@@ -9227,6 +9227,8 @@ pub struct ID3D12CommandList_Vtbl {
     pub base__: ID3D12DeviceChild_Vtbl,
     pub GetType: unsafe extern "system" fn(*mut core::ffi::c_void) -> D3D12_COMMAND_LIST_TYPE,
 }
+unsafe impl Send for ID3D12CommandList {}
+unsafe impl Sync for ID3D12CommandList {}
 pub trait ID3D12CommandList_Impl: ID3D12DeviceChild_Impl {
     fn GetType(&self) -> D3D12_COMMAND_LIST_TYPE;
 }
@@ -9245,8 +9247,6 @@ impl ID3D12CommandList_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D12CommandList {}
-unsafe impl Send for ID3D12CommandList {}
-unsafe impl Sync for ID3D12CommandList {}
 windows_core::imp::define_interface!(ID3D12CommandQueue, ID3D12CommandQueue_Vtbl, 0x0ec870a6_5d7e_4c22_8cfc_5baae07616ed);
 impl core::ops::Deref for ID3D12CommandQueue {
     type Target = ID3D12Pageable;
@@ -9326,6 +9326,8 @@ pub struct ID3D12CommandQueue_Vtbl {
     pub GetClockCalibration: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u64, *mut u64) -> windows_core::HRESULT,
     pub GetDesc: unsafe extern "system" fn(*mut core::ffi::c_void, *mut D3D12_COMMAND_QUEUE_DESC),
 }
+unsafe impl Send for ID3D12CommandQueue {}
+unsafe impl Sync for ID3D12CommandQueue {}
 pub trait ID3D12CommandQueue_Impl: ID3D12Pageable_Impl {
     fn UpdateTileMappings(&self, presource: windows_core::Ref<ID3D12Resource>, numresourceregions: u32, presourceregionstartcoordinates: *const D3D12_TILED_RESOURCE_COORDINATE, presourceregionsizes: *const D3D12_TILE_REGION_SIZE, pheap: windows_core::Ref<ID3D12Heap>, numranges: u32, prangeflags: *const D3D12_TILE_RANGE_FLAGS, pheaprangestartoffsets: *const u32, prangetilecounts: *const u32, flags: D3D12_TILE_MAPPING_FLAGS);
     fn CopyTileMappings(&self, pdstresource: windows_core::Ref<ID3D12Resource>, pdstregionstartcoordinate: *const D3D12_TILED_RESOURCE_COORDINATE, psrcresource: windows_core::Ref<ID3D12Resource>, psrcregionstartcoordinate: *const D3D12_TILED_RESOURCE_COORDINATE, pregionsize: *const D3D12_TILE_REGION_SIZE, flags: D3D12_TILE_MAPPING_FLAGS);
@@ -9433,8 +9435,6 @@ impl ID3D12CommandQueue_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D12CommandQueue {}
-unsafe impl Send for ID3D12CommandQueue {}
-unsafe impl Sync for ID3D12CommandQueue {}
 windows_core::imp::define_interface!(ID3D12CommandSignature, ID3D12CommandSignature_Vtbl, 0xc36a797c_ec80_4f0a_8985_a7b2475082d1);
 impl core::ops::Deref for ID3D12CommandSignature {
     type Target = ID3D12Pageable;
@@ -9447,6 +9447,8 @@ windows_core::imp::interface_hierarchy!(ID3D12CommandSignature, windows_core::IU
 pub struct ID3D12CommandSignature_Vtbl {
     pub base__: ID3D12Pageable_Vtbl,
 }
+unsafe impl Send for ID3D12CommandSignature {}
+unsafe impl Sync for ID3D12CommandSignature {}
 pub trait ID3D12CommandSignature_Impl: ID3D12Pageable_Impl {}
 impl ID3D12CommandSignature_Vtbl {
     pub const fn new<Identity: ID3D12CommandSignature_Impl, const OFFSET: isize>() -> Self {
@@ -9457,8 +9459,6 @@ impl ID3D12CommandSignature_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D12CommandSignature {}
-unsafe impl Send for ID3D12CommandSignature {}
-unsafe impl Sync for ID3D12CommandSignature {}
 windows_core::imp::define_interface!(ID3D12Debug, ID3D12Debug_Vtbl, 0x344488b7_6846_474b_b989_f027448245e0);
 windows_core::imp::interface_hierarchy!(ID3D12Debug, windows_core::IUnknown);
 impl ID3D12Debug {
@@ -9471,6 +9471,8 @@ pub struct ID3D12Debug_Vtbl {
     pub base__: windows_core::IUnknown_Vtbl,
     pub EnableDebugLayer: unsafe extern "system" fn(*mut core::ffi::c_void),
 }
+unsafe impl Send for ID3D12Debug {}
+unsafe impl Sync for ID3D12Debug {}
 pub trait ID3D12Debug_Impl: windows_core::IUnknownImpl {
     fn EnableDebugLayer(&self);
 }
@@ -9489,8 +9491,6 @@ impl ID3D12Debug_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D12Debug {}
-unsafe impl Send for ID3D12Debug {}
-unsafe impl Sync for ID3D12Debug {}
 windows_core::imp::define_interface!(ID3D12Debug1, ID3D12Debug1_Vtbl, 0xaffaa4ca_63fe_4d8e_b8ad_159000af4304);
 windows_core::imp::interface_hierarchy!(ID3D12Debug1, windows_core::IUnknown);
 impl ID3D12Debug1 {
@@ -9511,6 +9511,8 @@ pub struct ID3D12Debug1_Vtbl {
     pub SetEnableGPUBasedValidation: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::BOOL),
     pub SetEnableSynchronizedCommandQueueValidation: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::BOOL),
 }
+unsafe impl Send for ID3D12Debug1 {}
+unsafe impl Sync for ID3D12Debug1 {}
 pub trait ID3D12Debug1_Impl: windows_core::IUnknownImpl {
     fn EnableDebugLayer(&self);
     fn SetEnableGPUBasedValidation(&self, enable: super::super::Foundation::BOOL);
@@ -9548,8 +9550,6 @@ impl ID3D12Debug1_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D12Debug1 {}
-unsafe impl Send for ID3D12Debug1 {}
-unsafe impl Sync for ID3D12Debug1 {}
 windows_core::imp::define_interface!(ID3D12Debug2, ID3D12Debug2_Vtbl, 0x93a665c4_a3b2_4e5d_b692_a26ae14e3374);
 windows_core::imp::interface_hierarchy!(ID3D12Debug2, windows_core::IUnknown);
 impl ID3D12Debug2 {
@@ -9562,6 +9562,8 @@ pub struct ID3D12Debug2_Vtbl {
     pub base__: windows_core::IUnknown_Vtbl,
     pub SetGPUBasedValidationFlags: unsafe extern "system" fn(*mut core::ffi::c_void, D3D12_GPU_BASED_VALIDATION_FLAGS),
 }
+unsafe impl Send for ID3D12Debug2 {}
+unsafe impl Sync for ID3D12Debug2 {}
 pub trait ID3D12Debug2_Impl: windows_core::IUnknownImpl {
     fn SetGPUBasedValidationFlags(&self, flags: D3D12_GPU_BASED_VALIDATION_FLAGS);
 }
@@ -9580,8 +9582,6 @@ impl ID3D12Debug2_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D12Debug2 {}
-unsafe impl Send for ID3D12Debug2 {}
-unsafe impl Sync for ID3D12Debug2 {}
 windows_core::imp::define_interface!(ID3D12Debug3, ID3D12Debug3_Vtbl, 0x5cf4e58f_f671_4ff1_a542_3686e3d153d1);
 impl core::ops::Deref for ID3D12Debug3 {
     type Target = ID3D12Debug;
@@ -9608,6 +9608,8 @@ pub struct ID3D12Debug3_Vtbl {
     pub SetEnableSynchronizedCommandQueueValidation: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::BOOL),
     pub SetGPUBasedValidationFlags: unsafe extern "system" fn(*mut core::ffi::c_void, D3D12_GPU_BASED_VALIDATION_FLAGS),
 }
+unsafe impl Send for ID3D12Debug3 {}
+unsafe impl Sync for ID3D12Debug3 {}
 pub trait ID3D12Debug3_Impl: ID3D12Debug_Impl {
     fn SetEnableGPUBasedValidation(&self, enable: super::super::Foundation::BOOL);
     fn SetEnableSynchronizedCommandQueueValidation(&self, enable: super::super::Foundation::BOOL);
@@ -9645,8 +9647,6 @@ impl ID3D12Debug3_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D12Debug3 {}
-unsafe impl Send for ID3D12Debug3 {}
-unsafe impl Sync for ID3D12Debug3 {}
 windows_core::imp::define_interface!(ID3D12Debug4, ID3D12Debug4_Vtbl, 0x014b816e_9ec5_4a2f_a845_ffbe441ce13a);
 impl core::ops::Deref for ID3D12Debug4 {
     type Target = ID3D12Debug3;
@@ -9665,6 +9665,8 @@ pub struct ID3D12Debug4_Vtbl {
     pub base__: ID3D12Debug3_Vtbl,
     pub DisableDebugLayer: unsafe extern "system" fn(*mut core::ffi::c_void),
 }
+unsafe impl Send for ID3D12Debug4 {}
+unsafe impl Sync for ID3D12Debug4 {}
 pub trait ID3D12Debug4_Impl: ID3D12Debug3_Impl {
     fn DisableDebugLayer(&self);
 }
@@ -9683,8 +9685,6 @@ impl ID3D12Debug4_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D12Debug4 {}
-unsafe impl Send for ID3D12Debug4 {}
-unsafe impl Sync for ID3D12Debug4 {}
 windows_core::imp::define_interface!(ID3D12Debug5, ID3D12Debug5_Vtbl, 0x548d6b12_09fa_40e0_9069_5dcd589a52c9);
 impl core::ops::Deref for ID3D12Debug5 {
     type Target = ID3D12Debug4;
@@ -9703,6 +9703,8 @@ pub struct ID3D12Debug5_Vtbl {
     pub base__: ID3D12Debug4_Vtbl,
     pub SetEnableAutoName: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::BOOL),
 }
+unsafe impl Send for ID3D12Debug5 {}
+unsafe impl Sync for ID3D12Debug5 {}
 pub trait ID3D12Debug5_Impl: ID3D12Debug4_Impl {
     fn SetEnableAutoName(&self, enable: super::super::Foundation::BOOL);
 }
@@ -9721,8 +9723,6 @@ impl ID3D12Debug5_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D12Debug5 {}
-unsafe impl Send for ID3D12Debug5 {}
-unsafe impl Sync for ID3D12Debug5 {}
 windows_core::imp::define_interface!(ID3D12Debug6, ID3D12Debug6_Vtbl, 0x82a816d6_5d01_4157_97d0_4975463fd1ed);
 impl core::ops::Deref for ID3D12Debug6 {
     type Target = ID3D12Debug5;
@@ -9741,6 +9741,8 @@ pub struct ID3D12Debug6_Vtbl {
     pub base__: ID3D12Debug5_Vtbl,
     pub SetForceLegacyBarrierValidation: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::BOOL),
 }
+unsafe impl Send for ID3D12Debug6 {}
+unsafe impl Sync for ID3D12Debug6 {}
 pub trait ID3D12Debug6_Impl: ID3D12Debug5_Impl {
     fn SetForceLegacyBarrierValidation(&self, enable: super::super::Foundation::BOOL);
 }
@@ -9759,8 +9761,6 @@ impl ID3D12Debug6_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D12Debug6 {}
-unsafe impl Send for ID3D12Debug6 {}
-unsafe impl Sync for ID3D12Debug6 {}
 windows_core::imp::define_interface!(ID3D12DebugCommandList, ID3D12DebugCommandList_Vtbl, 0x09e0bf36_54ac_484f_8847_4baeeab6053f);
 windows_core::imp::interface_hierarchy!(ID3D12DebugCommandList, windows_core::IUnknown);
 impl ID3D12DebugCommandList {
@@ -9784,6 +9784,8 @@ pub struct ID3D12DebugCommandList_Vtbl {
     pub SetFeatureMask: unsafe extern "system" fn(*mut core::ffi::c_void, D3D12_DEBUG_FEATURE) -> windows_core::HRESULT,
     pub GetFeatureMask: unsafe extern "system" fn(*mut core::ffi::c_void) -> D3D12_DEBUG_FEATURE,
 }
+unsafe impl Send for ID3D12DebugCommandList {}
+unsafe impl Sync for ID3D12DebugCommandList {}
 pub trait ID3D12DebugCommandList_Impl: windows_core::IUnknownImpl {
     fn AssertResourceState(&self, presource: windows_core::Ref<ID3D12Resource>, subresource: u32, state: u32) -> super::super::Foundation::BOOL;
     fn SetFeatureMask(&self, mask: D3D12_DEBUG_FEATURE) -> windows_core::Result<()>;
@@ -9821,8 +9823,6 @@ impl ID3D12DebugCommandList_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D12DebugCommandList {}
-unsafe impl Send for ID3D12DebugCommandList {}
-unsafe impl Sync for ID3D12DebugCommandList {}
 windows_core::imp::define_interface!(ID3D12DebugCommandList1, ID3D12DebugCommandList1_Vtbl, 0x102ca951_311b_4b01_b11f_ecb83e061b37);
 windows_core::imp::interface_hierarchy!(ID3D12DebugCommandList1, windows_core::IUnknown);
 impl ID3D12DebugCommandList1 {
@@ -9846,6 +9846,8 @@ pub struct ID3D12DebugCommandList1_Vtbl {
     pub SetDebugParameter: unsafe extern "system" fn(*mut core::ffi::c_void, D3D12_DEBUG_COMMAND_LIST_PARAMETER_TYPE, *const core::ffi::c_void, u32) -> windows_core::HRESULT,
     pub GetDebugParameter: unsafe extern "system" fn(*mut core::ffi::c_void, D3D12_DEBUG_COMMAND_LIST_PARAMETER_TYPE, *mut core::ffi::c_void, u32) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID3D12DebugCommandList1 {}
+unsafe impl Sync for ID3D12DebugCommandList1 {}
 pub trait ID3D12DebugCommandList1_Impl: windows_core::IUnknownImpl {
     fn AssertResourceState(&self, presource: windows_core::Ref<ID3D12Resource>, subresource: u32, state: u32) -> super::super::Foundation::BOOL;
     fn SetDebugParameter(&self, r#type: D3D12_DEBUG_COMMAND_LIST_PARAMETER_TYPE, pdata: *const core::ffi::c_void, datasize: u32) -> windows_core::Result<()>;
@@ -9883,8 +9885,6 @@ impl ID3D12DebugCommandList1_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D12DebugCommandList1 {}
-unsafe impl Send for ID3D12DebugCommandList1 {}
-unsafe impl Sync for ID3D12DebugCommandList1 {}
 windows_core::imp::define_interface!(ID3D12DebugCommandList2, ID3D12DebugCommandList2_Vtbl, 0xaeb575cf_4e06_48be_ba3b_c450fc96652e);
 impl core::ops::Deref for ID3D12DebugCommandList2 {
     type Target = ID3D12DebugCommandList;
@@ -9907,6 +9907,8 @@ pub struct ID3D12DebugCommandList2_Vtbl {
     pub SetDebugParameter: unsafe extern "system" fn(*mut core::ffi::c_void, D3D12_DEBUG_COMMAND_LIST_PARAMETER_TYPE, *const core::ffi::c_void, u32) -> windows_core::HRESULT,
     pub GetDebugParameter: unsafe extern "system" fn(*mut core::ffi::c_void, D3D12_DEBUG_COMMAND_LIST_PARAMETER_TYPE, *mut core::ffi::c_void, u32) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID3D12DebugCommandList2 {}
+unsafe impl Sync for ID3D12DebugCommandList2 {}
 pub trait ID3D12DebugCommandList2_Impl: ID3D12DebugCommandList_Impl {
     fn SetDebugParameter(&self, r#type: D3D12_DEBUG_COMMAND_LIST_PARAMETER_TYPE, pdata: *const core::ffi::c_void, datasize: u32) -> windows_core::Result<()>;
     fn GetDebugParameter(&self, r#type: D3D12_DEBUG_COMMAND_LIST_PARAMETER_TYPE, pdata: *mut core::ffi::c_void, datasize: u32) -> windows_core::Result<()>;
@@ -9936,8 +9938,6 @@ impl ID3D12DebugCommandList2_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D12DebugCommandList2 {}
-unsafe impl Send for ID3D12DebugCommandList2 {}
-unsafe impl Sync for ID3D12DebugCommandList2 {}
 windows_core::imp::define_interface!(ID3D12DebugCommandList3, ID3D12DebugCommandList3_Vtbl, 0x197d5e15_4d37_4d34_af78_724cd70fdb1f);
 impl core::ops::Deref for ID3D12DebugCommandList3 {
     type Target = ID3D12DebugCommandList2;
@@ -9966,6 +9966,8 @@ pub struct ID3D12DebugCommandList3_Vtbl {
     pub AssertResourceAccess: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, u32, D3D12_BARRIER_ACCESS),
     pub AssertTextureLayout: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, u32, D3D12_BARRIER_LAYOUT),
 }
+unsafe impl Send for ID3D12DebugCommandList3 {}
+unsafe impl Sync for ID3D12DebugCommandList3 {}
 pub trait ID3D12DebugCommandList3_Impl: ID3D12DebugCommandList2_Impl {
     fn AssertResourceAccess(&self, presource: windows_core::Ref<ID3D12Resource>, subresource: u32, access: D3D12_BARRIER_ACCESS);
     fn AssertTextureLayout(&self, presource: windows_core::Ref<ID3D12Resource>, subresource: u32, layout: D3D12_BARRIER_LAYOUT);
@@ -9995,8 +9997,6 @@ impl ID3D12DebugCommandList3_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D12DebugCommandList3 {}
-unsafe impl Send for ID3D12DebugCommandList3 {}
-unsafe impl Sync for ID3D12DebugCommandList3 {}
 windows_core::imp::define_interface!(ID3D12DebugCommandQueue, ID3D12DebugCommandQueue_Vtbl, 0x09e0bf36_54ac_484f_8847_4baeeab6053a);
 windows_core::imp::interface_hierarchy!(ID3D12DebugCommandQueue, windows_core::IUnknown);
 impl ID3D12DebugCommandQueue {
@@ -10012,6 +10012,8 @@ pub struct ID3D12DebugCommandQueue_Vtbl {
     pub base__: windows_core::IUnknown_Vtbl,
     pub AssertResourceState: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, u32, u32) -> super::super::Foundation::BOOL,
 }
+unsafe impl Send for ID3D12DebugCommandQueue {}
+unsafe impl Sync for ID3D12DebugCommandQueue {}
 pub trait ID3D12DebugCommandQueue_Impl: windows_core::IUnknownImpl {
     fn AssertResourceState(&self, presource: windows_core::Ref<ID3D12Resource>, subresource: u32, state: u32) -> super::super::Foundation::BOOL;
 }
@@ -10030,8 +10032,6 @@ impl ID3D12DebugCommandQueue_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D12DebugCommandQueue {}
-unsafe impl Send for ID3D12DebugCommandQueue {}
-unsafe impl Sync for ID3D12DebugCommandQueue {}
 windows_core::imp::define_interface!(ID3D12DebugCommandQueue1, ID3D12DebugCommandQueue1_Vtbl, 0x16be35a2_bfd6_49f2_bcae_eaae4aff862d);
 impl core::ops::Deref for ID3D12DebugCommandQueue1 {
     type Target = ID3D12DebugCommandQueue;
@@ -10060,6 +10060,8 @@ pub struct ID3D12DebugCommandQueue1_Vtbl {
     pub AssertResourceAccess: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, u32, D3D12_BARRIER_ACCESS),
     pub AssertTextureLayout: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, u32, D3D12_BARRIER_LAYOUT),
 }
+unsafe impl Send for ID3D12DebugCommandQueue1 {}
+unsafe impl Sync for ID3D12DebugCommandQueue1 {}
 pub trait ID3D12DebugCommandQueue1_Impl: ID3D12DebugCommandQueue_Impl {
     fn AssertResourceAccess(&self, presource: windows_core::Ref<ID3D12Resource>, subresource: u32, access: D3D12_BARRIER_ACCESS);
     fn AssertTextureLayout(&self, presource: windows_core::Ref<ID3D12Resource>, subresource: u32, layout: D3D12_BARRIER_LAYOUT);
@@ -10089,8 +10091,6 @@ impl ID3D12DebugCommandQueue1_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D12DebugCommandQueue1 {}
-unsafe impl Send for ID3D12DebugCommandQueue1 {}
-unsafe impl Sync for ID3D12DebugCommandQueue1 {}
 windows_core::imp::define_interface!(ID3D12DebugDevice, ID3D12DebugDevice_Vtbl, 0x3febd6dd_4973_4787_8194_e45f9e28923e);
 windows_core::imp::interface_hierarchy!(ID3D12DebugDevice, windows_core::IUnknown);
 impl ID3D12DebugDevice {
@@ -10111,6 +10111,8 @@ pub struct ID3D12DebugDevice_Vtbl {
     pub GetFeatureMask: unsafe extern "system" fn(*mut core::ffi::c_void) -> D3D12_DEBUG_FEATURE,
     pub ReportLiveDeviceObjects: unsafe extern "system" fn(*mut core::ffi::c_void, D3D12_RLDO_FLAGS) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID3D12DebugDevice {}
+unsafe impl Sync for ID3D12DebugDevice {}
 pub trait ID3D12DebugDevice_Impl: windows_core::IUnknownImpl {
     fn SetFeatureMask(&self, mask: D3D12_DEBUG_FEATURE) -> windows_core::Result<()>;
     fn GetFeatureMask(&self) -> D3D12_DEBUG_FEATURE;
@@ -10148,8 +10150,6 @@ impl ID3D12DebugDevice_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D12DebugDevice {}
-unsafe impl Send for ID3D12DebugDevice {}
-unsafe impl Sync for ID3D12DebugDevice {}
 windows_core::imp::define_interface!(ID3D12DebugDevice1, ID3D12DebugDevice1_Vtbl, 0xa9b71770_d099_4a65_a698_3dee10020f88);
 windows_core::imp::interface_hierarchy!(ID3D12DebugDevice1, windows_core::IUnknown);
 impl ID3D12DebugDevice1 {
@@ -10170,6 +10170,8 @@ pub struct ID3D12DebugDevice1_Vtbl {
     pub GetDebugParameter: unsafe extern "system" fn(*mut core::ffi::c_void, D3D12_DEBUG_DEVICE_PARAMETER_TYPE, *mut core::ffi::c_void, u32) -> windows_core::HRESULT,
     pub ReportLiveDeviceObjects: unsafe extern "system" fn(*mut core::ffi::c_void, D3D12_RLDO_FLAGS) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID3D12DebugDevice1 {}
+unsafe impl Sync for ID3D12DebugDevice1 {}
 pub trait ID3D12DebugDevice1_Impl: windows_core::IUnknownImpl {
     fn SetDebugParameter(&self, r#type: D3D12_DEBUG_DEVICE_PARAMETER_TYPE, pdata: *const core::ffi::c_void, datasize: u32) -> windows_core::Result<()>;
     fn GetDebugParameter(&self, r#type: D3D12_DEBUG_DEVICE_PARAMETER_TYPE, pdata: *mut core::ffi::c_void, datasize: u32) -> windows_core::Result<()>;
@@ -10207,8 +10209,6 @@ impl ID3D12DebugDevice1_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D12DebugDevice1 {}
-unsafe impl Send for ID3D12DebugDevice1 {}
-unsafe impl Sync for ID3D12DebugDevice1 {}
 windows_core::imp::define_interface!(ID3D12DebugDevice2, ID3D12DebugDevice2_Vtbl, 0x60eccbc1_378d_4df1_894c_f8ac5ce4d7dd);
 impl core::ops::Deref for ID3D12DebugDevice2 {
     type Target = ID3D12DebugDevice;
@@ -10231,6 +10231,8 @@ pub struct ID3D12DebugDevice2_Vtbl {
     pub SetDebugParameter: unsafe extern "system" fn(*mut core::ffi::c_void, D3D12_DEBUG_DEVICE_PARAMETER_TYPE, *const core::ffi::c_void, u32) -> windows_core::HRESULT,
     pub GetDebugParameter: unsafe extern "system" fn(*mut core::ffi::c_void, D3D12_DEBUG_DEVICE_PARAMETER_TYPE, *mut core::ffi::c_void, u32) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID3D12DebugDevice2 {}
+unsafe impl Sync for ID3D12DebugDevice2 {}
 pub trait ID3D12DebugDevice2_Impl: ID3D12DebugDevice_Impl {
     fn SetDebugParameter(&self, r#type: D3D12_DEBUG_DEVICE_PARAMETER_TYPE, pdata: *const core::ffi::c_void, datasize: u32) -> windows_core::Result<()>;
     fn GetDebugParameter(&self, r#type: D3D12_DEBUG_DEVICE_PARAMETER_TYPE, pdata: *mut core::ffi::c_void, datasize: u32) -> windows_core::Result<()>;
@@ -10260,8 +10262,6 @@ impl ID3D12DebugDevice2_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D12DebugDevice2 {}
-unsafe impl Send for ID3D12DebugDevice2 {}
-unsafe impl Sync for ID3D12DebugDevice2 {}
 windows_core::imp::define_interface!(ID3D12DescriptorHeap, ID3D12DescriptorHeap_Vtbl, 0x8efb471d_616c_4f49_90f7_127bb763fa51);
 impl core::ops::Deref for ID3D12DescriptorHeap {
     type Target = ID3D12Pageable;
@@ -10300,6 +10300,8 @@ pub struct ID3D12DescriptorHeap_Vtbl {
     pub GetCPUDescriptorHandleForHeapStart: unsafe extern "system" fn(*mut core::ffi::c_void, *mut D3D12_CPU_DESCRIPTOR_HANDLE),
     pub GetGPUDescriptorHandleForHeapStart: unsafe extern "system" fn(*mut core::ffi::c_void, *mut D3D12_GPU_DESCRIPTOR_HANDLE),
 }
+unsafe impl Send for ID3D12DescriptorHeap {}
+unsafe impl Sync for ID3D12DescriptorHeap {}
 pub trait ID3D12DescriptorHeap_Impl: ID3D12Pageable_Impl {
     fn GetDesc(&self) -> D3D12_DESCRIPTOR_HEAP_DESC;
     fn GetCPUDescriptorHandleForHeapStart(&self) -> D3D12_CPU_DESCRIPTOR_HANDLE;
@@ -10337,8 +10339,6 @@ impl ID3D12DescriptorHeap_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D12DescriptorHeap {}
-unsafe impl Send for ID3D12DescriptorHeap {}
-unsafe impl Sync for ID3D12DescriptorHeap {}
 windows_core::imp::define_interface!(ID3D12Device, ID3D12Device_Vtbl, 0x189819f1_1db6_4b57_be54_1821339b85f7);
 impl core::ops::Deref for ID3D12Device {
     type Target = ID3D12Object;
@@ -10643,6 +10643,8 @@ pub struct ID3D12Device_Vtbl {
     pub GetResourceTiling: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut u32, *mut D3D12_PACKED_MIP_INFO, *mut D3D12_TILE_SHAPE, *mut u32, u32, *mut D3D12_SUBRESOURCE_TILING),
     pub GetAdapterLuid: unsafe extern "system" fn(*mut core::ffi::c_void, *mut super::super::Foundation::LUID),
 }
+unsafe impl Send for ID3D12Device {}
+unsafe impl Sync for ID3D12Device {}
 #[cfg(all(feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Security"))]
 pub trait ID3D12Device_Impl: ID3D12Object_Impl {
     fn GetNodeCount(&self) -> u32;
@@ -10967,10 +10969,6 @@ impl ID3D12Device_Vtbl {
 }
 #[cfg(all(feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Security"))]
 impl windows_core::RuntimeName for ID3D12Device {}
-#[cfg(all(feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Security"))]
-unsafe impl Send for ID3D12Device {}
-#[cfg(all(feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Security"))]
-unsafe impl Sync for ID3D12Device {}
 windows_core::imp::define_interface!(ID3D12Device1, ID3D12Device1_Vtbl, 0x77acce80_638e_4e65_8895_c1f23386863e);
 impl core::ops::Deref for ID3D12Device1 {
     type Target = ID3D12Device;
@@ -11001,6 +10999,8 @@ pub struct ID3D12Device1_Vtbl {
     pub SetEventOnMultipleFenceCompletion: unsafe extern "system" fn(*mut core::ffi::c_void, *const *mut core::ffi::c_void, *const u64, u32, D3D12_MULTIPLE_FENCE_WAIT_FLAGS, super::super::Foundation::HANDLE) -> windows_core::HRESULT,
     pub SetResidencyPriority: unsafe extern "system" fn(*mut core::ffi::c_void, u32, *const *mut core::ffi::c_void, *const D3D12_RESIDENCY_PRIORITY) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID3D12Device1 {}
+unsafe impl Sync for ID3D12Device1 {}
 #[cfg(all(feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Security"))]
 pub trait ID3D12Device1_Impl: ID3D12Device_Impl {
     fn CreatePipelineLibrary(&self, plibraryblob: *const core::ffi::c_void, bloblength: usize, riid: *const windows_core::GUID, pppipelinelibrary: *mut *mut core::ffi::c_void) -> windows_core::Result<()>;
@@ -11041,10 +11041,6 @@ impl ID3D12Device1_Vtbl {
 }
 #[cfg(all(feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Security"))]
 impl windows_core::RuntimeName for ID3D12Device1 {}
-#[cfg(all(feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Security"))]
-unsafe impl Send for ID3D12Device1 {}
-#[cfg(all(feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Security"))]
-unsafe impl Sync for ID3D12Device1 {}
 windows_core::imp::define_interface!(ID3D12Device10, ID3D12Device10_Vtbl, 0x517f8718_aa66_49f9_b02b_a7ab89c06031);
 impl core::ops::Deref for ID3D12Device10 {
     type Target = ID3D12Device9;
@@ -11095,6 +11091,8 @@ pub struct ID3D12Device10_Vtbl {
     #[cfg(not(feature = "Win32_Graphics_Dxgi_Common"))]
     CreateReservedResource2: usize,
 }
+unsafe impl Send for ID3D12Device10 {}
+unsafe impl Sync for ID3D12Device10 {}
 #[cfg(all(feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Security"))]
 pub trait ID3D12Device10_Impl: ID3D12Device9_Impl {
     fn CreateCommittedResource3(&self, pheapproperties: *const D3D12_HEAP_PROPERTIES, heapflags: D3D12_HEAP_FLAGS, pdesc: *const D3D12_RESOURCE_DESC1, initiallayout: D3D12_BARRIER_LAYOUT, poptimizedclearvalue: *const D3D12_CLEAR_VALUE, pprotectedsession: windows_core::Ref<ID3D12ProtectedResourceSession>, numcastableformats: u32, pcastableformats: *const super::Dxgi::Common::DXGI_FORMAT, riidresource: *const windows_core::GUID, ppvresource: *mut *mut core::ffi::c_void) -> windows_core::Result<()>;
@@ -11135,10 +11133,6 @@ impl ID3D12Device10_Vtbl {
 }
 #[cfg(all(feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Security"))]
 impl windows_core::RuntimeName for ID3D12Device10 {}
-#[cfg(all(feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Security"))]
-unsafe impl Send for ID3D12Device10 {}
-#[cfg(all(feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Security"))]
-unsafe impl Sync for ID3D12Device10 {}
 windows_core::imp::define_interface!(ID3D12Device11, ID3D12Device11_Vtbl, 0x5405c344_d457_444e_b4dd_2366e45aee39);
 impl core::ops::Deref for ID3D12Device11 {
     type Target = ID3D12Device10;
@@ -11157,6 +11151,8 @@ pub struct ID3D12Device11_Vtbl {
     pub base__: ID3D12Device10_Vtbl,
     pub CreateSampler2: unsafe extern "system" fn(*mut core::ffi::c_void, *const D3D12_SAMPLER_DESC2, D3D12_CPU_DESCRIPTOR_HANDLE),
 }
+unsafe impl Send for ID3D12Device11 {}
+unsafe impl Sync for ID3D12Device11 {}
 #[cfg(all(feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Security"))]
 pub trait ID3D12Device11_Impl: ID3D12Device10_Impl {
     fn CreateSampler2(&self, pdesc: *const D3D12_SAMPLER_DESC2, destdescriptor: &D3D12_CPU_DESCRIPTOR_HANDLE);
@@ -11178,10 +11174,6 @@ impl ID3D12Device11_Vtbl {
 }
 #[cfg(all(feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Security"))]
 impl windows_core::RuntimeName for ID3D12Device11 {}
-#[cfg(all(feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Security"))]
-unsafe impl Send for ID3D12Device11 {}
-#[cfg(all(feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Security"))]
-unsafe impl Sync for ID3D12Device11 {}
 windows_core::imp::define_interface!(ID3D12Device12, ID3D12Device12_Vtbl, 0x5af5c532_4c91_4cd0_b541_15a405395fc5);
 impl core::ops::Deref for ID3D12Device12 {
     type Target = ID3D12Device11;
@@ -11208,6 +11200,8 @@ pub struct ID3D12Device12_Vtbl {
     #[cfg(not(feature = "Win32_Graphics_Dxgi_Common"))]
     GetResourceAllocationInfo3: usize,
 }
+unsafe impl Send for ID3D12Device12 {}
+unsafe impl Sync for ID3D12Device12 {}
 #[cfg(all(feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Security"))]
 pub trait ID3D12Device12_Impl: ID3D12Device11_Impl {
     fn GetResourceAllocationInfo3(&self, visiblemask: u32, numresourcedescs: u32, presourcedescs: *const D3D12_RESOURCE_DESC1, pnumcastableformats: *const u32, ppcastableformats: *const *const super::Dxgi::Common::DXGI_FORMAT, presourceallocationinfo1: *mut D3D12_RESOURCE_ALLOCATION_INFO1) -> D3D12_RESOURCE_ALLOCATION_INFO;
@@ -11242,10 +11236,6 @@ impl ID3D12Device12_Vtbl {
 }
 #[cfg(all(feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Security"))]
 impl windows_core::RuntimeName for ID3D12Device12 {}
-#[cfg(all(feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Security"))]
-unsafe impl Send for ID3D12Device12 {}
-#[cfg(all(feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Security"))]
-unsafe impl Sync for ID3D12Device12 {}
 windows_core::imp::define_interface!(ID3D12Device13, ID3D12Device13_Vtbl, 0x14eecffc_4df8_40f7_a118_5c816f45695e);
 impl core::ops::Deref for ID3D12Device13 {
     type Target = ID3D12Device12;
@@ -11268,6 +11258,8 @@ pub struct ID3D12Device13_Vtbl {
     pub base__: ID3D12Device12_Vtbl,
     pub OpenExistingHeapFromAddress1: unsafe extern "system" fn(*mut core::ffi::c_void, *const core::ffi::c_void, usize, *const windows_core::GUID, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID3D12Device13 {}
+unsafe impl Sync for ID3D12Device13 {}
 #[cfg(all(feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Security"))]
 pub trait ID3D12Device13_Impl: ID3D12Device12_Impl {
     fn OpenExistingHeapFromAddress1(&self, paddress: *const core::ffi::c_void, size: usize, riid: *const windows_core::GUID, ppvheap: *mut *mut core::ffi::c_void) -> windows_core::Result<()>;
@@ -11303,10 +11295,6 @@ impl ID3D12Device13_Vtbl {
 }
 #[cfg(all(feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Security"))]
 impl windows_core::RuntimeName for ID3D12Device13 {}
-#[cfg(all(feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Security"))]
-unsafe impl Send for ID3D12Device13 {}
-#[cfg(all(feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Security"))]
-unsafe impl Sync for ID3D12Device13 {}
 windows_core::imp::define_interface!(ID3D12Device14, ID3D12Device14_Vtbl, 0x5f6e592d_d895_44c2_8e4a_88ad4926d323);
 impl core::ops::Deref for ID3D12Device14 {
     type Target = ID3D12Device13;
@@ -11330,6 +11318,8 @@ pub struct ID3D12Device14_Vtbl {
     pub base__: ID3D12Device13_Vtbl,
     pub CreateRootSignatureFromSubobjectInLibrary: unsafe extern "system" fn(*mut core::ffi::c_void, u32, *const core::ffi::c_void, usize, windows_core::PCWSTR, *const windows_core::GUID, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID3D12Device14 {}
+unsafe impl Sync for ID3D12Device14 {}
 #[cfg(all(feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Security"))]
 pub trait ID3D12Device14_Impl: ID3D12Device13_Impl {
     fn CreateRootSignatureFromSubobjectInLibrary(&self, nodemask: u32, plibraryblob: *const core::ffi::c_void, bloblengthinbytes: usize, subobjectname: &windows_core::PCWSTR, riid: *const windows_core::GUID, ppvrootsignature: *mut *mut core::ffi::c_void) -> windows_core::Result<()>;
@@ -11369,10 +11359,6 @@ impl ID3D12Device14_Vtbl {
 }
 #[cfg(all(feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Security"))]
 impl windows_core::RuntimeName for ID3D12Device14 {}
-#[cfg(all(feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Security"))]
-unsafe impl Send for ID3D12Device14 {}
-#[cfg(all(feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Security"))]
-unsafe impl Sync for ID3D12Device14 {}
 windows_core::imp::define_interface!(ID3D12Device2, ID3D12Device2_Vtbl, 0x30baa41e_b15b_475c_a0bb_1af5c5b64328);
 impl core::ops::Deref for ID3D12Device2 {
     type Target = ID3D12Device1;
@@ -11395,6 +11381,8 @@ pub struct ID3D12Device2_Vtbl {
     pub base__: ID3D12Device1_Vtbl,
     pub CreatePipelineState: unsafe extern "system" fn(*mut core::ffi::c_void, *const D3D12_PIPELINE_STATE_STREAM_DESC, *const windows_core::GUID, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID3D12Device2 {}
+unsafe impl Sync for ID3D12Device2 {}
 #[cfg(all(feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Security"))]
 pub trait ID3D12Device2_Impl: ID3D12Device1_Impl {
     fn CreatePipelineState(&self, pdesc: *const D3D12_PIPELINE_STATE_STREAM_DESC, riid: *const windows_core::GUID, pppipelinestate: *mut *mut core::ffi::c_void) -> windows_core::Result<()>;
@@ -11416,10 +11404,6 @@ impl ID3D12Device2_Vtbl {
 }
 #[cfg(all(feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Security"))]
 impl windows_core::RuntimeName for ID3D12Device2 {}
-#[cfg(all(feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Security"))]
-unsafe impl Send for ID3D12Device2 {}
-#[cfg(all(feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Security"))]
-unsafe impl Sync for ID3D12Device2 {}
 windows_core::imp::define_interface!(ID3D12Device3, ID3D12Device3_Vtbl, 0x81dadc15_2bad_4392_93c5_101345c4aa98);
 impl core::ops::Deref for ID3D12Device3 {
     type Target = ID3D12Device2;
@@ -11457,6 +11441,8 @@ pub struct ID3D12Device3_Vtbl {
     pub OpenExistingHeapFromFileMapping: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::HANDLE, *const windows_core::GUID, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
     pub EnqueueMakeResident: unsafe extern "system" fn(*mut core::ffi::c_void, D3D12_RESIDENCY_FLAGS, u32, *const *mut core::ffi::c_void, *mut core::ffi::c_void, u64) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID3D12Device3 {}
+unsafe impl Sync for ID3D12Device3 {}
 #[cfg(all(feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Security"))]
 pub trait ID3D12Device3_Impl: ID3D12Device2_Impl {
     fn OpenExistingHeapFromAddress(&self, paddress: *const core::ffi::c_void, riid: *const windows_core::GUID, ppvheap: *mut *mut core::ffi::c_void) -> windows_core::Result<()>;
@@ -11497,10 +11483,6 @@ impl ID3D12Device3_Vtbl {
 }
 #[cfg(all(feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Security"))]
 impl windows_core::RuntimeName for ID3D12Device3 {}
-#[cfg(all(feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Security"))]
-unsafe impl Send for ID3D12Device3 {}
-#[cfg(all(feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Security"))]
-unsafe impl Sync for ID3D12Device3 {}
 windows_core::imp::define_interface!(ID3D12Device4, ID3D12Device4_Vtbl, 0xe865df17_a9ee_46f9_a463_3098315aa2e5);
 impl core::ops::Deref for ID3D12Device4 {
     type Target = ID3D12Device3;
@@ -11575,6 +11557,8 @@ pub struct ID3D12Device4_Vtbl {
     #[cfg(not(feature = "Win32_Graphics_Dxgi_Common"))]
     GetResourceAllocationInfo1: usize,
 }
+unsafe impl Send for ID3D12Device4 {}
+unsafe impl Sync for ID3D12Device4 {}
 #[cfg(all(feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Security"))]
 pub trait ID3D12Device4_Impl: ID3D12Device3_Impl {
     fn CreateCommandList1(&self, nodemask: u32, r#type: D3D12_COMMAND_LIST_TYPE, flags: D3D12_COMMAND_LIST_FLAGS, riid: *const windows_core::GUID, ppcommandlist: *mut *mut core::ffi::c_void) -> windows_core::Result<()>;
@@ -11639,10 +11623,6 @@ impl ID3D12Device4_Vtbl {
 }
 #[cfg(all(feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Security"))]
 impl windows_core::RuntimeName for ID3D12Device4 {}
-#[cfg(all(feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Security"))]
-unsafe impl Send for ID3D12Device4 {}
-#[cfg(all(feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Security"))]
-unsafe impl Sync for ID3D12Device4 {}
 windows_core::imp::define_interface!(ID3D12Device5, ID3D12Device5_Vtbl, 0x8b4f173b_2fea_4b80_8f58_4307191ab95d);
 impl core::ops::Deref for ID3D12Device5 {
     type Target = ID3D12Device4;
@@ -11706,6 +11686,8 @@ pub struct ID3D12Device5_Vtbl {
     GetRaytracingAccelerationStructurePrebuildInfo: usize,
     pub CheckDriverMatchingIdentifier: unsafe extern "system" fn(*mut core::ffi::c_void, D3D12_SERIALIZED_DATA_TYPE, *const D3D12_SERIALIZED_DATA_DRIVER_MATCHING_IDENTIFIER) -> D3D12_DRIVER_MATCHING_IDENTIFIER_STATUS,
 }
+unsafe impl Send for ID3D12Device5 {}
+unsafe impl Sync for ID3D12Device5 {}
 #[cfg(all(feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Security"))]
 pub trait ID3D12Device5_Impl: ID3D12Device4_Impl {
     fn CreateLifetimeTracker(&self, powner: windows_core::Ref<ID3D12LifetimeOwner>, riid: *const windows_core::GUID, ppvtracker: *mut *mut core::ffi::c_void) -> windows_core::Result<()>;
@@ -11786,10 +11768,6 @@ impl ID3D12Device5_Vtbl {
 }
 #[cfg(all(feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Security"))]
 impl windows_core::RuntimeName for ID3D12Device5 {}
-#[cfg(all(feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Security"))]
-unsafe impl Send for ID3D12Device5 {}
-#[cfg(all(feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Security"))]
-unsafe impl Sync for ID3D12Device5 {}
 windows_core::imp::define_interface!(ID3D12Device6, ID3D12Device6_Vtbl, 0xc70b221b_40e4_4a17_89af_025a0727a6dc);
 impl core::ops::Deref for ID3D12Device6 {
     type Target = ID3D12Device5;
@@ -11808,6 +11786,8 @@ pub struct ID3D12Device6_Vtbl {
     pub base__: ID3D12Device5_Vtbl,
     pub SetBackgroundProcessingMode: unsafe extern "system" fn(*mut core::ffi::c_void, D3D12_BACKGROUND_PROCESSING_MODE, D3D12_MEASUREMENTS_ACTION, super::super::Foundation::HANDLE, *mut super::super::Foundation::BOOL) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID3D12Device6 {}
+unsafe impl Sync for ID3D12Device6 {}
 #[cfg(all(feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Security"))]
 pub trait ID3D12Device6_Impl: ID3D12Device5_Impl {
     fn SetBackgroundProcessingMode(&self, mode: D3D12_BACKGROUND_PROCESSING_MODE, measurementsaction: D3D12_MEASUREMENTS_ACTION, heventtosignaluponcompletion: super::super::Foundation::HANDLE, pbfurthermeasurementsdesired: *mut super::super::Foundation::BOOL) -> windows_core::Result<()>;
@@ -11829,10 +11809,6 @@ impl ID3D12Device6_Vtbl {
 }
 #[cfg(all(feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Security"))]
 impl windows_core::RuntimeName for ID3D12Device6 {}
-#[cfg(all(feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Security"))]
-unsafe impl Send for ID3D12Device6 {}
-#[cfg(all(feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Security"))]
-unsafe impl Sync for ID3D12Device6 {}
 windows_core::imp::define_interface!(ID3D12Device7, ID3D12Device7_Vtbl, 0x5c014b53_68a1_4b9b_8bd1_dd6046b9358b);
 impl core::ops::Deref for ID3D12Device7 {
     type Target = ID3D12Device6;
@@ -11864,6 +11840,8 @@ pub struct ID3D12Device7_Vtbl {
     pub AddToStateObject: unsafe extern "system" fn(*mut core::ffi::c_void, *const D3D12_STATE_OBJECT_DESC, *mut core::ffi::c_void, *const windows_core::GUID, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
     pub CreateProtectedResourceSession1: unsafe extern "system" fn(*mut core::ffi::c_void, *const D3D12_PROTECTED_RESOURCE_SESSION_DESC1, *const windows_core::GUID, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID3D12Device7 {}
+unsafe impl Sync for ID3D12Device7 {}
 #[cfg(all(feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Security"))]
 pub trait ID3D12Device7_Impl: ID3D12Device6_Impl {
     fn AddToStateObject(&self, paddition: *const D3D12_STATE_OBJECT_DESC, pstateobjecttogrowfrom: windows_core::Ref<ID3D12StateObject>, riid: *const windows_core::GUID, ppnewstateobject: *mut *mut core::ffi::c_void) -> windows_core::Result<()>;
@@ -11896,10 +11874,6 @@ impl ID3D12Device7_Vtbl {
 }
 #[cfg(all(feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Security"))]
 impl windows_core::RuntimeName for ID3D12Device7 {}
-#[cfg(all(feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Security"))]
-unsafe impl Send for ID3D12Device7 {}
-#[cfg(all(feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Security"))]
-unsafe impl Sync for ID3D12Device7 {}
 windows_core::imp::define_interface!(ID3D12Device8, ID3D12Device8_Vtbl, 0x9218e6bb_f944_4f7e_a75c_b1b2c7b701f3);
 impl core::ops::Deref for ID3D12Device8 {
     type Target = ID3D12Device7;
@@ -11966,6 +11940,8 @@ pub struct ID3D12Device8_Vtbl {
     #[cfg(not(feature = "Win32_Graphics_Dxgi_Common"))]
     GetCopyableFootprints1: usize,
 }
+unsafe impl Send for ID3D12Device8 {}
+unsafe impl Sync for ID3D12Device8 {}
 #[cfg(all(feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Security"))]
 pub trait ID3D12Device8_Impl: ID3D12Device7_Impl {
     fn GetResourceAllocationInfo2(&self, visiblemask: u32, numresourcedescs: u32, presourcedescs: *const D3D12_RESOURCE_DESC1, presourceallocationinfo1: *mut D3D12_RESOURCE_ALLOCATION_INFO1) -> D3D12_RESOURCE_ALLOCATION_INFO;
@@ -12022,10 +11998,6 @@ impl ID3D12Device8_Vtbl {
 }
 #[cfg(all(feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Security"))]
 impl windows_core::RuntimeName for ID3D12Device8 {}
-#[cfg(all(feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Security"))]
-unsafe impl Send for ID3D12Device8 {}
-#[cfg(all(feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Security"))]
-unsafe impl Sync for ID3D12Device8 {}
 windows_core::imp::define_interface!(ID3D12Device9, ID3D12Device9_Vtbl, 0x4c80e962_f032_4f60_bc9e_ebc2cfa1d83c);
 impl core::ops::Deref for ID3D12Device9 {
     type Target = ID3D12Device8;
@@ -12059,6 +12031,8 @@ pub struct ID3D12Device9_Vtbl {
     pub ShaderCacheControl: unsafe extern "system" fn(*mut core::ffi::c_void, D3D12_SHADER_CACHE_KIND_FLAGS, D3D12_SHADER_CACHE_CONTROL_FLAGS) -> windows_core::HRESULT,
     pub CreateCommandQueue1: unsafe extern "system" fn(*mut core::ffi::c_void, *const D3D12_COMMAND_QUEUE_DESC, *const windows_core::GUID, *const windows_core::GUID, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID3D12Device9 {}
+unsafe impl Sync for ID3D12Device9 {}
 #[cfg(all(feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Security"))]
 pub trait ID3D12Device9_Impl: ID3D12Device8_Impl {
     fn CreateShaderCacheSession(&self, pdesc: *const D3D12_SHADER_CACHE_SESSION_DESC, riid: *const windows_core::GUID, ppvsession: *mut *mut core::ffi::c_void) -> windows_core::Result<()>;
@@ -12099,10 +12073,6 @@ impl ID3D12Device9_Vtbl {
 }
 #[cfg(all(feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Security"))]
 impl windows_core::RuntimeName for ID3D12Device9 {}
-#[cfg(all(feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Security"))]
-unsafe impl Send for ID3D12Device9 {}
-#[cfg(all(feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Security"))]
-unsafe impl Sync for ID3D12Device9 {}
 windows_core::imp::define_interface!(ID3D12DeviceChild, ID3D12DeviceChild_Vtbl, 0x905db94b_a00c_4140_9df5_2b64ca9ea357);
 impl core::ops::Deref for ID3D12DeviceChild {
     type Target = ID3D12Object;
@@ -12124,6 +12094,8 @@ pub struct ID3D12DeviceChild_Vtbl {
     pub base__: ID3D12Object_Vtbl,
     pub GetDevice: unsafe extern "system" fn(*mut core::ffi::c_void, *const windows_core::GUID, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID3D12DeviceChild {}
+unsafe impl Sync for ID3D12DeviceChild {}
 pub trait ID3D12DeviceChild_Impl: ID3D12Object_Impl {
     fn GetDevice(&self, riid: *const windows_core::GUID, ppvdevice: *mut *mut core::ffi::c_void) -> windows_core::Result<()>;
 }
@@ -12142,8 +12114,6 @@ impl ID3D12DeviceChild_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D12DeviceChild {}
-unsafe impl Send for ID3D12DeviceChild {}
-unsafe impl Sync for ID3D12DeviceChild {}
 windows_core::imp::define_interface!(ID3D12DeviceConfiguration, ID3D12DeviceConfiguration_Vtbl, 0x78dbf87b_f766_422b_a61c_c8c446bdb9ad);
 windows_core::imp::interface_hierarchy!(ID3D12DeviceConfiguration, windows_core::IUnknown);
 impl ID3D12DeviceConfiguration {
@@ -12180,6 +12150,8 @@ pub struct ID3D12DeviceConfiguration_Vtbl {
     SerializeVersionedRootSignature: usize,
     pub CreateVersionedRootSignatureDeserializer: unsafe extern "system" fn(*mut core::ffi::c_void, *const core::ffi::c_void, usize, *const windows_core::GUID, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID3D12DeviceConfiguration {}
+unsafe impl Sync for ID3D12DeviceConfiguration {}
 #[cfg(feature = "Win32_Graphics_Direct3D")]
 pub trait ID3D12DeviceConfiguration_Impl: windows_core::IUnknownImpl {
     fn GetDesc(&self) -> D3D12_DEVICE_CONFIGURATION_DESC;
@@ -12228,10 +12200,6 @@ impl ID3D12DeviceConfiguration_Vtbl {
 }
 #[cfg(feature = "Win32_Graphics_Direct3D")]
 impl windows_core::RuntimeName for ID3D12DeviceConfiguration {}
-#[cfg(feature = "Win32_Graphics_Direct3D")]
-unsafe impl Send for ID3D12DeviceConfiguration {}
-#[cfg(feature = "Win32_Graphics_Direct3D")]
-unsafe impl Sync for ID3D12DeviceConfiguration {}
 windows_core::imp::define_interface!(ID3D12DeviceConfiguration1, ID3D12DeviceConfiguration1_Vtbl, 0xed342442_6343_4e16_bb82_a3a577874e56);
 impl core::ops::Deref for ID3D12DeviceConfiguration1 {
     type Target = ID3D12DeviceConfiguration;
@@ -12255,6 +12223,8 @@ pub struct ID3D12DeviceConfiguration1_Vtbl {
     pub base__: ID3D12DeviceConfiguration_Vtbl,
     pub CreateVersionedRootSignatureDeserializerFromSubobjectInLibrary: unsafe extern "system" fn(*mut core::ffi::c_void, *const core::ffi::c_void, usize, windows_core::PCWSTR, *const windows_core::GUID, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID3D12DeviceConfiguration1 {}
+unsafe impl Sync for ID3D12DeviceConfiguration1 {}
 #[cfg(feature = "Win32_Graphics_Direct3D")]
 pub trait ID3D12DeviceConfiguration1_Impl: ID3D12DeviceConfiguration_Impl {
     fn CreateVersionedRootSignatureDeserializerFromSubobjectInLibrary(&self, plibraryblob: *const core::ffi::c_void, size: usize, rootsignaturesubobjectname: &windows_core::PCWSTR, riid: *const windows_core::GUID, ppvdeserializer: *mut *mut core::ffi::c_void) -> windows_core::Result<()>;
@@ -12279,10 +12249,6 @@ impl ID3D12DeviceConfiguration1_Vtbl {
 }
 #[cfg(feature = "Win32_Graphics_Direct3D")]
 impl windows_core::RuntimeName for ID3D12DeviceConfiguration1 {}
-#[cfg(feature = "Win32_Graphics_Direct3D")]
-unsafe impl Send for ID3D12DeviceConfiguration1 {}
-#[cfg(feature = "Win32_Graphics_Direct3D")]
-unsafe impl Sync for ID3D12DeviceConfiguration1 {}
 windows_core::imp::define_interface!(ID3D12DeviceFactory, ID3D12DeviceFactory_Vtbl, 0x61f307d3_d34e_4e7c_8374_3ba4de23cccb);
 windows_core::imp::interface_hierarchy!(ID3D12DeviceFactory, windows_core::IUnknown);
 impl ID3D12DeviceFactory {
@@ -12331,6 +12297,8 @@ pub struct ID3D12DeviceFactory_Vtbl {
     #[cfg(not(feature = "Win32_Graphics_Direct3D"))]
     CreateDevice: usize,
 }
+unsafe impl Send for ID3D12DeviceFactory {}
+unsafe impl Sync for ID3D12DeviceFactory {}
 #[cfg(feature = "Win32_Graphics_Direct3D")]
 pub trait ID3D12DeviceFactory_Impl: windows_core::IUnknownImpl {
     fn InitializeFromGlobalState(&self) -> windows_core::Result<()>;
@@ -12403,10 +12371,6 @@ impl ID3D12DeviceFactory_Vtbl {
 }
 #[cfg(feature = "Win32_Graphics_Direct3D")]
 impl windows_core::RuntimeName for ID3D12DeviceFactory {}
-#[cfg(feature = "Win32_Graphics_Direct3D")]
-unsafe impl Send for ID3D12DeviceFactory {}
-#[cfg(feature = "Win32_Graphics_Direct3D")]
-unsafe impl Sync for ID3D12DeviceFactory {}
 windows_core::imp::define_interface!(ID3D12DeviceRemovedExtendedData, ID3D12DeviceRemovedExtendedData_Vtbl, 0x98931d33_5ae8_4791_aa3c_1a73a2934e71);
 windows_core::imp::interface_hierarchy!(ID3D12DeviceRemovedExtendedData, windows_core::IUnknown);
 impl ID3D12DeviceRemovedExtendedData {
@@ -12429,6 +12393,8 @@ pub struct ID3D12DeviceRemovedExtendedData_Vtbl {
     pub GetAutoBreadcrumbsOutput: unsafe extern "system" fn(*mut core::ffi::c_void, *mut D3D12_DRED_AUTO_BREADCRUMBS_OUTPUT) -> windows_core::HRESULT,
     pub GetPageFaultAllocationOutput: unsafe extern "system" fn(*mut core::ffi::c_void, *mut D3D12_DRED_PAGE_FAULT_OUTPUT) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID3D12DeviceRemovedExtendedData {}
+unsafe impl Sync for ID3D12DeviceRemovedExtendedData {}
 pub trait ID3D12DeviceRemovedExtendedData_Impl: windows_core::IUnknownImpl {
     fn GetAutoBreadcrumbsOutput(&self) -> windows_core::Result<D3D12_DRED_AUTO_BREADCRUMBS_OUTPUT>;
     fn GetPageFaultAllocationOutput(&self) -> windows_core::Result<D3D12_DRED_PAGE_FAULT_OUTPUT>;
@@ -12470,8 +12436,6 @@ impl ID3D12DeviceRemovedExtendedData_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D12DeviceRemovedExtendedData {}
-unsafe impl Send for ID3D12DeviceRemovedExtendedData {}
-unsafe impl Sync for ID3D12DeviceRemovedExtendedData {}
 windows_core::imp::define_interface!(ID3D12DeviceRemovedExtendedData1, ID3D12DeviceRemovedExtendedData1_Vtbl, 0x9727a022_cf1d_4dda_9eba_effa653fc506);
 impl core::ops::Deref for ID3D12DeviceRemovedExtendedData1 {
     type Target = ID3D12DeviceRemovedExtendedData;
@@ -12500,6 +12464,8 @@ pub struct ID3D12DeviceRemovedExtendedData1_Vtbl {
     pub GetAutoBreadcrumbsOutput1: unsafe extern "system" fn(*mut core::ffi::c_void, *mut D3D12_DRED_AUTO_BREADCRUMBS_OUTPUT1) -> windows_core::HRESULT,
     pub GetPageFaultAllocationOutput1: unsafe extern "system" fn(*mut core::ffi::c_void, *mut D3D12_DRED_PAGE_FAULT_OUTPUT1) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID3D12DeviceRemovedExtendedData1 {}
+unsafe impl Sync for ID3D12DeviceRemovedExtendedData1 {}
 pub trait ID3D12DeviceRemovedExtendedData1_Impl: ID3D12DeviceRemovedExtendedData_Impl {
     fn GetAutoBreadcrumbsOutput1(&self) -> windows_core::Result<D3D12_DRED_AUTO_BREADCRUMBS_OUTPUT1>;
     fn GetPageFaultAllocationOutput1(&self) -> windows_core::Result<D3D12_DRED_PAGE_FAULT_OUTPUT1>;
@@ -12541,8 +12507,6 @@ impl ID3D12DeviceRemovedExtendedData1_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D12DeviceRemovedExtendedData1 {}
-unsafe impl Send for ID3D12DeviceRemovedExtendedData1 {}
-unsafe impl Sync for ID3D12DeviceRemovedExtendedData1 {}
 windows_core::imp::define_interface!(ID3D12DeviceRemovedExtendedData2, ID3D12DeviceRemovedExtendedData2_Vtbl, 0x67fc5816_e4ca_4915_bf18_42541272da54);
 impl core::ops::Deref for ID3D12DeviceRemovedExtendedData2 {
     type Target = ID3D12DeviceRemovedExtendedData1;
@@ -12565,6 +12529,8 @@ pub struct ID3D12DeviceRemovedExtendedData2_Vtbl {
     pub GetPageFaultAllocationOutput2: unsafe extern "system" fn(*mut core::ffi::c_void, *mut D3D12_DRED_PAGE_FAULT_OUTPUT2) -> windows_core::HRESULT,
     pub GetDeviceState: unsafe extern "system" fn(*mut core::ffi::c_void) -> D3D12_DRED_DEVICE_STATE,
 }
+unsafe impl Send for ID3D12DeviceRemovedExtendedData2 {}
+unsafe impl Sync for ID3D12DeviceRemovedExtendedData2 {}
 pub trait ID3D12DeviceRemovedExtendedData2_Impl: ID3D12DeviceRemovedExtendedData1_Impl {
     fn GetPageFaultAllocationOutput2(&self, poutput: *mut D3D12_DRED_PAGE_FAULT_OUTPUT2) -> windows_core::Result<()>;
     fn GetDeviceState(&self) -> D3D12_DRED_DEVICE_STATE;
@@ -12594,8 +12560,6 @@ impl ID3D12DeviceRemovedExtendedData2_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D12DeviceRemovedExtendedData2 {}
-unsafe impl Send for ID3D12DeviceRemovedExtendedData2 {}
-unsafe impl Sync for ID3D12DeviceRemovedExtendedData2 {}
 windows_core::imp::define_interface!(ID3D12DeviceRemovedExtendedDataSettings, ID3D12DeviceRemovedExtendedDataSettings_Vtbl, 0x82bc481c_6b9b_4030_aedb_7ee3d1df1e63);
 windows_core::imp::interface_hierarchy!(ID3D12DeviceRemovedExtendedDataSettings, windows_core::IUnknown);
 impl ID3D12DeviceRemovedExtendedDataSettings {
@@ -12616,6 +12580,8 @@ pub struct ID3D12DeviceRemovedExtendedDataSettings_Vtbl {
     pub SetPageFaultEnablement: unsafe extern "system" fn(*mut core::ffi::c_void, D3D12_DRED_ENABLEMENT),
     pub SetWatsonDumpEnablement: unsafe extern "system" fn(*mut core::ffi::c_void, D3D12_DRED_ENABLEMENT),
 }
+unsafe impl Send for ID3D12DeviceRemovedExtendedDataSettings {}
+unsafe impl Sync for ID3D12DeviceRemovedExtendedDataSettings {}
 pub trait ID3D12DeviceRemovedExtendedDataSettings_Impl: windows_core::IUnknownImpl {
     fn SetAutoBreadcrumbsEnablement(&self, enablement: D3D12_DRED_ENABLEMENT);
     fn SetPageFaultEnablement(&self, enablement: D3D12_DRED_ENABLEMENT);
@@ -12653,8 +12619,6 @@ impl ID3D12DeviceRemovedExtendedDataSettings_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D12DeviceRemovedExtendedDataSettings {}
-unsafe impl Send for ID3D12DeviceRemovedExtendedDataSettings {}
-unsafe impl Sync for ID3D12DeviceRemovedExtendedDataSettings {}
 windows_core::imp::define_interface!(ID3D12DeviceRemovedExtendedDataSettings1, ID3D12DeviceRemovedExtendedDataSettings1_Vtbl, 0xdbd5ae51_3317_4f0a_adf9_1d7cedcaae0b);
 impl core::ops::Deref for ID3D12DeviceRemovedExtendedDataSettings1 {
     type Target = ID3D12DeviceRemovedExtendedDataSettings;
@@ -12673,6 +12637,8 @@ pub struct ID3D12DeviceRemovedExtendedDataSettings1_Vtbl {
     pub base__: ID3D12DeviceRemovedExtendedDataSettings_Vtbl,
     pub SetBreadcrumbContextEnablement: unsafe extern "system" fn(*mut core::ffi::c_void, D3D12_DRED_ENABLEMENT),
 }
+unsafe impl Send for ID3D12DeviceRemovedExtendedDataSettings1 {}
+unsafe impl Sync for ID3D12DeviceRemovedExtendedDataSettings1 {}
 pub trait ID3D12DeviceRemovedExtendedDataSettings1_Impl: ID3D12DeviceRemovedExtendedDataSettings_Impl {
     fn SetBreadcrumbContextEnablement(&self, enablement: D3D12_DRED_ENABLEMENT);
 }
@@ -12694,8 +12660,6 @@ impl ID3D12DeviceRemovedExtendedDataSettings1_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D12DeviceRemovedExtendedDataSettings1 {}
-unsafe impl Send for ID3D12DeviceRemovedExtendedDataSettings1 {}
-unsafe impl Sync for ID3D12DeviceRemovedExtendedDataSettings1 {}
 windows_core::imp::define_interface!(ID3D12DeviceRemovedExtendedDataSettings2, ID3D12DeviceRemovedExtendedDataSettings2_Vtbl, 0x61552388_01ab_4008_a436_83db189566ea);
 impl core::ops::Deref for ID3D12DeviceRemovedExtendedDataSettings2 {
     type Target = ID3D12DeviceRemovedExtendedDataSettings1;
@@ -12714,6 +12678,8 @@ pub struct ID3D12DeviceRemovedExtendedDataSettings2_Vtbl {
     pub base__: ID3D12DeviceRemovedExtendedDataSettings1_Vtbl,
     pub UseMarkersOnlyAutoBreadcrumbs: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::BOOL),
 }
+unsafe impl Send for ID3D12DeviceRemovedExtendedDataSettings2 {}
+unsafe impl Sync for ID3D12DeviceRemovedExtendedDataSettings2 {}
 pub trait ID3D12DeviceRemovedExtendedDataSettings2_Impl: ID3D12DeviceRemovedExtendedDataSettings1_Impl {
     fn UseMarkersOnlyAutoBreadcrumbs(&self, markersonly: super::super::Foundation::BOOL);
 }
@@ -12735,8 +12701,6 @@ impl ID3D12DeviceRemovedExtendedDataSettings2_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D12DeviceRemovedExtendedDataSettings2 {}
-unsafe impl Send for ID3D12DeviceRemovedExtendedDataSettings2 {}
-unsafe impl Sync for ID3D12DeviceRemovedExtendedDataSettings2 {}
 windows_core::imp::define_interface!(ID3D12Fence, ID3D12Fence_Vtbl, 0x0a753dcf_c4d8_4b91_adf6_be5a60d95a76);
 impl core::ops::Deref for ID3D12Fence {
     type Target = ID3D12Pageable;
@@ -12763,6 +12727,8 @@ pub struct ID3D12Fence_Vtbl {
     pub SetEventOnCompletion: unsafe extern "system" fn(*mut core::ffi::c_void, u64, super::super::Foundation::HANDLE) -> windows_core::HRESULT,
     pub Signal: unsafe extern "system" fn(*mut core::ffi::c_void, u64) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID3D12Fence {}
+unsafe impl Sync for ID3D12Fence {}
 pub trait ID3D12Fence_Impl: ID3D12Pageable_Impl {
     fn GetCompletedValue(&self) -> u64;
     fn SetEventOnCompletion(&self, value: u64, hevent: super::super::Foundation::HANDLE) -> windows_core::Result<()>;
@@ -12800,8 +12766,6 @@ impl ID3D12Fence_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D12Fence {}
-unsafe impl Send for ID3D12Fence {}
-unsafe impl Sync for ID3D12Fence {}
 windows_core::imp::define_interface!(ID3D12Fence1, ID3D12Fence1_Vtbl, 0x433685fe_e22b_4ca0_a8db_b5b4f4dd0e4a);
 impl core::ops::Deref for ID3D12Fence1 {
     type Target = ID3D12Fence;
@@ -12820,6 +12784,8 @@ pub struct ID3D12Fence1_Vtbl {
     pub base__: ID3D12Fence_Vtbl,
     pub GetCreationFlags: unsafe extern "system" fn(*mut core::ffi::c_void) -> D3D12_FENCE_FLAGS,
 }
+unsafe impl Send for ID3D12Fence1 {}
+unsafe impl Sync for ID3D12Fence1 {}
 pub trait ID3D12Fence1_Impl: ID3D12Fence_Impl {
     fn GetCreationFlags(&self) -> D3D12_FENCE_FLAGS;
 }
@@ -12838,8 +12804,6 @@ impl ID3D12Fence1_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D12Fence1 {}
-unsafe impl Send for ID3D12Fence1 {}
-unsafe impl Sync for ID3D12Fence1 {}
 windows_core::imp::define_interface!(ID3D12FunctionParameterReflection, ID3D12FunctionParameterReflection_Vtbl);
 impl ID3D12FunctionParameterReflection {
     #[cfg(feature = "Win32_Graphics_Direct3D")]
@@ -12854,6 +12818,8 @@ pub struct ID3D12FunctionParameterReflection_Vtbl {
     #[cfg(not(feature = "Win32_Graphics_Direct3D"))]
     GetDesc: usize,
 }
+unsafe impl Send for ID3D12FunctionParameterReflection {}
+unsafe impl Sync for ID3D12FunctionParameterReflection {}
 #[cfg(feature = "Win32_Graphics_Direct3D")]
 pub trait ID3D12FunctionParameterReflection_Impl {
     fn GetDesc(&self, pdesc: *mut D3D12_PARAMETER_DESC) -> windows_core::Result<()>;
@@ -12885,10 +12851,6 @@ impl ID3D12FunctionParameterReflection {
         unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
     }
 }
-#[cfg(feature = "Win32_Graphics_Direct3D")]
-unsafe impl Send for ID3D12FunctionParameterReflection {}
-#[cfg(feature = "Win32_Graphics_Direct3D")]
-unsafe impl Sync for ID3D12FunctionParameterReflection {}
 windows_core::imp::define_interface!(ID3D12FunctionReflection, ID3D12FunctionReflection_Vtbl);
 impl ID3D12FunctionReflection {
     #[cfg(feature = "Win32_Graphics_Direct3D")]
@@ -12944,6 +12906,8 @@ pub struct ID3D12FunctionReflection_Vtbl {
     GetResourceBindingDescByName: usize,
     pub GetFunctionParameter: unsafe extern "system" fn(*mut core::ffi::c_void, i32) -> Option<ID3D12FunctionParameterReflection>,
 }
+unsafe impl Send for ID3D12FunctionReflection {}
+unsafe impl Sync for ID3D12FunctionReflection {}
 #[cfg(feature = "Win32_Graphics_Direct3D")]
 pub trait ID3D12FunctionReflection_Impl {
     fn GetDesc(&self, pdesc: *mut D3D12_FUNCTION_DESC) -> windows_core::Result<()>;
@@ -13031,10 +12995,6 @@ impl ID3D12FunctionReflection {
         unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
     }
 }
-#[cfg(feature = "Win32_Graphics_Direct3D")]
-unsafe impl Send for ID3D12FunctionReflection {}
-#[cfg(feature = "Win32_Graphics_Direct3D")]
-unsafe impl Sync for ID3D12FunctionReflection {}
 windows_core::imp::define_interface!(ID3D12GBVDiagnostics, ID3D12GBVDiagnostics_Vtbl, 0x597985ab_9b75_4dbb_be23_0761195bebee);
 windows_core::imp::interface_hierarchy!(ID3D12GBVDiagnostics, windows_core::IUnknown);
 impl ID3D12GBVDiagnostics {
@@ -13089,6 +13049,8 @@ pub struct ID3D12GBVDiagnostics_Vtbl {
     pub GBVReserved0: unsafe extern "system" fn(*mut core::ffi::c_void),
     pub GBVReserved1: unsafe extern "system" fn(*mut core::ffi::c_void),
 }
+unsafe impl Send for ID3D12GBVDiagnostics {}
+unsafe impl Sync for ID3D12GBVDiagnostics {}
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 pub trait ID3D12GBVDiagnostics_Impl: windows_core::IUnknownImpl {
     fn GetGBVEntireSubresourceStatesData(&self, presource: windows_core::Ref<ID3D12Resource>, pdata: *mut i32, datasize: u32) -> windows_core::Result<()>;
@@ -13165,10 +13127,6 @@ impl ID3D12GBVDiagnostics_Vtbl {
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl windows_core::RuntimeName for ID3D12GBVDiagnostics {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-unsafe impl Send for ID3D12GBVDiagnostics {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-unsafe impl Sync for ID3D12GBVDiagnostics {}
 windows_core::imp::define_interface!(ID3D12GraphicsCommandList, ID3D12GraphicsCommandList_Vtbl, 0x5b160d0f_ac1b_4185_8ba8_b3ae42a5a455);
 impl core::ops::Deref for ID3D12GraphicsCommandList {
     type Target = ID3D12CommandList;
@@ -13465,6 +13423,8 @@ pub struct ID3D12GraphicsCommandList_Vtbl {
     pub EndEvent: unsafe extern "system" fn(*mut core::ffi::c_void),
     pub ExecuteIndirect: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, u32, *mut core::ffi::c_void, u64, *mut core::ffi::c_void, u64),
 }
+unsafe impl Send for ID3D12GraphicsCommandList {}
+unsafe impl Sync for ID3D12GraphicsCommandList {}
 #[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait ID3D12GraphicsCommandList_Impl: ID3D12CommandList_Impl {
     fn Close(&self) -> windows_core::Result<()>;
@@ -13889,10 +13849,6 @@ impl ID3D12GraphicsCommandList_Vtbl {
 }
 #[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
 impl windows_core::RuntimeName for ID3D12GraphicsCommandList {}
-#[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
-unsafe impl Send for ID3D12GraphicsCommandList {}
-#[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
-unsafe impl Sync for ID3D12GraphicsCommandList {}
 windows_core::imp::define_interface!(ID3D12GraphicsCommandList1, ID3D12GraphicsCommandList1_Vtbl, 0x553103fb_1fe7_4557_bb38_946d7d0e7ca7);
 impl core::ops::Deref for ID3D12GraphicsCommandList1 {
     type Target = ID3D12GraphicsCommandList;
@@ -13947,6 +13903,8 @@ pub struct ID3D12GraphicsCommandList1_Vtbl {
     ResolveSubresourceRegion: usize,
     pub SetViewInstanceMask: unsafe extern "system" fn(*mut core::ffi::c_void, u32),
 }
+unsafe impl Send for ID3D12GraphicsCommandList1 {}
+unsafe impl Sync for ID3D12GraphicsCommandList1 {}
 #[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait ID3D12GraphicsCommandList1_Impl: ID3D12GraphicsCommandList_Impl {
     fn AtomicCopyBufferUINT(&self, pdstbuffer: windows_core::Ref<ID3D12Resource>, dstoffset: u64, psrcbuffer: windows_core::Ref<ID3D12Resource>, srcoffset: u64, dependencies: u32, ppdependentresources: *const Option<ID3D12Resource>, pdependentsubresourceranges: *const D3D12_SUBRESOURCE_RANGE_UINT64);
@@ -14011,10 +13969,6 @@ impl ID3D12GraphicsCommandList1_Vtbl {
 }
 #[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
 impl windows_core::RuntimeName for ID3D12GraphicsCommandList1 {}
-#[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
-unsafe impl Send for ID3D12GraphicsCommandList1 {}
-#[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
-unsafe impl Sync for ID3D12GraphicsCommandList1 {}
 windows_core::imp::define_interface!(ID3D12GraphicsCommandList10, ID3D12GraphicsCommandList10_Vtbl, 0x7013c015_d161_4b63_a08c_238552dd8acc);
 impl core::ops::Deref for ID3D12GraphicsCommandList10 {
     type Target = ID3D12GraphicsCommandList9;
@@ -14037,6 +13991,8 @@ pub struct ID3D12GraphicsCommandList10_Vtbl {
     pub SetProgram: unsafe extern "system" fn(*mut core::ffi::c_void, *const D3D12_SET_PROGRAM_DESC),
     pub DispatchGraph: unsafe extern "system" fn(*mut core::ffi::c_void, *const D3D12_DISPATCH_GRAPH_DESC),
 }
+unsafe impl Send for ID3D12GraphicsCommandList10 {}
+unsafe impl Sync for ID3D12GraphicsCommandList10 {}
 #[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait ID3D12GraphicsCommandList10_Impl: ID3D12GraphicsCommandList9_Impl {
     fn SetProgram(&self, pdesc: *const D3D12_SET_PROGRAM_DESC);
@@ -14082,10 +14038,6 @@ impl ID3D12GraphicsCommandList10_Vtbl {
 }
 #[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
 impl windows_core::RuntimeName for ID3D12GraphicsCommandList10 {}
-#[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
-unsafe impl Send for ID3D12GraphicsCommandList10 {}
-#[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
-unsafe impl Sync for ID3D12GraphicsCommandList10 {}
 windows_core::imp::define_interface!(ID3D12GraphicsCommandList2, ID3D12GraphicsCommandList2_Vtbl, 0x38c3e585_ff17_412c_9150_4fc6f9d72a28);
 impl core::ops::Deref for ID3D12GraphicsCommandList2 {
     type Target = ID3D12GraphicsCommandList1;
@@ -14104,6 +14056,8 @@ pub struct ID3D12GraphicsCommandList2_Vtbl {
     pub base__: ID3D12GraphicsCommandList1_Vtbl,
     pub WriteBufferImmediate: unsafe extern "system" fn(*mut core::ffi::c_void, u32, *const D3D12_WRITEBUFFERIMMEDIATE_PARAMETER, *const D3D12_WRITEBUFFERIMMEDIATE_MODE),
 }
+unsafe impl Send for ID3D12GraphicsCommandList2 {}
+unsafe impl Sync for ID3D12GraphicsCommandList2 {}
 #[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait ID3D12GraphicsCommandList2_Impl: ID3D12GraphicsCommandList1_Impl {
     fn WriteBufferImmediate(&self, count: u32, pparams: *const D3D12_WRITEBUFFERIMMEDIATE_PARAMETER, pmodes: *const D3D12_WRITEBUFFERIMMEDIATE_MODE);
@@ -14125,10 +14079,6 @@ impl ID3D12GraphicsCommandList2_Vtbl {
 }
 #[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
 impl windows_core::RuntimeName for ID3D12GraphicsCommandList2 {}
-#[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
-unsafe impl Send for ID3D12GraphicsCommandList2 {}
-#[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
-unsafe impl Sync for ID3D12GraphicsCommandList2 {}
 windows_core::imp::define_interface!(ID3D12GraphicsCommandList3, ID3D12GraphicsCommandList3_Vtbl, 0x6fda83a7_b84c_4e38_9ac8_c7bd22016b3d);
 impl core::ops::Deref for ID3D12GraphicsCommandList3 {
     type Target = ID3D12GraphicsCommandList2;
@@ -14150,6 +14100,8 @@ pub struct ID3D12GraphicsCommandList3_Vtbl {
     pub base__: ID3D12GraphicsCommandList2_Vtbl,
     pub SetProtectedResourceSession: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void),
 }
+unsafe impl Send for ID3D12GraphicsCommandList3 {}
+unsafe impl Sync for ID3D12GraphicsCommandList3 {}
 #[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait ID3D12GraphicsCommandList3_Impl: ID3D12GraphicsCommandList2_Impl {
     fn SetProtectedResourceSession(&self, pprotectedresourcesession: windows_core::Ref<ID3D12ProtectedResourceSession>);
@@ -14171,10 +14123,6 @@ impl ID3D12GraphicsCommandList3_Vtbl {
 }
 #[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
 impl windows_core::RuntimeName for ID3D12GraphicsCommandList3 {}
-#[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
-unsafe impl Send for ID3D12GraphicsCommandList3 {}
-#[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
-unsafe impl Sync for ID3D12GraphicsCommandList3 {}
 windows_core::imp::define_interface!(ID3D12GraphicsCommandList4, ID3D12GraphicsCommandList4_Vtbl, 0x8754318e_d3a9_4541_98cf_645b50dc4874);
 impl core::ops::Deref for ID3D12GraphicsCommandList4 {
     type Target = ID3D12GraphicsCommandList3;
@@ -14242,6 +14190,8 @@ pub struct ID3D12GraphicsCommandList4_Vtbl {
     pub SetPipelineState1: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void),
     pub DispatchRays: unsafe extern "system" fn(*mut core::ffi::c_void, *const D3D12_DISPATCH_RAYS_DESC),
 }
+unsafe impl Send for ID3D12GraphicsCommandList4 {}
+unsafe impl Sync for ID3D12GraphicsCommandList4 {}
 #[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait ID3D12GraphicsCommandList4_Impl: ID3D12GraphicsCommandList3_Impl {
     fn BeginRenderPass(&self, numrendertargets: u32, prendertargets: *const D3D12_RENDER_PASS_RENDER_TARGET_DESC, pdepthstencil: *const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC, flags: D3D12_RENDER_PASS_FLAGS);
@@ -14330,10 +14280,6 @@ impl ID3D12GraphicsCommandList4_Vtbl {
 }
 #[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
 impl windows_core::RuntimeName for ID3D12GraphicsCommandList4 {}
-#[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
-unsafe impl Send for ID3D12GraphicsCommandList4 {}
-#[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
-unsafe impl Sync for ID3D12GraphicsCommandList4 {}
 windows_core::imp::define_interface!(ID3D12GraphicsCommandList5, ID3D12GraphicsCommandList5_Vtbl, 0x55050859_4024_474c_87f5_6472eaee44ea);
 impl core::ops::Deref for ID3D12GraphicsCommandList5 {
     type Target = ID3D12GraphicsCommandList4;
@@ -14359,6 +14305,8 @@ pub struct ID3D12GraphicsCommandList5_Vtbl {
     pub RSSetShadingRate: unsafe extern "system" fn(*mut core::ffi::c_void, D3D12_SHADING_RATE, *const D3D12_SHADING_RATE_COMBINER),
     pub RSSetShadingRateImage: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void),
 }
+unsafe impl Send for ID3D12GraphicsCommandList5 {}
+unsafe impl Sync for ID3D12GraphicsCommandList5 {}
 #[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait ID3D12GraphicsCommandList5_Impl: ID3D12GraphicsCommandList4_Impl {
     fn RSSetShadingRate(&self, baseshadingrate: D3D12_SHADING_RATE, combiners: *const D3D12_SHADING_RATE_COMBINER);
@@ -14391,10 +14339,6 @@ impl ID3D12GraphicsCommandList5_Vtbl {
 }
 #[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
 impl windows_core::RuntimeName for ID3D12GraphicsCommandList5 {}
-#[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
-unsafe impl Send for ID3D12GraphicsCommandList5 {}
-#[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
-unsafe impl Sync for ID3D12GraphicsCommandList5 {}
 windows_core::imp::define_interface!(ID3D12GraphicsCommandList6, ID3D12GraphicsCommandList6_Vtbl, 0xc3827890_e548_4cfa_96cf_5689a9370f80);
 impl core::ops::Deref for ID3D12GraphicsCommandList6 {
     type Target = ID3D12GraphicsCommandList5;
@@ -14413,6 +14357,8 @@ pub struct ID3D12GraphicsCommandList6_Vtbl {
     pub base__: ID3D12GraphicsCommandList5_Vtbl,
     pub DispatchMesh: unsafe extern "system" fn(*mut core::ffi::c_void, u32, u32, u32),
 }
+unsafe impl Send for ID3D12GraphicsCommandList6 {}
+unsafe impl Sync for ID3D12GraphicsCommandList6 {}
 #[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait ID3D12GraphicsCommandList6_Impl: ID3D12GraphicsCommandList5_Impl {
     fn DispatchMesh(&self, threadgroupcountx: u32, threadgroupcounty: u32, threadgroupcountz: u32);
@@ -14434,10 +14380,6 @@ impl ID3D12GraphicsCommandList6_Vtbl {
 }
 #[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
 impl windows_core::RuntimeName for ID3D12GraphicsCommandList6 {}
-#[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
-unsafe impl Send for ID3D12GraphicsCommandList6 {}
-#[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
-unsafe impl Sync for ID3D12GraphicsCommandList6 {}
 windows_core::imp::define_interface!(ID3D12GraphicsCommandList7, ID3D12GraphicsCommandList7_Vtbl, 0xdd171223_8b61_4769_90e3_160ccde4e2c1);
 impl core::ops::Deref for ID3D12GraphicsCommandList7 {
     type Target = ID3D12GraphicsCommandList6;
@@ -14456,6 +14398,8 @@ pub struct ID3D12GraphicsCommandList7_Vtbl {
     pub base__: ID3D12GraphicsCommandList6_Vtbl,
     pub Barrier: unsafe extern "system" fn(*mut core::ffi::c_void, u32, *const D3D12_BARRIER_GROUP),
 }
+unsafe impl Send for ID3D12GraphicsCommandList7 {}
+unsafe impl Sync for ID3D12GraphicsCommandList7 {}
 #[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait ID3D12GraphicsCommandList7_Impl: ID3D12GraphicsCommandList6_Impl {
     fn Barrier(&self, numbarriergroups: u32, pbarriergroups: *const D3D12_BARRIER_GROUP);
@@ -14477,10 +14421,6 @@ impl ID3D12GraphicsCommandList7_Vtbl {
 }
 #[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
 impl windows_core::RuntimeName for ID3D12GraphicsCommandList7 {}
-#[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
-unsafe impl Send for ID3D12GraphicsCommandList7 {}
-#[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
-unsafe impl Sync for ID3D12GraphicsCommandList7 {}
 windows_core::imp::define_interface!(ID3D12GraphicsCommandList8, ID3D12GraphicsCommandList8_Vtbl, 0xee936ef9_599d_4d28_938e_23c4ad05ce51);
 impl core::ops::Deref for ID3D12GraphicsCommandList8 {
     type Target = ID3D12GraphicsCommandList7;
@@ -14499,6 +14439,8 @@ pub struct ID3D12GraphicsCommandList8_Vtbl {
     pub base__: ID3D12GraphicsCommandList7_Vtbl,
     pub OMSetFrontAndBackStencilRef: unsafe extern "system" fn(*mut core::ffi::c_void, u32, u32),
 }
+unsafe impl Send for ID3D12GraphicsCommandList8 {}
+unsafe impl Sync for ID3D12GraphicsCommandList8 {}
 #[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait ID3D12GraphicsCommandList8_Impl: ID3D12GraphicsCommandList7_Impl {
     fn OMSetFrontAndBackStencilRef(&self, frontstencilref: u32, backstencilref: u32);
@@ -14531,10 +14473,6 @@ impl ID3D12GraphicsCommandList8_Vtbl {
 }
 #[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
 impl windows_core::RuntimeName for ID3D12GraphicsCommandList8 {}
-#[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
-unsafe impl Send for ID3D12GraphicsCommandList8 {}
-#[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
-unsafe impl Sync for ID3D12GraphicsCommandList8 {}
 windows_core::imp::define_interface!(ID3D12GraphicsCommandList9, ID3D12GraphicsCommandList9_Vtbl, 0x34ed2808_ffe6_4c2b_b11a_cabd2b0c59e1);
 impl core::ops::Deref for ID3D12GraphicsCommandList9 {
     type Target = ID3D12GraphicsCommandList8;
@@ -14557,6 +14495,8 @@ pub struct ID3D12GraphicsCommandList9_Vtbl {
     pub RSSetDepthBias: unsafe extern "system" fn(*mut core::ffi::c_void, f32, f32, f32),
     pub IASetIndexBufferStripCutValue: unsafe extern "system" fn(*mut core::ffi::c_void, D3D12_INDEX_BUFFER_STRIP_CUT_VALUE),
 }
+unsafe impl Send for ID3D12GraphicsCommandList9 {}
+unsafe impl Sync for ID3D12GraphicsCommandList9 {}
 #[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait ID3D12GraphicsCommandList9_Impl: ID3D12GraphicsCommandList8_Impl {
     fn RSSetDepthBias(&self, depthbias: f32, depthbiasclamp: f32, slopescaleddepthbias: f32);
@@ -14601,10 +14541,6 @@ impl ID3D12GraphicsCommandList9_Vtbl {
 }
 #[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
 impl windows_core::RuntimeName for ID3D12GraphicsCommandList9 {}
-#[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
-unsafe impl Send for ID3D12GraphicsCommandList9 {}
-#[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
-unsafe impl Sync for ID3D12GraphicsCommandList9 {}
 windows_core::imp::define_interface!(ID3D12Heap, ID3D12Heap_Vtbl, 0x6b3b2502_6e51_45b3_90ee_9884265e8df3);
 impl core::ops::Deref for ID3D12Heap {
     type Target = ID3D12Pageable;
@@ -14627,6 +14563,8 @@ pub struct ID3D12Heap_Vtbl {
     pub base__: ID3D12Pageable_Vtbl,
     pub GetDesc: unsafe extern "system" fn(*mut core::ffi::c_void, *mut D3D12_HEAP_DESC),
 }
+unsafe impl Send for ID3D12Heap {}
+unsafe impl Sync for ID3D12Heap {}
 pub trait ID3D12Heap_Impl: ID3D12Pageable_Impl {
     fn GetDesc(&self) -> D3D12_HEAP_DESC;
 }
@@ -14645,8 +14583,6 @@ impl ID3D12Heap_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D12Heap {}
-unsafe impl Send for ID3D12Heap {}
-unsafe impl Sync for ID3D12Heap {}
 windows_core::imp::define_interface!(ID3D12Heap1, ID3D12Heap1_Vtbl, 0x572f7389_2168_49e3_9693_d6df5871bf6d);
 impl core::ops::Deref for ID3D12Heap1 {
     type Target = ID3D12Heap;
@@ -14668,6 +14604,8 @@ pub struct ID3D12Heap1_Vtbl {
     pub base__: ID3D12Heap_Vtbl,
     pub GetProtectedResourceSession: unsafe extern "system" fn(*mut core::ffi::c_void, *const windows_core::GUID, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID3D12Heap1 {}
+unsafe impl Sync for ID3D12Heap1 {}
 pub trait ID3D12Heap1_Impl: ID3D12Heap_Impl {
     fn GetProtectedResourceSession(&self, riid: *const windows_core::GUID, ppprotectedsession: *mut *mut core::ffi::c_void) -> windows_core::Result<()>;
 }
@@ -14686,8 +14624,6 @@ impl ID3D12Heap1_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D12Heap1 {}
-unsafe impl Send for ID3D12Heap1 {}
-unsafe impl Sync for ID3D12Heap1 {}
 windows_core::imp::define_interface!(ID3D12InfoQueue, ID3D12InfoQueue_Vtbl, 0x0742a90b_c387_483f_b946_30a7e4e61458);
 windows_core::imp::interface_hierarchy!(ID3D12InfoQueue, windows_core::IUnknown);
 impl ID3D12InfoQueue {
@@ -14842,6 +14778,8 @@ pub struct ID3D12InfoQueue_Vtbl {
     pub SetMuteDebugOutput: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::BOOL),
     pub GetMuteDebugOutput: unsafe extern "system" fn(*mut core::ffi::c_void) -> super::super::Foundation::BOOL,
 }
+unsafe impl Send for ID3D12InfoQueue {}
+unsafe impl Sync for ID3D12InfoQueue {}
 pub trait ID3D12InfoQueue_Impl: windows_core::IUnknownImpl {
     fn SetMessageCountLimit(&self, messagecountlimit: u64) -> windows_core::Result<()>;
     fn ClearStoredMessages(&self);
@@ -15135,8 +15073,6 @@ impl ID3D12InfoQueue_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D12InfoQueue {}
-unsafe impl Send for ID3D12InfoQueue {}
-unsafe impl Sync for ID3D12InfoQueue {}
 windows_core::imp::define_interface!(ID3D12InfoQueue1, ID3D12InfoQueue1_Vtbl, 0x2852dd88_b484_4c0c_b6b1_67168500e600);
 impl core::ops::Deref for ID3D12InfoQueue1 {
     type Target = ID3D12InfoQueue;
@@ -15159,6 +15095,8 @@ pub struct ID3D12InfoQueue1_Vtbl {
     pub RegisterMessageCallback: unsafe extern "system" fn(*mut core::ffi::c_void, D3D12MessageFunc, D3D12_MESSAGE_CALLBACK_FLAGS, *mut core::ffi::c_void, *mut u32) -> windows_core::HRESULT,
     pub UnregisterMessageCallback: unsafe extern "system" fn(*mut core::ffi::c_void, u32) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID3D12InfoQueue1 {}
+unsafe impl Sync for ID3D12InfoQueue1 {}
 pub trait ID3D12InfoQueue1_Impl: ID3D12InfoQueue_Impl {
     fn RegisterMessageCallback(&self, callbackfunc: D3D12MessageFunc, callbackfilterflags: D3D12_MESSAGE_CALLBACK_FLAGS, pcontext: *mut core::ffi::c_void, pcallbackcookie: *mut u32) -> windows_core::Result<()>;
     fn UnregisterMessageCallback(&self, callbackcookie: u32) -> windows_core::Result<()>;
@@ -15188,8 +15126,6 @@ impl ID3D12InfoQueue1_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D12InfoQueue1 {}
-unsafe impl Send for ID3D12InfoQueue1 {}
-unsafe impl Sync for ID3D12InfoQueue1 {}
 windows_core::imp::define_interface!(ID3D12LibraryReflection, ID3D12LibraryReflection_Vtbl, 0x8e349d19_54db_4a56_9dc9_119d87bdb804);
 windows_core::imp::interface_hierarchy!(ID3D12LibraryReflection, windows_core::IUnknown);
 impl ID3D12LibraryReflection {
@@ -15209,6 +15145,8 @@ pub struct ID3D12LibraryReflection_Vtbl {
     pub GetDesc: unsafe extern "system" fn(*mut core::ffi::c_void, *mut D3D12_LIBRARY_DESC) -> windows_core::HRESULT,
     pub GetFunctionByIndex: unsafe extern "system" fn(*mut core::ffi::c_void, i32) -> Option<ID3D12FunctionReflection>,
 }
+unsafe impl Send for ID3D12LibraryReflection {}
+unsafe impl Sync for ID3D12LibraryReflection {}
 pub trait ID3D12LibraryReflection_Impl: windows_core::IUnknownImpl {
     fn GetDesc(&self) -> windows_core::Result<D3D12_LIBRARY_DESC>;
     fn GetFunctionByIndex(&self, functionindex: i32) -> Option<ID3D12FunctionReflection>;
@@ -15244,8 +15182,6 @@ impl ID3D12LibraryReflection_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D12LibraryReflection {}
-unsafe impl Send for ID3D12LibraryReflection {}
-unsafe impl Sync for ID3D12LibraryReflection {}
 windows_core::imp::define_interface!(ID3D12LifetimeOwner, ID3D12LifetimeOwner_Vtbl, 0xe667af9f_cd56_4f46_83ce_032e595d70a8);
 windows_core::imp::interface_hierarchy!(ID3D12LifetimeOwner, windows_core::IUnknown);
 impl ID3D12LifetimeOwner {
@@ -15258,6 +15194,8 @@ pub struct ID3D12LifetimeOwner_Vtbl {
     pub base__: windows_core::IUnknown_Vtbl,
     pub LifetimeStateUpdated: unsafe extern "system" fn(*mut core::ffi::c_void, D3D12_LIFETIME_STATE),
 }
+unsafe impl Send for ID3D12LifetimeOwner {}
+unsafe impl Sync for ID3D12LifetimeOwner {}
 pub trait ID3D12LifetimeOwner_Impl: windows_core::IUnknownImpl {
     fn LifetimeStateUpdated(&self, newstate: D3D12_LIFETIME_STATE);
 }
@@ -15276,8 +15214,6 @@ impl ID3D12LifetimeOwner_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D12LifetimeOwner {}
-unsafe impl Send for ID3D12LifetimeOwner {}
-unsafe impl Sync for ID3D12LifetimeOwner {}
 windows_core::imp::define_interface!(ID3D12LifetimeTracker, ID3D12LifetimeTracker_Vtbl, 0x3fd03d36_4eb1_424a_a582_494ecb8ba813);
 impl core::ops::Deref for ID3D12LifetimeTracker {
     type Target = ID3D12DeviceChild;
@@ -15299,6 +15235,8 @@ pub struct ID3D12LifetimeTracker_Vtbl {
     pub base__: ID3D12DeviceChild_Vtbl,
     pub DestroyOwnedObject: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID3D12LifetimeTracker {}
+unsafe impl Sync for ID3D12LifetimeTracker {}
 pub trait ID3D12LifetimeTracker_Impl: ID3D12DeviceChild_Impl {
     fn DestroyOwnedObject(&self, pobject: windows_core::Ref<ID3D12DeviceChild>) -> windows_core::Result<()>;
 }
@@ -15317,8 +15255,6 @@ impl ID3D12LifetimeTracker_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D12LifetimeTracker {}
-unsafe impl Send for ID3D12LifetimeTracker {}
-unsafe impl Sync for ID3D12LifetimeTracker {}
 windows_core::imp::define_interface!(ID3D12ManualWriteTrackingResource, ID3D12ManualWriteTrackingResource_Vtbl, 0x86ca3b85_49ad_4b6e_aed5_eddb18540f41);
 windows_core::imp::interface_hierarchy!(ID3D12ManualWriteTrackingResource, windows_core::IUnknown);
 impl ID3D12ManualWriteTrackingResource {
@@ -15331,6 +15267,8 @@ pub struct ID3D12ManualWriteTrackingResource_Vtbl {
     pub base__: windows_core::IUnknown_Vtbl,
     pub TrackWrite: unsafe extern "system" fn(*mut core::ffi::c_void, u32, *const D3D12_RANGE),
 }
+unsafe impl Send for ID3D12ManualWriteTrackingResource {}
+unsafe impl Sync for ID3D12ManualWriteTrackingResource {}
 pub trait ID3D12ManualWriteTrackingResource_Impl: windows_core::IUnknownImpl {
     fn TrackWrite(&self, subresource: u32, pwrittenrange: *const D3D12_RANGE);
 }
@@ -15349,8 +15287,6 @@ impl ID3D12ManualWriteTrackingResource_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D12ManualWriteTrackingResource {}
-unsafe impl Send for ID3D12ManualWriteTrackingResource {}
-unsafe impl Sync for ID3D12ManualWriteTrackingResource {}
 windows_core::imp::define_interface!(ID3D12MetaCommand, ID3D12MetaCommand_Vtbl, 0xdbb84c27_36ce_4fc9_b801_f048c46ac570);
 impl core::ops::Deref for ID3D12MetaCommand {
     type Target = ID3D12Pageable;
@@ -15369,6 +15305,8 @@ pub struct ID3D12MetaCommand_Vtbl {
     pub base__: ID3D12Pageable_Vtbl,
     pub GetRequiredParameterResourceSize: unsafe extern "system" fn(*mut core::ffi::c_void, D3D12_META_COMMAND_PARAMETER_STAGE, u32) -> u64,
 }
+unsafe impl Send for ID3D12MetaCommand {}
+unsafe impl Sync for ID3D12MetaCommand {}
 pub trait ID3D12MetaCommand_Impl: ID3D12Pageable_Impl {
     fn GetRequiredParameterResourceSize(&self, stage: D3D12_META_COMMAND_PARAMETER_STAGE, parameterindex: u32) -> u64;
 }
@@ -15387,8 +15325,6 @@ impl ID3D12MetaCommand_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D12MetaCommand {}
-unsafe impl Send for ID3D12MetaCommand {}
-unsafe impl Sync for ID3D12MetaCommand {}
 windows_core::imp::define_interface!(ID3D12Object, ID3D12Object_Vtbl, 0xc4fec28f_7966_4e95_9f94_f431cb56c3b8);
 windows_core::imp::interface_hierarchy!(ID3D12Object, windows_core::IUnknown);
 impl ID3D12Object {
@@ -15419,6 +15355,8 @@ pub struct ID3D12Object_Vtbl {
     pub SetPrivateDataInterface: unsafe extern "system" fn(*mut core::ffi::c_void, *const windows_core::GUID, *mut core::ffi::c_void) -> windows_core::HRESULT,
     pub SetName: unsafe extern "system" fn(*mut core::ffi::c_void, windows_core::PCWSTR) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID3D12Object {}
+unsafe impl Sync for ID3D12Object {}
 pub trait ID3D12Object_Impl: windows_core::IUnknownImpl {
     fn GetPrivateData(&self, guid: *const windows_core::GUID, pdatasize: *mut u32, pdata: *mut core::ffi::c_void) -> windows_core::Result<()>;
     fn SetPrivateData(&self, guid: *const windows_core::GUID, datasize: u32, pdata: *const core::ffi::c_void) -> windows_core::Result<()>;
@@ -15464,8 +15402,6 @@ impl ID3D12Object_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D12Object {}
-unsafe impl Send for ID3D12Object {}
-unsafe impl Sync for ID3D12Object {}
 windows_core::imp::define_interface!(ID3D12Pageable, ID3D12Pageable_Vtbl, 0x63ee58fb_1268_4835_86da_f008ce62f0d6);
 impl core::ops::Deref for ID3D12Pageable {
     type Target = ID3D12DeviceChild;
@@ -15478,6 +15414,8 @@ windows_core::imp::interface_hierarchy!(ID3D12Pageable, windows_core::IUnknown, 
 pub struct ID3D12Pageable_Vtbl {
     pub base__: ID3D12DeviceChild_Vtbl,
 }
+unsafe impl Send for ID3D12Pageable {}
+unsafe impl Sync for ID3D12Pageable {}
 pub trait ID3D12Pageable_Impl: ID3D12DeviceChild_Impl {}
 impl ID3D12Pageable_Vtbl {
     pub const fn new<Identity: ID3D12Pageable_Impl, const OFFSET: isize>() -> Self {
@@ -15488,8 +15426,6 @@ impl ID3D12Pageable_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D12Pageable {}
-unsafe impl Send for ID3D12Pageable {}
-unsafe impl Sync for ID3D12Pageable {}
 windows_core::imp::define_interface!(ID3D12PipelineLibrary, ID3D12PipelineLibrary_Vtbl, 0xc64226a8_9201_46af_b4cc_53fb9ff7414f);
 impl core::ops::Deref for ID3D12PipelineLibrary {
     type Target = ID3D12DeviceChild;
@@ -15542,6 +15478,8 @@ pub struct ID3D12PipelineLibrary_Vtbl {
     pub GetSerializedSize: unsafe extern "system" fn(*mut core::ffi::c_void) -> usize,
     pub Serialize: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, usize) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID3D12PipelineLibrary {}
+unsafe impl Sync for ID3D12PipelineLibrary {}
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 pub trait ID3D12PipelineLibrary_Impl: ID3D12DeviceChild_Impl {
     fn StorePipeline(&self, pname: &windows_core::PCWSTR, ppipeline: windows_core::Ref<ID3D12PipelineState>) -> windows_core::Result<()>;
@@ -15598,10 +15536,6 @@ impl ID3D12PipelineLibrary_Vtbl {
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl windows_core::RuntimeName for ID3D12PipelineLibrary {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-unsafe impl Send for ID3D12PipelineLibrary {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-unsafe impl Sync for ID3D12PipelineLibrary {}
 windows_core::imp::define_interface!(ID3D12PipelineLibrary1, ID3D12PipelineLibrary1_Vtbl, 0x80eabf42_2568_4e5e_bd82_c37f86961dc3);
 impl core::ops::Deref for ID3D12PipelineLibrary1 {
     type Target = ID3D12PipelineLibrary;
@@ -15625,6 +15559,8 @@ pub struct ID3D12PipelineLibrary1_Vtbl {
     pub base__: ID3D12PipelineLibrary_Vtbl,
     pub LoadPipeline: unsafe extern "system" fn(*mut core::ffi::c_void, windows_core::PCWSTR, *const D3D12_PIPELINE_STATE_STREAM_DESC, *const windows_core::GUID, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID3D12PipelineLibrary1 {}
+unsafe impl Sync for ID3D12PipelineLibrary1 {}
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 pub trait ID3D12PipelineLibrary1_Impl: ID3D12PipelineLibrary_Impl {
     fn LoadPipeline(&self, pname: &windows_core::PCWSTR, pdesc: *const D3D12_PIPELINE_STATE_STREAM_DESC, riid: *const windows_core::GUID, pppipelinestate: *mut *mut core::ffi::c_void) -> windows_core::Result<()>;
@@ -15646,10 +15582,6 @@ impl ID3D12PipelineLibrary1_Vtbl {
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl windows_core::RuntimeName for ID3D12PipelineLibrary1 {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-unsafe impl Send for ID3D12PipelineLibrary1 {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-unsafe impl Sync for ID3D12PipelineLibrary1 {}
 windows_core::imp::define_interface!(ID3D12PipelineState, ID3D12PipelineState_Vtbl, 0x765a30f3_f624_4c6f_a828_ace948622445);
 impl core::ops::Deref for ID3D12PipelineState {
     type Target = ID3D12Pageable;
@@ -15675,6 +15607,8 @@ pub struct ID3D12PipelineState_Vtbl {
     #[cfg(not(feature = "Win32_Graphics_Direct3D"))]
     GetCachedBlob: usize,
 }
+unsafe impl Send for ID3D12PipelineState {}
+unsafe impl Sync for ID3D12PipelineState {}
 #[cfg(feature = "Win32_Graphics_Direct3D")]
 pub trait ID3D12PipelineState_Impl: ID3D12Pageable_Impl {
     fn GetCachedBlob(&self) -> windows_core::Result<super::Direct3D::ID3DBlob>;
@@ -15702,10 +15636,6 @@ impl ID3D12PipelineState_Vtbl {
 }
 #[cfg(feature = "Win32_Graphics_Direct3D")]
 impl windows_core::RuntimeName for ID3D12PipelineState {}
-#[cfg(feature = "Win32_Graphics_Direct3D")]
-unsafe impl Send for ID3D12PipelineState {}
-#[cfg(feature = "Win32_Graphics_Direct3D")]
-unsafe impl Sync for ID3D12PipelineState {}
 windows_core::imp::define_interface!(ID3D12ProtectedResourceSession, ID3D12ProtectedResourceSession_Vtbl, 0x6cd696f4_f289_40cc_8091_5a6c0a099c3d);
 impl core::ops::Deref for ID3D12ProtectedResourceSession {
     type Target = ID3D12ProtectedSession;
@@ -15728,6 +15658,8 @@ pub struct ID3D12ProtectedResourceSession_Vtbl {
     pub base__: ID3D12ProtectedSession_Vtbl,
     pub GetDesc: unsafe extern "system" fn(*mut core::ffi::c_void, *mut D3D12_PROTECTED_RESOURCE_SESSION_DESC),
 }
+unsafe impl Send for ID3D12ProtectedResourceSession {}
+unsafe impl Sync for ID3D12ProtectedResourceSession {}
 pub trait ID3D12ProtectedResourceSession_Impl: ID3D12ProtectedSession_Impl {
     fn GetDesc(&self) -> D3D12_PROTECTED_RESOURCE_SESSION_DESC;
 }
@@ -15746,8 +15678,6 @@ impl ID3D12ProtectedResourceSession_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D12ProtectedResourceSession {}
-unsafe impl Send for ID3D12ProtectedResourceSession {}
-unsafe impl Sync for ID3D12ProtectedResourceSession {}
 windows_core::imp::define_interface!(ID3D12ProtectedResourceSession1, ID3D12ProtectedResourceSession1_Vtbl, 0xd6f12dd6_76fb_406e_8961_4296eefc0409);
 impl core::ops::Deref for ID3D12ProtectedResourceSession1 {
     type Target = ID3D12ProtectedResourceSession;
@@ -15770,6 +15700,8 @@ pub struct ID3D12ProtectedResourceSession1_Vtbl {
     pub base__: ID3D12ProtectedResourceSession_Vtbl,
     pub GetDesc1: unsafe extern "system" fn(*mut core::ffi::c_void, *mut D3D12_PROTECTED_RESOURCE_SESSION_DESC1),
 }
+unsafe impl Send for ID3D12ProtectedResourceSession1 {}
+unsafe impl Sync for ID3D12ProtectedResourceSession1 {}
 pub trait ID3D12ProtectedResourceSession1_Impl: ID3D12ProtectedResourceSession_Impl {
     fn GetDesc1(&self) -> D3D12_PROTECTED_RESOURCE_SESSION_DESC1;
 }
@@ -15788,8 +15720,6 @@ impl ID3D12ProtectedResourceSession1_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D12ProtectedResourceSession1 {}
-unsafe impl Send for ID3D12ProtectedResourceSession1 {}
-unsafe impl Sync for ID3D12ProtectedResourceSession1 {}
 windows_core::imp::define_interface!(ID3D12ProtectedSession, ID3D12ProtectedSession_Vtbl, 0xa1533d18_0ac1_4084_85b9_89a96116806b);
 impl core::ops::Deref for ID3D12ProtectedSession {
     type Target = ID3D12DeviceChild;
@@ -15815,6 +15745,8 @@ pub struct ID3D12ProtectedSession_Vtbl {
     pub GetStatusFence: unsafe extern "system" fn(*mut core::ffi::c_void, *const windows_core::GUID, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
     pub GetSessionStatus: unsafe extern "system" fn(*mut core::ffi::c_void) -> D3D12_PROTECTED_SESSION_STATUS,
 }
+unsafe impl Send for ID3D12ProtectedSession {}
+unsafe impl Sync for ID3D12ProtectedSession {}
 pub trait ID3D12ProtectedSession_Impl: ID3D12DeviceChild_Impl {
     fn GetStatusFence(&self, riid: *const windows_core::GUID, ppfence: *mut *mut core::ffi::c_void) -> windows_core::Result<()>;
     fn GetSessionStatus(&self) -> D3D12_PROTECTED_SESSION_STATUS;
@@ -15844,8 +15776,6 @@ impl ID3D12ProtectedSession_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D12ProtectedSession {}
-unsafe impl Send for ID3D12ProtectedSession {}
-unsafe impl Sync for ID3D12ProtectedSession {}
 windows_core::imp::define_interface!(ID3D12QueryHeap, ID3D12QueryHeap_Vtbl, 0x0d9658ae_ed45_469e_a61d_970ec583cab4);
 impl core::ops::Deref for ID3D12QueryHeap {
     type Target = ID3D12Pageable;
@@ -15858,6 +15788,8 @@ windows_core::imp::interface_hierarchy!(ID3D12QueryHeap, windows_core::IUnknown,
 pub struct ID3D12QueryHeap_Vtbl {
     pub base__: ID3D12Pageable_Vtbl,
 }
+unsafe impl Send for ID3D12QueryHeap {}
+unsafe impl Sync for ID3D12QueryHeap {}
 pub trait ID3D12QueryHeap_Impl: ID3D12Pageable_Impl {}
 impl ID3D12QueryHeap_Vtbl {
     pub const fn new<Identity: ID3D12QueryHeap_Impl, const OFFSET: isize>() -> Self {
@@ -15868,8 +15800,6 @@ impl ID3D12QueryHeap_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D12QueryHeap {}
-unsafe impl Send for ID3D12QueryHeap {}
-unsafe impl Sync for ID3D12QueryHeap {}
 windows_core::imp::define_interface!(ID3D12Resource, ID3D12Resource_Vtbl, 0x696442be_a72e_4059_bc79_5b5c98040fad);
 impl core::ops::Deref for ID3D12Resource {
     type Target = ID3D12Pageable;
@@ -15920,6 +15850,8 @@ pub struct ID3D12Resource_Vtbl {
     pub ReadFromSubresource: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, u32, u32, u32, *const D3D12_BOX) -> windows_core::HRESULT,
     pub GetHeapProperties: unsafe extern "system" fn(*mut core::ffi::c_void, *mut D3D12_HEAP_PROPERTIES, *mut D3D12_HEAP_FLAGS) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID3D12Resource {}
+unsafe impl Sync for ID3D12Resource {}
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 pub trait ID3D12Resource_Impl: ID3D12Pageable_Impl {
     fn Map(&self, subresource: u32, preadrange: *const D3D12_RANGE, ppdata: *mut *mut core::ffi::c_void) -> windows_core::Result<()>;
@@ -15992,10 +15924,6 @@ impl ID3D12Resource_Vtbl {
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl windows_core::RuntimeName for ID3D12Resource {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-unsafe impl Send for ID3D12Resource {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-unsafe impl Sync for ID3D12Resource {}
 windows_core::imp::define_interface!(ID3D12Resource1, ID3D12Resource1_Vtbl, 0x9d5e227a_4430_4161_88b3_3eca6bb16e19);
 impl core::ops::Deref for ID3D12Resource1 {
     type Target = ID3D12Resource;
@@ -16017,6 +15945,8 @@ pub struct ID3D12Resource1_Vtbl {
     pub base__: ID3D12Resource_Vtbl,
     pub GetProtectedResourceSession: unsafe extern "system" fn(*mut core::ffi::c_void, *const windows_core::GUID, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID3D12Resource1 {}
+unsafe impl Sync for ID3D12Resource1 {}
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 pub trait ID3D12Resource1_Impl: ID3D12Resource_Impl {
     fn GetProtectedResourceSession(&self, riid: *const windows_core::GUID, ppprotectedsession: *mut *mut core::ffi::c_void) -> windows_core::Result<()>;
@@ -16038,10 +15968,6 @@ impl ID3D12Resource1_Vtbl {
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl windows_core::RuntimeName for ID3D12Resource1 {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-unsafe impl Send for ID3D12Resource1 {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-unsafe impl Sync for ID3D12Resource1 {}
 windows_core::imp::define_interface!(ID3D12Resource2, ID3D12Resource2_Vtbl, 0xbe36ec3b_ea85_4aeb_a45a_e9d76404a495);
 impl core::ops::Deref for ID3D12Resource2 {
     type Target = ID3D12Resource1;
@@ -16068,6 +15994,8 @@ pub struct ID3D12Resource2_Vtbl {
     #[cfg(not(feature = "Win32_Graphics_Dxgi_Common"))]
     GetDesc1: usize,
 }
+unsafe impl Send for ID3D12Resource2 {}
+unsafe impl Sync for ID3D12Resource2 {}
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 pub trait ID3D12Resource2_Impl: ID3D12Resource1_Impl {
     fn GetDesc1(&self) -> D3D12_RESOURCE_DESC1;
@@ -16089,10 +16017,6 @@ impl ID3D12Resource2_Vtbl {
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl windows_core::RuntimeName for ID3D12Resource2 {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-unsafe impl Send for ID3D12Resource2 {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-unsafe impl Sync for ID3D12Resource2 {}
 windows_core::imp::define_interface!(ID3D12RootSignature, ID3D12RootSignature_Vtbl, 0xc54a6b66_72df_4ee8_8be5_a946a1429214);
 impl core::ops::Deref for ID3D12RootSignature {
     type Target = ID3D12DeviceChild;
@@ -16105,6 +16029,8 @@ windows_core::imp::interface_hierarchy!(ID3D12RootSignature, windows_core::IUnkn
 pub struct ID3D12RootSignature_Vtbl {
     pub base__: ID3D12DeviceChild_Vtbl,
 }
+unsafe impl Send for ID3D12RootSignature {}
+unsafe impl Sync for ID3D12RootSignature {}
 pub trait ID3D12RootSignature_Impl: ID3D12DeviceChild_Impl {}
 impl ID3D12RootSignature_Vtbl {
     pub const fn new<Identity: ID3D12RootSignature_Impl, const OFFSET: isize>() -> Self {
@@ -16115,8 +16041,6 @@ impl ID3D12RootSignature_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D12RootSignature {}
-unsafe impl Send for ID3D12RootSignature {}
-unsafe impl Sync for ID3D12RootSignature {}
 windows_core::imp::define_interface!(ID3D12RootSignatureDeserializer, ID3D12RootSignatureDeserializer_Vtbl, 0x34ab647b_3cc8_46ac_841b_c0965645c046);
 windows_core::imp::interface_hierarchy!(ID3D12RootSignatureDeserializer, windows_core::IUnknown);
 impl ID3D12RootSignatureDeserializer {
@@ -16129,6 +16053,8 @@ pub struct ID3D12RootSignatureDeserializer_Vtbl {
     pub base__: windows_core::IUnknown_Vtbl,
     pub GetRootSignatureDesc: unsafe extern "system" fn(*mut core::ffi::c_void) -> *mut D3D12_ROOT_SIGNATURE_DESC,
 }
+unsafe impl Send for ID3D12RootSignatureDeserializer {}
+unsafe impl Sync for ID3D12RootSignatureDeserializer {}
 pub trait ID3D12RootSignatureDeserializer_Impl: windows_core::IUnknownImpl {
     fn GetRootSignatureDesc(&self) -> *mut D3D12_ROOT_SIGNATURE_DESC;
 }
@@ -16147,8 +16073,6 @@ impl ID3D12RootSignatureDeserializer_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D12RootSignatureDeserializer {}
-unsafe impl Send for ID3D12RootSignatureDeserializer {}
-unsafe impl Sync for ID3D12RootSignatureDeserializer {}
 windows_core::imp::define_interface!(ID3D12SDKConfiguration, ID3D12SDKConfiguration_Vtbl, 0xe9eb5314_33aa_42b2_a718_d77f58b1f1c7);
 windows_core::imp::interface_hierarchy!(ID3D12SDKConfiguration, windows_core::IUnknown);
 impl ID3D12SDKConfiguration {
@@ -16164,6 +16088,8 @@ pub struct ID3D12SDKConfiguration_Vtbl {
     pub base__: windows_core::IUnknown_Vtbl,
     pub SetSDKVersion: unsafe extern "system" fn(*mut core::ffi::c_void, u32, windows_core::PCSTR) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID3D12SDKConfiguration {}
+unsafe impl Sync for ID3D12SDKConfiguration {}
 pub trait ID3D12SDKConfiguration_Impl: windows_core::IUnknownImpl {
     fn SetSDKVersion(&self, sdkversion: u32, sdkpath: &windows_core::PCSTR) -> windows_core::Result<()>;
 }
@@ -16182,8 +16108,6 @@ impl ID3D12SDKConfiguration_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D12SDKConfiguration {}
-unsafe impl Send for ID3D12SDKConfiguration {}
-unsafe impl Sync for ID3D12SDKConfiguration {}
 windows_core::imp::define_interface!(ID3D12SDKConfiguration1, ID3D12SDKConfiguration1_Vtbl, 0x8aaf9303_ad25_48b9_9a57_d9c37e009d9f);
 impl core::ops::Deref for ID3D12SDKConfiguration1 {
     type Target = ID3D12SDKConfiguration;
@@ -16211,6 +16135,8 @@ pub struct ID3D12SDKConfiguration1_Vtbl {
     pub CreateDeviceFactory: unsafe extern "system" fn(*mut core::ffi::c_void, u32, windows_core::PCSTR, *const windows_core::GUID, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
     pub FreeUnusedSDKs: unsafe extern "system" fn(*mut core::ffi::c_void),
 }
+unsafe impl Send for ID3D12SDKConfiguration1 {}
+unsafe impl Sync for ID3D12SDKConfiguration1 {}
 pub trait ID3D12SDKConfiguration1_Impl: ID3D12SDKConfiguration_Impl {
     fn CreateDeviceFactory(&self, sdkversion: u32, sdkpath: &windows_core::PCSTR, riid: *const windows_core::GUID, ppvfactory: *mut *mut core::ffi::c_void) -> windows_core::Result<()>;
     fn FreeUnusedSDKs(&self);
@@ -16240,8 +16166,6 @@ impl ID3D12SDKConfiguration1_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D12SDKConfiguration1 {}
-unsafe impl Send for ID3D12SDKConfiguration1 {}
-unsafe impl Sync for ID3D12SDKConfiguration1 {}
 windows_core::imp::define_interface!(ID3D12ShaderCacheSession, ID3D12ShaderCacheSession_Vtbl, 0x28e2495d_0f64_4ae4_a6ec_129255dc49a8);
 impl core::ops::Deref for ID3D12ShaderCacheSession {
     type Target = ID3D12DeviceChild;
@@ -16276,6 +16200,8 @@ pub struct ID3D12ShaderCacheSession_Vtbl {
     pub SetDeleteOnDestroy: unsafe extern "system" fn(*mut core::ffi::c_void),
     pub GetDesc: unsafe extern "system" fn(*mut core::ffi::c_void, *mut D3D12_SHADER_CACHE_SESSION_DESC),
 }
+unsafe impl Send for ID3D12ShaderCacheSession {}
+unsafe impl Sync for ID3D12ShaderCacheSession {}
 pub trait ID3D12ShaderCacheSession_Impl: ID3D12DeviceChild_Impl {
     fn FindValue(&self, pkey: *const core::ffi::c_void, keysize: u32, pvalue: *mut core::ffi::c_void, pvaluesize: *mut u32) -> windows_core::Result<()>;
     fn StoreValue(&self, pkey: *const core::ffi::c_void, keysize: u32, pvalue: *const core::ffi::c_void, valuesize: u32) -> windows_core::Result<()>;
@@ -16321,8 +16247,6 @@ impl ID3D12ShaderCacheSession_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D12ShaderCacheSession {}
-unsafe impl Send for ID3D12ShaderCacheSession {}
-unsafe impl Sync for ID3D12ShaderCacheSession {}
 windows_core::imp::define_interface!(ID3D12ShaderReflection, ID3D12ShaderReflection_Vtbl, 0x5a58797d_a72c_478d_8ba2_efc6b0efe88e);
 windows_core::imp::interface_hierarchy!(ID3D12ShaderReflection, windows_core::IUnknown);
 impl ID3D12ShaderReflection {
@@ -16451,6 +16375,8 @@ pub struct ID3D12ShaderReflection_Vtbl {
     pub GetThreadGroupSize: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u32, *mut u32, *mut u32) -> u32,
     pub GetRequiresFlags: unsafe extern "system" fn(*mut core::ffi::c_void) -> u64,
 }
+unsafe impl Send for ID3D12ShaderReflection {}
+unsafe impl Sync for ID3D12ShaderReflection {}
 #[cfg(feature = "Win32_Graphics_Direct3D")]
 pub trait ID3D12ShaderReflection_Impl: windows_core::IUnknownImpl {
     fn GetDesc(&self, pdesc: *mut D3D12_SHADER_DESC) -> windows_core::Result<()>;
@@ -16625,10 +16551,6 @@ impl ID3D12ShaderReflection_Vtbl {
 }
 #[cfg(feature = "Win32_Graphics_Direct3D")]
 impl windows_core::RuntimeName for ID3D12ShaderReflection {}
-#[cfg(feature = "Win32_Graphics_Direct3D")]
-unsafe impl Send for ID3D12ShaderReflection {}
-#[cfg(feature = "Win32_Graphics_Direct3D")]
-unsafe impl Sync for ID3D12ShaderReflection {}
 windows_core::imp::define_interface!(ID3D12ShaderReflectionConstantBuffer, ID3D12ShaderReflectionConstantBuffer_Vtbl);
 impl ID3D12ShaderReflectionConstantBuffer {
     #[cfg(feature = "Win32_Graphics_Direct3D")]
@@ -16654,6 +16576,8 @@ pub struct ID3D12ShaderReflectionConstantBuffer_Vtbl {
     pub GetVariableByIndex: unsafe extern "system" fn(*mut core::ffi::c_void, u32) -> Option<ID3D12ShaderReflectionVariable>,
     pub GetVariableByName: unsafe extern "system" fn(*mut core::ffi::c_void, windows_core::PCSTR) -> Option<ID3D12ShaderReflectionVariable>,
 }
+unsafe impl Send for ID3D12ShaderReflectionConstantBuffer {}
+unsafe impl Sync for ID3D12ShaderReflectionConstantBuffer {}
 #[cfg(feature = "Win32_Graphics_Direct3D")]
 pub trait ID3D12ShaderReflectionConstantBuffer_Impl {
     fn GetDesc(&self, pdesc: *mut D3D12_SHADER_BUFFER_DESC) -> windows_core::Result<()>;
@@ -16701,10 +16625,6 @@ impl ID3D12ShaderReflectionConstantBuffer {
         unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
     }
 }
-#[cfg(feature = "Win32_Graphics_Direct3D")]
-unsafe impl Send for ID3D12ShaderReflectionConstantBuffer {}
-#[cfg(feature = "Win32_Graphics_Direct3D")]
-unsafe impl Sync for ID3D12ShaderReflectionConstantBuffer {}
 windows_core::imp::define_interface!(ID3D12ShaderReflectionType, ID3D12ShaderReflectionType_Vtbl);
 impl ID3D12ShaderReflectionType {
     #[cfg(feature = "Win32_Graphics_Direct3D")]
@@ -16771,6 +16691,8 @@ pub struct ID3D12ShaderReflectionType_Vtbl {
     pub IsOfType: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
     pub ImplementsInterface: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID3D12ShaderReflectionType {}
+unsafe impl Sync for ID3D12ShaderReflectionType {}
 #[cfg(feature = "Win32_Graphics_Direct3D")]
 pub trait ID3D12ShaderReflectionType_Impl {
     fn GetDesc(&self, pdesc: *mut D3D12_SHADER_TYPE_DESC) -> windows_core::Result<()>;
@@ -16894,10 +16816,6 @@ impl ID3D12ShaderReflectionType {
         unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
     }
 }
-#[cfg(feature = "Win32_Graphics_Direct3D")]
-unsafe impl Send for ID3D12ShaderReflectionType {}
-#[cfg(feature = "Win32_Graphics_Direct3D")]
-unsafe impl Sync for ID3D12ShaderReflectionType {}
 windows_core::imp::define_interface!(ID3D12ShaderReflectionVariable, ID3D12ShaderReflectionVariable_Vtbl);
 impl ID3D12ShaderReflectionVariable {
     pub unsafe fn GetDesc(&self, pdesc: *mut D3D12_SHADER_VARIABLE_DESC) -> windows_core::Result<()> {
@@ -16920,6 +16838,8 @@ pub struct ID3D12ShaderReflectionVariable_Vtbl {
     pub GetBuffer: unsafe extern "system" fn(*mut core::ffi::c_void) -> Option<ID3D12ShaderReflectionConstantBuffer>,
     pub GetInterfaceSlot: unsafe extern "system" fn(*mut core::ffi::c_void, u32) -> u32,
 }
+unsafe impl Send for ID3D12ShaderReflectionVariable {}
+unsafe impl Sync for ID3D12ShaderReflectionVariable {}
 pub trait ID3D12ShaderReflectionVariable_Impl {
     fn GetDesc(&self, pdesc: *mut D3D12_SHADER_VARIABLE_DESC) -> windows_core::Result<()>;
     fn GetType(&self) -> Option<ID3D12ShaderReflectionType>;
@@ -16970,8 +16890,6 @@ impl ID3D12ShaderReflectionVariable {
         unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
     }
 }
-unsafe impl Send for ID3D12ShaderReflectionVariable {}
-unsafe impl Sync for ID3D12ShaderReflectionVariable {}
 windows_core::imp::define_interface!(ID3D12SharingContract, ID3D12SharingContract_Vtbl, 0x0adf7d52_929c_4e61_addb_ffed30de66ef);
 windows_core::imp::interface_hierarchy!(ID3D12SharingContract, windows_core::IUnknown);
 impl ID3D12SharingContract {
@@ -17002,6 +16920,8 @@ pub struct ID3D12SharingContract_Vtbl {
     pub BeginCapturableWork: unsafe extern "system" fn(*mut core::ffi::c_void, *const windows_core::GUID),
     pub EndCapturableWork: unsafe extern "system" fn(*mut core::ffi::c_void, *const windows_core::GUID),
 }
+unsafe impl Send for ID3D12SharingContract {}
+unsafe impl Sync for ID3D12SharingContract {}
 pub trait ID3D12SharingContract_Impl: windows_core::IUnknownImpl {
     fn Present(&self, presource: windows_core::Ref<ID3D12Resource>, subresource: u32, window: super::super::Foundation::HWND);
     fn SharedFenceSignal(&self, pfence: windows_core::Ref<ID3D12Fence>, fencevalue: u64);
@@ -17047,8 +16967,6 @@ impl ID3D12SharingContract_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D12SharingContract {}
-unsafe impl Send for ID3D12SharingContract {}
-unsafe impl Sync for ID3D12SharingContract {}
 windows_core::imp::define_interface!(ID3D12StateObject, ID3D12StateObject_Vtbl, 0x47016943_fca8_4594_93ea_af258b55346d);
 impl core::ops::Deref for ID3D12StateObject {
     type Target = ID3D12Pageable;
@@ -17061,6 +16979,8 @@ windows_core::imp::interface_hierarchy!(ID3D12StateObject, windows_core::IUnknow
 pub struct ID3D12StateObject_Vtbl {
     pub base__: ID3D12Pageable_Vtbl,
 }
+unsafe impl Send for ID3D12StateObject {}
+unsafe impl Sync for ID3D12StateObject {}
 pub trait ID3D12StateObject_Impl: ID3D12Pageable_Impl {}
 impl ID3D12StateObject_Vtbl {
     pub const fn new<Identity: ID3D12StateObject_Impl, const OFFSET: isize>() -> Self {
@@ -17071,8 +16991,6 @@ impl ID3D12StateObject_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D12StateObject {}
-unsafe impl Send for ID3D12StateObject {}
-unsafe impl Sync for ID3D12StateObject {}
 windows_core::imp::define_interface!(ID3D12StateObjectProperties, ID3D12StateObjectProperties_Vtbl, 0xde5fa827_9bf9_4f26_89ff_d7f56fde3860);
 windows_core::imp::interface_hierarchy!(ID3D12StateObjectProperties, windows_core::IUnknown);
 impl ID3D12StateObjectProperties {
@@ -17103,6 +17021,8 @@ pub struct ID3D12StateObjectProperties_Vtbl {
     pub GetPipelineStackSize: unsafe extern "system" fn(*mut core::ffi::c_void) -> u64,
     pub SetPipelineStackSize: unsafe extern "system" fn(*mut core::ffi::c_void, u64),
 }
+unsafe impl Send for ID3D12StateObjectProperties {}
+unsafe impl Sync for ID3D12StateObjectProperties {}
 pub trait ID3D12StateObjectProperties_Impl: windows_core::IUnknownImpl {
     fn GetShaderIdentifier(&self, pexportname: &windows_core::PCWSTR) -> *mut core::ffi::c_void;
     fn GetShaderStackSize(&self, pexportname: &windows_core::PCWSTR) -> u64;
@@ -17148,8 +17068,6 @@ impl ID3D12StateObjectProperties_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D12StateObjectProperties {}
-unsafe impl Send for ID3D12StateObjectProperties {}
-unsafe impl Sync for ID3D12StateObjectProperties {}
 windows_core::imp::define_interface!(ID3D12StateObjectProperties1, ID3D12StateObjectProperties1_Vtbl, 0x460caac7_1d24_446a_a184_ca67db494138);
 impl core::ops::Deref for ID3D12StateObjectProperties1 {
     type Target = ID3D12StateObjectProperties;
@@ -17175,6 +17093,8 @@ pub struct ID3D12StateObjectProperties1_Vtbl {
     pub base__: ID3D12StateObjectProperties_Vtbl,
     pub GetProgramIdentifier: unsafe extern "system" fn(*mut core::ffi::c_void, *mut D3D12_PROGRAM_IDENTIFIER, windows_core::PCWSTR),
 }
+unsafe impl Send for ID3D12StateObjectProperties1 {}
+unsafe impl Sync for ID3D12StateObjectProperties1 {}
 pub trait ID3D12StateObjectProperties1_Impl: ID3D12StateObjectProperties_Impl {
     fn GetProgramIdentifier(&self, pprogramname: &windows_core::PCWSTR) -> D3D12_PROGRAM_IDENTIFIER;
 }
@@ -17193,8 +17113,6 @@ impl ID3D12StateObjectProperties1_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D12StateObjectProperties1 {}
-unsafe impl Send for ID3D12StateObjectProperties1 {}
-unsafe impl Sync for ID3D12StateObjectProperties1 {}
 windows_core::imp::define_interface!(ID3D12SwapChainAssistant, ID3D12SwapChainAssistant_Vtbl, 0xf1df64b6_57fd_49cd_8807_c0eb88b45c8f);
 windows_core::imp::interface_hierarchy!(ID3D12SwapChainAssistant, windows_core::IUnknown);
 impl ID3D12SwapChainAssistant {
@@ -17231,6 +17149,8 @@ pub struct ID3D12SwapChainAssistant_Vtbl {
     pub GetCurrentResourceAndCommandQueue: unsafe extern "system" fn(*mut core::ffi::c_void, *const windows_core::GUID, *mut *mut core::ffi::c_void, *const windows_core::GUID, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
     pub InsertImplicitSync: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID3D12SwapChainAssistant {}
+unsafe impl Sync for ID3D12SwapChainAssistant {}
 pub trait ID3D12SwapChainAssistant_Impl: windows_core::IUnknownImpl {
     fn GetLUID(&self) -> super::super::Foundation::LUID;
     fn GetSwapChainObject(&self, riid: *const windows_core::GUID, ppv: *mut *mut core::ffi::c_void) -> windows_core::Result<()>;
@@ -17276,8 +17196,6 @@ impl ID3D12SwapChainAssistant_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D12SwapChainAssistant {}
-unsafe impl Send for ID3D12SwapChainAssistant {}
-unsafe impl Sync for ID3D12SwapChainAssistant {}
 windows_core::imp::define_interface!(ID3D12Tools, ID3D12Tools_Vtbl, 0x7071e1f0_e84b_4b33_974f_12fa49de65c5);
 windows_core::imp::interface_hierarchy!(ID3D12Tools, windows_core::IUnknown);
 impl ID3D12Tools {
@@ -17294,6 +17212,8 @@ pub struct ID3D12Tools_Vtbl {
     pub EnableShaderInstrumentation: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::BOOL),
     pub ShaderInstrumentationEnabled: unsafe extern "system" fn(*mut core::ffi::c_void) -> super::super::Foundation::BOOL,
 }
+unsafe impl Send for ID3D12Tools {}
+unsafe impl Sync for ID3D12Tools {}
 pub trait ID3D12Tools_Impl: windows_core::IUnknownImpl {
     fn EnableShaderInstrumentation(&self, benable: super::super::Foundation::BOOL);
     fn ShaderInstrumentationEnabled(&self) -> super::super::Foundation::BOOL;
@@ -17323,8 +17243,6 @@ impl ID3D12Tools_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D12Tools {}
-unsafe impl Send for ID3D12Tools {}
-unsafe impl Sync for ID3D12Tools {}
 windows_core::imp::define_interface!(ID3D12VersionedRootSignatureDeserializer, ID3D12VersionedRootSignatureDeserializer_Vtbl, 0x7f91ce67_090c_4bb7_b78e_ed8ff2e31da0);
 windows_core::imp::interface_hierarchy!(ID3D12VersionedRootSignatureDeserializer, windows_core::IUnknown);
 impl ID3D12VersionedRootSignatureDeserializer {
@@ -17344,6 +17262,8 @@ pub struct ID3D12VersionedRootSignatureDeserializer_Vtbl {
     pub GetRootSignatureDescAtVersion: unsafe extern "system" fn(*mut core::ffi::c_void, D3D_ROOT_SIGNATURE_VERSION, *mut *mut D3D12_VERSIONED_ROOT_SIGNATURE_DESC) -> windows_core::HRESULT,
     pub GetUnconvertedRootSignatureDesc: unsafe extern "system" fn(*mut core::ffi::c_void) -> *mut D3D12_VERSIONED_ROOT_SIGNATURE_DESC,
 }
+unsafe impl Send for ID3D12VersionedRootSignatureDeserializer {}
+unsafe impl Sync for ID3D12VersionedRootSignatureDeserializer {}
 pub trait ID3D12VersionedRootSignatureDeserializer_Impl: windows_core::IUnknownImpl {
     fn GetRootSignatureDescAtVersion(&self, converttoversion: D3D_ROOT_SIGNATURE_VERSION) -> windows_core::Result<*mut D3D12_VERSIONED_ROOT_SIGNATURE_DESC>;
     fn GetUnconvertedRootSignatureDesc(&self) -> *mut D3D12_VERSIONED_ROOT_SIGNATURE_DESC;
@@ -17379,8 +17299,6 @@ impl ID3D12VersionedRootSignatureDeserializer_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D12VersionedRootSignatureDeserializer {}
-unsafe impl Send for ID3D12VersionedRootSignatureDeserializer {}
-unsafe impl Sync for ID3D12VersionedRootSignatureDeserializer {}
 windows_core::imp::define_interface!(ID3D12VirtualizationGuestDevice, ID3D12VirtualizationGuestDevice_Vtbl, 0xbc66d368_7373_4943_8757_fc87dc79e476);
 windows_core::imp::interface_hierarchy!(ID3D12VirtualizationGuestDevice, windows_core::IUnknown);
 impl ID3D12VirtualizationGuestDevice {
@@ -17409,6 +17327,8 @@ pub struct ID3D12VirtualizationGuestDevice_Vtbl {
     pub ShareWithHost: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut super::super::Foundation::HANDLE) -> windows_core::HRESULT,
     pub CreateFenceFd: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, u64, *mut i32) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID3D12VirtualizationGuestDevice {}
+unsafe impl Sync for ID3D12VirtualizationGuestDevice {}
 pub trait ID3D12VirtualizationGuestDevice_Impl: windows_core::IUnknownImpl {
     fn ShareWithHost(&self, pobject: windows_core::Ref<ID3D12DeviceChild>) -> windows_core::Result<super::super::Foundation::HANDLE>;
     fn CreateFenceFd(&self, pfence: windows_core::Ref<ID3D12Fence>, fencevalue: u64) -> windows_core::Result<i32>;
@@ -17450,8 +17370,6 @@ impl ID3D12VirtualizationGuestDevice_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D12VirtualizationGuestDevice {}
-unsafe impl Send for ID3D12VirtualizationGuestDevice {}
-unsafe impl Sync for ID3D12VirtualizationGuestDevice {}
 windows_core::imp::define_interface!(ID3D12WorkGraphProperties, ID3D12WorkGraphProperties_Vtbl, 0x065acf71_f863_4b89_82f4_02e4d5886757);
 windows_core::imp::interface_hierarchy!(ID3D12WorkGraphProperties, windows_core::IUnknown);
 impl ID3D12WorkGraphProperties {
@@ -17523,6 +17441,8 @@ pub struct ID3D12WorkGraphProperties_Vtbl {
     pub GetWorkGraphMemoryRequirements: unsafe extern "system" fn(*mut core::ffi::c_void, u32, *mut D3D12_WORK_GRAPH_MEMORY_REQUIREMENTS),
     pub GetEntrypointRecordAlignmentInBytes: unsafe extern "system" fn(*mut core::ffi::c_void, u32, u32) -> u32,
 }
+unsafe impl Send for ID3D12WorkGraphProperties {}
+unsafe impl Sync for ID3D12WorkGraphProperties {}
 pub trait ID3D12WorkGraphProperties_Impl: windows_core::IUnknownImpl {
     fn GetNumWorkGraphs(&self) -> u32;
     fn GetProgramName(&self, workgraphindex: u32) -> windows_core::PCWSTR;
@@ -17640,8 +17560,6 @@ impl ID3D12WorkGraphProperties_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D12WorkGraphProperties {}
-unsafe impl Send for ID3D12WorkGraphProperties {}
-unsafe impl Sync for ID3D12WorkGraphProperties {}
 pub const LUID_DEFINED: u32 = 1u32;
 pub const NUM_D3D12_GPU_BASED_VALIDATION_SHADER_PATCH_MODES: D3D12_GPU_BASED_VALIDATION_SHADER_PATCH_MODE = D3D12_GPU_BASED_VALIDATION_SHADER_PATCH_MODE(4i32);
 #[cfg(feature = "Win32_Graphics_Direct3D")]

--- a/crates/libs/windows/src/Windows/Win32/Graphics/DirectWrite/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/DirectWrite/mod.rs
@@ -1856,6 +1856,8 @@ pub struct IDWriteAsyncResult_Vtbl {
     pub GetWaitHandle: unsafe extern "system" fn(*mut core::ffi::c_void) -> super::super::Foundation::HANDLE,
     pub GetResult: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
+unsafe impl Send for IDWriteAsyncResult {}
+unsafe impl Sync for IDWriteAsyncResult {}
 pub trait IDWriteAsyncResult_Impl: windows_core::IUnknownImpl {
     fn GetWaitHandle(&self) -> super::super::Foundation::HANDLE;
     fn GetResult(&self) -> windows_core::Result<()>;
@@ -1885,8 +1887,6 @@ impl IDWriteAsyncResult_Vtbl {
     }
 }
 impl windows_core::RuntimeName for IDWriteAsyncResult {}
-unsafe impl Send for IDWriteAsyncResult {}
-unsafe impl Sync for IDWriteAsyncResult {}
 windows_core::imp::define_interface!(IDWriteBitmapRenderTarget, IDWriteBitmapRenderTarget_Vtbl, 0x5e5a32a3_8dff_4773_9ff6_0696eab77267);
 windows_core::imp::interface_hierarchy!(IDWriteBitmapRenderTarget, windows_core::IUnknown);
 impl IDWriteBitmapRenderTarget {
@@ -1937,6 +1937,8 @@ pub struct IDWriteBitmapRenderTarget_Vtbl {
     pub GetSize: unsafe extern "system" fn(*mut core::ffi::c_void, *mut super::super::Foundation::SIZE) -> windows_core::HRESULT,
     pub Resize: unsafe extern "system" fn(*mut core::ffi::c_void, u32, u32) -> windows_core::HRESULT,
 }
+unsafe impl Send for IDWriteBitmapRenderTarget {}
+unsafe impl Sync for IDWriteBitmapRenderTarget {}
 #[cfg(feature = "Win32_Graphics_Gdi")]
 pub trait IDWriteBitmapRenderTarget_Impl: windows_core::IUnknownImpl {
     fn DrawGlyphRun(&self, baselineoriginx: f32, baselineoriginy: f32, measuringmode: DWRITE_MEASURING_MODE, glyphrun: *const DWRITE_GLYPH_RUN, renderingparams: windows_core::Ref<IDWriteRenderingParams>, textcolor: super::super::Foundation::COLORREF, blackboxrect: *mut super::super::Foundation::RECT) -> windows_core::Result<()>;
@@ -2023,10 +2025,6 @@ impl IDWriteBitmapRenderTarget_Vtbl {
 }
 #[cfg(feature = "Win32_Graphics_Gdi")]
 impl windows_core::RuntimeName for IDWriteBitmapRenderTarget {}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-unsafe impl Send for IDWriteBitmapRenderTarget {}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-unsafe impl Sync for IDWriteBitmapRenderTarget {}
 windows_core::imp::define_interface!(IDWriteBitmapRenderTarget1, IDWriteBitmapRenderTarget1_Vtbl, 0x791e8298_3ef3_4230_9880_c9bdecc42064);
 impl core::ops::Deref for IDWriteBitmapRenderTarget1 {
     type Target = IDWriteBitmapRenderTarget;
@@ -2049,6 +2047,8 @@ pub struct IDWriteBitmapRenderTarget1_Vtbl {
     pub GetTextAntialiasMode: unsafe extern "system" fn(*mut core::ffi::c_void) -> DWRITE_TEXT_ANTIALIAS_MODE,
     pub SetTextAntialiasMode: unsafe extern "system" fn(*mut core::ffi::c_void, DWRITE_TEXT_ANTIALIAS_MODE) -> windows_core::HRESULT,
 }
+unsafe impl Send for IDWriteBitmapRenderTarget1 {}
+unsafe impl Sync for IDWriteBitmapRenderTarget1 {}
 #[cfg(feature = "Win32_Graphics_Gdi")]
 pub trait IDWriteBitmapRenderTarget1_Impl: IDWriteBitmapRenderTarget_Impl {
     fn GetTextAntialiasMode(&self) -> DWRITE_TEXT_ANTIALIAS_MODE;
@@ -2081,10 +2081,6 @@ impl IDWriteBitmapRenderTarget1_Vtbl {
 }
 #[cfg(feature = "Win32_Graphics_Gdi")]
 impl windows_core::RuntimeName for IDWriteBitmapRenderTarget1 {}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-unsafe impl Send for IDWriteBitmapRenderTarget1 {}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-unsafe impl Sync for IDWriteBitmapRenderTarget1 {}
 windows_core::imp::define_interface!(IDWriteBitmapRenderTarget2, IDWriteBitmapRenderTarget2_Vtbl, 0xc553a742_fc01_44da_a66e_b8b9ed6c3995);
 impl core::ops::Deref for IDWriteBitmapRenderTarget2 {
     type Target = IDWriteBitmapRenderTarget1;
@@ -2106,6 +2102,8 @@ pub struct IDWriteBitmapRenderTarget2_Vtbl {
     pub base__: IDWriteBitmapRenderTarget1_Vtbl,
     pub GetBitmapData: unsafe extern "system" fn(*mut core::ffi::c_void, *mut DWRITE_BITMAP_DATA_BGRA32) -> windows_core::HRESULT,
 }
+unsafe impl Send for IDWriteBitmapRenderTarget2 {}
+unsafe impl Sync for IDWriteBitmapRenderTarget2 {}
 #[cfg(feature = "Win32_Graphics_Gdi")]
 pub trait IDWriteBitmapRenderTarget2_Impl: IDWriteBitmapRenderTarget1_Impl {
     fn GetBitmapData(&self) -> windows_core::Result<DWRITE_BITMAP_DATA_BGRA32>;
@@ -2133,10 +2131,6 @@ impl IDWriteBitmapRenderTarget2_Vtbl {
 }
 #[cfg(feature = "Win32_Graphics_Gdi")]
 impl windows_core::RuntimeName for IDWriteBitmapRenderTarget2 {}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-unsafe impl Send for IDWriteBitmapRenderTarget2 {}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-unsafe impl Sync for IDWriteBitmapRenderTarget2 {}
 windows_core::imp::define_interface!(IDWriteBitmapRenderTarget3, IDWriteBitmapRenderTarget3_Vtbl, 0xaeec37db_c337_40f1_8e2a_9a41b167b238);
 impl core::ops::Deref for IDWriteBitmapRenderTarget3 {
     type Target = IDWriteBitmapRenderTarget2;
@@ -2166,6 +2160,8 @@ pub struct IDWriteBitmapRenderTarget3_Vtbl {
     pub DrawPaintGlyphRun: unsafe extern "system" fn(*mut core::ffi::c_void, f32, f32, DWRITE_MEASURING_MODE, *const DWRITE_GLYPH_RUN, DWRITE_GLYPH_IMAGE_FORMATS, super::super::Foundation::COLORREF, u32, *mut super::super::Foundation::RECT) -> windows_core::HRESULT,
     pub DrawGlyphRunWithColorSupport: unsafe extern "system" fn(*mut core::ffi::c_void, f32, f32, DWRITE_MEASURING_MODE, *const DWRITE_GLYPH_RUN, *mut core::ffi::c_void, super::super::Foundation::COLORREF, u32, *mut super::super::Foundation::RECT) -> windows_core::HRESULT,
 }
+unsafe impl Send for IDWriteBitmapRenderTarget3 {}
+unsafe impl Sync for IDWriteBitmapRenderTarget3 {}
 #[cfg(feature = "Win32_Graphics_Gdi")]
 pub trait IDWriteBitmapRenderTarget3_Impl: IDWriteBitmapRenderTarget2_Impl {
     fn GetPaintFeatureLevel(&self) -> DWRITE_PAINT_FEATURE_LEVEL;
@@ -2206,10 +2202,6 @@ impl IDWriteBitmapRenderTarget3_Vtbl {
 }
 #[cfg(feature = "Win32_Graphics_Gdi")]
 impl windows_core::RuntimeName for IDWriteBitmapRenderTarget3 {}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-unsafe impl Send for IDWriteBitmapRenderTarget3 {}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-unsafe impl Sync for IDWriteBitmapRenderTarget3 {}
 windows_core::imp::define_interface!(IDWriteColorGlyphRunEnumerator, IDWriteColorGlyphRunEnumerator_Vtbl, 0xd31fbe17_f157_41a2_8d24_cb779e0560e8);
 windows_core::imp::interface_hierarchy!(IDWriteColorGlyphRunEnumerator, windows_core::IUnknown);
 impl IDWriteColorGlyphRunEnumerator {
@@ -2232,6 +2224,8 @@ pub struct IDWriteColorGlyphRunEnumerator_Vtbl {
     pub MoveNext: unsafe extern "system" fn(*mut core::ffi::c_void, *mut super::super::Foundation::BOOL) -> windows_core::HRESULT,
     pub GetCurrentRun: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut DWRITE_COLOR_GLYPH_RUN) -> windows_core::HRESULT,
 }
+unsafe impl Send for IDWriteColorGlyphRunEnumerator {}
+unsafe impl Sync for IDWriteColorGlyphRunEnumerator {}
 pub trait IDWriteColorGlyphRunEnumerator_Impl: windows_core::IUnknownImpl {
     fn MoveNext(&self) -> windows_core::Result<super::super::Foundation::BOOL>;
     fn GetCurrentRun(&self) -> windows_core::Result<*mut DWRITE_COLOR_GLYPH_RUN>;
@@ -2273,8 +2267,6 @@ impl IDWriteColorGlyphRunEnumerator_Vtbl {
     }
 }
 impl windows_core::RuntimeName for IDWriteColorGlyphRunEnumerator {}
-unsafe impl Send for IDWriteColorGlyphRunEnumerator {}
-unsafe impl Sync for IDWriteColorGlyphRunEnumerator {}
 windows_core::imp::define_interface!(IDWriteColorGlyphRunEnumerator1, IDWriteColorGlyphRunEnumerator1_Vtbl, 0x7c5f86da_c7a1_4f05_b8e1_55a179fe5a35);
 impl core::ops::Deref for IDWriteColorGlyphRunEnumerator1 {
     type Target = IDWriteColorGlyphRunEnumerator;
@@ -2296,6 +2288,8 @@ pub struct IDWriteColorGlyphRunEnumerator1_Vtbl {
     pub base__: IDWriteColorGlyphRunEnumerator_Vtbl,
     pub GetCurrentRun: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut DWRITE_COLOR_GLYPH_RUN1) -> windows_core::HRESULT,
 }
+unsafe impl Send for IDWriteColorGlyphRunEnumerator1 {}
+unsafe impl Sync for IDWriteColorGlyphRunEnumerator1 {}
 pub trait IDWriteColorGlyphRunEnumerator1_Impl: IDWriteColorGlyphRunEnumerator_Impl {
     fn GetCurrentRun(&self) -> windows_core::Result<*mut DWRITE_COLOR_GLYPH_RUN1>;
 }
@@ -2320,8 +2314,6 @@ impl IDWriteColorGlyphRunEnumerator1_Vtbl {
     }
 }
 impl windows_core::RuntimeName for IDWriteColorGlyphRunEnumerator1 {}
-unsafe impl Send for IDWriteColorGlyphRunEnumerator1 {}
-unsafe impl Sync for IDWriteColorGlyphRunEnumerator1 {}
 windows_core::imp::define_interface!(IDWriteFactory, IDWriteFactory_Vtbl, 0xb859ee5a_d838_4b5b_a2e8_1adc7d93db48);
 windows_core::imp::interface_hierarchy!(IDWriteFactory, windows_core::IUnknown);
 impl IDWriteFactory {
@@ -2504,6 +2496,8 @@ pub struct IDWriteFactory_Vtbl {
     pub CreateNumberSubstitution: unsafe extern "system" fn(*mut core::ffi::c_void, DWRITE_NUMBER_SUBSTITUTION_METHOD, windows_core::PCWSTR, super::super::Foundation::BOOL, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
     pub CreateGlyphRunAnalysis: unsafe extern "system" fn(*mut core::ffi::c_void, *const DWRITE_GLYPH_RUN, f32, *const DWRITE_MATRIX, DWRITE_RENDERING_MODE, DWRITE_MEASURING_MODE, f32, f32, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
+unsafe impl Send for IDWriteFactory {}
+unsafe impl Sync for IDWriteFactory {}
 #[cfg(feature = "Win32_Graphics_Gdi")]
 pub trait IDWriteFactory_Impl: windows_core::IUnknownImpl {
     fn GetSystemFontCollection(&self, fontcollection: windows_core::OutRef<'_, IDWriteFontCollection>, checkforupdates: super::super::Foundation::BOOL) -> windows_core::Result<()>;
@@ -2784,10 +2778,6 @@ impl IDWriteFactory_Vtbl {
 }
 #[cfg(feature = "Win32_Graphics_Gdi")]
 impl windows_core::RuntimeName for IDWriteFactory {}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-unsafe impl Send for IDWriteFactory {}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-unsafe impl Sync for IDWriteFactory {}
 windows_core::imp::define_interface!(IDWriteFactory1, IDWriteFactory1_Vtbl, 0x30572f99_dac6_41db_a16e_0486307e606a);
 impl core::ops::Deref for IDWriteFactory1 {
     type Target = IDWriteFactory;
@@ -2813,6 +2803,8 @@ pub struct IDWriteFactory1_Vtbl {
     pub GetEudcFontCollection: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void, super::super::Foundation::BOOL) -> windows_core::HRESULT,
     pub CreateCustomRenderingParams: unsafe extern "system" fn(*mut core::ffi::c_void, f32, f32, f32, f32, DWRITE_PIXEL_GEOMETRY, DWRITE_RENDERING_MODE, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
+unsafe impl Send for IDWriteFactory1 {}
+unsafe impl Sync for IDWriteFactory1 {}
 #[cfg(feature = "Win32_Graphics_Gdi")]
 pub trait IDWriteFactory1_Impl: IDWriteFactory_Impl {
     fn GetEudcFontCollection(&self, fontcollection: windows_core::OutRef<'_, IDWriteFontCollection>, checkforupdates: super::super::Foundation::BOOL) -> windows_core::Result<()>;
@@ -2851,10 +2843,6 @@ impl IDWriteFactory1_Vtbl {
 }
 #[cfg(feature = "Win32_Graphics_Gdi")]
 impl windows_core::RuntimeName for IDWriteFactory1 {}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-unsafe impl Send for IDWriteFactory1 {}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-unsafe impl Sync for IDWriteFactory1 {}
 windows_core::imp::define_interface!(IDWriteFactory2, IDWriteFactory2_Vtbl, 0x0439fc60_ca44_4994_8dee_3a9af7b732ec);
 impl core::ops::Deref for IDWriteFactory2 {
     type Target = IDWriteFactory1;
@@ -2904,6 +2892,8 @@ pub struct IDWriteFactory2_Vtbl {
     pub CreateCustomRenderingParams: unsafe extern "system" fn(*mut core::ffi::c_void, f32, f32, f32, f32, DWRITE_PIXEL_GEOMETRY, DWRITE_RENDERING_MODE, DWRITE_GRID_FIT_MODE, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
     pub CreateGlyphRunAnalysis: unsafe extern "system" fn(*mut core::ffi::c_void, *const DWRITE_GLYPH_RUN, *const DWRITE_MATRIX, DWRITE_RENDERING_MODE, DWRITE_MEASURING_MODE, DWRITE_GRID_FIT_MODE, DWRITE_TEXT_ANTIALIAS_MODE, f32, f32, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
+unsafe impl Send for IDWriteFactory2 {}
+unsafe impl Sync for IDWriteFactory2 {}
 #[cfg(feature = "Win32_Graphics_Gdi")]
 pub trait IDWriteFactory2_Impl: IDWriteFactory1_Impl {
     fn GetSystemFontFallback(&self) -> windows_core::Result<IDWriteFontFallback>;
@@ -2990,10 +2980,6 @@ impl IDWriteFactory2_Vtbl {
 }
 #[cfg(feature = "Win32_Graphics_Gdi")]
 impl windows_core::RuntimeName for IDWriteFactory2 {}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-unsafe impl Send for IDWriteFactory2 {}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-unsafe impl Sync for IDWriteFactory2 {}
 windows_core::imp::define_interface!(IDWriteFactory3, IDWriteFactory3_Vtbl, 0x9a1b41c3_d3bb_466a_87fc_fe67556a3b65);
 impl core::ops::Deref for IDWriteFactory3 {
     type Target = IDWriteFactory2;
@@ -3077,6 +3063,8 @@ pub struct IDWriteFactory3_Vtbl {
     pub GetSystemFontCollection: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::BOOL, *mut *mut core::ffi::c_void, super::super::Foundation::BOOL) -> windows_core::HRESULT,
     pub GetFontDownloadQueue: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
+unsafe impl Send for IDWriteFactory3 {}
+unsafe impl Sync for IDWriteFactory3 {}
 #[cfg(feature = "Win32_Graphics_Gdi")]
 pub trait IDWriteFactory3_Impl: IDWriteFactory2_Impl {
     fn CreateGlyphRunAnalysis(&self, glyphrun: *const DWRITE_GLYPH_RUN, transform: *const DWRITE_MATRIX, renderingmode: DWRITE_RENDERING_MODE1, measuringmode: DWRITE_MEASURING_MODE, gridfitmode: DWRITE_GRID_FIT_MODE, antialiasmode: DWRITE_TEXT_ANTIALIAS_MODE, baselineoriginx: f32, baselineoriginy: f32) -> windows_core::Result<IDWriteGlyphRunAnalysis>;
@@ -3213,10 +3201,6 @@ impl IDWriteFactory3_Vtbl {
 }
 #[cfg(feature = "Win32_Graphics_Gdi")]
 impl windows_core::RuntimeName for IDWriteFactory3 {}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-unsafe impl Send for IDWriteFactory3 {}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-unsafe impl Sync for IDWriteFactory3 {}
 windows_core::imp::define_interface!(IDWriteFactory4, IDWriteFactory4_Vtbl, 0x4b0b5bd3_0797_4549_8ac5_fe915cc53856);
 impl core::ops::Deref for IDWriteFactory4 {
     type Target = IDWriteFactory3;
@@ -3264,6 +3248,8 @@ pub struct IDWriteFactory4_Vtbl {
     #[cfg(not(feature = "Win32_Graphics_Direct2D_Common"))]
     ComputeGlyphOrigins2: usize,
 }
+unsafe impl Send for IDWriteFactory4 {}
+unsafe impl Sync for IDWriteFactory4 {}
 #[cfg(all(feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_Gdi"))]
 pub trait IDWriteFactory4_Impl: IDWriteFactory3_Impl {
     fn TranslateColorGlyphRun(&self, baselineorigin: &super::Direct2D::Common::D2D_POINT_2F, glyphrun: *const DWRITE_GLYPH_RUN, glyphrundescription: *const DWRITE_GLYPH_RUN_DESCRIPTION, desiredglyphimageformats: DWRITE_GLYPH_IMAGE_FORMATS, measuringmode: DWRITE_MEASURING_MODE, worldanddpitransform: *const DWRITE_MATRIX, colorpaletteindex: u32) -> windows_core::Result<IDWriteColorGlyphRunEnumerator1>;
@@ -3322,10 +3308,6 @@ impl IDWriteFactory4_Vtbl {
 }
 #[cfg(all(feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_Gdi"))]
 impl windows_core::RuntimeName for IDWriteFactory4 {}
-#[cfg(all(feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_Gdi"))]
-unsafe impl Send for IDWriteFactory4 {}
-#[cfg(all(feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_Gdi"))]
-unsafe impl Sync for IDWriteFactory4 {}
 windows_core::imp::define_interface!(IDWriteFactory5, IDWriteFactory5_Vtbl, 0x958db99a_be2a_4f09_af7d_65189803d1d3);
 impl core::ops::Deref for IDWriteFactory5 {
     type Target = IDWriteFactory4;
@@ -3376,6 +3358,8 @@ pub struct IDWriteFactory5_Vtbl {
     pub AnalyzeContainerType: unsafe extern "system" fn(*mut core::ffi::c_void, *const core::ffi::c_void, u32) -> DWRITE_CONTAINER_TYPE,
     pub UnpackFontFile: unsafe extern "system" fn(*mut core::ffi::c_void, DWRITE_CONTAINER_TYPE, *const core::ffi::c_void, u32, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
+unsafe impl Send for IDWriteFactory5 {}
+unsafe impl Sync for IDWriteFactory5 {}
 #[cfg(all(feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_Gdi"))]
 pub trait IDWriteFactory5_Impl: IDWriteFactory4_Impl {
     fn CreateFontSetBuilder(&self) -> windows_core::Result<IDWriteFontSetBuilder1>;
@@ -3456,10 +3440,6 @@ impl IDWriteFactory5_Vtbl {
 }
 #[cfg(all(feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_Gdi"))]
 impl windows_core::RuntimeName for IDWriteFactory5 {}
-#[cfg(all(feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_Gdi"))]
-unsafe impl Send for IDWriteFactory5 {}
-#[cfg(all(feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_Gdi"))]
-unsafe impl Sync for IDWriteFactory5 {}
 windows_core::imp::define_interface!(IDWriteFactory6, IDWriteFactory6_Vtbl, 0xf3744d80_21f7_42eb_b35d_995bc72fc223);
 impl core::ops::Deref for IDWriteFactory6 {
     type Target = IDWriteFactory5;
@@ -3537,6 +3517,8 @@ pub struct IDWriteFactory6_Vtbl {
     pub CreateFontSetBuilder: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
     pub CreateTextFormat: unsafe extern "system" fn(*mut core::ffi::c_void, windows_core::PCWSTR, *mut core::ffi::c_void, *const DWRITE_FONT_AXIS_VALUE, u32, f32, windows_core::PCWSTR, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
+unsafe impl Send for IDWriteFactory6 {}
+unsafe impl Sync for IDWriteFactory6 {}
 #[cfg(all(feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_Gdi"))]
 pub trait IDWriteFactory6_Impl: IDWriteFactory5_Impl {
     fn CreateFontFaceReference(&self, fontfile: windows_core::Ref<IDWriteFontFile>, faceindex: u32, fontsimulations: DWRITE_FONT_SIMULATIONS, fontaxisvalues: *const DWRITE_FONT_AXIS_VALUE, fontaxisvaluecount: u32) -> windows_core::Result<IDWriteFontFaceReference1>;
@@ -3651,10 +3633,6 @@ impl IDWriteFactory6_Vtbl {
 }
 #[cfg(all(feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_Gdi"))]
 impl windows_core::RuntimeName for IDWriteFactory6 {}
-#[cfg(all(feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_Gdi"))]
-unsafe impl Send for IDWriteFactory6 {}
-#[cfg(all(feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_Gdi"))]
-unsafe impl Sync for IDWriteFactory6 {}
 windows_core::imp::define_interface!(IDWriteFactory7, IDWriteFactory7_Vtbl, 0x35d0e0b3_9076_4d2e_a016_a91b568a06b4);
 impl core::ops::Deref for IDWriteFactory7 {
     type Target = IDWriteFactory6;
@@ -3683,6 +3661,8 @@ pub struct IDWriteFactory7_Vtbl {
     pub GetSystemFontSet: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::BOOL, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
     pub GetSystemFontCollection: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::BOOL, DWRITE_FONT_FAMILY_MODEL, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
+unsafe impl Send for IDWriteFactory7 {}
+unsafe impl Sync for IDWriteFactory7 {}
 #[cfg(all(feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_Gdi"))]
 pub trait IDWriteFactory7_Impl: IDWriteFactory6_Impl {
     fn GetSystemFontSet(&self, includedownloadablefonts: super::super::Foundation::BOOL) -> windows_core::Result<IDWriteFontSet2>;
@@ -3727,10 +3707,6 @@ impl IDWriteFactory7_Vtbl {
 }
 #[cfg(all(feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_Gdi"))]
 impl windows_core::RuntimeName for IDWriteFactory7 {}
-#[cfg(all(feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_Gdi"))]
-unsafe impl Send for IDWriteFactory7 {}
-#[cfg(all(feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_Gdi"))]
-unsafe impl Sync for IDWriteFactory7 {}
 windows_core::imp::define_interface!(IDWriteFactory8, IDWriteFactory8_Vtbl, 0xee0a7fb5_def4_4c23_a454_c9c7dc878398);
 impl core::ops::Deref for IDWriteFactory8 {
     type Target = IDWriteFactory7;
@@ -3756,6 +3732,8 @@ pub struct IDWriteFactory8_Vtbl {
     #[cfg(not(feature = "Win32_Graphics_Direct2D_Common"))]
     TranslateColorGlyphRun: usize,
 }
+unsafe impl Send for IDWriteFactory8 {}
+unsafe impl Sync for IDWriteFactory8 {}
 #[cfg(all(feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_Gdi"))]
 pub trait IDWriteFactory8_Impl: IDWriteFactory7_Impl {
     fn TranslateColorGlyphRun(&self, baselineorigin: &super::Direct2D::Common::D2D_POINT_2F, glyphrun: *const DWRITE_GLYPH_RUN, glyphrundescription: *const DWRITE_GLYPH_RUN_DESCRIPTION, desiredglyphimageformats: DWRITE_GLYPH_IMAGE_FORMATS, paintfeaturelevel: DWRITE_PAINT_FEATURE_LEVEL, measuringmode: DWRITE_MEASURING_MODE, worldanddpitransform: *const DWRITE_MATRIX, colorpaletteindex: u32) -> windows_core::Result<IDWriteColorGlyphRunEnumerator1>;
@@ -3783,10 +3761,6 @@ impl IDWriteFactory8_Vtbl {
 }
 #[cfg(all(feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_Gdi"))]
 impl windows_core::RuntimeName for IDWriteFactory8 {}
-#[cfg(all(feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_Gdi"))]
-unsafe impl Send for IDWriteFactory8 {}
-#[cfg(all(feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_Gdi"))]
-unsafe impl Sync for IDWriteFactory8 {}
 windows_core::imp::define_interface!(IDWriteFont, IDWriteFont_Vtbl, 0xacd16696_8c14_4f5d_877e_fe3fc1d32737);
 windows_core::imp::interface_hierarchy!(IDWriteFont, windows_core::IUnknown);
 impl IDWriteFont {
@@ -3851,6 +3825,8 @@ pub struct IDWriteFont_Vtbl {
     pub HasCharacter: unsafe extern "system" fn(*mut core::ffi::c_void, u32, *mut super::super::Foundation::BOOL) -> windows_core::HRESULT,
     pub CreateFontFace: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
+unsafe impl Send for IDWriteFont {}
+unsafe impl Sync for IDWriteFont {}
 pub trait IDWriteFont_Impl: windows_core::IUnknownImpl {
     fn GetFontFamily(&self) -> windows_core::Result<IDWriteFontFamily>;
     fn GetWeight(&self) -> DWRITE_FONT_WEIGHT;
@@ -3976,8 +3952,6 @@ impl IDWriteFont_Vtbl {
     }
 }
 impl windows_core::RuntimeName for IDWriteFont {}
-unsafe impl Send for IDWriteFont {}
-unsafe impl Sync for IDWriteFont {}
 windows_core::imp::define_interface!(IDWriteFont1, IDWriteFont1_Vtbl, 0xacd16696_8c14_4f5d_877e_fe3fc1d32738);
 impl core::ops::Deref for IDWriteFont1 {
     type Target = IDWriteFont;
@@ -4012,6 +3986,8 @@ pub struct IDWriteFont1_Vtbl {
     pub GetUnicodeRanges: unsafe extern "system" fn(*mut core::ffi::c_void, u32, *mut DWRITE_UNICODE_RANGE, *mut u32) -> windows_core::HRESULT,
     pub IsMonospacedFont: unsafe extern "system" fn(*mut core::ffi::c_void) -> super::super::Foundation::BOOL,
 }
+unsafe impl Send for IDWriteFont1 {}
+unsafe impl Sync for IDWriteFont1 {}
 pub trait IDWriteFont1_Impl: IDWriteFont_Impl {
     fn GetMetrics(&self, fontmetrics: *mut DWRITE_FONT_METRICS1);
     fn GetPanose(&self, panose: *mut DWRITE_PANOSE);
@@ -4057,8 +4033,6 @@ impl IDWriteFont1_Vtbl {
     }
 }
 impl windows_core::RuntimeName for IDWriteFont1 {}
-unsafe impl Send for IDWriteFont1 {}
-unsafe impl Sync for IDWriteFont1 {}
 windows_core::imp::define_interface!(IDWriteFont2, IDWriteFont2_Vtbl, 0x29748ed6_8c9c_4a6a_be0b_d912e8538944);
 impl core::ops::Deref for IDWriteFont2 {
     type Target = IDWriteFont1;
@@ -4077,6 +4051,8 @@ pub struct IDWriteFont2_Vtbl {
     pub base__: IDWriteFont1_Vtbl,
     pub IsColorFont: unsafe extern "system" fn(*mut core::ffi::c_void) -> super::super::Foundation::BOOL,
 }
+unsafe impl Send for IDWriteFont2 {}
+unsafe impl Sync for IDWriteFont2 {}
 pub trait IDWriteFont2_Impl: IDWriteFont1_Impl {
     fn IsColorFont(&self) -> super::super::Foundation::BOOL;
 }
@@ -4095,8 +4071,6 @@ impl IDWriteFont2_Vtbl {
     }
 }
 impl windows_core::RuntimeName for IDWriteFont2 {}
-unsafe impl Send for IDWriteFont2 {}
-unsafe impl Sync for IDWriteFont2 {}
 windows_core::imp::define_interface!(IDWriteFont3, IDWriteFont3_Vtbl, 0x29748ed6_8c9c_4a6a_be0b_d912e8538944);
 impl core::ops::Deref for IDWriteFont3 {
     type Target = IDWriteFont2;
@@ -4140,6 +4114,8 @@ pub struct IDWriteFont3_Vtbl {
     pub HasCharacter: unsafe extern "system" fn(*mut core::ffi::c_void, u32) -> super::super::Foundation::BOOL,
     pub GetLocality: unsafe extern "system" fn(*mut core::ffi::c_void) -> DWRITE_LOCALITY,
 }
+unsafe impl Send for IDWriteFont3 {}
+unsafe impl Sync for IDWriteFont3 {}
 pub trait IDWriteFont3_Impl: IDWriteFont2_Impl {
     fn CreateFontFace(&self) -> windows_core::Result<IDWriteFontFace3>;
     fn Equals(&self, font: windows_core::Ref<IDWriteFont>) -> super::super::Foundation::BOOL;
@@ -4205,8 +4181,6 @@ impl IDWriteFont3_Vtbl {
     }
 }
 impl windows_core::RuntimeName for IDWriteFont3 {}
-unsafe impl Send for IDWriteFont3 {}
-unsafe impl Sync for IDWriteFont3 {}
 windows_core::imp::define_interface!(IDWriteFontCollection, IDWriteFontCollection_Vtbl, 0xa84cee02_3eea_4eee_a827_87c1a02a0fcc);
 windows_core::imp::interface_hierarchy!(IDWriteFontCollection, windows_core::IUnknown);
 impl IDWriteFontCollection {
@@ -4243,6 +4217,8 @@ pub struct IDWriteFontCollection_Vtbl {
     pub FindFamilyName: unsafe extern "system" fn(*mut core::ffi::c_void, windows_core::PCWSTR, *mut u32, *mut super::super::Foundation::BOOL) -> windows_core::HRESULT,
     pub GetFontFromFontFace: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
+unsafe impl Send for IDWriteFontCollection {}
+unsafe impl Sync for IDWriteFontCollection {}
 pub trait IDWriteFontCollection_Impl: windows_core::IUnknownImpl {
     fn GetFontFamilyCount(&self) -> u32;
     fn GetFontFamily(&self, index: u32) -> windows_core::Result<IDWriteFontFamily>;
@@ -4300,8 +4276,6 @@ impl IDWriteFontCollection_Vtbl {
     }
 }
 impl windows_core::RuntimeName for IDWriteFontCollection {}
-unsafe impl Send for IDWriteFontCollection {}
-unsafe impl Sync for IDWriteFontCollection {}
 windows_core::imp::define_interface!(IDWriteFontCollection1, IDWriteFontCollection1_Vtbl, 0x53585141_d9f8_4095_8321_d73cf6bd116c);
 impl core::ops::Deref for IDWriteFontCollection1 {
     type Target = IDWriteFontCollection;
@@ -4330,6 +4304,8 @@ pub struct IDWriteFontCollection1_Vtbl {
     pub GetFontSet: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
     pub GetFontFamily: unsafe extern "system" fn(*mut core::ffi::c_void, u32, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
+unsafe impl Send for IDWriteFontCollection1 {}
+unsafe impl Sync for IDWriteFontCollection1 {}
 pub trait IDWriteFontCollection1_Impl: IDWriteFontCollection_Impl {
     fn GetFontSet(&self) -> windows_core::Result<IDWriteFontSet>;
     fn GetFontFamily(&self, index: u32) -> windows_core::Result<IDWriteFontFamily1>;
@@ -4371,8 +4347,6 @@ impl IDWriteFontCollection1_Vtbl {
     }
 }
 impl windows_core::RuntimeName for IDWriteFontCollection1 {}
-unsafe impl Send for IDWriteFontCollection1 {}
-unsafe impl Sync for IDWriteFontCollection1 {}
 windows_core::imp::define_interface!(IDWriteFontCollection2, IDWriteFontCollection2_Vtbl, 0x514039c6_4617_4064_bf8b_92ea83e506e0);
 impl core::ops::Deref for IDWriteFontCollection2 {
     type Target = IDWriteFontCollection1;
@@ -4415,6 +4389,8 @@ pub struct IDWriteFontCollection2_Vtbl {
     pub GetFontFamilyModel: unsafe extern "system" fn(*mut core::ffi::c_void) -> DWRITE_FONT_FAMILY_MODEL,
     pub GetFontSet: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
+unsafe impl Send for IDWriteFontCollection2 {}
+unsafe impl Sync for IDWriteFontCollection2 {}
 pub trait IDWriteFontCollection2_Impl: IDWriteFontCollection1_Impl {
     fn GetFontFamily(&self, index: u32) -> windows_core::Result<IDWriteFontFamily2>;
     fn GetMatchingFonts(&self, familyname: &windows_core::PCWSTR, fontaxisvalues: *const DWRITE_FONT_AXIS_VALUE, fontaxisvaluecount: u32) -> windows_core::Result<IDWriteFontList2>;
@@ -4478,8 +4454,6 @@ impl IDWriteFontCollection2_Vtbl {
     }
 }
 impl windows_core::RuntimeName for IDWriteFontCollection2 {}
-unsafe impl Send for IDWriteFontCollection2 {}
-unsafe impl Sync for IDWriteFontCollection2 {}
 windows_core::imp::define_interface!(IDWriteFontCollection3, IDWriteFontCollection3_Vtbl, 0xa4d055a6_f9e3_4e25_93b7_9e309f3af8e9);
 impl core::ops::Deref for IDWriteFontCollection3 {
     type Target = IDWriteFontCollection2;
@@ -4498,6 +4472,8 @@ pub struct IDWriteFontCollection3_Vtbl {
     pub base__: IDWriteFontCollection2_Vtbl,
     pub GetExpirationEvent: unsafe extern "system" fn(*mut core::ffi::c_void) -> super::super::Foundation::HANDLE,
 }
+unsafe impl Send for IDWriteFontCollection3 {}
+unsafe impl Sync for IDWriteFontCollection3 {}
 pub trait IDWriteFontCollection3_Impl: IDWriteFontCollection2_Impl {
     fn GetExpirationEvent(&self) -> super::super::Foundation::HANDLE;
 }
@@ -4516,8 +4492,6 @@ impl IDWriteFontCollection3_Vtbl {
     }
 }
 impl windows_core::RuntimeName for IDWriteFontCollection3 {}
-unsafe impl Send for IDWriteFontCollection3 {}
-unsafe impl Sync for IDWriteFontCollection3 {}
 windows_core::imp::define_interface!(IDWriteFontCollectionLoader, IDWriteFontCollectionLoader_Vtbl, 0xcca920e4_52f0_492b_bfa8_29c72ee0a468);
 windows_core::imp::interface_hierarchy!(IDWriteFontCollectionLoader, windows_core::IUnknown);
 impl IDWriteFontCollectionLoader {
@@ -4536,6 +4510,8 @@ pub struct IDWriteFontCollectionLoader_Vtbl {
     pub base__: windows_core::IUnknown_Vtbl,
     pub CreateEnumeratorFromKey: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *const core::ffi::c_void, u32, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
+unsafe impl Send for IDWriteFontCollectionLoader {}
+unsafe impl Sync for IDWriteFontCollectionLoader {}
 pub trait IDWriteFontCollectionLoader_Impl: windows_core::IUnknownImpl {
     fn CreateEnumeratorFromKey(&self, factory: windows_core::Ref<IDWriteFactory>, collectionkey: *const core::ffi::c_void, collectionkeysize: u32) -> windows_core::Result<IDWriteFontFileEnumerator>;
 }
@@ -4560,8 +4536,6 @@ impl IDWriteFontCollectionLoader_Vtbl {
     }
 }
 impl windows_core::RuntimeName for IDWriteFontCollectionLoader {}
-unsafe impl Send for IDWriteFontCollectionLoader {}
-unsafe impl Sync for IDWriteFontCollectionLoader {}
 windows_core::imp::define_interface!(IDWriteFontDownloadListener, IDWriteFontDownloadListener_Vtbl, 0xb06fe5b9_43ec_4393_881b_dbe4dc72fda7);
 windows_core::imp::interface_hierarchy!(IDWriteFontDownloadListener, windows_core::IUnknown);
 impl IDWriteFontDownloadListener {
@@ -4578,6 +4552,8 @@ pub struct IDWriteFontDownloadListener_Vtbl {
     pub base__: windows_core::IUnknown_Vtbl,
     pub DownloadCompleted: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut core::ffi::c_void, windows_core::HRESULT),
 }
+unsafe impl Send for IDWriteFontDownloadListener {}
+unsafe impl Sync for IDWriteFontDownloadListener {}
 pub trait IDWriteFontDownloadListener_Impl: windows_core::IUnknownImpl {
     fn DownloadCompleted(&self, downloadqueue: windows_core::Ref<IDWriteFontDownloadQueue>, context: windows_core::Ref<windows_core::IUnknown>, downloadresult: windows_core::HRESULT);
 }
@@ -4596,8 +4572,6 @@ impl IDWriteFontDownloadListener_Vtbl {
     }
 }
 impl windows_core::RuntimeName for IDWriteFontDownloadListener {}
-unsafe impl Send for IDWriteFontDownloadListener {}
-unsafe impl Sync for IDWriteFontDownloadListener {}
 windows_core::imp::define_interface!(IDWriteFontDownloadQueue, IDWriteFontDownloadQueue_Vtbl, 0xb71e6052_5aea_4fa3_832e_f60d431f7e91);
 windows_core::imp::interface_hierarchy!(IDWriteFontDownloadQueue, windows_core::IUnknown);
 impl IDWriteFontDownloadQueue {
@@ -4639,6 +4613,8 @@ pub struct IDWriteFontDownloadQueue_Vtbl {
     pub CancelDownload: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
     pub GetGenerationCount: unsafe extern "system" fn(*mut core::ffi::c_void) -> u64,
 }
+unsafe impl Send for IDWriteFontDownloadQueue {}
+unsafe impl Sync for IDWriteFontDownloadQueue {}
 pub trait IDWriteFontDownloadQueue_Impl: windows_core::IUnknownImpl {
     fn AddListener(&self, listener: windows_core::Ref<IDWriteFontDownloadListener>) -> windows_core::Result<u32>;
     fn RemoveListener(&self, token: u32) -> windows_core::Result<()>;
@@ -4706,8 +4682,6 @@ impl IDWriteFontDownloadQueue_Vtbl {
     }
 }
 impl windows_core::RuntimeName for IDWriteFontDownloadQueue {}
-unsafe impl Send for IDWriteFontDownloadQueue {}
-unsafe impl Sync for IDWriteFontDownloadQueue {}
 windows_core::imp::define_interface!(IDWriteFontFace, IDWriteFontFace_Vtbl, 0x5f49804d_7024_4d43_bfa9_d25984f53849);
 windows_core::imp::interface_hierarchy!(IDWriteFontFace, windows_core::IUnknown);
 impl IDWriteFontFace {
@@ -4789,6 +4763,8 @@ pub struct IDWriteFontFace_Vtbl {
     pub GetGdiCompatibleMetrics: unsafe extern "system" fn(*mut core::ffi::c_void, f32, f32, *const DWRITE_MATRIX, *mut DWRITE_FONT_METRICS) -> windows_core::HRESULT,
     pub GetGdiCompatibleGlyphMetrics: unsafe extern "system" fn(*mut core::ffi::c_void, f32, f32, *const DWRITE_MATRIX, super::super::Foundation::BOOL, *const u16, u32, *mut DWRITE_GLYPH_METRICS, super::super::Foundation::BOOL) -> windows_core::HRESULT,
 }
+unsafe impl Send for IDWriteFontFace {}
+unsafe impl Sync for IDWriteFontFace {}
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
 pub trait IDWriteFontFace_Impl: windows_core::IUnknownImpl {
     fn GetType(&self) -> DWRITE_FONT_FACE_TYPE;
@@ -4931,10 +4907,6 @@ impl IDWriteFontFace_Vtbl {
 }
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
 impl windows_core::RuntimeName for IDWriteFontFace {}
-#[cfg(feature = "Win32_Graphics_Direct2D_Common")]
-unsafe impl Send for IDWriteFontFace {}
-#[cfg(feature = "Win32_Graphics_Direct2D_Common")]
-unsafe impl Sync for IDWriteFontFace {}
 windows_core::imp::define_interface!(IDWriteFontFace1, IDWriteFontFace1_Vtbl, 0xa71efdb4_9fdb_4838_ad90_cfc3be8c3daf);
 impl core::ops::Deref for IDWriteFontFace1 {
     type Target = IDWriteFontFace;
@@ -5004,6 +4976,8 @@ pub struct IDWriteFontFace1_Vtbl {
     pub GetVerticalGlyphVariants: unsafe extern "system" fn(*mut core::ffi::c_void, u32, *const u16, *mut u16) -> windows_core::HRESULT,
     pub HasVerticalGlyphVariants: unsafe extern "system" fn(*mut core::ffi::c_void) -> super::super::Foundation::BOOL,
 }
+unsafe impl Send for IDWriteFontFace1 {}
+unsafe impl Sync for IDWriteFontFace1 {}
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
 pub trait IDWriteFontFace1_Impl: IDWriteFontFace_Impl {
     fn GetMetrics(&self, fontmetrics: *mut DWRITE_FONT_METRICS1);
@@ -5122,10 +5096,6 @@ impl IDWriteFontFace1_Vtbl {
 }
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
 impl windows_core::RuntimeName for IDWriteFontFace1 {}
-#[cfg(feature = "Win32_Graphics_Direct2D_Common")]
-unsafe impl Send for IDWriteFontFace1 {}
-#[cfg(feature = "Win32_Graphics_Direct2D_Common")]
-unsafe impl Sync for IDWriteFontFace1 {}
 windows_core::imp::define_interface!(IDWriteFontFace2, IDWriteFontFace2_Vtbl, 0xd8b768ff_64bc_4e66_982b_ec8e87f693f7);
 impl core::ops::Deref for IDWriteFontFace2 {
     type Target = IDWriteFontFace1;
@@ -5163,6 +5133,8 @@ pub struct IDWriteFontFace2_Vtbl {
     pub GetPaletteEntries: unsafe extern "system" fn(*mut core::ffi::c_void, u32, u32, u32, *mut DWRITE_COLOR_F) -> windows_core::HRESULT,
     pub GetRecommendedRenderingMode: unsafe extern "system" fn(*mut core::ffi::c_void, f32, f32, f32, *const DWRITE_MATRIX, super::super::Foundation::BOOL, DWRITE_OUTLINE_THRESHOLD, DWRITE_MEASURING_MODE, *mut core::ffi::c_void, *mut DWRITE_RENDERING_MODE, *mut DWRITE_GRID_FIT_MODE) -> windows_core::HRESULT,
 }
+unsafe impl Send for IDWriteFontFace2 {}
+unsafe impl Sync for IDWriteFontFace2 {}
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
 pub trait IDWriteFontFace2_Impl: IDWriteFontFace1_Impl {
     fn IsColorFont(&self) -> super::super::Foundation::BOOL;
@@ -5219,10 +5191,6 @@ impl IDWriteFontFace2_Vtbl {
 }
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
 impl windows_core::RuntimeName for IDWriteFontFace2 {}
-#[cfg(feature = "Win32_Graphics_Direct2D_Common")]
-unsafe impl Send for IDWriteFontFace2 {}
-#[cfg(feature = "Win32_Graphics_Direct2D_Common")]
-unsafe impl Sync for IDWriteFontFace2 {}
 windows_core::imp::define_interface!(IDWriteFontFace3, IDWriteFontFace3_Vtbl, 0xd37d7598_09be_4222_a236_2081341cc1f2);
 impl core::ops::Deref for IDWriteFontFace3 {
     type Target = IDWriteFontFace2;
@@ -5315,6 +5283,8 @@ pub struct IDWriteFontFace3_Vtbl {
     pub AreCharactersLocal: unsafe extern "system" fn(*mut core::ffi::c_void, windows_core::PCWSTR, u32, super::super::Foundation::BOOL, *mut super::super::Foundation::BOOL) -> windows_core::HRESULT,
     pub AreGlyphsLocal: unsafe extern "system" fn(*mut core::ffi::c_void, *const u16, u32, super::super::Foundation::BOOL, *mut super::super::Foundation::BOOL) -> windows_core::HRESULT,
 }
+unsafe impl Send for IDWriteFontFace3 {}
+unsafe impl Sync for IDWriteFontFace3 {}
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
 pub trait IDWriteFontFace3_Impl: IDWriteFontFace2_Impl {
     fn GetFontFaceReference(&self) -> windows_core::Result<IDWriteFontFaceReference>;
@@ -5473,10 +5443,6 @@ impl IDWriteFontFace3_Vtbl {
 }
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
 impl windows_core::RuntimeName for IDWriteFontFace3 {}
-#[cfg(feature = "Win32_Graphics_Direct2D_Common")]
-unsafe impl Send for IDWriteFontFace3 {}
-#[cfg(feature = "Win32_Graphics_Direct2D_Common")]
-unsafe impl Sync for IDWriteFontFace3 {}
 windows_core::imp::define_interface!(IDWriteFontFace4, IDWriteFontFace4_Vtbl, 0x27f2a904_4eb8_441d_9678_0563f53e3e2f);
 impl core::ops::Deref for IDWriteFontFace4 {
     type Target = IDWriteFontFace3;
@@ -5514,6 +5480,8 @@ pub struct IDWriteFontFace4_Vtbl {
     GetGlyphImageData: usize,
     pub ReleaseGlyphImageData: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void),
 }
+unsafe impl Send for IDWriteFontFace4 {}
+unsafe impl Sync for IDWriteFontFace4 {}
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
 pub trait IDWriteFontFace4_Impl: IDWriteFontFace3_Impl {
     fn GetGlyphImageFormats(&self, glyphid: u16, pixelsperemfirst: u32, pixelsperemlast: u32) -> windows_core::Result<DWRITE_GLYPH_IMAGE_FORMATS>;
@@ -5568,10 +5536,6 @@ impl IDWriteFontFace4_Vtbl {
 }
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
 impl windows_core::RuntimeName for IDWriteFontFace4 {}
-#[cfg(feature = "Win32_Graphics_Direct2D_Common")]
-unsafe impl Send for IDWriteFontFace4 {}
-#[cfg(feature = "Win32_Graphics_Direct2D_Common")]
-unsafe impl Sync for IDWriteFontFace4 {}
 windows_core::imp::define_interface!(IDWriteFontFace5, IDWriteFontFace5_Vtbl, 0x98eff3a5_b667_479a_b145_e2fa5b9fdc29);
 impl core::ops::Deref for IDWriteFontFace5 {
     type Target = IDWriteFontFace4;
@@ -5612,6 +5576,8 @@ pub struct IDWriteFontFace5_Vtbl {
     pub GetFontResource: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
     pub Equals: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> super::super::Foundation::BOOL,
 }
+unsafe impl Send for IDWriteFontFace5 {}
+unsafe impl Sync for IDWriteFontFace5 {}
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
 pub trait IDWriteFontFace5_Impl: IDWriteFontFace4_Impl {
     fn GetFontAxisValueCount(&self) -> u32;
@@ -5674,10 +5640,6 @@ impl IDWriteFontFace5_Vtbl {
 }
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
 impl windows_core::RuntimeName for IDWriteFontFace5 {}
-#[cfg(feature = "Win32_Graphics_Direct2D_Common")]
-unsafe impl Send for IDWriteFontFace5 {}
-#[cfg(feature = "Win32_Graphics_Direct2D_Common")]
-unsafe impl Sync for IDWriteFontFace5 {}
 windows_core::imp::define_interface!(IDWriteFontFace6, IDWriteFontFace6_Vtbl, 0xc4b1fe1b_6e84_47d5_b54c_a597981b06ad);
 impl core::ops::Deref for IDWriteFontFace6 {
     type Target = IDWriteFontFace5;
@@ -5706,6 +5668,8 @@ pub struct IDWriteFontFace6_Vtbl {
     pub GetFamilyNames: unsafe extern "system" fn(*mut core::ffi::c_void, DWRITE_FONT_FAMILY_MODEL, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
     pub GetFaceNames: unsafe extern "system" fn(*mut core::ffi::c_void, DWRITE_FONT_FAMILY_MODEL, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
+unsafe impl Send for IDWriteFontFace6 {}
+unsafe impl Sync for IDWriteFontFace6 {}
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
 pub trait IDWriteFontFace6_Impl: IDWriteFontFace5_Impl {
     fn GetFamilyNames(&self, fontfamilymodel: DWRITE_FONT_FAMILY_MODEL) -> windows_core::Result<IDWriteLocalizedStrings>;
@@ -5750,10 +5714,6 @@ impl IDWriteFontFace6_Vtbl {
 }
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
 impl windows_core::RuntimeName for IDWriteFontFace6 {}
-#[cfg(feature = "Win32_Graphics_Direct2D_Common")]
-unsafe impl Send for IDWriteFontFace6 {}
-#[cfg(feature = "Win32_Graphics_Direct2D_Common")]
-unsafe impl Sync for IDWriteFontFace6 {}
 windows_core::imp::define_interface!(IDWriteFontFace7, IDWriteFontFace7_Vtbl, 0x3945b85b_bc95_40f7_b72c_8b73bfc7e13b);
 impl core::ops::Deref for IDWriteFontFace7 {
     type Target = IDWriteFontFace6;
@@ -5779,6 +5739,8 @@ pub struct IDWriteFontFace7_Vtbl {
     pub GetPaintFeatureLevel: unsafe extern "system" fn(*mut core::ffi::c_void, DWRITE_GLYPH_IMAGE_FORMATS) -> DWRITE_PAINT_FEATURE_LEVEL,
     pub CreatePaintReader: unsafe extern "system" fn(*mut core::ffi::c_void, DWRITE_GLYPH_IMAGE_FORMATS, DWRITE_PAINT_FEATURE_LEVEL, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
+unsafe impl Send for IDWriteFontFace7 {}
+unsafe impl Sync for IDWriteFontFace7 {}
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
 pub trait IDWriteFontFace7_Impl: IDWriteFontFace6_Impl {
     fn GetPaintFeatureLevel(&self, glyphimageformat: DWRITE_GLYPH_IMAGE_FORMATS) -> DWRITE_PAINT_FEATURE_LEVEL;
@@ -5817,10 +5779,6 @@ impl IDWriteFontFace7_Vtbl {
 }
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
 impl windows_core::RuntimeName for IDWriteFontFace7 {}
-#[cfg(feature = "Win32_Graphics_Direct2D_Common")]
-unsafe impl Send for IDWriteFontFace7 {}
-#[cfg(feature = "Win32_Graphics_Direct2D_Common")]
-unsafe impl Sync for IDWriteFontFace7 {}
 windows_core::imp::define_interface!(IDWriteFontFaceReference, IDWriteFontFaceReference_Vtbl, 0x5e7fa7ca_dde3_424c_89f0_9fcd6fed58cd);
 windows_core::imp::interface_hierarchy!(IDWriteFontFaceReference, windows_core::IUnknown);
 impl IDWriteFontFaceReference {
@@ -5900,6 +5858,8 @@ pub struct IDWriteFontFaceReference_Vtbl {
     pub EnqueueGlyphDownloadRequest: unsafe extern "system" fn(*mut core::ffi::c_void, *const u16, u32) -> windows_core::HRESULT,
     pub EnqueueFileFragmentDownloadRequest: unsafe extern "system" fn(*mut core::ffi::c_void, u64, u64) -> windows_core::HRESULT,
 }
+unsafe impl Send for IDWriteFontFaceReference {}
+unsafe impl Sync for IDWriteFontFaceReference {}
 pub trait IDWriteFontFaceReference_Impl: windows_core::IUnknownImpl {
     fn CreateFontFace(&self) -> windows_core::Result<IDWriteFontFace3>;
     fn CreateFontFaceWithSimulations(&self, fontfacesimulationflags: DWRITE_FONT_SIMULATIONS) -> windows_core::Result<IDWriteFontFace3>;
@@ -6049,8 +6009,6 @@ impl IDWriteFontFaceReference_Vtbl {
     }
 }
 impl windows_core::RuntimeName for IDWriteFontFaceReference {}
-unsafe impl Send for IDWriteFontFaceReference {}
-unsafe impl Sync for IDWriteFontFaceReference {}
 windows_core::imp::define_interface!(IDWriteFontFaceReference1, IDWriteFontFaceReference1_Vtbl, 0xc081fe77_2fd1_41ac_a5a3_34983c4ba61a);
 impl core::ops::Deref for IDWriteFontFaceReference1 {
     type Target = IDWriteFontFaceReference;
@@ -6080,6 +6038,8 @@ pub struct IDWriteFontFaceReference1_Vtbl {
     pub GetFontAxisValueCount: unsafe extern "system" fn(*mut core::ffi::c_void) -> u32,
     pub GetFontAxisValues: unsafe extern "system" fn(*mut core::ffi::c_void, *mut DWRITE_FONT_AXIS_VALUE, u32) -> windows_core::HRESULT,
 }
+unsafe impl Send for IDWriteFontFaceReference1 {}
+unsafe impl Sync for IDWriteFontFaceReference1 {}
 pub trait IDWriteFontFaceReference1_Impl: IDWriteFontFaceReference_Impl {
     fn CreateFontFace(&self) -> windows_core::Result<IDWriteFontFace5>;
     fn GetFontAxisValueCount(&self) -> u32;
@@ -6123,8 +6083,6 @@ impl IDWriteFontFaceReference1_Vtbl {
     }
 }
 impl windows_core::RuntimeName for IDWriteFontFaceReference1 {}
-unsafe impl Send for IDWriteFontFaceReference1 {}
-unsafe impl Sync for IDWriteFontFaceReference1 {}
 windows_core::imp::define_interface!(IDWriteFontFallback, IDWriteFontFallback_Vtbl, 0xefa008f9_f7a1_48bf_b05c_f224713cc0ff);
 windows_core::imp::interface_hierarchy!(IDWriteFontFallback, windows_core::IUnknown);
 impl IDWriteFontFallback {
@@ -6142,6 +6100,8 @@ pub struct IDWriteFontFallback_Vtbl {
     pub base__: windows_core::IUnknown_Vtbl,
     pub MapCharacters: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, u32, u32, *mut core::ffi::c_void, windows_core::PCWSTR, DWRITE_FONT_WEIGHT, DWRITE_FONT_STYLE, DWRITE_FONT_STRETCH, *mut u32, *mut *mut core::ffi::c_void, *mut f32) -> windows_core::HRESULT,
 }
+unsafe impl Send for IDWriteFontFallback {}
+unsafe impl Sync for IDWriteFontFallback {}
 pub trait IDWriteFontFallback_Impl: windows_core::IUnknownImpl {
     fn MapCharacters(&self, analysissource: windows_core::Ref<IDWriteTextAnalysisSource>, textposition: u32, textlength: u32, basefontcollection: windows_core::Ref<IDWriteFontCollection>, basefamilyname: &windows_core::PCWSTR, baseweight: DWRITE_FONT_WEIGHT, basestyle: DWRITE_FONT_STYLE, basestretch: DWRITE_FONT_STRETCH, mappedlength: *mut u32, mappedfont: windows_core::OutRef<'_, IDWriteFont>, scale: *mut f32) -> windows_core::Result<()>;
 }
@@ -6160,8 +6120,6 @@ impl IDWriteFontFallback_Vtbl {
     }
 }
 impl windows_core::RuntimeName for IDWriteFontFallback {}
-unsafe impl Send for IDWriteFontFallback {}
-unsafe impl Sync for IDWriteFontFallback {}
 windows_core::imp::define_interface!(IDWriteFontFallback1, IDWriteFontFallback1_Vtbl, 0x2397599d_dd0d_4681_bd6a_f4f31eaade77);
 impl core::ops::Deref for IDWriteFontFallback1 {
     type Target = IDWriteFontFallback;
@@ -6185,6 +6143,8 @@ pub struct IDWriteFontFallback1_Vtbl {
     pub base__: IDWriteFontFallback_Vtbl,
     pub MapCharacters: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, u32, u32, *mut core::ffi::c_void, windows_core::PCWSTR, *const DWRITE_FONT_AXIS_VALUE, u32, *mut u32, *mut f32, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
+unsafe impl Send for IDWriteFontFallback1 {}
+unsafe impl Sync for IDWriteFontFallback1 {}
 pub trait IDWriteFontFallback1_Impl: IDWriteFontFallback_Impl {
     fn MapCharacters(&self, analysissource: windows_core::Ref<IDWriteTextAnalysisSource>, textposition: u32, textlength: u32, basefontcollection: windows_core::Ref<IDWriteFontCollection>, basefamilyname: &windows_core::PCWSTR, fontaxisvalues: *const DWRITE_FONT_AXIS_VALUE, fontaxisvaluecount: u32, mappedlength: *mut u32, scale: *mut f32, mappedfontface: windows_core::OutRef<'_, IDWriteFontFace5>) -> windows_core::Result<()>;
 }
@@ -6203,8 +6163,6 @@ impl IDWriteFontFallback1_Vtbl {
     }
 }
 impl windows_core::RuntimeName for IDWriteFontFallback1 {}
-unsafe impl Send for IDWriteFontFallback1 {}
-unsafe impl Sync for IDWriteFontFallback1 {}
 windows_core::imp::define_interface!(IDWriteFontFallbackBuilder, IDWriteFontFallbackBuilder_Vtbl, 0xfd882d06_8aba_4fb8_b849_8be8b73e14de);
 windows_core::imp::interface_hierarchy!(IDWriteFontFallbackBuilder, windows_core::IUnknown);
 impl IDWriteFontFallbackBuilder {
@@ -6236,6 +6194,8 @@ pub struct IDWriteFontFallbackBuilder_Vtbl {
     pub AddMappings: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
     pub CreateFontFallback: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
+unsafe impl Send for IDWriteFontFallbackBuilder {}
+unsafe impl Sync for IDWriteFontFallbackBuilder {}
 pub trait IDWriteFontFallbackBuilder_Impl: windows_core::IUnknownImpl {
     fn AddMapping(&self, ranges: *const DWRITE_UNICODE_RANGE, rangescount: u32, targetfamilynames: *const *const u16, targetfamilynamescount: u32, fontcollection: windows_core::Ref<IDWriteFontCollection>, localename: &windows_core::PCWSTR, basefamilyname: &windows_core::PCWSTR, scale: f32) -> windows_core::Result<()>;
     fn AddMappings(&self, fontfallback: windows_core::Ref<IDWriteFontFallback>) -> windows_core::Result<()>;
@@ -6279,8 +6239,6 @@ impl IDWriteFontFallbackBuilder_Vtbl {
     }
 }
 impl windows_core::RuntimeName for IDWriteFontFallbackBuilder {}
-unsafe impl Send for IDWriteFontFallbackBuilder {}
-unsafe impl Sync for IDWriteFontFallbackBuilder {}
 windows_core::imp::define_interface!(IDWriteFontFamily, IDWriteFontFamily_Vtbl, 0xda20d8ef_812a_4c43_9802_62ec4abd7add);
 impl core::ops::Deref for IDWriteFontFamily {
     type Target = IDWriteFontList;
@@ -6316,6 +6274,8 @@ pub struct IDWriteFontFamily_Vtbl {
     pub GetFirstMatchingFont: unsafe extern "system" fn(*mut core::ffi::c_void, DWRITE_FONT_WEIGHT, DWRITE_FONT_STRETCH, DWRITE_FONT_STYLE, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
     pub GetMatchingFonts: unsafe extern "system" fn(*mut core::ffi::c_void, DWRITE_FONT_WEIGHT, DWRITE_FONT_STRETCH, DWRITE_FONT_STYLE, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
+unsafe impl Send for IDWriteFontFamily {}
+unsafe impl Sync for IDWriteFontFamily {}
 pub trait IDWriteFontFamily_Impl: IDWriteFontList_Impl {
     fn GetFamilyNames(&self) -> windows_core::Result<IDWriteLocalizedStrings>;
     fn GetFirstMatchingFont(&self, weight: DWRITE_FONT_WEIGHT, stretch: DWRITE_FONT_STRETCH, style: DWRITE_FONT_STYLE) -> windows_core::Result<IDWriteFont>;
@@ -6371,8 +6331,6 @@ impl IDWriteFontFamily_Vtbl {
     }
 }
 impl windows_core::RuntimeName for IDWriteFontFamily {}
-unsafe impl Send for IDWriteFontFamily {}
-unsafe impl Sync for IDWriteFontFamily {}
 windows_core::imp::define_interface!(IDWriteFontFamily1, IDWriteFontFamily1_Vtbl, 0xda20d8ef_812a_4c43_9802_62ec4abd7adf);
 impl core::ops::Deref for IDWriteFontFamily1 {
     type Target = IDWriteFontFamily;
@@ -6405,6 +6363,8 @@ pub struct IDWriteFontFamily1_Vtbl {
     pub GetFont: unsafe extern "system" fn(*mut core::ffi::c_void, u32, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
     pub GetFontFaceReference: unsafe extern "system" fn(*mut core::ffi::c_void, u32, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
+unsafe impl Send for IDWriteFontFamily1 {}
+unsafe impl Sync for IDWriteFontFamily1 {}
 pub trait IDWriteFontFamily1_Impl: IDWriteFontFamily_Impl {
     fn GetFontLocality(&self, listindex: u32) -> DWRITE_LOCALITY;
     fn GetFont(&self, listindex: u32) -> windows_core::Result<IDWriteFont3>;
@@ -6454,8 +6414,6 @@ impl IDWriteFontFamily1_Vtbl {
     }
 }
 impl windows_core::RuntimeName for IDWriteFontFamily1 {}
-unsafe impl Send for IDWriteFontFamily1 {}
-unsafe impl Sync for IDWriteFontFamily1 {}
 windows_core::imp::define_interface!(IDWriteFontFamily2, IDWriteFontFamily2_Vtbl, 0x3ed49e77_a398_4261_b9cf_c126c2131ef3);
 impl core::ops::Deref for IDWriteFontFamily2 {
     type Target = IDWriteFontFamily1;
@@ -6484,6 +6442,8 @@ pub struct IDWriteFontFamily2_Vtbl {
     pub GetMatchingFonts: unsafe extern "system" fn(*mut core::ffi::c_void, *const DWRITE_FONT_AXIS_VALUE, u32, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
     pub GetFontSet: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
+unsafe impl Send for IDWriteFontFamily2 {}
+unsafe impl Sync for IDWriteFontFamily2 {}
 pub trait IDWriteFontFamily2_Impl: IDWriteFontFamily1_Impl {
     fn GetMatchingFonts(&self, fontaxisvalues: *const DWRITE_FONT_AXIS_VALUE, fontaxisvaluecount: u32) -> windows_core::Result<IDWriteFontList2>;
     fn GetFontSet(&self) -> windows_core::Result<IDWriteFontSet1>;
@@ -6525,8 +6485,6 @@ impl IDWriteFontFamily2_Vtbl {
     }
 }
 impl windows_core::RuntimeName for IDWriteFontFamily2 {}
-unsafe impl Send for IDWriteFontFamily2 {}
-unsafe impl Sync for IDWriteFontFamily2 {}
 windows_core::imp::define_interface!(IDWriteFontFile, IDWriteFontFile_Vtbl, 0x739d886a_cef5_47dc_8769_1a8b41bebbb0);
 windows_core::imp::interface_hierarchy!(IDWriteFontFile, windows_core::IUnknown);
 impl IDWriteFontFile {
@@ -6550,6 +6508,8 @@ pub struct IDWriteFontFile_Vtbl {
     pub GetLoader: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
     pub Analyze: unsafe extern "system" fn(*mut core::ffi::c_void, *mut super::super::Foundation::BOOL, *mut DWRITE_FONT_FILE_TYPE, *mut DWRITE_FONT_FACE_TYPE, *mut u32) -> windows_core::HRESULT,
 }
+unsafe impl Send for IDWriteFontFile {}
+unsafe impl Sync for IDWriteFontFile {}
 pub trait IDWriteFontFile_Impl: windows_core::IUnknownImpl {
     fn GetReferenceKey(&self, fontfilereferencekey: *mut *mut core::ffi::c_void, fontfilereferencekeysize: *mut u32) -> windows_core::Result<()>;
     fn GetLoader(&self) -> windows_core::Result<IDWriteFontFileLoader>;
@@ -6593,8 +6553,6 @@ impl IDWriteFontFile_Vtbl {
     }
 }
 impl windows_core::RuntimeName for IDWriteFontFile {}
-unsafe impl Send for IDWriteFontFile {}
-unsafe impl Sync for IDWriteFontFile {}
 windows_core::imp::define_interface!(IDWriteFontFileEnumerator, IDWriteFontFileEnumerator_Vtbl, 0x72755049_5ff7_435d_8348_4be97cfa6c7c);
 windows_core::imp::interface_hierarchy!(IDWriteFontFileEnumerator, windows_core::IUnknown);
 impl IDWriteFontFileEnumerator {
@@ -6617,6 +6575,8 @@ pub struct IDWriteFontFileEnumerator_Vtbl {
     pub MoveNext: unsafe extern "system" fn(*mut core::ffi::c_void, *mut super::super::Foundation::BOOL) -> windows_core::HRESULT,
     pub GetCurrentFontFile: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
+unsafe impl Send for IDWriteFontFileEnumerator {}
+unsafe impl Sync for IDWriteFontFileEnumerator {}
 pub trait IDWriteFontFileEnumerator_Impl: windows_core::IUnknownImpl {
     fn MoveNext(&self) -> windows_core::Result<super::super::Foundation::BOOL>;
     fn GetCurrentFontFile(&self) -> windows_core::Result<IDWriteFontFile>;
@@ -6658,8 +6618,6 @@ impl IDWriteFontFileEnumerator_Vtbl {
     }
 }
 impl windows_core::RuntimeName for IDWriteFontFileEnumerator {}
-unsafe impl Send for IDWriteFontFileEnumerator {}
-unsafe impl Sync for IDWriteFontFileEnumerator {}
 windows_core::imp::define_interface!(IDWriteFontFileLoader, IDWriteFontFileLoader_Vtbl, 0x727cad4e_d6af_4c9e_8a08_d695b11caa49);
 windows_core::imp::interface_hierarchy!(IDWriteFontFileLoader, windows_core::IUnknown);
 impl IDWriteFontFileLoader {
@@ -6675,6 +6633,8 @@ pub struct IDWriteFontFileLoader_Vtbl {
     pub base__: windows_core::IUnknown_Vtbl,
     pub CreateStreamFromKey: unsafe extern "system" fn(*mut core::ffi::c_void, *const core::ffi::c_void, u32, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
+unsafe impl Send for IDWriteFontFileLoader {}
+unsafe impl Sync for IDWriteFontFileLoader {}
 pub trait IDWriteFontFileLoader_Impl: windows_core::IUnknownImpl {
     fn CreateStreamFromKey(&self, fontfilereferencekey: *const core::ffi::c_void, fontfilereferencekeysize: u32) -> windows_core::Result<IDWriteFontFileStream>;
 }
@@ -6699,8 +6659,6 @@ impl IDWriteFontFileLoader_Vtbl {
     }
 }
 impl windows_core::RuntimeName for IDWriteFontFileLoader {}
-unsafe impl Send for IDWriteFontFileLoader {}
-unsafe impl Sync for IDWriteFontFileLoader {}
 windows_core::imp::define_interface!(IDWriteFontFileStream, IDWriteFontFileStream_Vtbl, 0x6d4865fe_0ab8_4d91_8f62_5dd6be34a3e0);
 windows_core::imp::interface_hierarchy!(IDWriteFontFileStream, windows_core::IUnknown);
 impl IDWriteFontFileStream {
@@ -6731,6 +6689,8 @@ pub struct IDWriteFontFileStream_Vtbl {
     pub GetFileSize: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u64) -> windows_core::HRESULT,
     pub GetLastWriteTime: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u64) -> windows_core::HRESULT,
 }
+unsafe impl Send for IDWriteFontFileStream {}
+unsafe impl Sync for IDWriteFontFileStream {}
 pub trait IDWriteFontFileStream_Impl: windows_core::IUnknownImpl {
     fn ReadFileFragment(&self, fragmentstart: *mut *mut core::ffi::c_void, fileoffset: u64, fragmentsize: u64, fragmentcontext: *mut *mut core::ffi::c_void) -> windows_core::Result<()>;
     fn ReleaseFileFragment(&self, fragmentcontext: *mut core::ffi::c_void);
@@ -6788,8 +6748,6 @@ impl IDWriteFontFileStream_Vtbl {
     }
 }
 impl windows_core::RuntimeName for IDWriteFontFileStream {}
-unsafe impl Send for IDWriteFontFileStream {}
-unsafe impl Sync for IDWriteFontFileStream {}
 windows_core::imp::define_interface!(IDWriteFontList, IDWriteFontList_Vtbl, 0x1a0d8438_1d97_4ec1_aef9_a2fb86ed6acb);
 windows_core::imp::interface_hierarchy!(IDWriteFontList, windows_core::IUnknown);
 impl IDWriteFontList {
@@ -6816,6 +6774,8 @@ pub struct IDWriteFontList_Vtbl {
     pub GetFontCount: unsafe extern "system" fn(*mut core::ffi::c_void) -> u32,
     pub GetFont: unsafe extern "system" fn(*mut core::ffi::c_void, u32, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
+unsafe impl Send for IDWriteFontList {}
+unsafe impl Sync for IDWriteFontList {}
 pub trait IDWriteFontList_Impl: windows_core::IUnknownImpl {
     fn GetFontCollection(&self) -> windows_core::Result<IDWriteFontCollection>;
     fn GetFontCount(&self) -> u32;
@@ -6865,8 +6825,6 @@ impl IDWriteFontList_Vtbl {
     }
 }
 impl windows_core::RuntimeName for IDWriteFontList {}
-unsafe impl Send for IDWriteFontList {}
-unsafe impl Sync for IDWriteFontList {}
 windows_core::imp::define_interface!(IDWriteFontList1, IDWriteFontList1_Vtbl, 0xda20d8ef_812a_4c43_9802_62ec4abd7ade);
 impl core::ops::Deref for IDWriteFontList1 {
     type Target = IDWriteFontList;
@@ -6899,6 +6857,8 @@ pub struct IDWriteFontList1_Vtbl {
     pub GetFont: unsafe extern "system" fn(*mut core::ffi::c_void, u32, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
     pub GetFontFaceReference: unsafe extern "system" fn(*mut core::ffi::c_void, u32, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
+unsafe impl Send for IDWriteFontList1 {}
+unsafe impl Sync for IDWriteFontList1 {}
 pub trait IDWriteFontList1_Impl: IDWriteFontList_Impl {
     fn GetFontLocality(&self, listindex: u32) -> DWRITE_LOCALITY;
     fn GetFont(&self, listindex: u32) -> windows_core::Result<IDWriteFont3>;
@@ -6948,8 +6908,6 @@ impl IDWriteFontList1_Vtbl {
     }
 }
 impl windows_core::RuntimeName for IDWriteFontList1 {}
-unsafe impl Send for IDWriteFontList1 {}
-unsafe impl Sync for IDWriteFontList1 {}
 windows_core::imp::define_interface!(IDWriteFontList2, IDWriteFontList2_Vtbl, 0xc0763a34_77af_445a_b735_08c37b0a5bf5);
 impl core::ops::Deref for IDWriteFontList2 {
     type Target = IDWriteFontList1;
@@ -6971,6 +6929,8 @@ pub struct IDWriteFontList2_Vtbl {
     pub base__: IDWriteFontList1_Vtbl,
     pub GetFontSet: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
+unsafe impl Send for IDWriteFontList2 {}
+unsafe impl Sync for IDWriteFontList2 {}
 pub trait IDWriteFontList2_Impl: IDWriteFontList1_Impl {
     fn GetFontSet(&self) -> windows_core::Result<IDWriteFontSet1>;
 }
@@ -6995,8 +6955,6 @@ impl IDWriteFontList2_Vtbl {
     }
 }
 impl windows_core::RuntimeName for IDWriteFontList2 {}
-unsafe impl Send for IDWriteFontList2 {}
-unsafe impl Sync for IDWriteFontList2 {}
 windows_core::imp::define_interface!(IDWriteFontResource, IDWriteFontResource_Vtbl, 0x1f803a76_6871_48e8_987f_b975551c50f2);
 windows_core::imp::interface_hierarchy!(IDWriteFontResource, windows_core::IUnknown);
 impl IDWriteFontResource {
@@ -7065,6 +7023,8 @@ pub struct IDWriteFontResource_Vtbl {
     pub CreateFontFace: unsafe extern "system" fn(*mut core::ffi::c_void, DWRITE_FONT_SIMULATIONS, *const DWRITE_FONT_AXIS_VALUE, u32, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
     pub CreateFontFaceReference: unsafe extern "system" fn(*mut core::ffi::c_void, DWRITE_FONT_SIMULATIONS, *const DWRITE_FONT_AXIS_VALUE, u32, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
+unsafe impl Send for IDWriteFontResource {}
+unsafe impl Sync for IDWriteFontResource {}
 pub trait IDWriteFontResource_Impl: windows_core::IUnknownImpl {
     fn GetFontFile(&self) -> windows_core::Result<IDWriteFontFile>;
     fn GetFontFaceIndex(&self) -> u32;
@@ -7198,8 +7158,6 @@ impl IDWriteFontResource_Vtbl {
     }
 }
 impl windows_core::RuntimeName for IDWriteFontResource {}
-unsafe impl Send for IDWriteFontResource {}
-unsafe impl Sync for IDWriteFontResource {}
 windows_core::imp::define_interface!(IDWriteFontSet, IDWriteFontSet_Vtbl, 0x53585141_d9f8_4095_8321_d73cf6bd116b);
 windows_core::imp::interface_hierarchy!(IDWriteFontSet, windows_core::IUnknown);
 impl IDWriteFontSet {
@@ -7278,6 +7236,8 @@ pub struct IDWriteFontSet_Vtbl {
     pub GetMatchingFonts: unsafe extern "system" fn(*mut core::ffi::c_void, windows_core::PCWSTR, DWRITE_FONT_WEIGHT, DWRITE_FONT_STRETCH, DWRITE_FONT_STYLE, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
     pub GetMatchingFonts2: unsafe extern "system" fn(*mut core::ffi::c_void, *const DWRITE_FONT_PROPERTY, u32, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
+unsafe impl Send for IDWriteFontSet {}
+unsafe impl Sync for IDWriteFontSet {}
 pub trait IDWriteFontSet_Impl: windows_core::IUnknownImpl {
     fn GetFontCount(&self) -> u32;
     fn GetFontFaceReference(&self, listindex: u32) -> windows_core::Result<IDWriteFontFaceReference>;
@@ -7407,8 +7367,6 @@ impl IDWriteFontSet_Vtbl {
     }
 }
 impl windows_core::RuntimeName for IDWriteFontSet {}
-unsafe impl Send for IDWriteFontSet {}
-unsafe impl Sync for IDWriteFontSet {}
 windows_core::imp::define_interface!(IDWriteFontSet1, IDWriteFontSet1_Vtbl, 0x7e9fda85_6c92_4053_bc47_7ae3530db4d3);
 impl core::ops::Deref for IDWriteFontSet1 {
     type Target = IDWriteFontSet;
@@ -7499,6 +7457,8 @@ pub struct IDWriteFontSet1_Vtbl {
     pub CreateFontFace: unsafe extern "system" fn(*mut core::ffi::c_void, u32, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
     pub GetFontLocality: unsafe extern "system" fn(*mut core::ffi::c_void, u32) -> DWRITE_LOCALITY,
 }
+unsafe impl Send for IDWriteFontSet1 {}
+unsafe impl Sync for IDWriteFontSet1 {}
 pub trait IDWriteFontSet1_Impl: IDWriteFontSet_Impl {
     fn GetMatchingFonts(&self, fontproperty: *const DWRITE_FONT_PROPERTY, fontaxisvalues: *const DWRITE_FONT_AXIS_VALUE, fontaxisvaluecount: u32) -> windows_core::Result<IDWriteFontSet1>;
     fn GetFirstFontResources(&self) -> windows_core::Result<IDWriteFontSet1>;
@@ -7664,8 +7624,6 @@ impl IDWriteFontSet1_Vtbl {
     }
 }
 impl windows_core::RuntimeName for IDWriteFontSet1 {}
-unsafe impl Send for IDWriteFontSet1 {}
-unsafe impl Sync for IDWriteFontSet1 {}
 windows_core::imp::define_interface!(IDWriteFontSet2, IDWriteFontSet2_Vtbl, 0xdc7ead19_e54c_43af_b2da_4e2b79ba3f7f);
 impl core::ops::Deref for IDWriteFontSet2 {
     type Target = IDWriteFontSet1;
@@ -7684,6 +7642,8 @@ pub struct IDWriteFontSet2_Vtbl {
     pub base__: IDWriteFontSet1_Vtbl,
     pub GetExpirationEvent: unsafe extern "system" fn(*mut core::ffi::c_void) -> super::super::Foundation::HANDLE,
 }
+unsafe impl Send for IDWriteFontSet2 {}
+unsafe impl Sync for IDWriteFontSet2 {}
 pub trait IDWriteFontSet2_Impl: IDWriteFontSet1_Impl {
     fn GetExpirationEvent(&self) -> super::super::Foundation::HANDLE;
 }
@@ -7702,8 +7662,6 @@ impl IDWriteFontSet2_Vtbl {
     }
 }
 impl windows_core::RuntimeName for IDWriteFontSet2 {}
-unsafe impl Send for IDWriteFontSet2 {}
-unsafe impl Sync for IDWriteFontSet2 {}
 windows_core::imp::define_interface!(IDWriteFontSet3, IDWriteFontSet3_Vtbl, 0x7c073ef2_a7f4_4045_8c32_8ab8ae640f90);
 impl core::ops::Deref for IDWriteFontSet3 {
     type Target = IDWriteFontSet2;
@@ -7730,6 +7688,8 @@ pub struct IDWriteFontSet3_Vtbl {
     pub GetFontSourceNameLength: unsafe extern "system" fn(*mut core::ffi::c_void, u32) -> u32,
     pub GetFontSourceName: unsafe extern "system" fn(*mut core::ffi::c_void, u32, windows_core::PWSTR, u32) -> windows_core::HRESULT,
 }
+unsafe impl Send for IDWriteFontSet3 {}
+unsafe impl Sync for IDWriteFontSet3 {}
 pub trait IDWriteFontSet3_Impl: IDWriteFontSet2_Impl {
     fn GetFontSourceType(&self, fontindex: u32) -> DWRITE_FONT_SOURCE_TYPE;
     fn GetFontSourceNameLength(&self, listindex: u32) -> u32;
@@ -7767,8 +7727,6 @@ impl IDWriteFontSet3_Vtbl {
     }
 }
 impl windows_core::RuntimeName for IDWriteFontSet3 {}
-unsafe impl Send for IDWriteFontSet3 {}
-unsafe impl Sync for IDWriteFontSet3 {}
 windows_core::imp::define_interface!(IDWriteFontSet4, IDWriteFontSet4_Vtbl, 0xeec175fc_bea9_4c86_8b53_ccbdd7df0c82);
 impl core::ops::Deref for IDWriteFontSet4 {
     type Target = IDWriteFontSet3;
@@ -7797,6 +7755,8 @@ pub struct IDWriteFontSet4_Vtbl {
     pub ConvertWeightStretchStyleToFontAxisValues: unsafe extern "system" fn(*mut core::ffi::c_void, *const DWRITE_FONT_AXIS_VALUE, u32, DWRITE_FONT_WEIGHT, DWRITE_FONT_STRETCH, DWRITE_FONT_STYLE, f32, *mut DWRITE_FONT_AXIS_VALUE) -> u32,
     pub GetMatchingFonts: unsafe extern "system" fn(*mut core::ffi::c_void, windows_core::PCWSTR, *const DWRITE_FONT_AXIS_VALUE, u32, DWRITE_FONT_SIMULATIONS, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
+unsafe impl Send for IDWriteFontSet4 {}
+unsafe impl Sync for IDWriteFontSet4 {}
 pub trait IDWriteFontSet4_Impl: IDWriteFontSet3_Impl {
     fn ConvertWeightStretchStyleToFontAxisValues(&self, inputaxisvalues: *const DWRITE_FONT_AXIS_VALUE, inputaxiscount: u32, fontweight: DWRITE_FONT_WEIGHT, fontstretch: DWRITE_FONT_STRETCH, fontstyle: DWRITE_FONT_STYLE, fontsize: f32, outputaxisvalues: *mut DWRITE_FONT_AXIS_VALUE) -> u32;
     fn GetMatchingFonts(&self, familyname: &windows_core::PCWSTR, fontaxisvalues: *const DWRITE_FONT_AXIS_VALUE, fontaxisvaluecount: u32, allowedsimulations: DWRITE_FONT_SIMULATIONS) -> windows_core::Result<IDWriteFontSet4>;
@@ -7832,8 +7792,6 @@ impl IDWriteFontSet4_Vtbl {
     }
 }
 impl windows_core::RuntimeName for IDWriteFontSet4 {}
-unsafe impl Send for IDWriteFontSet4 {}
-unsafe impl Sync for IDWriteFontSet4 {}
 windows_core::imp::define_interface!(IDWriteFontSetBuilder, IDWriteFontSetBuilder_Vtbl, 0x2f642afe_9c68_4f40_b8be_457401afcb3d);
 windows_core::imp::interface_hierarchy!(IDWriteFontSetBuilder, windows_core::IUnknown);
 impl IDWriteFontSetBuilder {
@@ -7870,6 +7828,8 @@ pub struct IDWriteFontSetBuilder_Vtbl {
     pub AddFontSet: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
     pub CreateFontSet: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
+unsafe impl Send for IDWriteFontSetBuilder {}
+unsafe impl Sync for IDWriteFontSetBuilder {}
 pub trait IDWriteFontSetBuilder_Impl: windows_core::IUnknownImpl {
     fn AddFontFaceReference(&self, fontfacereference: windows_core::Ref<IDWriteFontFaceReference>, properties: *const DWRITE_FONT_PROPERTY, propertycount: u32) -> windows_core::Result<()>;
     fn AddFontFaceReference2(&self, fontfacereference: windows_core::Ref<IDWriteFontFaceReference>) -> windows_core::Result<()>;
@@ -7921,8 +7881,6 @@ impl IDWriteFontSetBuilder_Vtbl {
     }
 }
 impl windows_core::RuntimeName for IDWriteFontSetBuilder {}
-unsafe impl Send for IDWriteFontSetBuilder {}
-unsafe impl Sync for IDWriteFontSetBuilder {}
 windows_core::imp::define_interface!(IDWriteFontSetBuilder1, IDWriteFontSetBuilder1_Vtbl, 0x3ff7715f_3cdc_4dc6_9b72_ec5621dccafd);
 impl core::ops::Deref for IDWriteFontSetBuilder1 {
     type Target = IDWriteFontSetBuilder;
@@ -7944,6 +7902,8 @@ pub struct IDWriteFontSetBuilder1_Vtbl {
     pub base__: IDWriteFontSetBuilder_Vtbl,
     pub AddFontFile: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
+unsafe impl Send for IDWriteFontSetBuilder1 {}
+unsafe impl Sync for IDWriteFontSetBuilder1 {}
 pub trait IDWriteFontSetBuilder1_Impl: IDWriteFontSetBuilder_Impl {
     fn AddFontFile(&self, fontfile: windows_core::Ref<IDWriteFontFile>) -> windows_core::Result<()>;
 }
@@ -7962,8 +7922,6 @@ impl IDWriteFontSetBuilder1_Vtbl {
     }
 }
 impl windows_core::RuntimeName for IDWriteFontSetBuilder1 {}
-unsafe impl Send for IDWriteFontSetBuilder1 {}
-unsafe impl Sync for IDWriteFontSetBuilder1 {}
 windows_core::imp::define_interface!(IDWriteFontSetBuilder2, IDWriteFontSetBuilder2_Vtbl, 0xee5ba612_b131_463c_8f4f_3189b9401e45);
 impl core::ops::Deref for IDWriteFontSetBuilder2 {
     type Target = IDWriteFontSetBuilder1;
@@ -7992,6 +7950,8 @@ pub struct IDWriteFontSetBuilder2_Vtbl {
     pub AddFont: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, u32, DWRITE_FONT_SIMULATIONS, *const DWRITE_FONT_AXIS_VALUE, u32, *const DWRITE_FONT_AXIS_RANGE, u32, *const DWRITE_FONT_PROPERTY, u32) -> windows_core::HRESULT,
     pub AddFontFile: unsafe extern "system" fn(*mut core::ffi::c_void, windows_core::PCWSTR) -> windows_core::HRESULT,
 }
+unsafe impl Send for IDWriteFontSetBuilder2 {}
+unsafe impl Sync for IDWriteFontSetBuilder2 {}
 pub trait IDWriteFontSetBuilder2_Impl: IDWriteFontSetBuilder1_Impl {
     fn AddFont(&self, fontfile: windows_core::Ref<IDWriteFontFile>, fontfaceindex: u32, fontsimulations: DWRITE_FONT_SIMULATIONS, fontaxisvalues: *const DWRITE_FONT_AXIS_VALUE, fontaxisvaluecount: u32, fontaxisranges: *const DWRITE_FONT_AXIS_RANGE, fontaxisrangecount: u32, properties: *const DWRITE_FONT_PROPERTY, propertycount: u32) -> windows_core::Result<()>;
     fn AddFontFile(&self, filepath: &windows_core::PCWSTR) -> windows_core::Result<()>;
@@ -8021,8 +7981,6 @@ impl IDWriteFontSetBuilder2_Vtbl {
     }
 }
 impl windows_core::RuntimeName for IDWriteFontSetBuilder2 {}
-unsafe impl Send for IDWriteFontSetBuilder2 {}
-unsafe impl Sync for IDWriteFontSetBuilder2 {}
 windows_core::imp::define_interface!(IDWriteGdiInterop, IDWriteGdiInterop_Vtbl, 0x1edd9491_9853_4299_898f_6432983b6f3a);
 windows_core::imp::interface_hierarchy!(IDWriteGdiInterop, windows_core::IUnknown);
 impl IDWriteGdiInterop {
@@ -8086,6 +8044,8 @@ pub struct IDWriteGdiInterop_Vtbl {
     #[cfg(not(feature = "Win32_Graphics_Gdi"))]
     CreateBitmapRenderTarget: usize,
 }
+unsafe impl Send for IDWriteGdiInterop {}
+unsafe impl Sync for IDWriteGdiInterop {}
 #[cfg(feature = "Win32_Graphics_Gdi")]
 pub trait IDWriteGdiInterop_Impl: windows_core::IUnknownImpl {
     fn CreateFontFromLOGFONT(&self, logfont: *const super::Gdi::LOGFONTW) -> windows_core::Result<IDWriteFont>;
@@ -8160,10 +8120,6 @@ impl IDWriteGdiInterop_Vtbl {
 }
 #[cfg(feature = "Win32_Graphics_Gdi")]
 impl windows_core::RuntimeName for IDWriteGdiInterop {}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-unsafe impl Send for IDWriteGdiInterop {}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-unsafe impl Sync for IDWriteGdiInterop {}
 windows_core::imp::define_interface!(IDWriteGdiInterop1, IDWriteGdiInterop1_Vtbl, 0x4556be70_3abd_4f70_90be_421780a6f515);
 impl core::ops::Deref for IDWriteGdiInterop1 {
     type Target = IDWriteGdiInterop;
@@ -8228,6 +8184,8 @@ pub struct IDWriteGdiInterop1_Vtbl {
     #[cfg(not(feature = "Win32_Graphics_Gdi"))]
     GetMatchingFontsByLOGFONT: usize,
 }
+unsafe impl Send for IDWriteGdiInterop1 {}
+unsafe impl Sync for IDWriteGdiInterop1 {}
 #[cfg(all(feature = "Win32_Globalization", feature = "Win32_Graphics_Gdi"))]
 pub trait IDWriteGdiInterop1_Impl: IDWriteGdiInterop_Impl {
     fn CreateFontFromLOGFONT(&self, logfont: *const super::Gdi::LOGFONTW, fontcollection: windows_core::Ref<IDWriteFontCollection>) -> windows_core::Result<IDWriteFont>;
@@ -8288,10 +8246,6 @@ impl IDWriteGdiInterop1_Vtbl {
 }
 #[cfg(all(feature = "Win32_Globalization", feature = "Win32_Graphics_Gdi"))]
 impl windows_core::RuntimeName for IDWriteGdiInterop1 {}
-#[cfg(all(feature = "Win32_Globalization", feature = "Win32_Graphics_Gdi"))]
-unsafe impl Send for IDWriteGdiInterop1 {}
-#[cfg(all(feature = "Win32_Globalization", feature = "Win32_Graphics_Gdi"))]
-unsafe impl Sync for IDWriteGdiInterop1 {}
 windows_core::imp::define_interface!(IDWriteGlyphRunAnalysis, IDWriteGlyphRunAnalysis_Vtbl, 0x7d97dbf7_e085_42d4_81e3_6a883bded118);
 windows_core::imp::interface_hierarchy!(IDWriteGlyphRunAnalysis, windows_core::IUnknown);
 impl IDWriteGlyphRunAnalysis {
@@ -8318,6 +8272,8 @@ pub struct IDWriteGlyphRunAnalysis_Vtbl {
     pub CreateAlphaTexture: unsafe extern "system" fn(*mut core::ffi::c_void, DWRITE_TEXTURE_TYPE, *const super::super::Foundation::RECT, *mut u8, u32) -> windows_core::HRESULT,
     pub GetAlphaBlendParams: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut f32, *mut f32, *mut f32) -> windows_core::HRESULT,
 }
+unsafe impl Send for IDWriteGlyphRunAnalysis {}
+unsafe impl Sync for IDWriteGlyphRunAnalysis {}
 pub trait IDWriteGlyphRunAnalysis_Impl: windows_core::IUnknownImpl {
     fn GetAlphaTextureBounds(&self, texturetype: DWRITE_TEXTURE_TYPE) -> windows_core::Result<super::super::Foundation::RECT>;
     fn CreateAlphaTexture(&self, texturetype: DWRITE_TEXTURE_TYPE, texturebounds: *const super::super::Foundation::RECT, alphavalues: *mut u8, buffersize: u32) -> windows_core::Result<()>;
@@ -8361,8 +8317,6 @@ impl IDWriteGlyphRunAnalysis_Vtbl {
     }
 }
 impl windows_core::RuntimeName for IDWriteGlyphRunAnalysis {}
-unsafe impl Send for IDWriteGlyphRunAnalysis {}
-unsafe impl Sync for IDWriteGlyphRunAnalysis {}
 windows_core::imp::define_interface!(IDWriteInMemoryFontFileLoader, IDWriteInMemoryFontFileLoader_Vtbl, 0xdc102f47_a12d_4b1c_822d_9e117e33043f);
 impl core::ops::Deref for IDWriteInMemoryFontFileLoader {
     type Target = IDWriteFontFileLoader;
@@ -8392,6 +8346,8 @@ pub struct IDWriteInMemoryFontFileLoader_Vtbl {
     pub CreateInMemoryFontFileReference: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *const core::ffi::c_void, u32, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
     pub GetFileCount: unsafe extern "system" fn(*mut core::ffi::c_void) -> u32,
 }
+unsafe impl Send for IDWriteInMemoryFontFileLoader {}
+unsafe impl Sync for IDWriteInMemoryFontFileLoader {}
 pub trait IDWriteInMemoryFontFileLoader_Impl: IDWriteFontFileLoader_Impl {
     fn CreateInMemoryFontFileReference(&self, factory: windows_core::Ref<IDWriteFactory>, fontdata: *const core::ffi::c_void, fontdatasize: u32, ownerobject: windows_core::Ref<windows_core::IUnknown>) -> windows_core::Result<IDWriteFontFile>;
     fn GetFileCount(&self) -> u32;
@@ -8427,8 +8383,6 @@ impl IDWriteInMemoryFontFileLoader_Vtbl {
     }
 }
 impl windows_core::RuntimeName for IDWriteInMemoryFontFileLoader {}
-unsafe impl Send for IDWriteInMemoryFontFileLoader {}
-unsafe impl Sync for IDWriteInMemoryFontFileLoader {}
 windows_core::imp::define_interface!(IDWriteInlineObject, IDWriteInlineObject_Vtbl, 0x8339fde3_106f_47ab_8373_1c6295eb10b3);
 windows_core::imp::interface_hierarchy!(IDWriteInlineObject, windows_core::IUnknown);
 impl IDWriteInlineObject {
@@ -8463,6 +8417,8 @@ pub struct IDWriteInlineObject_Vtbl {
     pub GetOverhangMetrics: unsafe extern "system" fn(*mut core::ffi::c_void, *mut DWRITE_OVERHANG_METRICS) -> windows_core::HRESULT,
     pub GetBreakConditions: unsafe extern "system" fn(*mut core::ffi::c_void, *mut DWRITE_BREAK_CONDITION, *mut DWRITE_BREAK_CONDITION) -> windows_core::HRESULT,
 }
+unsafe impl Send for IDWriteInlineObject {}
+unsafe impl Sync for IDWriteInlineObject {}
 pub trait IDWriteInlineObject_Impl: windows_core::IUnknownImpl {
     fn Draw(&self, clientdrawingcontext: *const core::ffi::c_void, renderer: windows_core::Ref<IDWriteTextRenderer>, originx: f32, originy: f32, issideways: super::super::Foundation::BOOL, isrighttoleft: super::super::Foundation::BOOL, clientdrawingeffect: windows_core::Ref<windows_core::IUnknown>) -> windows_core::Result<()>;
     fn GetMetrics(&self) -> windows_core::Result<DWRITE_INLINE_OBJECT_METRICS>;
@@ -8520,8 +8476,6 @@ impl IDWriteInlineObject_Vtbl {
     }
 }
 impl windows_core::RuntimeName for IDWriteInlineObject {}
-unsafe impl Send for IDWriteInlineObject {}
-unsafe impl Sync for IDWriteInlineObject {}
 windows_core::imp::define_interface!(IDWriteLocalFontFileLoader, IDWriteLocalFontFileLoader_Vtbl, 0xb2d9f3ec_c9fe_4a11_a2ec_d86208f7c0a2);
 impl core::ops::Deref for IDWriteLocalFontFileLoader {
     type Target = IDWriteFontFileLoader;
@@ -8554,6 +8508,8 @@ pub struct IDWriteLocalFontFileLoader_Vtbl {
     pub GetFilePathFromKey: unsafe extern "system" fn(*mut core::ffi::c_void, *const core::ffi::c_void, u32, windows_core::PWSTR, u32) -> windows_core::HRESULT,
     pub GetLastWriteTimeFromKey: unsafe extern "system" fn(*mut core::ffi::c_void, *const core::ffi::c_void, u32, *mut super::super::Foundation::FILETIME) -> windows_core::HRESULT,
 }
+unsafe impl Send for IDWriteLocalFontFileLoader {}
+unsafe impl Sync for IDWriteLocalFontFileLoader {}
 pub trait IDWriteLocalFontFileLoader_Impl: IDWriteFontFileLoader_Impl {
     fn GetFilePathLengthFromKey(&self, fontfilereferencekey: *const core::ffi::c_void, fontfilereferencekeysize: u32) -> windows_core::Result<u32>;
     fn GetFilePathFromKey(&self, fontfilereferencekey: *const core::ffi::c_void, fontfilereferencekeysize: u32, filepath: windows_core::PWSTR, filepathsize: u32) -> windows_core::Result<()>;
@@ -8603,8 +8559,6 @@ impl IDWriteLocalFontFileLoader_Vtbl {
     }
 }
 impl windows_core::RuntimeName for IDWriteLocalFontFileLoader {}
-unsafe impl Send for IDWriteLocalFontFileLoader {}
-unsafe impl Sync for IDWriteLocalFontFileLoader {}
 windows_core::imp::define_interface!(IDWriteLocalizedStrings, IDWriteLocalizedStrings_Vtbl, 0x08256209_099a_4b34_b86d_c22b110e7771);
 windows_core::imp::interface_hierarchy!(IDWriteLocalizedStrings, windows_core::IUnknown);
 impl IDWriteLocalizedStrings {
@@ -8646,6 +8600,8 @@ pub struct IDWriteLocalizedStrings_Vtbl {
     pub GetStringLength: unsafe extern "system" fn(*mut core::ffi::c_void, u32, *mut u32) -> windows_core::HRESULT,
     pub GetString: unsafe extern "system" fn(*mut core::ffi::c_void, u32, windows_core::PWSTR, u32) -> windows_core::HRESULT,
 }
+unsafe impl Send for IDWriteLocalizedStrings {}
+unsafe impl Sync for IDWriteLocalizedStrings {}
 pub trait IDWriteLocalizedStrings_Impl: windows_core::IUnknownImpl {
     fn GetCount(&self) -> u32;
     fn FindLocaleName(&self, localename: &windows_core::PCWSTR, index: *mut u32, exists: *mut super::super::Foundation::BOOL) -> windows_core::Result<()>;
@@ -8719,14 +8675,14 @@ impl IDWriteLocalizedStrings_Vtbl {
     }
 }
 impl windows_core::RuntimeName for IDWriteLocalizedStrings {}
-unsafe impl Send for IDWriteLocalizedStrings {}
-unsafe impl Sync for IDWriteLocalizedStrings {}
 windows_core::imp::define_interface!(IDWriteNumberSubstitution, IDWriteNumberSubstitution_Vtbl, 0x14885cc9_bab0_4f90_b6ed_5c366a2cd03d);
 windows_core::imp::interface_hierarchy!(IDWriteNumberSubstitution, windows_core::IUnknown);
 #[repr(C)]
 pub struct IDWriteNumberSubstitution_Vtbl {
     pub base__: windows_core::IUnknown_Vtbl,
 }
+unsafe impl Send for IDWriteNumberSubstitution {}
+unsafe impl Sync for IDWriteNumberSubstitution {}
 pub trait IDWriteNumberSubstitution_Impl: windows_core::IUnknownImpl {}
 impl IDWriteNumberSubstitution_Vtbl {
     pub const fn new<Identity: IDWriteNumberSubstitution_Impl, const OFFSET: isize>() -> Self {
@@ -8737,8 +8693,6 @@ impl IDWriteNumberSubstitution_Vtbl {
     }
 }
 impl windows_core::RuntimeName for IDWriteNumberSubstitution {}
-unsafe impl Send for IDWriteNumberSubstitution {}
-unsafe impl Sync for IDWriteNumberSubstitution {}
 windows_core::imp::define_interface!(IDWritePaintReader, IDWritePaintReader_Vtbl, 0x8128e912_3b97_42a5_ab6c_24aad3a86e54);
 windows_core::imp::interface_hierarchy!(IDWritePaintReader, windows_core::IUnknown);
 impl IDWritePaintReader {
@@ -8799,6 +8753,8 @@ pub struct IDWritePaintReader_Vtbl {
     GetGradientStops: usize,
     pub GetGradientStopColors: unsafe extern "system" fn(*mut core::ffi::c_void, u32, u32, *mut DWRITE_PAINT_COLOR) -> windows_core::HRESULT,
 }
+unsafe impl Send for IDWritePaintReader {}
+unsafe impl Sync for IDWritePaintReader {}
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
 pub trait IDWritePaintReader_Impl: windows_core::IUnknownImpl {
     fn SetCurrentGlyph(&self, glyphindex: u32, paintelement: *mut DWRITE_PAINT_ELEMENT, structsize: u32, clipbox: *mut super::Direct2D::Common::D2D_RECT_F, glyphattributes: *mut DWRITE_PAINT_ATTRIBUTES) -> windows_core::Result<()>;
@@ -8887,10 +8843,6 @@ impl IDWritePaintReader_Vtbl {
 }
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
 impl windows_core::RuntimeName for IDWritePaintReader {}
-#[cfg(feature = "Win32_Graphics_Direct2D_Common")]
-unsafe impl Send for IDWritePaintReader {}
-#[cfg(feature = "Win32_Graphics_Direct2D_Common")]
-unsafe impl Sync for IDWritePaintReader {}
 windows_core::imp::define_interface!(IDWritePixelSnapping, IDWritePixelSnapping_Vtbl, 0xeaf3a2da_ecf4_4d24_b644_b34f6842024b);
 windows_core::imp::interface_hierarchy!(IDWritePixelSnapping, windows_core::IUnknown);
 impl IDWritePixelSnapping {
@@ -8917,6 +8869,8 @@ pub struct IDWritePixelSnapping_Vtbl {
     pub GetCurrentTransform: unsafe extern "system" fn(*mut core::ffi::c_void, *const core::ffi::c_void, *mut DWRITE_MATRIX) -> windows_core::HRESULT,
     pub GetPixelsPerDip: unsafe extern "system" fn(*mut core::ffi::c_void, *const core::ffi::c_void, *mut f32) -> windows_core::HRESULT,
 }
+unsafe impl Send for IDWritePixelSnapping {}
+unsafe impl Sync for IDWritePixelSnapping {}
 pub trait IDWritePixelSnapping_Impl: windows_core::IUnknownImpl {
     fn IsPixelSnappingDisabled(&self, clientdrawingcontext: *const core::ffi::c_void) -> windows_core::Result<super::super::Foundation::BOOL>;
     fn GetCurrentTransform(&self, clientdrawingcontext: *const core::ffi::c_void, transform: *mut DWRITE_MATRIX) -> windows_core::Result<()>;
@@ -8966,8 +8920,6 @@ impl IDWritePixelSnapping_Vtbl {
     }
 }
 impl windows_core::RuntimeName for IDWritePixelSnapping {}
-unsafe impl Send for IDWritePixelSnapping {}
-unsafe impl Sync for IDWritePixelSnapping {}
 windows_core::imp::define_interface!(IDWriteRemoteFontFileLoader, IDWriteRemoteFontFileLoader_Vtbl, 0x68648c83_6ede_46c0_ab46_20083a887fde);
 impl core::ops::Deref for IDWriteRemoteFontFileLoader {
     type Target = IDWriteFontFileLoader;
@@ -9008,6 +8960,8 @@ pub struct IDWriteRemoteFontFileLoader_Vtbl {
     pub GetLocalityFromKey: unsafe extern "system" fn(*mut core::ffi::c_void, *const core::ffi::c_void, u32, *mut DWRITE_LOCALITY) -> windows_core::HRESULT,
     pub CreateFontFileReferenceFromUrl: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, windows_core::PCWSTR, windows_core::PCWSTR, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
+unsafe impl Send for IDWriteRemoteFontFileLoader {}
+unsafe impl Sync for IDWriteRemoteFontFileLoader {}
 pub trait IDWriteRemoteFontFileLoader_Impl: IDWriteFontFileLoader_Impl {
     fn CreateRemoteStreamFromKey(&self, fontfilereferencekey: *const core::ffi::c_void, fontfilereferencekeysize: u32) -> windows_core::Result<IDWriteRemoteFontFileStream>;
     fn GetLocalityFromKey(&self, fontfilereferencekey: *const core::ffi::c_void, fontfilereferencekeysize: u32) -> windows_core::Result<DWRITE_LOCALITY>;
@@ -9063,8 +9017,6 @@ impl IDWriteRemoteFontFileLoader_Vtbl {
     }
 }
 impl windows_core::RuntimeName for IDWriteRemoteFontFileLoader {}
-unsafe impl Send for IDWriteRemoteFontFileLoader {}
-unsafe impl Sync for IDWriteRemoteFontFileLoader {}
 windows_core::imp::define_interface!(IDWriteRemoteFontFileStream, IDWriteRemoteFontFileStream_Vtbl, 0x4db3757a_2c72_4ed9_b2b6_1ababe1aff9c);
 impl core::ops::Deref for IDWriteRemoteFontFileStream {
     type Target = IDWriteFontFileStream;
@@ -9101,6 +9053,8 @@ pub struct IDWriteRemoteFontFileStream_Vtbl {
     pub GetLocality: unsafe extern "system" fn(*mut core::ffi::c_void) -> DWRITE_LOCALITY,
     pub BeginDownload: unsafe extern "system" fn(*mut core::ffi::c_void, *const windows_core::GUID, *const DWRITE_FILE_FRAGMENT, u32, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
+unsafe impl Send for IDWriteRemoteFontFileStream {}
+unsafe impl Sync for IDWriteRemoteFontFileStream {}
 pub trait IDWriteRemoteFontFileStream_Impl: IDWriteFontFileStream_Impl {
     fn GetLocalFileSize(&self) -> windows_core::Result<u64>;
     fn GetFileFragmentLocality(&self, fileoffset: u64, fragmentsize: u64, islocal: *mut super::super::Foundation::BOOL, partialsize: *mut u64) -> windows_core::Result<()>;
@@ -9158,8 +9112,6 @@ impl IDWriteRemoteFontFileStream_Vtbl {
     }
 }
 impl windows_core::RuntimeName for IDWriteRemoteFontFileStream {}
-unsafe impl Send for IDWriteRemoteFontFileStream {}
-unsafe impl Sync for IDWriteRemoteFontFileStream {}
 windows_core::imp::define_interface!(IDWriteRenderingParams, IDWriteRenderingParams_Vtbl, 0x2f0da53a_2add_47cd_82ee_d9ec34688e75);
 windows_core::imp::interface_hierarchy!(IDWriteRenderingParams, windows_core::IUnknown);
 impl IDWriteRenderingParams {
@@ -9188,6 +9140,8 @@ pub struct IDWriteRenderingParams_Vtbl {
     pub GetPixelGeometry: unsafe extern "system" fn(*mut core::ffi::c_void) -> DWRITE_PIXEL_GEOMETRY,
     pub GetRenderingMode: unsafe extern "system" fn(*mut core::ffi::c_void) -> DWRITE_RENDERING_MODE,
 }
+unsafe impl Send for IDWriteRenderingParams {}
+unsafe impl Sync for IDWriteRenderingParams {}
 pub trait IDWriteRenderingParams_Impl: windows_core::IUnknownImpl {
     fn GetGamma(&self) -> f32;
     fn GetEnhancedContrast(&self) -> f32;
@@ -9241,8 +9195,6 @@ impl IDWriteRenderingParams_Vtbl {
     }
 }
 impl windows_core::RuntimeName for IDWriteRenderingParams {}
-unsafe impl Send for IDWriteRenderingParams {}
-unsafe impl Sync for IDWriteRenderingParams {}
 windows_core::imp::define_interface!(IDWriteRenderingParams1, IDWriteRenderingParams1_Vtbl, 0x94413cf4_a6fc_4248_8b50_6674348fcad3);
 impl core::ops::Deref for IDWriteRenderingParams1 {
     type Target = IDWriteRenderingParams;
@@ -9261,6 +9213,8 @@ pub struct IDWriteRenderingParams1_Vtbl {
     pub base__: IDWriteRenderingParams_Vtbl,
     pub GetGrayscaleEnhancedContrast: unsafe extern "system" fn(*mut core::ffi::c_void) -> f32,
 }
+unsafe impl Send for IDWriteRenderingParams1 {}
+unsafe impl Sync for IDWriteRenderingParams1 {}
 pub trait IDWriteRenderingParams1_Impl: IDWriteRenderingParams_Impl {
     fn GetGrayscaleEnhancedContrast(&self) -> f32;
 }
@@ -9279,8 +9233,6 @@ impl IDWriteRenderingParams1_Vtbl {
     }
 }
 impl windows_core::RuntimeName for IDWriteRenderingParams1 {}
-unsafe impl Send for IDWriteRenderingParams1 {}
-unsafe impl Sync for IDWriteRenderingParams1 {}
 windows_core::imp::define_interface!(IDWriteRenderingParams2, IDWriteRenderingParams2_Vtbl, 0xf9d711c3_9777_40ae_87e8_3e5af9bf0948);
 impl core::ops::Deref for IDWriteRenderingParams2 {
     type Target = IDWriteRenderingParams1;
@@ -9299,6 +9251,8 @@ pub struct IDWriteRenderingParams2_Vtbl {
     pub base__: IDWriteRenderingParams1_Vtbl,
     pub GetGridFitMode: unsafe extern "system" fn(*mut core::ffi::c_void) -> DWRITE_GRID_FIT_MODE,
 }
+unsafe impl Send for IDWriteRenderingParams2 {}
+unsafe impl Sync for IDWriteRenderingParams2 {}
 pub trait IDWriteRenderingParams2_Impl: IDWriteRenderingParams1_Impl {
     fn GetGridFitMode(&self) -> DWRITE_GRID_FIT_MODE;
 }
@@ -9317,8 +9271,6 @@ impl IDWriteRenderingParams2_Vtbl {
     }
 }
 impl windows_core::RuntimeName for IDWriteRenderingParams2 {}
-unsafe impl Send for IDWriteRenderingParams2 {}
-unsafe impl Sync for IDWriteRenderingParams2 {}
 windows_core::imp::define_interface!(IDWriteRenderingParams3, IDWriteRenderingParams3_Vtbl, 0xb7924baa_391b_412a_8c5c_e44cc2d867dc);
 impl core::ops::Deref for IDWriteRenderingParams3 {
     type Target = IDWriteRenderingParams2;
@@ -9337,6 +9289,8 @@ pub struct IDWriteRenderingParams3_Vtbl {
     pub base__: IDWriteRenderingParams2_Vtbl,
     pub GetRenderingMode1: unsafe extern "system" fn(*mut core::ffi::c_void) -> DWRITE_RENDERING_MODE1,
 }
+unsafe impl Send for IDWriteRenderingParams3 {}
+unsafe impl Sync for IDWriteRenderingParams3 {}
 pub trait IDWriteRenderingParams3_Impl: IDWriteRenderingParams2_Impl {
     fn GetRenderingMode1(&self) -> DWRITE_RENDERING_MODE1;
 }
@@ -9355,8 +9309,6 @@ impl IDWriteRenderingParams3_Vtbl {
     }
 }
 impl windows_core::RuntimeName for IDWriteRenderingParams3 {}
-unsafe impl Send for IDWriteRenderingParams3 {}
-unsafe impl Sync for IDWriteRenderingParams3 {}
 windows_core::imp::define_interface!(IDWriteStringList, IDWriteStringList_Vtbl, 0xcfee3140_1157_47ca_8b85_31bfcf3f2d0e);
 windows_core::imp::interface_hierarchy!(IDWriteStringList, windows_core::IUnknown);
 impl IDWriteStringList {
@@ -9391,6 +9343,8 @@ pub struct IDWriteStringList_Vtbl {
     pub GetStringLength: unsafe extern "system" fn(*mut core::ffi::c_void, u32, *mut u32) -> windows_core::HRESULT,
     pub GetString: unsafe extern "system" fn(*mut core::ffi::c_void, u32, windows_core::PWSTR, u32) -> windows_core::HRESULT,
 }
+unsafe impl Send for IDWriteStringList {}
+unsafe impl Sync for IDWriteStringList {}
 pub trait IDWriteStringList_Impl: windows_core::IUnknownImpl {
     fn GetCount(&self) -> u32;
     fn GetLocaleNameLength(&self, listindex: u32) -> windows_core::Result<u32>;
@@ -9456,8 +9410,6 @@ impl IDWriteStringList_Vtbl {
     }
 }
 impl windows_core::RuntimeName for IDWriteStringList {}
-unsafe impl Send for IDWriteStringList {}
-unsafe impl Sync for IDWriteStringList {}
 windows_core::imp::define_interface!(IDWriteTextAnalysisSink, IDWriteTextAnalysisSink_Vtbl, 0x5810cd44_0ca0_4701_b3fa_bec5182ae4f6);
 windows_core::imp::interface_hierarchy!(IDWriteTextAnalysisSink, windows_core::IUnknown);
 impl IDWriteTextAnalysisSink {
@@ -9485,6 +9437,8 @@ pub struct IDWriteTextAnalysisSink_Vtbl {
     pub SetBidiLevel: unsafe extern "system" fn(*mut core::ffi::c_void, u32, u32, u8, u8) -> windows_core::HRESULT,
     pub SetNumberSubstitution: unsafe extern "system" fn(*mut core::ffi::c_void, u32, u32, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
+unsafe impl Send for IDWriteTextAnalysisSink {}
+unsafe impl Sync for IDWriteTextAnalysisSink {}
 pub trait IDWriteTextAnalysisSink_Impl: windows_core::IUnknownImpl {
     fn SetScriptAnalysis(&self, textposition: u32, textlength: u32, scriptanalysis: *const DWRITE_SCRIPT_ANALYSIS) -> windows_core::Result<()>;
     fn SetLineBreakpoints(&self, textposition: u32, textlength: u32, linebreakpoints: *const DWRITE_LINE_BREAKPOINT) -> windows_core::Result<()>;
@@ -9530,8 +9484,6 @@ impl IDWriteTextAnalysisSink_Vtbl {
     }
 }
 impl windows_core::RuntimeName for IDWriteTextAnalysisSink {}
-unsafe impl Send for IDWriteTextAnalysisSink {}
-unsafe impl Sync for IDWriteTextAnalysisSink {}
 windows_core::imp::define_interface!(IDWriteTextAnalysisSink1, IDWriteTextAnalysisSink1_Vtbl, 0xb0d941a0_85e7_4d8b_9fd3_5ced9934482a);
 impl core::ops::Deref for IDWriteTextAnalysisSink1 {
     type Target = IDWriteTextAnalysisSink;
@@ -9550,6 +9502,8 @@ pub struct IDWriteTextAnalysisSink1_Vtbl {
     pub base__: IDWriteTextAnalysisSink_Vtbl,
     pub SetGlyphOrientation: unsafe extern "system" fn(*mut core::ffi::c_void, u32, u32, DWRITE_GLYPH_ORIENTATION_ANGLE, u8, super::super::Foundation::BOOL, super::super::Foundation::BOOL) -> windows_core::HRESULT,
 }
+unsafe impl Send for IDWriteTextAnalysisSink1 {}
+unsafe impl Sync for IDWriteTextAnalysisSink1 {}
 pub trait IDWriteTextAnalysisSink1_Impl: IDWriteTextAnalysisSink_Impl {
     fn SetGlyphOrientation(&self, textposition: u32, textlength: u32, glyphorientationangle: DWRITE_GLYPH_ORIENTATION_ANGLE, adjustedbidilevel: u8, issideways: super::super::Foundation::BOOL, isrighttoleft: super::super::Foundation::BOOL) -> windows_core::Result<()>;
 }
@@ -9568,8 +9522,6 @@ impl IDWriteTextAnalysisSink1_Vtbl {
     }
 }
 impl windows_core::RuntimeName for IDWriteTextAnalysisSink1 {}
-unsafe impl Send for IDWriteTextAnalysisSink1 {}
-unsafe impl Sync for IDWriteTextAnalysisSink1 {}
 windows_core::imp::define_interface!(IDWriteTextAnalysisSource, IDWriteTextAnalysisSource_Vtbl, 0x688e1a58_5094_47c8_adc8_fbcea60ae92b);
 windows_core::imp::interface_hierarchy!(IDWriteTextAnalysisSource, windows_core::IUnknown);
 impl IDWriteTextAnalysisSource {
@@ -9598,6 +9550,8 @@ pub struct IDWriteTextAnalysisSource_Vtbl {
     pub GetLocaleName: unsafe extern "system" fn(*mut core::ffi::c_void, u32, *mut u32, *mut *mut u16) -> windows_core::HRESULT,
     pub GetNumberSubstitution: unsafe extern "system" fn(*mut core::ffi::c_void, u32, *mut u32, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
+unsafe impl Send for IDWriteTextAnalysisSource {}
+unsafe impl Sync for IDWriteTextAnalysisSource {}
 pub trait IDWriteTextAnalysisSource_Impl: windows_core::IUnknownImpl {
     fn GetTextAtPosition(&self, textposition: u32, textstring: *mut *mut u16, textlength: *mut u32) -> windows_core::Result<()>;
     fn GetTextBeforePosition(&self, textposition: u32, textstring: *mut *mut u16, textlength: *mut u32) -> windows_core::Result<()>;
@@ -9651,8 +9605,6 @@ impl IDWriteTextAnalysisSource_Vtbl {
     }
 }
 impl windows_core::RuntimeName for IDWriteTextAnalysisSource {}
-unsafe impl Send for IDWriteTextAnalysisSource {}
-unsafe impl Sync for IDWriteTextAnalysisSource {}
 windows_core::imp::define_interface!(IDWriteTextAnalysisSource1, IDWriteTextAnalysisSource1_Vtbl, 0x639cfad8_0fb4_4b21_a58a_067920120009);
 impl core::ops::Deref for IDWriteTextAnalysisSource1 {
     type Target = IDWriteTextAnalysisSource;
@@ -9671,6 +9623,8 @@ pub struct IDWriteTextAnalysisSource1_Vtbl {
     pub base__: IDWriteTextAnalysisSource_Vtbl,
     pub GetVerticalGlyphOrientation: unsafe extern "system" fn(*mut core::ffi::c_void, u32, *mut u32, *mut DWRITE_VERTICAL_GLYPH_ORIENTATION, *mut u8) -> windows_core::HRESULT,
 }
+unsafe impl Send for IDWriteTextAnalysisSource1 {}
+unsafe impl Sync for IDWriteTextAnalysisSource1 {}
 pub trait IDWriteTextAnalysisSource1_Impl: IDWriteTextAnalysisSource_Impl {
     fn GetVerticalGlyphOrientation(&self, textposition: u32, textlength: *mut u32, glyphorientation: *mut DWRITE_VERTICAL_GLYPH_ORIENTATION, bidilevel: *mut u8) -> windows_core::Result<()>;
 }
@@ -9689,8 +9643,6 @@ impl IDWriteTextAnalysisSource1_Vtbl {
     }
 }
 impl windows_core::RuntimeName for IDWriteTextAnalysisSource1 {}
-unsafe impl Send for IDWriteTextAnalysisSource1 {}
-unsafe impl Sync for IDWriteTextAnalysisSource1 {}
 windows_core::imp::define_interface!(IDWriteTextAnalyzer, IDWriteTextAnalyzer_Vtbl, 0xb7e6163e_7f46_43b4_84b3_e4e6249c365d);
 windows_core::imp::interface_hierarchy!(IDWriteTextAnalyzer, windows_core::IUnknown);
 impl IDWriteTextAnalyzer {
@@ -9785,6 +9737,8 @@ pub struct IDWriteTextAnalyzer_Vtbl {
     pub GetGlyphPlacements: unsafe extern "system" fn(*mut core::ffi::c_void, windows_core::PCWSTR, *const u16, *mut DWRITE_SHAPING_TEXT_PROPERTIES, u32, *const u16, *const DWRITE_SHAPING_GLYPH_PROPERTIES, u32, *mut core::ffi::c_void, f32, super::super::Foundation::BOOL, super::super::Foundation::BOOL, *const DWRITE_SCRIPT_ANALYSIS, windows_core::PCWSTR, *const *const DWRITE_TYPOGRAPHIC_FEATURES, *const u32, u32, *mut f32, *mut DWRITE_GLYPH_OFFSET) -> windows_core::HRESULT,
     pub GetGdiCompatibleGlyphPlacements: unsafe extern "system" fn(*mut core::ffi::c_void, windows_core::PCWSTR, *const u16, *const DWRITE_SHAPING_TEXT_PROPERTIES, u32, *const u16, *const DWRITE_SHAPING_GLYPH_PROPERTIES, u32, *mut core::ffi::c_void, f32, f32, *const DWRITE_MATRIX, super::super::Foundation::BOOL, super::super::Foundation::BOOL, super::super::Foundation::BOOL, *const DWRITE_SCRIPT_ANALYSIS, windows_core::PCWSTR, *const *const DWRITE_TYPOGRAPHIC_FEATURES, *const u32, u32, *mut f32, *mut DWRITE_GLYPH_OFFSET) -> windows_core::HRESULT,
 }
+unsafe impl Send for IDWriteTextAnalyzer {}
+unsafe impl Sync for IDWriteTextAnalyzer {}
 pub trait IDWriteTextAnalyzer_Impl: windows_core::IUnknownImpl {
     fn AnalyzeScript(&self, analysissource: windows_core::Ref<IDWriteTextAnalysisSource>, textposition: u32, textlength: u32, analysissink: windows_core::Ref<IDWriteTextAnalysisSink>) -> windows_core::Result<()>;
     fn AnalyzeBidi(&self, analysissource: windows_core::Ref<IDWriteTextAnalysisSource>, textposition: u32, textlength: u32, analysissink: windows_core::Ref<IDWriteTextAnalysisSink>) -> windows_core::Result<()>;
@@ -9965,8 +9919,6 @@ impl IDWriteTextAnalyzer_Vtbl {
     }
 }
 impl windows_core::RuntimeName for IDWriteTextAnalyzer {}
-unsafe impl Send for IDWriteTextAnalyzer {}
-unsafe impl Sync for IDWriteTextAnalyzer {}
 windows_core::imp::define_interface!(IDWriteTextAnalyzer1, IDWriteTextAnalyzer1_Vtbl, 0x80dad800_e21f_4e83_96ce_bfcce500db7c);
 impl core::ops::Deref for IDWriteTextAnalyzer1 {
     type Target = IDWriteTextAnalyzer;
@@ -10036,6 +9988,8 @@ pub struct IDWriteTextAnalyzer1_Vtbl {
     pub JustifyGlyphAdvances: unsafe extern "system" fn(*mut core::ffi::c_void, f32, u32, *const DWRITE_JUSTIFICATION_OPPORTUNITY, *const f32, *const DWRITE_GLYPH_OFFSET, *mut f32, *mut DWRITE_GLYPH_OFFSET) -> windows_core::HRESULT,
     pub GetJustifiedGlyphs: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, f32, DWRITE_SCRIPT_ANALYSIS, u32, u32, u32, *const u16, *const u16, *const f32, *const f32, *const DWRITE_GLYPH_OFFSET, *const DWRITE_SHAPING_GLYPH_PROPERTIES, *mut u32, *mut u16, *mut u16, *mut f32, *mut DWRITE_GLYPH_OFFSET) -> windows_core::HRESULT,
 }
+unsafe impl Send for IDWriteTextAnalyzer1 {}
+unsafe impl Sync for IDWriteTextAnalyzer1 {}
 pub trait IDWriteTextAnalyzer1_Impl: IDWriteTextAnalyzer_Impl {
     fn ApplyCharacterSpacing(&self, leadingspacing: f32, trailingspacing: f32, minimumadvancewidth: f32, textlength: u32, glyphcount: u32, clustermap: *const u16, glyphadvances: *const f32, glyphoffsets: *const DWRITE_GLYPH_OFFSET, glyphproperties: *const DWRITE_SHAPING_GLYPH_PROPERTIES, modifiedglyphadvances: *mut f32, modifiedglyphoffsets: *mut DWRITE_GLYPH_OFFSET) -> windows_core::Result<()>;
     fn GetBaseline(&self, fontface: windows_core::Ref<IDWriteFontFace>, baseline: DWRITE_BASELINE, isvertical: super::super::Foundation::BOOL, issimulationallowed: super::super::Foundation::BOOL, scriptanalysis: &DWRITE_SCRIPT_ANALYSIS, localename: &windows_core::PCWSTR, baselinecoordinate: *mut i32, exists: *mut super::super::Foundation::BOOL) -> windows_core::Result<()>;
@@ -10155,8 +10109,6 @@ impl IDWriteTextAnalyzer1_Vtbl {
     }
 }
 impl windows_core::RuntimeName for IDWriteTextAnalyzer1 {}
-unsafe impl Send for IDWriteTextAnalyzer1 {}
-unsafe impl Sync for IDWriteTextAnalyzer1 {}
 windows_core::imp::define_interface!(IDWriteTextAnalyzer2, IDWriteTextAnalyzer2_Vtbl, 0x553a9ff3_5693_4df7_b52b_74806f7f2eb9);
 impl core::ops::Deref for IDWriteTextAnalyzer2 {
     type Target = IDWriteTextAnalyzer1;
@@ -10191,6 +10143,8 @@ pub struct IDWriteTextAnalyzer2_Vtbl {
     pub GetTypographicFeatures: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, DWRITE_SCRIPT_ANALYSIS, windows_core::PCWSTR, u32, *mut u32, *mut DWRITE_FONT_FEATURE_TAG) -> windows_core::HRESULT,
     pub CheckTypographicFeature: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, DWRITE_SCRIPT_ANALYSIS, windows_core::PCWSTR, DWRITE_FONT_FEATURE_TAG, u32, *const u16, *mut u8) -> windows_core::HRESULT,
 }
+unsafe impl Send for IDWriteTextAnalyzer2 {}
+unsafe impl Sync for IDWriteTextAnalyzer2 {}
 pub trait IDWriteTextAnalyzer2_Impl: IDWriteTextAnalyzer1_Impl {
     fn GetGlyphOrientationTransform(&self, glyphorientationangle: DWRITE_GLYPH_ORIENTATION_ANGLE, issideways: super::super::Foundation::BOOL, originx: f32, originy: f32, transform: *mut DWRITE_MATRIX) -> windows_core::Result<()>;
     fn GetTypographicFeatures(&self, fontface: windows_core::Ref<IDWriteFontFace>, scriptanalysis: &DWRITE_SCRIPT_ANALYSIS, localename: &windows_core::PCWSTR, maxtagcount: u32, actualtagcount: *mut u32, tags: *mut DWRITE_FONT_FEATURE_TAG) -> windows_core::Result<()>;
@@ -10228,8 +10182,6 @@ impl IDWriteTextAnalyzer2_Vtbl {
     }
 }
 impl windows_core::RuntimeName for IDWriteTextAnalyzer2 {}
-unsafe impl Send for IDWriteTextAnalyzer2 {}
-unsafe impl Sync for IDWriteTextAnalyzer2 {}
 windows_core::imp::define_interface!(IDWriteTextFormat, IDWriteTextFormat_Vtbl, 0x9c906818_31d7_4fd3_a151_7c5e225db55a);
 windows_core::imp::interface_hierarchy!(IDWriteTextFormat, windows_core::IUnknown);
 impl IDWriteTextFormat {
@@ -10344,6 +10296,8 @@ pub struct IDWriteTextFormat_Vtbl {
     pub GetLocaleNameLength: unsafe extern "system" fn(*mut core::ffi::c_void) -> u32,
     pub GetLocaleName: unsafe extern "system" fn(*mut core::ffi::c_void, windows_core::PWSTR, u32) -> windows_core::HRESULT,
 }
+unsafe impl Send for IDWriteTextFormat {}
+unsafe impl Sync for IDWriteTextFormat {}
 pub trait IDWriteTextFormat_Impl: windows_core::IUnknownImpl {
     fn SetTextAlignment(&self, textalignment: DWRITE_TEXT_ALIGNMENT) -> windows_core::Result<()>;
     fn SetParagraphAlignment(&self, paragraphalignment: DWRITE_PARAGRAPH_ALIGNMENT) -> windows_core::Result<()>;
@@ -10563,8 +10517,6 @@ impl IDWriteTextFormat_Vtbl {
     }
 }
 impl windows_core::RuntimeName for IDWriteTextFormat {}
-unsafe impl Send for IDWriteTextFormat {}
-unsafe impl Sync for IDWriteTextFormat {}
 windows_core::imp::define_interface!(IDWriteTextFormat1, IDWriteTextFormat1_Vtbl, 0x5f174b49_0d8b_4cfb_8bca_f1cce9d06c67);
 impl core::ops::Deref for IDWriteTextFormat1 {
     type Target = IDWriteTextFormat;
@@ -10617,6 +10569,8 @@ pub struct IDWriteTextFormat1_Vtbl {
     pub SetFontFallback: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
     pub GetFontFallback: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
+unsafe impl Send for IDWriteTextFormat1 {}
+unsafe impl Sync for IDWriteTextFormat1 {}
 pub trait IDWriteTextFormat1_Impl: IDWriteTextFormat_Impl {
     fn SetVerticalGlyphOrientation(&self, glyphorientation: DWRITE_VERTICAL_GLYPH_ORIENTATION) -> windows_core::Result<()>;
     fn GetVerticalGlyphOrientation(&self) -> DWRITE_VERTICAL_GLYPH_ORIENTATION;
@@ -10700,8 +10654,6 @@ impl IDWriteTextFormat1_Vtbl {
     }
 }
 impl windows_core::RuntimeName for IDWriteTextFormat1 {}
-unsafe impl Send for IDWriteTextFormat1 {}
-unsafe impl Sync for IDWriteTextFormat1 {}
 windows_core::imp::define_interface!(IDWriteTextFormat2, IDWriteTextFormat2_Vtbl, 0xf67e0edd_9e3d_4ecc_8c32_4183253dfe70);
 impl core::ops::Deref for IDWriteTextFormat2 {
     type Target = IDWriteTextFormat1;
@@ -10724,6 +10676,8 @@ pub struct IDWriteTextFormat2_Vtbl {
     pub SetLineSpacing: unsafe extern "system" fn(*mut core::ffi::c_void, *const DWRITE_LINE_SPACING) -> windows_core::HRESULT,
     pub GetLineSpacing: unsafe extern "system" fn(*mut core::ffi::c_void, *mut DWRITE_LINE_SPACING) -> windows_core::HRESULT,
 }
+unsafe impl Send for IDWriteTextFormat2 {}
+unsafe impl Sync for IDWriteTextFormat2 {}
 pub trait IDWriteTextFormat2_Impl: IDWriteTextFormat1_Impl {
     fn SetLineSpacing(&self, linespacingoptions: *const DWRITE_LINE_SPACING) -> windows_core::Result<()>;
     fn GetLineSpacing(&self, linespacingoptions: *mut DWRITE_LINE_SPACING) -> windows_core::Result<()>;
@@ -10753,8 +10707,6 @@ impl IDWriteTextFormat2_Vtbl {
     }
 }
 impl windows_core::RuntimeName for IDWriteTextFormat2 {}
-unsafe impl Send for IDWriteTextFormat2 {}
-unsafe impl Sync for IDWriteTextFormat2 {}
 windows_core::imp::define_interface!(IDWriteTextFormat3, IDWriteTextFormat3_Vtbl, 0x6d3b5641_e550_430d_a85b_b7bf48a93427);
 impl core::ops::Deref for IDWriteTextFormat3 {
     type Target = IDWriteTextFormat2;
@@ -10789,6 +10741,8 @@ pub struct IDWriteTextFormat3_Vtbl {
     pub GetAutomaticFontAxes: unsafe extern "system" fn(*mut core::ffi::c_void) -> DWRITE_AUTOMATIC_FONT_AXES,
     pub SetAutomaticFontAxes: unsafe extern "system" fn(*mut core::ffi::c_void, DWRITE_AUTOMATIC_FONT_AXES) -> windows_core::HRESULT,
 }
+unsafe impl Send for IDWriteTextFormat3 {}
+unsafe impl Sync for IDWriteTextFormat3 {}
 pub trait IDWriteTextFormat3_Impl: IDWriteTextFormat2_Impl {
     fn SetFontAxisValues(&self, fontaxisvalues: *const DWRITE_FONT_AXIS_VALUE, fontaxisvaluecount: u32) -> windows_core::Result<()>;
     fn GetFontAxisValueCount(&self) -> u32;
@@ -10842,8 +10796,6 @@ impl IDWriteTextFormat3_Vtbl {
     }
 }
 impl windows_core::RuntimeName for IDWriteTextFormat3 {}
-unsafe impl Send for IDWriteTextFormat3 {}
-unsafe impl Sync for IDWriteTextFormat3 {}
 windows_core::imp::define_interface!(IDWriteTextLayout, IDWriteTextLayout_Vtbl, 0x53737037_6d14_410b_9bfe_0b182bb70961);
 impl core::ops::Deref for IDWriteTextLayout {
     type Target = IDWriteTextFormat;
@@ -11041,6 +10993,8 @@ pub struct IDWriteTextLayout_Vtbl {
     pub HitTestTextPosition: unsafe extern "system" fn(*mut core::ffi::c_void, u32, super::super::Foundation::BOOL, *mut f32, *mut f32, *mut DWRITE_HIT_TEST_METRICS) -> windows_core::HRESULT,
     pub HitTestTextRange: unsafe extern "system" fn(*mut core::ffi::c_void, u32, u32, f32, f32, *mut DWRITE_HIT_TEST_METRICS, u32, *mut u32) -> windows_core::HRESULT,
 }
+unsafe impl Send for IDWriteTextLayout {}
+unsafe impl Sync for IDWriteTextLayout {}
 pub trait IDWriteTextLayout_Impl: IDWriteTextFormat_Impl {
     fn SetMaxWidth(&self, maxwidth: f32) -> windows_core::Result<()>;
     fn SetMaxHeight(&self, maxheight: f32) -> windows_core::Result<()>;
@@ -11378,8 +11332,6 @@ impl IDWriteTextLayout_Vtbl {
     }
 }
 impl windows_core::RuntimeName for IDWriteTextLayout {}
-unsafe impl Send for IDWriteTextLayout {}
-unsafe impl Sync for IDWriteTextLayout {}
 windows_core::imp::define_interface!(IDWriteTextLayout1, IDWriteTextLayout1_Vtbl, 0x9064d822_80a7_465c_a986_df65f78b8feb);
 impl core::ops::Deref for IDWriteTextLayout1 {
     type Target = IDWriteTextLayout;
@@ -11410,6 +11362,8 @@ pub struct IDWriteTextLayout1_Vtbl {
     pub SetCharacterSpacing: unsafe extern "system" fn(*mut core::ffi::c_void, f32, f32, f32, DWRITE_TEXT_RANGE) -> windows_core::HRESULT,
     pub GetCharacterSpacing: unsafe extern "system" fn(*mut core::ffi::c_void, u32, *mut f32, *mut f32, *mut f32, *mut DWRITE_TEXT_RANGE) -> windows_core::HRESULT,
 }
+unsafe impl Send for IDWriteTextLayout1 {}
+unsafe impl Sync for IDWriteTextLayout1 {}
 pub trait IDWriteTextLayout1_Impl: IDWriteTextLayout_Impl {
     fn SetPairKerning(&self, ispairkerningenabled: super::super::Foundation::BOOL, textrange: &DWRITE_TEXT_RANGE) -> windows_core::Result<()>;
     fn GetPairKerning(&self, currentposition: u32, ispairkerningenabled: *mut super::super::Foundation::BOOL, textrange: *mut DWRITE_TEXT_RANGE) -> windows_core::Result<()>;
@@ -11455,8 +11409,6 @@ impl IDWriteTextLayout1_Vtbl {
     }
 }
 impl windows_core::RuntimeName for IDWriteTextLayout1 {}
-unsafe impl Send for IDWriteTextLayout1 {}
-unsafe impl Sync for IDWriteTextLayout1 {}
 windows_core::imp::define_interface!(IDWriteTextLayout2, IDWriteTextLayout2_Vtbl, 0x1093c18f_8d5e_43f0_b064_0917311b525e);
 impl core::ops::Deref for IDWriteTextLayout2 {
     type Target = IDWriteTextLayout1;
@@ -11513,6 +11465,8 @@ pub struct IDWriteTextLayout2_Vtbl {
     pub SetFontFallback: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
     pub GetFontFallback: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
+unsafe impl Send for IDWriteTextLayout2 {}
+unsafe impl Sync for IDWriteTextLayout2 {}
 pub trait IDWriteTextLayout2_Impl: IDWriteTextLayout1_Impl {
     fn GetMetrics(&self, textmetrics: *mut DWRITE_TEXT_METRICS1) -> windows_core::Result<()>;
     fn SetVerticalGlyphOrientation(&self, glyphorientation: DWRITE_VERTICAL_GLYPH_ORIENTATION) -> windows_core::Result<()>;
@@ -11604,8 +11558,6 @@ impl IDWriteTextLayout2_Vtbl {
     }
 }
 impl windows_core::RuntimeName for IDWriteTextLayout2 {}
-unsafe impl Send for IDWriteTextLayout2 {}
-unsafe impl Sync for IDWriteTextLayout2 {}
 windows_core::imp::define_interface!(IDWriteTextLayout3, IDWriteTextLayout3_Vtbl, 0x07ddcd52_020e_4de8_ac33_6c953d83f92d);
 impl core::ops::Deref for IDWriteTextLayout3 {
     type Target = IDWriteTextLayout2;
@@ -11636,6 +11588,8 @@ pub struct IDWriteTextLayout3_Vtbl {
     pub GetLineSpacing: unsafe extern "system" fn(*mut core::ffi::c_void, *mut DWRITE_LINE_SPACING) -> windows_core::HRESULT,
     pub GetLineMetrics: unsafe extern "system" fn(*mut core::ffi::c_void, *mut DWRITE_LINE_METRICS1, u32, *mut u32) -> windows_core::HRESULT,
 }
+unsafe impl Send for IDWriteTextLayout3 {}
+unsafe impl Sync for IDWriteTextLayout3 {}
 pub trait IDWriteTextLayout3_Impl: IDWriteTextLayout2_Impl {
     fn InvalidateLayout(&self) -> windows_core::Result<()>;
     fn SetLineSpacing(&self, linespacingoptions: *const DWRITE_LINE_SPACING) -> windows_core::Result<()>;
@@ -11681,8 +11635,6 @@ impl IDWriteTextLayout3_Vtbl {
     }
 }
 impl windows_core::RuntimeName for IDWriteTextLayout3 {}
-unsafe impl Send for IDWriteTextLayout3 {}
-unsafe impl Sync for IDWriteTextLayout3 {}
 windows_core::imp::define_interface!(IDWriteTextLayout4, IDWriteTextLayout4_Vtbl, 0x05a9bf42_223f_4441_b5fb_8263685f55e9);
 impl core::ops::Deref for IDWriteTextLayout4 {
     type Target = IDWriteTextLayout3;
@@ -11717,6 +11669,8 @@ pub struct IDWriteTextLayout4_Vtbl {
     pub GetAutomaticFontAxes: unsafe extern "system" fn(*mut core::ffi::c_void) -> DWRITE_AUTOMATIC_FONT_AXES,
     pub SetAutomaticFontAxes: unsafe extern "system" fn(*mut core::ffi::c_void, DWRITE_AUTOMATIC_FONT_AXES) -> windows_core::HRESULT,
 }
+unsafe impl Send for IDWriteTextLayout4 {}
+unsafe impl Sync for IDWriteTextLayout4 {}
 pub trait IDWriteTextLayout4_Impl: IDWriteTextLayout3_Impl {
     fn SetFontAxisValues(&self, fontaxisvalues: *const DWRITE_FONT_AXIS_VALUE, fontaxisvaluecount: u32, textrange: &DWRITE_TEXT_RANGE) -> windows_core::Result<()>;
     fn GetFontAxisValueCount(&self, currentposition: u32) -> u32;
@@ -11770,8 +11724,6 @@ impl IDWriteTextLayout4_Vtbl {
     }
 }
 impl windows_core::RuntimeName for IDWriteTextLayout4 {}
-unsafe impl Send for IDWriteTextLayout4 {}
-unsafe impl Sync for IDWriteTextLayout4 {}
 windows_core::imp::define_interface!(IDWriteTextRenderer, IDWriteTextRenderer_Vtbl, 0xef8a8135_5cc6_45fe_8825_c5a0724eb819);
 impl core::ops::Deref for IDWriteTextRenderer {
     type Target = IDWritePixelSnapping;
@@ -11815,6 +11767,8 @@ pub struct IDWriteTextRenderer_Vtbl {
     pub DrawStrikethrough: unsafe extern "system" fn(*mut core::ffi::c_void, *const core::ffi::c_void, f32, f32, *const DWRITE_STRIKETHROUGH, *mut core::ffi::c_void) -> windows_core::HRESULT,
     pub DrawInlineObject: unsafe extern "system" fn(*mut core::ffi::c_void, *const core::ffi::c_void, f32, f32, *mut core::ffi::c_void, super::super::Foundation::BOOL, super::super::Foundation::BOOL, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
+unsafe impl Send for IDWriteTextRenderer {}
+unsafe impl Sync for IDWriteTextRenderer {}
 pub trait IDWriteTextRenderer_Impl: IDWritePixelSnapping_Impl {
     fn DrawGlyphRun(&self, clientdrawingcontext: *const core::ffi::c_void, baselineoriginx: f32, baselineoriginy: f32, measuringmode: DWRITE_MEASURING_MODE, glyphrun: *const DWRITE_GLYPH_RUN, glyphrundescription: *const DWRITE_GLYPH_RUN_DESCRIPTION, clientdrawingeffect: windows_core::Ref<windows_core::IUnknown>) -> windows_core::Result<()>;
     fn DrawUnderline(&self, clientdrawingcontext: *const core::ffi::c_void, baselineoriginx: f32, baselineoriginy: f32, underline: *const DWRITE_UNDERLINE, clientdrawingeffect: windows_core::Ref<windows_core::IUnknown>) -> windows_core::Result<()>;
@@ -11860,8 +11814,6 @@ impl IDWriteTextRenderer_Vtbl {
     }
 }
 impl windows_core::RuntimeName for IDWriteTextRenderer {}
-unsafe impl Send for IDWriteTextRenderer {}
-unsafe impl Sync for IDWriteTextRenderer {}
 windows_core::imp::define_interface!(IDWriteTextRenderer1, IDWriteTextRenderer1_Vtbl, 0xd3e0e934_22a0_427e_aae4_7d9574b59db1);
 impl core::ops::Deref for IDWriteTextRenderer1 {
     type Target = IDWriteTextRenderer;
@@ -11905,6 +11857,8 @@ pub struct IDWriteTextRenderer1_Vtbl {
     pub DrawStrikethrough: unsafe extern "system" fn(*mut core::ffi::c_void, *const core::ffi::c_void, f32, f32, DWRITE_GLYPH_ORIENTATION_ANGLE, *const DWRITE_STRIKETHROUGH, *mut core::ffi::c_void) -> windows_core::HRESULT,
     pub DrawInlineObject: unsafe extern "system" fn(*mut core::ffi::c_void, *const core::ffi::c_void, f32, f32, DWRITE_GLYPH_ORIENTATION_ANGLE, *mut core::ffi::c_void, super::super::Foundation::BOOL, super::super::Foundation::BOOL, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
+unsafe impl Send for IDWriteTextRenderer1 {}
+unsafe impl Sync for IDWriteTextRenderer1 {}
 pub trait IDWriteTextRenderer1_Impl: IDWriteTextRenderer_Impl {
     fn DrawGlyphRun(&self, clientdrawingcontext: *const core::ffi::c_void, baselineoriginx: f32, baselineoriginy: f32, orientationangle: DWRITE_GLYPH_ORIENTATION_ANGLE, measuringmode: DWRITE_MEASURING_MODE, glyphrun: *const DWRITE_GLYPH_RUN, glyphrundescription: *const DWRITE_GLYPH_RUN_DESCRIPTION, clientdrawingeffect: windows_core::Ref<windows_core::IUnknown>) -> windows_core::Result<()>;
     fn DrawUnderline(&self, clientdrawingcontext: *const core::ffi::c_void, baselineoriginx: f32, baselineoriginy: f32, orientationangle: DWRITE_GLYPH_ORIENTATION_ANGLE, underline: *const DWRITE_UNDERLINE, clientdrawingeffect: windows_core::Ref<windows_core::IUnknown>) -> windows_core::Result<()>;
@@ -11950,8 +11904,6 @@ impl IDWriteTextRenderer1_Vtbl {
     }
 }
 impl windows_core::RuntimeName for IDWriteTextRenderer1 {}
-unsafe impl Send for IDWriteTextRenderer1 {}
-unsafe impl Sync for IDWriteTextRenderer1 {}
 windows_core::imp::define_interface!(IDWriteTypography, IDWriteTypography_Vtbl, 0x55f1112b_1dc2_4b3c_9541_f46894ed85b6);
 windows_core::imp::interface_hierarchy!(IDWriteTypography, windows_core::IUnknown);
 impl IDWriteTypography {
@@ -11975,6 +11927,8 @@ pub struct IDWriteTypography_Vtbl {
     pub GetFontFeatureCount: unsafe extern "system" fn(*mut core::ffi::c_void) -> u32,
     pub GetFontFeature: unsafe extern "system" fn(*mut core::ffi::c_void, u32, *mut DWRITE_FONT_FEATURE) -> windows_core::HRESULT,
 }
+unsafe impl Send for IDWriteTypography {}
+unsafe impl Sync for IDWriteTypography {}
 pub trait IDWriteTypography_Impl: windows_core::IUnknownImpl {
     fn AddFontFeature(&self, fontfeature: &DWRITE_FONT_FEATURE) -> windows_core::Result<()>;
     fn GetFontFeatureCount(&self) -> u32;
@@ -12018,5 +11972,3 @@ impl IDWriteTypography_Vtbl {
     }
 }
 impl windows_core::RuntimeName for IDWriteTypography {}
-unsafe impl Send for IDWriteTypography {}
-unsafe impl Sync for IDWriteTypography {}

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Dxgi/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Dxgi/mod.rs
@@ -1755,6 +1755,8 @@ pub struct IDXGIAdapter_Vtbl {
     pub GetDesc: unsafe extern "system" fn(*mut core::ffi::c_void, *mut DXGI_ADAPTER_DESC) -> windows_core::HRESULT,
     pub CheckInterfaceSupport: unsafe extern "system" fn(*mut core::ffi::c_void, *const windows_core::GUID, *mut i64) -> windows_core::HRESULT,
 }
+unsafe impl Send for IDXGIAdapter {}
+unsafe impl Sync for IDXGIAdapter {}
 pub trait IDXGIAdapter_Impl: IDXGIObject_Impl {
     fn EnumOutputs(&self, output: u32) -> windows_core::Result<IDXGIOutput>;
     fn GetDesc(&self) -> windows_core::Result<DXGI_ADAPTER_DESC>;
@@ -1810,8 +1812,6 @@ impl IDXGIAdapter_Vtbl {
     }
 }
 impl windows_core::RuntimeName for IDXGIAdapter {}
-unsafe impl Send for IDXGIAdapter {}
-unsafe impl Sync for IDXGIAdapter {}
 windows_core::imp::define_interface!(IDXGIAdapter1, IDXGIAdapter1_Vtbl, 0x29038f61_3839_4626_91fd_086879011a05);
 impl core::ops::Deref for IDXGIAdapter1 {
     type Target = IDXGIAdapter;
@@ -1833,6 +1833,8 @@ pub struct IDXGIAdapter1_Vtbl {
     pub base__: IDXGIAdapter_Vtbl,
     pub GetDesc1: unsafe extern "system" fn(*mut core::ffi::c_void, *mut DXGI_ADAPTER_DESC1) -> windows_core::HRESULT,
 }
+unsafe impl Send for IDXGIAdapter1 {}
+unsafe impl Sync for IDXGIAdapter1 {}
 pub trait IDXGIAdapter1_Impl: IDXGIAdapter_Impl {
     fn GetDesc1(&self) -> windows_core::Result<DXGI_ADAPTER_DESC1>;
 }
@@ -1857,8 +1859,6 @@ impl IDXGIAdapter1_Vtbl {
     }
 }
 impl windows_core::RuntimeName for IDXGIAdapter1 {}
-unsafe impl Send for IDXGIAdapter1 {}
-unsafe impl Sync for IDXGIAdapter1 {}
 windows_core::imp::define_interface!(IDXGIAdapter2, IDXGIAdapter2_Vtbl, 0x0aa1ae0a_fa0e_4b84_8644_e05ff8e5acb5);
 impl core::ops::Deref for IDXGIAdapter2 {
     type Target = IDXGIAdapter1;
@@ -1880,6 +1880,8 @@ pub struct IDXGIAdapter2_Vtbl {
     pub base__: IDXGIAdapter1_Vtbl,
     pub GetDesc2: unsafe extern "system" fn(*mut core::ffi::c_void, *mut DXGI_ADAPTER_DESC2) -> windows_core::HRESULT,
 }
+unsafe impl Send for IDXGIAdapter2 {}
+unsafe impl Sync for IDXGIAdapter2 {}
 pub trait IDXGIAdapter2_Impl: IDXGIAdapter1_Impl {
     fn GetDesc2(&self) -> windows_core::Result<DXGI_ADAPTER_DESC2>;
 }
@@ -1904,8 +1906,6 @@ impl IDXGIAdapter2_Vtbl {
     }
 }
 impl windows_core::RuntimeName for IDXGIAdapter2 {}
-unsafe impl Send for IDXGIAdapter2 {}
-unsafe impl Sync for IDXGIAdapter2 {}
 windows_core::imp::define_interface!(IDXGIAdapter3, IDXGIAdapter3_Vtbl, 0x645967a4_1392_4310_a798_8053ce3e93fd);
 impl core::ops::Deref for IDXGIAdapter3 {
     type Target = IDXGIAdapter2;
@@ -1950,6 +1950,8 @@ pub struct IDXGIAdapter3_Vtbl {
     pub RegisterVideoMemoryBudgetChangeNotificationEvent: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::HANDLE, *mut u32) -> windows_core::HRESULT,
     pub UnregisterVideoMemoryBudgetChangeNotification: unsafe extern "system" fn(*mut core::ffi::c_void, u32),
 }
+unsafe impl Send for IDXGIAdapter3 {}
+unsafe impl Sync for IDXGIAdapter3 {}
 pub trait IDXGIAdapter3_Impl: IDXGIAdapter2_Impl {
     fn RegisterHardwareContentProtectionTeardownStatusEvent(&self, hevent: super::super::Foundation::HANDLE) -> windows_core::Result<u32>;
     fn UnregisterHardwareContentProtectionTeardownStatus(&self, dwcookie: u32);
@@ -2023,8 +2025,6 @@ impl IDXGIAdapter3_Vtbl {
     }
 }
 impl windows_core::RuntimeName for IDXGIAdapter3 {}
-unsafe impl Send for IDXGIAdapter3 {}
-unsafe impl Sync for IDXGIAdapter3 {}
 windows_core::imp::define_interface!(IDXGIAdapter4, IDXGIAdapter4_Vtbl, 0x3c8d99d1_4fbf_4181_a82c_af66bf7bd24e);
 impl core::ops::Deref for IDXGIAdapter4 {
     type Target = IDXGIAdapter3;
@@ -2046,6 +2046,8 @@ pub struct IDXGIAdapter4_Vtbl {
     pub base__: IDXGIAdapter3_Vtbl,
     pub GetDesc3: unsafe extern "system" fn(*mut core::ffi::c_void, *mut DXGI_ADAPTER_DESC3) -> windows_core::HRESULT,
 }
+unsafe impl Send for IDXGIAdapter4 {}
+unsafe impl Sync for IDXGIAdapter4 {}
 pub trait IDXGIAdapter4_Impl: IDXGIAdapter3_Impl {
     fn GetDesc3(&self) -> windows_core::Result<DXGI_ADAPTER_DESC3>;
 }
@@ -2070,8 +2072,6 @@ impl IDXGIAdapter4_Vtbl {
     }
 }
 impl windows_core::RuntimeName for IDXGIAdapter4 {}
-unsafe impl Send for IDXGIAdapter4 {}
-unsafe impl Sync for IDXGIAdapter4 {}
 windows_core::imp::define_interface!(IDXGIDebug, IDXGIDebug_Vtbl, 0x119e7452_de9e_40fe_8806_88f90c12b441);
 windows_core::imp::interface_hierarchy!(IDXGIDebug, windows_core::IUnknown);
 impl IDXGIDebug {
@@ -2084,6 +2084,8 @@ pub struct IDXGIDebug_Vtbl {
     pub base__: windows_core::IUnknown_Vtbl,
     pub ReportLiveObjects: unsafe extern "system" fn(*mut core::ffi::c_void, windows_core::GUID, DXGI_DEBUG_RLO_FLAGS) -> windows_core::HRESULT,
 }
+unsafe impl Send for IDXGIDebug {}
+unsafe impl Sync for IDXGIDebug {}
 pub trait IDXGIDebug_Impl: windows_core::IUnknownImpl {
     fn ReportLiveObjects(&self, apiid: &windows_core::GUID, flags: DXGI_DEBUG_RLO_FLAGS) -> windows_core::Result<()>;
 }
@@ -2102,8 +2104,6 @@ impl IDXGIDebug_Vtbl {
     }
 }
 impl windows_core::RuntimeName for IDXGIDebug {}
-unsafe impl Send for IDXGIDebug {}
-unsafe impl Sync for IDXGIDebug {}
 windows_core::imp::define_interface!(IDXGIDebug1, IDXGIDebug1_Vtbl, 0xc5a05f0c_16f2_4adf_9f4d_a8c4d58ac550);
 impl core::ops::Deref for IDXGIDebug1 {
     type Target = IDXGIDebug;
@@ -2130,6 +2130,8 @@ pub struct IDXGIDebug1_Vtbl {
     pub DisableLeakTrackingForThread: unsafe extern "system" fn(*mut core::ffi::c_void),
     pub IsLeakTrackingEnabledForThread: unsafe extern "system" fn(*mut core::ffi::c_void) -> super::super::Foundation::BOOL,
 }
+unsafe impl Send for IDXGIDebug1 {}
+unsafe impl Sync for IDXGIDebug1 {}
 pub trait IDXGIDebug1_Impl: IDXGIDebug_Impl {
     fn EnableLeakTrackingForThread(&self);
     fn DisableLeakTrackingForThread(&self);
@@ -2167,8 +2169,6 @@ impl IDXGIDebug1_Vtbl {
     }
 }
 impl windows_core::RuntimeName for IDXGIDebug1 {}
-unsafe impl Send for IDXGIDebug1 {}
-unsafe impl Sync for IDXGIDebug1 {}
 windows_core::imp::define_interface!(IDXGIDecodeSwapChain, IDXGIDecodeSwapChain_Vtbl, 0x2633066b_4514_4c7a_8fd8_12ea98059d18);
 windows_core::imp::interface_hierarchy!(IDXGIDecodeSwapChain, windows_core::IUnknown);
 impl IDXGIDecodeSwapChain {
@@ -2219,6 +2219,8 @@ pub struct IDXGIDecodeSwapChain_Vtbl {
     pub SetColorSpace: unsafe extern "system" fn(*mut core::ffi::c_void, DXGI_MULTIPLANE_OVERLAY_YCbCr_FLAGS) -> windows_core::HRESULT,
     pub GetColorSpace: unsafe extern "system" fn(*mut core::ffi::c_void) -> DXGI_MULTIPLANE_OVERLAY_YCbCr_FLAGS,
 }
+unsafe impl Send for IDXGIDecodeSwapChain {}
+unsafe impl Sync for IDXGIDecodeSwapChain {}
 pub trait IDXGIDecodeSwapChain_Impl: windows_core::IUnknownImpl {
     fn PresentBuffer(&self, buffertopresent: u32, syncinterval: u32, flags: DXGI_PRESENT) -> windows_core::HRESULT;
     fn SetSourceRect(&self, prect: *const super::super::Foundation::RECT) -> windows_core::Result<()>;
@@ -2316,8 +2318,6 @@ impl IDXGIDecodeSwapChain_Vtbl {
     }
 }
 impl windows_core::RuntimeName for IDXGIDecodeSwapChain {}
-unsafe impl Send for IDXGIDecodeSwapChain {}
-unsafe impl Sync for IDXGIDecodeSwapChain {}
 windows_core::imp::define_interface!(IDXGIDevice, IDXGIDevice_Vtbl, 0x54ec77fa_1377_44e6_8c32_88fd5f44c84c);
 impl core::ops::Deref for IDXGIDevice {
     type Target = IDXGIObject;
@@ -2362,6 +2362,8 @@ pub struct IDXGIDevice_Vtbl {
     pub SetGPUThreadPriority: unsafe extern "system" fn(*mut core::ffi::c_void, i32) -> windows_core::HRESULT,
     pub GetGPUThreadPriority: unsafe extern "system" fn(*mut core::ffi::c_void, *mut i32) -> windows_core::HRESULT,
 }
+unsafe impl Send for IDXGIDevice {}
+unsafe impl Sync for IDXGIDevice {}
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 pub trait IDXGIDevice_Impl: IDXGIObject_Impl {
     fn GetAdapter(&self) -> windows_core::Result<IDXGIAdapter>;
@@ -2430,10 +2432,6 @@ impl IDXGIDevice_Vtbl {
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl windows_core::RuntimeName for IDXGIDevice {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-unsafe impl Send for IDXGIDevice {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-unsafe impl Sync for IDXGIDevice {}
 windows_core::imp::define_interface!(IDXGIDevice1, IDXGIDevice1_Vtbl, 0x77db970f_6276_48ba_ba28_070143b4392c);
 impl core::ops::Deref for IDXGIDevice1 {
     type Target = IDXGIDevice;
@@ -2459,6 +2457,8 @@ pub struct IDXGIDevice1_Vtbl {
     pub SetMaximumFrameLatency: unsafe extern "system" fn(*mut core::ffi::c_void, u32) -> windows_core::HRESULT,
     pub GetMaximumFrameLatency: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u32) -> windows_core::HRESULT,
 }
+unsafe impl Send for IDXGIDevice1 {}
+unsafe impl Sync for IDXGIDevice1 {}
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 pub trait IDXGIDevice1_Impl: IDXGIDevice_Impl {
     fn SetMaximumFrameLatency(&self, maxlatency: u32) -> windows_core::Result<()>;
@@ -2497,10 +2497,6 @@ impl IDXGIDevice1_Vtbl {
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl windows_core::RuntimeName for IDXGIDevice1 {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-unsafe impl Send for IDXGIDevice1 {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-unsafe impl Sync for IDXGIDevice1 {}
 windows_core::imp::define_interface!(IDXGIDevice2, IDXGIDevice2_Vtbl, 0x05008617_fbfd_4051_a790_144884b4f6a9);
 impl core::ops::Deref for IDXGIDevice2 {
     type Target = IDXGIDevice1;
@@ -2527,6 +2523,8 @@ pub struct IDXGIDevice2_Vtbl {
     pub ReclaimResources: unsafe extern "system" fn(*mut core::ffi::c_void, u32, *const *mut core::ffi::c_void, *mut super::super::Foundation::BOOL) -> windows_core::HRESULT,
     pub EnqueueSetEvent: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::HANDLE) -> windows_core::HRESULT,
 }
+unsafe impl Send for IDXGIDevice2 {}
+unsafe impl Sync for IDXGIDevice2 {}
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 pub trait IDXGIDevice2_Impl: IDXGIDevice1_Impl {
     fn OfferResources(&self, numresources: u32, ppresources: *const Option<IDXGIResource>, priority: DXGI_OFFER_RESOURCE_PRIORITY) -> windows_core::Result<()>;
@@ -2567,10 +2565,6 @@ impl IDXGIDevice2_Vtbl {
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl windows_core::RuntimeName for IDXGIDevice2 {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-unsafe impl Send for IDXGIDevice2 {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-unsafe impl Sync for IDXGIDevice2 {}
 windows_core::imp::define_interface!(IDXGIDevice3, IDXGIDevice3_Vtbl, 0x6007896c_3244_4afd_bf18_a6d3beda5023);
 impl core::ops::Deref for IDXGIDevice3 {
     type Target = IDXGIDevice2;
@@ -2589,6 +2583,8 @@ pub struct IDXGIDevice3_Vtbl {
     pub base__: IDXGIDevice2_Vtbl,
     pub Trim: unsafe extern "system" fn(*mut core::ffi::c_void),
 }
+unsafe impl Send for IDXGIDevice3 {}
+unsafe impl Sync for IDXGIDevice3 {}
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 pub trait IDXGIDevice3_Impl: IDXGIDevice2_Impl {
     fn Trim(&self);
@@ -2610,10 +2606,6 @@ impl IDXGIDevice3_Vtbl {
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl windows_core::RuntimeName for IDXGIDevice3 {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-unsafe impl Send for IDXGIDevice3 {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-unsafe impl Sync for IDXGIDevice3 {}
 windows_core::imp::define_interface!(IDXGIDevice4, IDXGIDevice4_Vtbl, 0x95b4f95f_d8da_4ca4_9ee6_3b76d5968a10);
 impl core::ops::Deref for IDXGIDevice4 {
     type Target = IDXGIDevice3;
@@ -2636,6 +2628,8 @@ pub struct IDXGIDevice4_Vtbl {
     pub OfferResources1: unsafe extern "system" fn(*mut core::ffi::c_void, u32, *const *mut core::ffi::c_void, DXGI_OFFER_RESOURCE_PRIORITY, u32) -> windows_core::HRESULT,
     pub ReclaimResources1: unsafe extern "system" fn(*mut core::ffi::c_void, u32, *const *mut core::ffi::c_void, *mut DXGI_RECLAIM_RESOURCE_RESULTS) -> windows_core::HRESULT,
 }
+unsafe impl Send for IDXGIDevice4 {}
+unsafe impl Sync for IDXGIDevice4 {}
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 pub trait IDXGIDevice4_Impl: IDXGIDevice3_Impl {
     fn OfferResources1(&self, numresources: u32, ppresources: *const Option<IDXGIResource>, priority: DXGI_OFFER_RESOURCE_PRIORITY, flags: &DXGI_OFFER_RESOURCE_FLAGS) -> windows_core::Result<()>;
@@ -2668,10 +2662,6 @@ impl IDXGIDevice4_Vtbl {
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl windows_core::RuntimeName for IDXGIDevice4 {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-unsafe impl Send for IDXGIDevice4 {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-unsafe impl Sync for IDXGIDevice4 {}
 windows_core::imp::define_interface!(IDXGIDeviceSubObject, IDXGIDeviceSubObject_Vtbl, 0x3d3e0379_f9de_4d58_bb6c_18d62992f1a6);
 impl core::ops::Deref for IDXGIDeviceSubObject {
     type Target = IDXGIObject;
@@ -2694,6 +2684,8 @@ pub struct IDXGIDeviceSubObject_Vtbl {
     pub base__: IDXGIObject_Vtbl,
     pub GetDevice: unsafe extern "system" fn(*mut core::ffi::c_void, *const windows_core::GUID, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
+unsafe impl Send for IDXGIDeviceSubObject {}
+unsafe impl Sync for IDXGIDeviceSubObject {}
 pub trait IDXGIDeviceSubObject_Impl: IDXGIObject_Impl {
     fn GetDevice(&self, riid: *const windows_core::GUID, ppdevice: *mut *mut core::ffi::c_void) -> windows_core::Result<()>;
 }
@@ -2712,8 +2704,6 @@ impl IDXGIDeviceSubObject_Vtbl {
     }
 }
 impl windows_core::RuntimeName for IDXGIDeviceSubObject {}
-unsafe impl Send for IDXGIDeviceSubObject {}
-unsafe impl Sync for IDXGIDeviceSubObject {}
 windows_core::imp::define_interface!(IDXGIDisplayControl, IDXGIDisplayControl_Vtbl, 0xea9dbf1a_c88e_4486_854a_98aa0138f30c);
 windows_core::imp::interface_hierarchy!(IDXGIDisplayControl, windows_core::IUnknown);
 impl IDXGIDisplayControl {
@@ -2730,6 +2720,8 @@ pub struct IDXGIDisplayControl_Vtbl {
     pub IsStereoEnabled: unsafe extern "system" fn(*mut core::ffi::c_void) -> super::super::Foundation::BOOL,
     pub SetStereoEnabled: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::BOOL),
 }
+unsafe impl Send for IDXGIDisplayControl {}
+unsafe impl Sync for IDXGIDisplayControl {}
 pub trait IDXGIDisplayControl_Impl: windows_core::IUnknownImpl {
     fn IsStereoEnabled(&self) -> super::super::Foundation::BOOL;
     fn SetStereoEnabled(&self, enabled: super::super::Foundation::BOOL);
@@ -2759,8 +2751,6 @@ impl IDXGIDisplayControl_Vtbl {
     }
 }
 impl windows_core::RuntimeName for IDXGIDisplayControl {}
-unsafe impl Send for IDXGIDisplayControl {}
-unsafe impl Sync for IDXGIDisplayControl {}
 windows_core::imp::define_interface!(IDXGIFactory, IDXGIFactory_Vtbl, 0x7b7166ec_21c7_44ae_b21a_c9ae321ae369);
 impl core::ops::Deref for IDXGIFactory {
     type Target = IDXGIObject;
@@ -2811,6 +2801,8 @@ pub struct IDXGIFactory_Vtbl {
     CreateSwapChain: usize,
     pub CreateSoftwareAdapter: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::HMODULE, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
+unsafe impl Send for IDXGIFactory {}
+unsafe impl Sync for IDXGIFactory {}
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 pub trait IDXGIFactory_Impl: IDXGIObject_Impl {
     fn EnumAdapters(&self, adapter: u32) -> windows_core::Result<IDXGIAdapter>;
@@ -2885,10 +2877,6 @@ impl IDXGIFactory_Vtbl {
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl windows_core::RuntimeName for IDXGIFactory {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-unsafe impl Send for IDXGIFactory {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-unsafe impl Sync for IDXGIFactory {}
 windows_core::imp::define_interface!(IDXGIFactory1, IDXGIFactory1_Vtbl, 0x770aae78_f26f_4dba_a829_253c83d1b387);
 impl core::ops::Deref for IDXGIFactory1 {
     type Target = IDXGIFactory;
@@ -2914,6 +2902,8 @@ pub struct IDXGIFactory1_Vtbl {
     pub EnumAdapters1: unsafe extern "system" fn(*mut core::ffi::c_void, u32, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
     pub IsCurrent: unsafe extern "system" fn(*mut core::ffi::c_void) -> super::super::Foundation::BOOL,
 }
+unsafe impl Send for IDXGIFactory1 {}
+unsafe impl Sync for IDXGIFactory1 {}
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 pub trait IDXGIFactory1_Impl: IDXGIFactory_Impl {
     fn EnumAdapters1(&self, adapter: u32) -> windows_core::Result<IDXGIAdapter1>;
@@ -2948,10 +2938,6 @@ impl IDXGIFactory1_Vtbl {
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl windows_core::RuntimeName for IDXGIFactory1 {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-unsafe impl Send for IDXGIFactory1 {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-unsafe impl Sync for IDXGIFactory1 {}
 windows_core::imp::define_interface!(IDXGIFactory2, IDXGIFactory2_Vtbl, 0x50c83a1c_e072_4c48_87b0_3630fa36a6d0);
 impl core::ops::Deref for IDXGIFactory2 {
     type Target = IDXGIFactory1;
@@ -3059,6 +3045,8 @@ pub struct IDXGIFactory2_Vtbl {
     #[cfg(not(feature = "Win32_Graphics_Dxgi_Common"))]
     CreateSwapChainForComposition: usize,
 }
+unsafe impl Send for IDXGIFactory2 {}
+unsafe impl Sync for IDXGIFactory2 {}
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 pub trait IDXGIFactory2_Impl: IDXGIFactory1_Impl {
     fn IsWindowedStereoEnabled(&self) -> super::super::Foundation::BOOL;
@@ -3211,10 +3199,6 @@ impl IDXGIFactory2_Vtbl {
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl windows_core::RuntimeName for IDXGIFactory2 {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-unsafe impl Send for IDXGIFactory2 {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-unsafe impl Sync for IDXGIFactory2 {}
 windows_core::imp::define_interface!(IDXGIFactory3, IDXGIFactory3_Vtbl, 0x25483823_cd46_4c7d_86ca_47aa95b837bd);
 impl core::ops::Deref for IDXGIFactory3 {
     type Target = IDXGIFactory2;
@@ -3233,6 +3217,8 @@ pub struct IDXGIFactory3_Vtbl {
     pub base__: IDXGIFactory2_Vtbl,
     pub GetCreationFlags: unsafe extern "system" fn(*mut core::ffi::c_void) -> DXGI_CREATE_FACTORY_FLAGS,
 }
+unsafe impl Send for IDXGIFactory3 {}
+unsafe impl Sync for IDXGIFactory3 {}
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 pub trait IDXGIFactory3_Impl: IDXGIFactory2_Impl {
     fn GetCreationFlags(&self) -> DXGI_CREATE_FACTORY_FLAGS;
@@ -3254,10 +3240,6 @@ impl IDXGIFactory3_Vtbl {
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl windows_core::RuntimeName for IDXGIFactory3 {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-unsafe impl Send for IDXGIFactory3 {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-unsafe impl Sync for IDXGIFactory3 {}
 windows_core::imp::define_interface!(IDXGIFactory4, IDXGIFactory4_Vtbl, 0x1bc6ea02_ef36_464f_bf0c_21ca39e5168a);
 impl core::ops::Deref for IDXGIFactory4 {
     type Target = IDXGIFactory3;
@@ -3288,6 +3270,8 @@ pub struct IDXGIFactory4_Vtbl {
     pub EnumAdapterByLuid: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::LUID, *const windows_core::GUID, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
     pub EnumWarpAdapter: unsafe extern "system" fn(*mut core::ffi::c_void, *const windows_core::GUID, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
+unsafe impl Send for IDXGIFactory4 {}
+unsafe impl Sync for IDXGIFactory4 {}
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 pub trait IDXGIFactory4_Impl: IDXGIFactory3_Impl {
     fn EnumAdapterByLuid(&self, adapterluid: &super::super::Foundation::LUID, riid: *const windows_core::GUID, ppvadapter: *mut *mut core::ffi::c_void) -> windows_core::Result<()>;
@@ -3320,10 +3304,6 @@ impl IDXGIFactory4_Vtbl {
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl windows_core::RuntimeName for IDXGIFactory4 {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-unsafe impl Send for IDXGIFactory4 {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-unsafe impl Sync for IDXGIFactory4 {}
 windows_core::imp::define_interface!(IDXGIFactory5, IDXGIFactory5_Vtbl, 0x7632e1f5_ee65_4dca_87fd_84cd75f8838d);
 impl core::ops::Deref for IDXGIFactory5 {
     type Target = IDXGIFactory4;
@@ -3342,6 +3322,8 @@ pub struct IDXGIFactory5_Vtbl {
     pub base__: IDXGIFactory4_Vtbl,
     pub CheckFeatureSupport: unsafe extern "system" fn(*mut core::ffi::c_void, DXGI_FEATURE, *mut core::ffi::c_void, u32) -> windows_core::HRESULT,
 }
+unsafe impl Send for IDXGIFactory5 {}
+unsafe impl Sync for IDXGIFactory5 {}
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 pub trait IDXGIFactory5_Impl: IDXGIFactory4_Impl {
     fn CheckFeatureSupport(&self, feature: DXGI_FEATURE, pfeaturesupportdata: *mut core::ffi::c_void, featuresupportdatasize: u32) -> windows_core::Result<()>;
@@ -3363,10 +3345,6 @@ impl IDXGIFactory5_Vtbl {
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl windows_core::RuntimeName for IDXGIFactory5 {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-unsafe impl Send for IDXGIFactory5 {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-unsafe impl Sync for IDXGIFactory5 {}
 windows_core::imp::define_interface!(IDXGIFactory6, IDXGIFactory6_Vtbl, 0xc1b6694f_ff09_44a9_b03c_77900a0a1d17);
 impl core::ops::Deref for IDXGIFactory6 {
     type Target = IDXGIFactory5;
@@ -3389,6 +3367,8 @@ pub struct IDXGIFactory6_Vtbl {
     pub base__: IDXGIFactory5_Vtbl,
     pub EnumAdapterByGpuPreference: unsafe extern "system" fn(*mut core::ffi::c_void, u32, DXGI_GPU_PREFERENCE, *const windows_core::GUID, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
+unsafe impl Send for IDXGIFactory6 {}
+unsafe impl Sync for IDXGIFactory6 {}
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 pub trait IDXGIFactory6_Impl: IDXGIFactory5_Impl {
     fn EnumAdapterByGpuPreference(&self, adapter: u32, gpupreference: DXGI_GPU_PREFERENCE, riid: *const windows_core::GUID, ppvadapter: *mut *mut core::ffi::c_void) -> windows_core::Result<()>;
@@ -3410,10 +3390,6 @@ impl IDXGIFactory6_Vtbl {
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl windows_core::RuntimeName for IDXGIFactory6 {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-unsafe impl Send for IDXGIFactory6 {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-unsafe impl Sync for IDXGIFactory6 {}
 windows_core::imp::define_interface!(IDXGIFactory7, IDXGIFactory7_Vtbl, 0xa4966eed_76db_44da_84c1_ee9a7afb20a8);
 impl core::ops::Deref for IDXGIFactory7 {
     type Target = IDXGIFactory6;
@@ -3439,6 +3415,8 @@ pub struct IDXGIFactory7_Vtbl {
     pub RegisterAdaptersChangedEvent: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::HANDLE, *mut u32) -> windows_core::HRESULT,
     pub UnregisterAdaptersChangedEvent: unsafe extern "system" fn(*mut core::ffi::c_void, u32) -> windows_core::HRESULT,
 }
+unsafe impl Send for IDXGIFactory7 {}
+unsafe impl Sync for IDXGIFactory7 {}
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 pub trait IDXGIFactory7_Impl: IDXGIFactory6_Impl {
     fn RegisterAdaptersChangedEvent(&self, hevent: super::super::Foundation::HANDLE) -> windows_core::Result<u32>;
@@ -3477,10 +3455,6 @@ impl IDXGIFactory7_Vtbl {
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl windows_core::RuntimeName for IDXGIFactory7 {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-unsafe impl Send for IDXGIFactory7 {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-unsafe impl Sync for IDXGIFactory7 {}
 windows_core::imp::define_interface!(IDXGIFactoryMedia, IDXGIFactoryMedia_Vtbl, 0x41e7d1f2_a591_4f7b_a2e5_fa9c843e1c12);
 windows_core::imp::interface_hierarchy!(IDXGIFactoryMedia, windows_core::IUnknown);
 impl IDXGIFactoryMedia {
@@ -3516,6 +3490,8 @@ pub struct IDXGIFactoryMedia_Vtbl {
     CreateSwapChainForCompositionSurfaceHandle: usize,
     pub CreateDecodeSwapChainForCompositionSurfaceHandle: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, super::super::Foundation::HANDLE, *const DXGI_DECODE_SWAP_CHAIN_DESC, *mut core::ffi::c_void, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
+unsafe impl Send for IDXGIFactoryMedia {}
+unsafe impl Sync for IDXGIFactoryMedia {}
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 pub trait IDXGIFactoryMedia_Impl: windows_core::IUnknownImpl {
     fn CreateSwapChainForCompositionSurfaceHandle(&self, pdevice: windows_core::Ref<windows_core::IUnknown>, hsurface: super::super::Foundation::HANDLE, pdesc: *const DXGI_SWAP_CHAIN_DESC1, prestricttooutput: windows_core::Ref<IDXGIOutput>) -> windows_core::Result<IDXGISwapChain1>;
@@ -3560,10 +3536,6 @@ impl IDXGIFactoryMedia_Vtbl {
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl windows_core::RuntimeName for IDXGIFactoryMedia {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-unsafe impl Send for IDXGIFactoryMedia {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-unsafe impl Sync for IDXGIFactoryMedia {}
 windows_core::imp::define_interface!(IDXGIInfoQueue, IDXGIInfoQueue_Vtbl, 0xd67441c7_672a_476f_9e82_cd55b44949ce);
 windows_core::imp::interface_hierarchy!(IDXGIInfoQueue, windows_core::IUnknown);
 impl IDXGIInfoQueue {
@@ -3726,6 +3698,8 @@ pub struct IDXGIInfoQueue_Vtbl {
     pub SetMuteDebugOutput: unsafe extern "system" fn(*mut core::ffi::c_void, windows_core::GUID, super::super::Foundation::BOOL),
     pub GetMuteDebugOutput: unsafe extern "system" fn(*mut core::ffi::c_void, windows_core::GUID) -> super::super::Foundation::BOOL,
 }
+unsafe impl Send for IDXGIInfoQueue {}
+unsafe impl Sync for IDXGIInfoQueue {}
 pub trait IDXGIInfoQueue_Impl: windows_core::IUnknownImpl {
     fn SetMessageCountLimit(&self, producer: &windows_core::GUID, messagecountlimit: u64) -> windows_core::Result<()>;
     fn ClearStoredMessages(&self, producer: &windows_core::GUID);
@@ -4035,8 +4009,6 @@ impl IDXGIInfoQueue_Vtbl {
     }
 }
 impl windows_core::RuntimeName for IDXGIInfoQueue {}
-unsafe impl Send for IDXGIInfoQueue {}
-unsafe impl Sync for IDXGIInfoQueue {}
 windows_core::imp::define_interface!(IDXGIKeyedMutex, IDXGIKeyedMutex_Vtbl, 0x9d8e1289_d7b3_465f_8126_250e349af85d);
 impl core::ops::Deref for IDXGIKeyedMutex {
     type Target = IDXGIDeviceSubObject;
@@ -4059,6 +4031,8 @@ pub struct IDXGIKeyedMutex_Vtbl {
     pub AcquireSync: unsafe extern "system" fn(*mut core::ffi::c_void, u64, u32) -> windows_core::HRESULT,
     pub ReleaseSync: unsafe extern "system" fn(*mut core::ffi::c_void, u64) -> windows_core::HRESULT,
 }
+unsafe impl Send for IDXGIKeyedMutex {}
+unsafe impl Sync for IDXGIKeyedMutex {}
 pub trait IDXGIKeyedMutex_Impl: IDXGIDeviceSubObject_Impl {
     fn AcquireSync(&self, key: u64, dwmilliseconds: u32) -> windows_core::Result<()>;
     fn ReleaseSync(&self, key: u64) -> windows_core::Result<()>;
@@ -4088,8 +4062,6 @@ impl IDXGIKeyedMutex_Vtbl {
     }
 }
 impl windows_core::RuntimeName for IDXGIKeyedMutex {}
-unsafe impl Send for IDXGIKeyedMutex {}
-unsafe impl Sync for IDXGIKeyedMutex {}
 windows_core::imp::define_interface!(IDXGIObject, IDXGIObject_Vtbl, 0xaec22fb8_76f3_4639_9be0_28eb43a67a2e);
 windows_core::imp::interface_hierarchy!(IDXGIObject, windows_core::IUnknown);
 impl IDXGIObject {
@@ -4121,6 +4093,8 @@ pub struct IDXGIObject_Vtbl {
     pub GetPrivateData: unsafe extern "system" fn(*mut core::ffi::c_void, *const windows_core::GUID, *mut u32, *mut core::ffi::c_void) -> windows_core::HRESULT,
     pub GetParent: unsafe extern "system" fn(*mut core::ffi::c_void, *const windows_core::GUID, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
+unsafe impl Send for IDXGIObject {}
+unsafe impl Sync for IDXGIObject {}
 pub trait IDXGIObject_Impl: windows_core::IUnknownImpl {
     fn SetPrivateData(&self, name: *const windows_core::GUID, datasize: u32, pdata: *const core::ffi::c_void) -> windows_core::Result<()>;
     fn SetPrivateDataInterface(&self, name: *const windows_core::GUID, punknown: windows_core::Ref<windows_core::IUnknown>) -> windows_core::Result<()>;
@@ -4166,8 +4140,6 @@ impl IDXGIObject_Vtbl {
     }
 }
 impl windows_core::RuntimeName for IDXGIObject {}
-unsafe impl Send for IDXGIObject {}
-unsafe impl Sync for IDXGIObject {}
 windows_core::imp::define_interface!(IDXGIOutput, IDXGIOutput_Vtbl, 0xae02eedb_c735_4690_8d52_5a8dc20213aa);
 impl core::ops::Deref for IDXGIOutput {
     type Target = IDXGIObject;
@@ -4269,6 +4241,8 @@ pub struct IDXGIOutput_Vtbl {
     pub GetDisplaySurfaceData: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
     pub GetFrameStatistics: unsafe extern "system" fn(*mut core::ffi::c_void, *mut DXGI_FRAME_STATISTICS) -> windows_core::HRESULT,
 }
+unsafe impl Send for IDXGIOutput {}
+unsafe impl Sync for IDXGIOutput {}
 #[cfg(all(feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Gdi"))]
 pub trait IDXGIOutput_Impl: IDXGIObject_Impl {
     fn GetDesc(&self) -> windows_core::Result<DXGI_OUTPUT_DESC>;
@@ -4387,10 +4361,6 @@ impl IDXGIOutput_Vtbl {
 }
 #[cfg(all(feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Gdi"))]
 impl windows_core::RuntimeName for IDXGIOutput {}
-#[cfg(all(feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Gdi"))]
-unsafe impl Send for IDXGIOutput {}
-#[cfg(all(feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Gdi"))]
-unsafe impl Sync for IDXGIOutput {}
 windows_core::imp::define_interface!(IDXGIOutput1, IDXGIOutput1_Vtbl, 0x00cddea8_939b_4b83_a340_a685226666cc);
 impl core::ops::Deref for IDXGIOutput1 {
     type Target = IDXGIOutput;
@@ -4441,6 +4411,8 @@ pub struct IDXGIOutput1_Vtbl {
     pub GetDisplaySurfaceData1: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
     pub DuplicateOutput: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
+unsafe impl Send for IDXGIOutput1 {}
+unsafe impl Sync for IDXGIOutput1 {}
 #[cfg(all(feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Gdi"))]
 pub trait IDXGIOutput1_Impl: IDXGIOutput_Impl {
     fn GetDisplayModeList1(&self, enumformat: Common::DXGI_FORMAT, flags: DXGI_ENUM_MODES, pnummodes: *mut u32, pdesc: *mut DXGI_MODE_DESC1) -> windows_core::Result<()>;
@@ -4495,10 +4467,6 @@ impl IDXGIOutput1_Vtbl {
 }
 #[cfg(all(feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Gdi"))]
 impl windows_core::RuntimeName for IDXGIOutput1 {}
-#[cfg(all(feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Gdi"))]
-unsafe impl Send for IDXGIOutput1 {}
-#[cfg(all(feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Gdi"))]
-unsafe impl Sync for IDXGIOutput1 {}
 windows_core::imp::define_interface!(IDXGIOutput2, IDXGIOutput2_Vtbl, 0x595e39d1_2724_4663_99b1_da969de28364);
 impl core::ops::Deref for IDXGIOutput2 {
     type Target = IDXGIOutput1;
@@ -4517,6 +4485,8 @@ pub struct IDXGIOutput2_Vtbl {
     pub base__: IDXGIOutput1_Vtbl,
     pub SupportsOverlays: unsafe extern "system" fn(*mut core::ffi::c_void) -> super::super::Foundation::BOOL,
 }
+unsafe impl Send for IDXGIOutput2 {}
+unsafe impl Sync for IDXGIOutput2 {}
 #[cfg(all(feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Gdi"))]
 pub trait IDXGIOutput2_Impl: IDXGIOutput1_Impl {
     fn SupportsOverlays(&self) -> super::super::Foundation::BOOL;
@@ -4538,10 +4508,6 @@ impl IDXGIOutput2_Vtbl {
 }
 #[cfg(all(feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Gdi"))]
 impl windows_core::RuntimeName for IDXGIOutput2 {}
-#[cfg(all(feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Gdi"))]
-unsafe impl Send for IDXGIOutput2 {}
-#[cfg(all(feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Gdi"))]
-unsafe impl Sync for IDXGIOutput2 {}
 windows_core::imp::define_interface!(IDXGIOutput3, IDXGIOutput3_Vtbl, 0x8a6bb301_7e7e_41f4_a8e0_5b32f7f99b18);
 impl core::ops::Deref for IDXGIOutput3 {
     type Target = IDXGIOutput2;
@@ -4570,6 +4536,8 @@ pub struct IDXGIOutput3_Vtbl {
     #[cfg(not(feature = "Win32_Graphics_Dxgi_Common"))]
     CheckOverlaySupport: usize,
 }
+unsafe impl Send for IDXGIOutput3 {}
+unsafe impl Sync for IDXGIOutput3 {}
 #[cfg(all(feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Gdi"))]
 pub trait IDXGIOutput3_Impl: IDXGIOutput2_Impl {
     fn CheckOverlaySupport(&self, enumformat: Common::DXGI_FORMAT, pconcerneddevice: windows_core::Ref<windows_core::IUnknown>) -> windows_core::Result<u32>;
@@ -4597,10 +4565,6 @@ impl IDXGIOutput3_Vtbl {
 }
 #[cfg(all(feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Gdi"))]
 impl windows_core::RuntimeName for IDXGIOutput3 {}
-#[cfg(all(feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Gdi"))]
-unsafe impl Send for IDXGIOutput3 {}
-#[cfg(all(feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Gdi"))]
-unsafe impl Sync for IDXGIOutput3 {}
 windows_core::imp::define_interface!(IDXGIOutput4, IDXGIOutput4_Vtbl, 0xdc7dca35_2196_414d_9f53_617884032a60);
 impl core::ops::Deref for IDXGIOutput4 {
     type Target = IDXGIOutput3;
@@ -4629,6 +4593,8 @@ pub struct IDXGIOutput4_Vtbl {
     #[cfg(not(feature = "Win32_Graphics_Dxgi_Common"))]
     CheckOverlayColorSpaceSupport: usize,
 }
+unsafe impl Send for IDXGIOutput4 {}
+unsafe impl Sync for IDXGIOutput4 {}
 #[cfg(all(feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Gdi"))]
 pub trait IDXGIOutput4_Impl: IDXGIOutput3_Impl {
     fn CheckOverlayColorSpaceSupport(&self, format: Common::DXGI_FORMAT, colorspace: Common::DXGI_COLOR_SPACE_TYPE, pconcerneddevice: windows_core::Ref<windows_core::IUnknown>) -> windows_core::Result<u32>;
@@ -4656,10 +4622,6 @@ impl IDXGIOutput4_Vtbl {
 }
 #[cfg(all(feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Gdi"))]
 impl windows_core::RuntimeName for IDXGIOutput4 {}
-#[cfg(all(feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Gdi"))]
-unsafe impl Send for IDXGIOutput4 {}
-#[cfg(all(feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Gdi"))]
-unsafe impl Sync for IDXGIOutput4 {}
 windows_core::imp::define_interface!(IDXGIOutput5, IDXGIOutput5_Vtbl, 0x80a07424_ab52_42eb_833c_0c42fd282d98);
 impl core::ops::Deref for IDXGIOutput5 {
     type Target = IDXGIOutput4;
@@ -4688,6 +4650,8 @@ pub struct IDXGIOutput5_Vtbl {
     #[cfg(not(feature = "Win32_Graphics_Dxgi_Common"))]
     DuplicateOutput1: usize,
 }
+unsafe impl Send for IDXGIOutput5 {}
+unsafe impl Sync for IDXGIOutput5 {}
 #[cfg(all(feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Gdi"))]
 pub trait IDXGIOutput5_Impl: IDXGIOutput4_Impl {
     fn DuplicateOutput1(&self, pdevice: windows_core::Ref<windows_core::IUnknown>, flags: u32, supportedformatscount: u32, psupportedformats: *const Common::DXGI_FORMAT) -> windows_core::Result<IDXGIOutputDuplication>;
@@ -4715,10 +4679,6 @@ impl IDXGIOutput5_Vtbl {
 }
 #[cfg(all(feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Gdi"))]
 impl windows_core::RuntimeName for IDXGIOutput5 {}
-#[cfg(all(feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Gdi"))]
-unsafe impl Send for IDXGIOutput5 {}
-#[cfg(all(feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Gdi"))]
-unsafe impl Sync for IDXGIOutput5 {}
 windows_core::imp::define_interface!(IDXGIOutput6, IDXGIOutput6_Vtbl, 0x068346e8_aaec_4b84_add7_137f513f77a1);
 impl core::ops::Deref for IDXGIOutput6 {
     type Target = IDXGIOutput5;
@@ -4751,6 +4711,8 @@ pub struct IDXGIOutput6_Vtbl {
     GetDesc1: usize,
     pub CheckHardwareCompositionSupport: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u32) -> windows_core::HRESULT,
 }
+unsafe impl Send for IDXGIOutput6 {}
+unsafe impl Sync for IDXGIOutput6 {}
 #[cfg(all(feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Gdi"))]
 pub trait IDXGIOutput6_Impl: IDXGIOutput5_Impl {
     fn GetDesc1(&self) -> windows_core::Result<DXGI_OUTPUT_DESC1>;
@@ -4795,10 +4757,6 @@ impl IDXGIOutput6_Vtbl {
 }
 #[cfg(all(feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Gdi"))]
 impl windows_core::RuntimeName for IDXGIOutput6 {}
-#[cfg(all(feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Gdi"))]
-unsafe impl Send for IDXGIOutput6 {}
-#[cfg(all(feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Gdi"))]
-unsafe impl Sync for IDXGIOutput6 {}
 windows_core::imp::define_interface!(IDXGIOutputDuplication, IDXGIOutputDuplication_Vtbl, 0x191cfac3_a341_470d_b26e_a864f428319c);
 impl core::ops::Deref for IDXGIOutputDuplication {
     type Target = IDXGIObject;
@@ -4856,6 +4814,8 @@ pub struct IDXGIOutputDuplication_Vtbl {
     pub UnMapDesktopSurface: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
     pub ReleaseFrame: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
+unsafe impl Send for IDXGIOutputDuplication {}
+unsafe impl Sync for IDXGIOutputDuplication {}
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 pub trait IDXGIOutputDuplication_Impl: IDXGIObject_Impl {
     fn GetDesc(&self, pdesc: *mut DXGI_OUTDUPL_DESC);
@@ -4942,10 +4902,6 @@ impl IDXGIOutputDuplication_Vtbl {
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl windows_core::RuntimeName for IDXGIOutputDuplication {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-unsafe impl Send for IDXGIOutputDuplication {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-unsafe impl Sync for IDXGIOutputDuplication {}
 windows_core::imp::define_interface!(IDXGIResource, IDXGIResource_Vtbl, 0x035f3ab4_482e_4e50_b41f_8a7f8bd8960b);
 impl core::ops::Deref for IDXGIResource {
     type Target = IDXGIDeviceSubObject;
@@ -4985,6 +4941,8 @@ pub struct IDXGIResource_Vtbl {
     pub SetEvictionPriority: unsafe extern "system" fn(*mut core::ffi::c_void, DXGI_RESOURCE_PRIORITY) -> windows_core::HRESULT,
     pub GetEvictionPriority: unsafe extern "system" fn(*mut core::ffi::c_void, *mut DXGI_RESOURCE_PRIORITY) -> windows_core::HRESULT,
 }
+unsafe impl Send for IDXGIResource {}
+unsafe impl Sync for IDXGIResource {}
 pub trait IDXGIResource_Impl: IDXGIDeviceSubObject_Impl {
     fn GetSharedHandle(&self) -> windows_core::Result<super::super::Foundation::HANDLE>;
     fn GetUsage(&self) -> windows_core::Result<DXGI_USAGE>;
@@ -5048,8 +5006,6 @@ impl IDXGIResource_Vtbl {
     }
 }
 impl windows_core::RuntimeName for IDXGIResource {}
-unsafe impl Send for IDXGIResource {}
-unsafe impl Sync for IDXGIResource {}
 windows_core::imp::define_interface!(IDXGIResource1, IDXGIResource1_Vtbl, 0x30961379_4609_4a41_998e_54fe567ee0c1);
 impl core::ops::Deref for IDXGIResource1 {
     type Target = IDXGIResource;
@@ -5085,6 +5041,8 @@ pub struct IDXGIResource1_Vtbl {
     #[cfg(not(feature = "Win32_Security"))]
     CreateSharedHandle: usize,
 }
+unsafe impl Send for IDXGIResource1 {}
+unsafe impl Sync for IDXGIResource1 {}
 #[cfg(feature = "Win32_Security")]
 pub trait IDXGIResource1_Impl: IDXGIResource_Impl {
     fn CreateSubresourceSurface(&self, index: u32) -> windows_core::Result<IDXGISurface2>;
@@ -5129,10 +5087,6 @@ impl IDXGIResource1_Vtbl {
 }
 #[cfg(feature = "Win32_Security")]
 impl windows_core::RuntimeName for IDXGIResource1 {}
-#[cfg(feature = "Win32_Security")]
-unsafe impl Send for IDXGIResource1 {}
-#[cfg(feature = "Win32_Security")]
-unsafe impl Sync for IDXGIResource1 {}
 windows_core::imp::define_interface!(IDXGISurface, IDXGISurface_Vtbl, 0xcafcb56c_6ac3_4889_bf47_9e23bbd260ec);
 impl core::ops::Deref for IDXGISurface {
     type Target = IDXGIDeviceSubObject;
@@ -5166,6 +5120,8 @@ pub struct IDXGISurface_Vtbl {
     pub Map: unsafe extern "system" fn(*mut core::ffi::c_void, *mut DXGI_MAPPED_RECT, DXGI_MAP_FLAGS) -> windows_core::HRESULT,
     pub Unmap: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
+unsafe impl Send for IDXGISurface {}
+unsafe impl Sync for IDXGISurface {}
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 pub trait IDXGISurface_Impl: IDXGIDeviceSubObject_Impl {
     fn GetDesc(&self) -> windows_core::Result<DXGI_SURFACE_DESC>;
@@ -5212,10 +5168,6 @@ impl IDXGISurface_Vtbl {
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl windows_core::RuntimeName for IDXGISurface {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-unsafe impl Send for IDXGISurface {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-unsafe impl Sync for IDXGISurface {}
 windows_core::imp::define_interface!(IDXGISurface1, IDXGISurface1_Vtbl, 0x4ae63092_6327_4c1b_80ae_bfe12ea32b86);
 impl core::ops::Deref for IDXGISurface1 {
     type Target = IDXGISurface;
@@ -5245,6 +5197,8 @@ pub struct IDXGISurface1_Vtbl {
     GetDC: usize,
     pub ReleaseDC: unsafe extern "system" fn(*mut core::ffi::c_void, *const super::super::Foundation::RECT) -> windows_core::HRESULT,
 }
+unsafe impl Send for IDXGISurface1 {}
+unsafe impl Sync for IDXGISurface1 {}
 #[cfg(all(feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Gdi"))]
 pub trait IDXGISurface1_Impl: IDXGISurface_Impl {
     fn GetDC(&self, discard: super::super::Foundation::BOOL) -> windows_core::Result<super::Gdi::HDC>;
@@ -5279,10 +5233,6 @@ impl IDXGISurface1_Vtbl {
 }
 #[cfg(all(feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Gdi"))]
 impl windows_core::RuntimeName for IDXGISurface1 {}
-#[cfg(all(feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Gdi"))]
-unsafe impl Send for IDXGISurface1 {}
-#[cfg(all(feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Gdi"))]
-unsafe impl Sync for IDXGISurface1 {}
 windows_core::imp::define_interface!(IDXGISurface2, IDXGISurface2_Vtbl, 0xaba496dd_b617_4cb8_a866_bc44d7eb1fa2);
 impl core::ops::Deref for IDXGISurface2 {
     type Target = IDXGISurface1;
@@ -5305,6 +5255,8 @@ pub struct IDXGISurface2_Vtbl {
     pub base__: IDXGISurface1_Vtbl,
     pub GetResource: unsafe extern "system" fn(*mut core::ffi::c_void, *const windows_core::GUID, *mut *mut core::ffi::c_void, *mut u32) -> windows_core::HRESULT,
 }
+unsafe impl Send for IDXGISurface2 {}
+unsafe impl Sync for IDXGISurface2 {}
 #[cfg(all(feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Gdi"))]
 pub trait IDXGISurface2_Impl: IDXGISurface1_Impl {
     fn GetResource(&self, riid: *const windows_core::GUID, ppparentresource: *mut *mut core::ffi::c_void, psubresourceindex: *mut u32) -> windows_core::Result<()>;
@@ -5326,10 +5278,6 @@ impl IDXGISurface2_Vtbl {
 }
 #[cfg(all(feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Gdi"))]
 impl windows_core::RuntimeName for IDXGISurface2 {}
-#[cfg(all(feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Gdi"))]
-unsafe impl Send for IDXGISurface2 {}
-#[cfg(all(feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Gdi"))]
-unsafe impl Sync for IDXGISurface2 {}
 windows_core::imp::define_interface!(IDXGISwapChain, IDXGISwapChain_Vtbl, 0x310d36a0_d2e7_4c0a_aa04_6a9d23b8886a);
 impl core::ops::Deref for IDXGISwapChain {
     type Target = IDXGIDeviceSubObject;
@@ -5412,6 +5360,8 @@ pub struct IDXGISwapChain_Vtbl {
     pub GetFrameStatistics: unsafe extern "system" fn(*mut core::ffi::c_void, *mut DXGI_FRAME_STATISTICS) -> windows_core::HRESULT,
     pub GetLastPresentCount: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u32) -> windows_core::HRESULT,
 }
+unsafe impl Send for IDXGISwapChain {}
+unsafe impl Sync for IDXGISwapChain {}
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 pub trait IDXGISwapChain_Impl: IDXGIDeviceSubObject_Impl {
     fn Present(&self, syncinterval: u32, flags: DXGI_PRESENT) -> windows_core::HRESULT;
@@ -5526,10 +5476,6 @@ impl IDXGISwapChain_Vtbl {
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl windows_core::RuntimeName for IDXGISwapChain {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-unsafe impl Send for IDXGISwapChain {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-unsafe impl Sync for IDXGISwapChain {}
 windows_core::imp::define_interface!(IDXGISwapChain1, IDXGISwapChain1_Vtbl, 0x790a45f7_0d42_4876_983a_0a55cfe6f4aa);
 impl core::ops::Deref for IDXGISwapChain1 {
     type Target = IDXGISwapChain;
@@ -5626,6 +5572,8 @@ pub struct IDXGISwapChain1_Vtbl {
     #[cfg(not(feature = "Win32_Graphics_Dxgi_Common"))]
     GetRotation: usize,
 }
+unsafe impl Send for IDXGISwapChain1 {}
+unsafe impl Sync for IDXGISwapChain1 {}
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 pub trait IDXGISwapChain1_Impl: IDXGISwapChain_Impl {
     fn GetDesc1(&self) -> windows_core::Result<DXGI_SWAP_CHAIN_DESC1>;
@@ -5766,10 +5714,6 @@ impl IDXGISwapChain1_Vtbl {
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl windows_core::RuntimeName for IDXGISwapChain1 {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-unsafe impl Send for IDXGISwapChain1 {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-unsafe impl Sync for IDXGISwapChain1 {}
 windows_core::imp::define_interface!(IDXGISwapChain2, IDXGISwapChain2_Vtbl, 0xa8be2ac4_199f_4946_b331_79599fb98de7);
 impl core::ops::Deref for IDXGISwapChain2 {
     type Target = IDXGISwapChain1;
@@ -5815,6 +5759,8 @@ pub struct IDXGISwapChain2_Vtbl {
     pub SetMatrixTransform: unsafe extern "system" fn(*mut core::ffi::c_void, *const DXGI_MATRIX_3X2_F) -> windows_core::HRESULT,
     pub GetMatrixTransform: unsafe extern "system" fn(*mut core::ffi::c_void, *mut DXGI_MATRIX_3X2_F) -> windows_core::HRESULT,
 }
+unsafe impl Send for IDXGISwapChain2 {}
+unsafe impl Sync for IDXGISwapChain2 {}
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 pub trait IDXGISwapChain2_Impl: IDXGISwapChain1_Impl {
     fn SetSourceSize(&self, width: u32, height: u32) -> windows_core::Result<()>;
@@ -5893,10 +5839,6 @@ impl IDXGISwapChain2_Vtbl {
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl windows_core::RuntimeName for IDXGISwapChain2 {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-unsafe impl Send for IDXGISwapChain2 {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-unsafe impl Sync for IDXGISwapChain2 {}
 windows_core::imp::define_interface!(IDXGISwapChain3, IDXGISwapChain3_Vtbl, 0x94d99bdb_f1f8_4ab0_b236_7da0170edab1);
 impl core::ops::Deref for IDXGISwapChain3 {
     type Target = IDXGISwapChain2;
@@ -5942,6 +5884,8 @@ pub struct IDXGISwapChain3_Vtbl {
     #[cfg(not(feature = "Win32_Graphics_Dxgi_Common"))]
     ResizeBuffers1: usize,
 }
+unsafe impl Send for IDXGISwapChain3 {}
+unsafe impl Sync for IDXGISwapChain3 {}
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 pub trait IDXGISwapChain3_Impl: IDXGISwapChain2_Impl {
     fn GetCurrentBackBufferIndex(&self) -> u32;
@@ -5996,10 +5940,6 @@ impl IDXGISwapChain3_Vtbl {
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl windows_core::RuntimeName for IDXGISwapChain3 {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-unsafe impl Send for IDXGISwapChain3 {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-unsafe impl Sync for IDXGISwapChain3 {}
 windows_core::imp::define_interface!(IDXGISwapChain4, IDXGISwapChain4_Vtbl, 0x3d585d5a_bd4a_489e_b1f4_3dbcb6452ffb);
 impl core::ops::Deref for IDXGISwapChain4 {
     type Target = IDXGISwapChain3;
@@ -6018,6 +5958,8 @@ pub struct IDXGISwapChain4_Vtbl {
     pub base__: IDXGISwapChain3_Vtbl,
     pub SetHDRMetaData: unsafe extern "system" fn(*mut core::ffi::c_void, DXGI_HDR_METADATA_TYPE, u32, *const core::ffi::c_void) -> windows_core::HRESULT,
 }
+unsafe impl Send for IDXGISwapChain4 {}
+unsafe impl Sync for IDXGISwapChain4 {}
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 pub trait IDXGISwapChain4_Impl: IDXGISwapChain3_Impl {
     fn SetHDRMetaData(&self, r#type: DXGI_HDR_METADATA_TYPE, size: u32, pmetadata: *const core::ffi::c_void) -> windows_core::Result<()>;
@@ -6039,10 +5981,6 @@ impl IDXGISwapChain4_Vtbl {
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl windows_core::RuntimeName for IDXGISwapChain4 {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-unsafe impl Send for IDXGISwapChain4 {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-unsafe impl Sync for IDXGISwapChain4 {}
 windows_core::imp::define_interface!(IDXGISwapChainMedia, IDXGISwapChainMedia_Vtbl, 0xdd95b90b_f05f_4f6a_bd65_25bfb264bd84);
 windows_core::imp::interface_hierarchy!(IDXGISwapChainMedia, windows_core::IUnknown);
 impl IDXGISwapChainMedia {
@@ -6063,6 +6001,8 @@ pub struct IDXGISwapChainMedia_Vtbl {
     pub SetPresentDuration: unsafe extern "system" fn(*mut core::ffi::c_void, u32) -> windows_core::HRESULT,
     pub CheckPresentDurationSupport: unsafe extern "system" fn(*mut core::ffi::c_void, u32, *mut u32, *mut u32) -> windows_core::HRESULT,
 }
+unsafe impl Send for IDXGISwapChainMedia {}
+unsafe impl Sync for IDXGISwapChainMedia {}
 pub trait IDXGISwapChainMedia_Impl: windows_core::IUnknownImpl {
     fn GetFrameStatisticsMedia(&self, pstats: *mut DXGI_FRAME_STATISTICS_MEDIA) -> windows_core::Result<()>;
     fn SetPresentDuration(&self, duration: u32) -> windows_core::Result<()>;
@@ -6100,8 +6040,6 @@ impl IDXGISwapChainMedia_Vtbl {
     }
 }
 impl windows_core::RuntimeName for IDXGISwapChainMedia {}
-unsafe impl Send for IDXGISwapChainMedia {}
-unsafe impl Sync for IDXGISwapChainMedia {}
 windows_core::imp::define_interface!(IDXGraphicsAnalysis, IDXGraphicsAnalysis_Vtbl, 0x9f251514_9d4d_4902_9d60_18988ab7d4b5);
 windows_core::imp::interface_hierarchy!(IDXGraphicsAnalysis, windows_core::IUnknown);
 impl IDXGraphicsAnalysis {

--- a/crates/libs/windows/src/Windows/Win32/Media/MediaFoundation/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/MediaFoundation/mod.rs
@@ -10162,6 +10162,10 @@ pub struct ID3D12VideoDecodeCommandList_Vtbl {
     DecodeFrame: usize,
     pub WriteBufferImmediate: unsafe extern "system" fn(*mut core::ffi::c_void, u32, *const super::super::Graphics::Direct3D12::D3D12_WRITEBUFFERIMMEDIATE_PARAMETER, *const super::super::Graphics::Direct3D12::D3D12_WRITEBUFFERIMMEDIATE_MODE),
 }
+#[cfg(feature = "Win32_Graphics_Direct3D12")]
+unsafe impl Send for ID3D12VideoDecodeCommandList {}
+#[cfg(feature = "Win32_Graphics_Direct3D12")]
+unsafe impl Sync for ID3D12VideoDecodeCommandList {}
 #[cfg(all(feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait ID3D12VideoDecodeCommandList_Impl: super::super::Graphics::Direct3D12::ID3D12CommandList_Impl {
     fn Close(&self) -> windows_core::Result<()>;
@@ -10290,10 +10294,6 @@ impl ID3D12VideoDecodeCommandList_Vtbl {
 }
 #[cfg(all(feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
 impl windows_core::RuntimeName for ID3D12VideoDecodeCommandList {}
-#[cfg(all(feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
-unsafe impl Send for ID3D12VideoDecodeCommandList {}
-#[cfg(all(feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
-unsafe impl Sync for ID3D12VideoDecodeCommandList {}
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
 windows_core::imp::define_interface!(ID3D12VideoDecodeCommandList1, ID3D12VideoDecodeCommandList1_Vtbl, 0xd52f011b_b56e_453c_a05a_a7f311c8f472);
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
@@ -10324,6 +10324,10 @@ pub struct ID3D12VideoDecodeCommandList1_Vtbl {
     #[cfg(not(feature = "Win32_Graphics_Dxgi_Common"))]
     DecodeFrame1: usize,
 }
+#[cfg(feature = "Win32_Graphics_Direct3D12")]
+unsafe impl Send for ID3D12VideoDecodeCommandList1 {}
+#[cfg(feature = "Win32_Graphics_Direct3D12")]
+unsafe impl Sync for ID3D12VideoDecodeCommandList1 {}
 #[cfg(all(feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait ID3D12VideoDecodeCommandList1_Impl: ID3D12VideoDecodeCommandList_Impl {
     fn DecodeFrame1(&self, pdecoder: windows_core::Ref<ID3D12VideoDecoder>, poutputarguments: *const D3D12_VIDEO_DECODE_OUTPUT_STREAM_ARGUMENTS1, pinputarguments: *const D3D12_VIDEO_DECODE_INPUT_STREAM_ARGUMENTS);
@@ -10345,10 +10349,6 @@ impl ID3D12VideoDecodeCommandList1_Vtbl {
 }
 #[cfg(all(feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
 impl windows_core::RuntimeName for ID3D12VideoDecodeCommandList1 {}
-#[cfg(all(feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
-unsafe impl Send for ID3D12VideoDecodeCommandList1 {}
-#[cfg(all(feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
-unsafe impl Sync for ID3D12VideoDecodeCommandList1 {}
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
 windows_core::imp::define_interface!(ID3D12VideoDecodeCommandList2, ID3D12VideoDecodeCommandList2_Vtbl, 0x6e120880_c114_4153_8036_d247051e1729);
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
@@ -10389,6 +10389,10 @@ pub struct ID3D12VideoDecodeCommandList2_Vtbl {
     pub InitializeExtensionCommand: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *const core::ffi::c_void, usize),
     pub ExecuteExtensionCommand: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *const core::ffi::c_void, usize),
 }
+#[cfg(feature = "Win32_Graphics_Direct3D12")]
+unsafe impl Send for ID3D12VideoDecodeCommandList2 {}
+#[cfg(feature = "Win32_Graphics_Direct3D12")]
+unsafe impl Sync for ID3D12VideoDecodeCommandList2 {}
 #[cfg(all(feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait ID3D12VideoDecodeCommandList2_Impl: ID3D12VideoDecodeCommandList1_Impl {
     fn SetProtectedResourceSession(&self, pprotectedresourcesession: windows_core::Ref<super::super::Graphics::Direct3D12::ID3D12ProtectedResourceSession>);
@@ -10429,10 +10433,6 @@ impl ID3D12VideoDecodeCommandList2_Vtbl {
 }
 #[cfg(all(feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
 impl windows_core::RuntimeName for ID3D12VideoDecodeCommandList2 {}
-#[cfg(all(feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
-unsafe impl Send for ID3D12VideoDecodeCommandList2 {}
-#[cfg(all(feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
-unsafe impl Sync for ID3D12VideoDecodeCommandList2 {}
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
 windows_core::imp::define_interface!(ID3D12VideoDecodeCommandList3, ID3D12VideoDecodeCommandList3_Vtbl, 0x2aee8c37_9562_42da_8abf_61efeb2e4513);
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
@@ -10456,6 +10456,10 @@ pub struct ID3D12VideoDecodeCommandList3_Vtbl {
     pub base__: ID3D12VideoDecodeCommandList2_Vtbl,
     pub Barrier: unsafe extern "system" fn(*mut core::ffi::c_void, u32, *const super::super::Graphics::Direct3D12::D3D12_BARRIER_GROUP),
 }
+#[cfg(feature = "Win32_Graphics_Direct3D12")]
+unsafe impl Send for ID3D12VideoDecodeCommandList3 {}
+#[cfg(feature = "Win32_Graphics_Direct3D12")]
+unsafe impl Sync for ID3D12VideoDecodeCommandList3 {}
 #[cfg(all(feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait ID3D12VideoDecodeCommandList3_Impl: ID3D12VideoDecodeCommandList2_Impl {
     fn Barrier(&self, numbarriergroups: u32, pbarriergroups: *const super::super::Graphics::Direct3D12::D3D12_BARRIER_GROUP);
@@ -10477,10 +10481,6 @@ impl ID3D12VideoDecodeCommandList3_Vtbl {
 }
 #[cfg(all(feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
 impl windows_core::RuntimeName for ID3D12VideoDecodeCommandList3 {}
-#[cfg(all(feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
-unsafe impl Send for ID3D12VideoDecodeCommandList3 {}
-#[cfg(all(feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
-unsafe impl Sync for ID3D12VideoDecodeCommandList3 {}
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
 windows_core::imp::define_interface!(ID3D12VideoDecoder, ID3D12VideoDecoder_Vtbl, 0xc59b6bdc_7720_4074_a136_17a156037470);
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
@@ -10509,6 +10509,10 @@ pub struct ID3D12VideoDecoder_Vtbl {
     pub GetDesc: unsafe extern "system" fn(*mut core::ffi::c_void, *mut D3D12_VIDEO_DECODER_DESC),
 }
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
+unsafe impl Send for ID3D12VideoDecoder {}
+#[cfg(feature = "Win32_Graphics_Direct3D12")]
+unsafe impl Sync for ID3D12VideoDecoder {}
+#[cfg(feature = "Win32_Graphics_Direct3D12")]
 pub trait ID3D12VideoDecoder_Impl: super::super::Graphics::Direct3D12::ID3D12Pageable_Impl {
     fn GetDesc(&self) -> D3D12_VIDEO_DECODER_DESC;
 }
@@ -10529,10 +10533,6 @@ impl ID3D12VideoDecoder_Vtbl {
 }
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
 impl windows_core::RuntimeName for ID3D12VideoDecoder {}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-unsafe impl Send for ID3D12VideoDecoder {}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-unsafe impl Sync for ID3D12VideoDecoder {}
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
 windows_core::imp::define_interface!(ID3D12VideoDecoder1, ID3D12VideoDecoder1_Vtbl, 0x79a2e5fb_ccd2_469a_9fde_195d10951f7e);
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
@@ -10560,6 +10560,10 @@ pub struct ID3D12VideoDecoder1_Vtbl {
     pub GetProtectedResourceSession: unsafe extern "system" fn(*mut core::ffi::c_void, *const windows_core::GUID, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
+unsafe impl Send for ID3D12VideoDecoder1 {}
+#[cfg(feature = "Win32_Graphics_Direct3D12")]
+unsafe impl Sync for ID3D12VideoDecoder1 {}
+#[cfg(feature = "Win32_Graphics_Direct3D12")]
 pub trait ID3D12VideoDecoder1_Impl: ID3D12VideoDecoder_Impl {
     fn GetProtectedResourceSession(&self, riid: *const windows_core::GUID, ppprotectedsession: *mut *mut core::ffi::c_void) -> windows_core::Result<()>;
 }
@@ -10580,10 +10584,6 @@ impl ID3D12VideoDecoder1_Vtbl {
 }
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
 impl windows_core::RuntimeName for ID3D12VideoDecoder1 {}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-unsafe impl Send for ID3D12VideoDecoder1 {}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-unsafe impl Sync for ID3D12VideoDecoder1 {}
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
 windows_core::imp::define_interface!(ID3D12VideoDecoderHeap, ID3D12VideoDecoderHeap_Vtbl, 0x0946b7c9_ebf6_4047_bb73_8683e27dbb1f);
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
@@ -10615,6 +10615,10 @@ pub struct ID3D12VideoDecoderHeap_Vtbl {
     #[cfg(not(feature = "Win32_Graphics_Dxgi_Common"))]
     GetDesc: usize,
 }
+#[cfg(feature = "Win32_Graphics_Direct3D12")]
+unsafe impl Send for ID3D12VideoDecoderHeap {}
+#[cfg(feature = "Win32_Graphics_Direct3D12")]
+unsafe impl Sync for ID3D12VideoDecoderHeap {}
 #[cfg(all(feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait ID3D12VideoDecoderHeap_Impl: super::super::Graphics::Direct3D12::ID3D12Pageable_Impl {
     fn GetDesc(&self) -> D3D12_VIDEO_DECODER_HEAP_DESC;
@@ -10636,10 +10640,6 @@ impl ID3D12VideoDecoderHeap_Vtbl {
 }
 #[cfg(all(feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
 impl windows_core::RuntimeName for ID3D12VideoDecoderHeap {}
-#[cfg(all(feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
-unsafe impl Send for ID3D12VideoDecoderHeap {}
-#[cfg(all(feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
-unsafe impl Sync for ID3D12VideoDecoderHeap {}
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
 windows_core::imp::define_interface!(ID3D12VideoDecoderHeap1, ID3D12VideoDecoderHeap1_Vtbl, 0xda1d98c5_539f_41b2_bf6b_1198a03b6d26);
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
@@ -10666,6 +10666,10 @@ pub struct ID3D12VideoDecoderHeap1_Vtbl {
     pub base__: ID3D12VideoDecoderHeap_Vtbl,
     pub GetProtectedResourceSession: unsafe extern "system" fn(*mut core::ffi::c_void, *const windows_core::GUID, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
+#[cfg(feature = "Win32_Graphics_Direct3D12")]
+unsafe impl Send for ID3D12VideoDecoderHeap1 {}
+#[cfg(feature = "Win32_Graphics_Direct3D12")]
+unsafe impl Sync for ID3D12VideoDecoderHeap1 {}
 #[cfg(all(feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait ID3D12VideoDecoderHeap1_Impl: ID3D12VideoDecoderHeap_Impl {
     fn GetProtectedResourceSession(&self, riid: *const windows_core::GUID, ppprotectedsession: *mut *mut core::ffi::c_void) -> windows_core::Result<()>;
@@ -10687,10 +10691,6 @@ impl ID3D12VideoDecoderHeap1_Vtbl {
 }
 #[cfg(all(feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
 impl windows_core::RuntimeName for ID3D12VideoDecoderHeap1 {}
-#[cfg(all(feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
-unsafe impl Send for ID3D12VideoDecoderHeap1 {}
-#[cfg(all(feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
-unsafe impl Sync for ID3D12VideoDecoderHeap1 {}
 windows_core::imp::define_interface!(ID3D12VideoDevice, ID3D12VideoDevice_Vtbl, 0x1f052807_0b46_4acc_8a89_364f793718a4);
 windows_core::imp::interface_hierarchy!(ID3D12VideoDevice, windows_core::IUnknown);
 impl ID3D12VideoDevice {
@@ -10735,6 +10735,8 @@ pub struct ID3D12VideoDevice_Vtbl {
     #[cfg(not(feature = "Win32_Graphics_Dxgi_Common"))]
     CreateVideoProcessor: usize,
 }
+unsafe impl Send for ID3D12VideoDevice {}
+unsafe impl Sync for ID3D12VideoDevice {}
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 pub trait ID3D12VideoDevice_Impl: windows_core::IUnknownImpl {
     fn CheckFeatureSupport(&self, featurevideo: D3D12_FEATURE_VIDEO, pfeaturesupportdata: *mut core::ffi::c_void, featuresupportdatasize: u32) -> windows_core::Result<()>;
@@ -10783,10 +10785,6 @@ impl ID3D12VideoDevice_Vtbl {
 }
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 impl windows_core::RuntimeName for ID3D12VideoDevice {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-unsafe impl Send for ID3D12VideoDevice {}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-unsafe impl Sync for ID3D12VideoDevice {}
 windows_core::imp::define_interface!(ID3D12VideoDevice1, ID3D12VideoDevice1_Vtbl, 0x981611ad_a144_4c83_9890_f30e26d658ab);
 impl core::ops::Deref for ID3D12VideoDevice1 {
     type Target = ID3D12VideoDevice;
@@ -10827,6 +10825,8 @@ pub struct ID3D12VideoDevice1_Vtbl {
     #[cfg(not(all(feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common")))]
     CreateVideoMotionVectorHeap: usize,
 }
+unsafe impl Send for ID3D12VideoDevice1 {}
+unsafe impl Sync for ID3D12VideoDevice1 {}
 #[cfg(all(feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait ID3D12VideoDevice1_Impl: ID3D12VideoDevice_Impl {
     fn CreateVideoMotionEstimator(&self, pdesc: *const D3D12_VIDEO_MOTION_ESTIMATOR_DESC, pprotectedresourcesession: windows_core::Ref<super::super::Graphics::Direct3D12::ID3D12ProtectedResourceSession>, riid: *const windows_core::GUID, ppvideomotionestimator: *mut *mut core::ffi::c_void) -> windows_core::Result<()>;
@@ -10859,10 +10859,6 @@ impl ID3D12VideoDevice1_Vtbl {
 }
 #[cfg(all(feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
 impl windows_core::RuntimeName for ID3D12VideoDevice1 {}
-#[cfg(all(feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
-unsafe impl Send for ID3D12VideoDevice1 {}
-#[cfg(all(feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
-unsafe impl Sync for ID3D12VideoDevice1 {}
 windows_core::imp::define_interface!(ID3D12VideoDevice2, ID3D12VideoDevice2_Vtbl, 0xf019ac49_f838_4a95_9b17_579437c8f513);
 impl core::ops::Deref for ID3D12VideoDevice2 {
     type Target = ID3D12VideoDevice1;
@@ -10940,6 +10936,8 @@ pub struct ID3D12VideoDevice2_Vtbl {
     #[cfg(not(feature = "Win32_Graphics_Direct3D12"))]
     ExecuteExtensionCommand: usize,
 }
+unsafe impl Send for ID3D12VideoDevice2 {}
+unsafe impl Sync for ID3D12VideoDevice2 {}
 #[cfg(all(feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait ID3D12VideoDevice2_Impl: ID3D12VideoDevice1_Impl {
     fn CreateVideoDecoder1(&self, pdesc: *const D3D12_VIDEO_DECODER_DESC, pprotectedresourcesession: windows_core::Ref<super::super::Graphics::Direct3D12::ID3D12ProtectedResourceSession>, riid: *const windows_core::GUID, ppvideodecoder: *mut *mut core::ffi::c_void) -> windows_core::Result<()>;
@@ -10996,10 +10994,6 @@ impl ID3D12VideoDevice2_Vtbl {
 }
 #[cfg(all(feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
 impl windows_core::RuntimeName for ID3D12VideoDevice2 {}
-#[cfg(all(feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
-unsafe impl Send for ID3D12VideoDevice2 {}
-#[cfg(all(feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
-unsafe impl Sync for ID3D12VideoDevice2 {}
 windows_core::imp::define_interface!(ID3D12VideoDevice3, ID3D12VideoDevice3_Vtbl, 0x4243adb4_3a32_4666_973c_0ccc5625dc44);
 impl core::ops::Deref for ID3D12VideoDevice3 {
     type Target = ID3D12VideoDevice2;
@@ -11034,6 +11028,8 @@ pub struct ID3D12VideoDevice3_Vtbl {
     CreateVideoEncoder: usize,
     pub CreateVideoEncoderHeap: unsafe extern "system" fn(*mut core::ffi::c_void, *const D3D12_VIDEO_ENCODER_HEAP_DESC, *const windows_core::GUID, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID3D12VideoDevice3 {}
+unsafe impl Sync for ID3D12VideoDevice3 {}
 #[cfg(all(feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait ID3D12VideoDevice3_Impl: ID3D12VideoDevice2_Impl {
     fn CreateVideoEncoder(&self, pdesc: *const D3D12_VIDEO_ENCODER_DESC, riid: *const windows_core::GUID, ppvideoencoder: *mut *mut core::ffi::c_void) -> windows_core::Result<()>;
@@ -11066,10 +11062,6 @@ impl ID3D12VideoDevice3_Vtbl {
 }
 #[cfg(all(feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
 impl windows_core::RuntimeName for ID3D12VideoDevice3 {}
-#[cfg(all(feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
-unsafe impl Send for ID3D12VideoDevice3 {}
-#[cfg(all(feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
-unsafe impl Sync for ID3D12VideoDevice3 {}
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
 windows_core::imp::define_interface!(ID3D12VideoEncodeCommandList, ID3D12VideoEncodeCommandList_Vtbl, 0x8455293a_0cbd_4831_9b39_fbdbab724723);
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
@@ -11178,6 +11170,10 @@ pub struct ID3D12VideoEncodeCommandList_Vtbl {
     pub WriteBufferImmediate: unsafe extern "system" fn(*mut core::ffi::c_void, u32, *const super::super::Graphics::Direct3D12::D3D12_WRITEBUFFERIMMEDIATE_PARAMETER, *const super::super::Graphics::Direct3D12::D3D12_WRITEBUFFERIMMEDIATE_MODE),
     pub SetProtectedResourceSession: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void),
 }
+#[cfg(feature = "Win32_Graphics_Direct3D12")]
+unsafe impl Send for ID3D12VideoEncodeCommandList {}
+#[cfg(feature = "Win32_Graphics_Direct3D12")]
+unsafe impl Sync for ID3D12VideoEncodeCommandList {}
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
 pub trait ID3D12VideoEncodeCommandList_Impl: super::super::Graphics::Direct3D12::ID3D12CommandList_Impl {
     fn Close(&self) -> windows_core::Result<()>;
@@ -11323,10 +11319,6 @@ impl ID3D12VideoEncodeCommandList_Vtbl {
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
 impl windows_core::RuntimeName for ID3D12VideoEncodeCommandList {}
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
-unsafe impl Send for ID3D12VideoEncodeCommandList {}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-unsafe impl Sync for ID3D12VideoEncodeCommandList {}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
 windows_core::imp::define_interface!(ID3D12VideoEncodeCommandList1, ID3D12VideoEncodeCommandList1_Vtbl, 0x94971eca_2bdb_4769_88cf_3675ea757ebc);
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
 impl core::ops::Deref for ID3D12VideoEncodeCommandList1 {
@@ -11360,6 +11352,10 @@ pub struct ID3D12VideoEncodeCommandList1_Vtbl {
     pub ExecuteExtensionCommand: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *const core::ffi::c_void, usize),
 }
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
+unsafe impl Send for ID3D12VideoEncodeCommandList1 {}
+#[cfg(feature = "Win32_Graphics_Direct3D12")]
+unsafe impl Sync for ID3D12VideoEncodeCommandList1 {}
+#[cfg(feature = "Win32_Graphics_Direct3D12")]
 pub trait ID3D12VideoEncodeCommandList1_Impl: ID3D12VideoEncodeCommandList_Impl {
     fn InitializeExtensionCommand(&self, pextensioncommand: windows_core::Ref<ID3D12VideoExtensionCommand>, pinitializationparameters: *const core::ffi::c_void, initializationparameterssizeinbytes: usize);
     fn ExecuteExtensionCommand(&self, pextensioncommand: windows_core::Ref<ID3D12VideoExtensionCommand>, pexecutionparameters: *const core::ffi::c_void, executionparameterssizeinbytes: usize);
@@ -11391,10 +11387,6 @@ impl ID3D12VideoEncodeCommandList1_Vtbl {
 }
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
 impl windows_core::RuntimeName for ID3D12VideoEncodeCommandList1 {}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-unsafe impl Send for ID3D12VideoEncodeCommandList1 {}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-unsafe impl Sync for ID3D12VideoEncodeCommandList1 {}
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
 windows_core::imp::define_interface!(ID3D12VideoEncodeCommandList2, ID3D12VideoEncodeCommandList2_Vtbl, 0x895491e2_e701_46a9_9a1f_8d3480ed867a);
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
@@ -11434,6 +11426,10 @@ pub struct ID3D12VideoEncodeCommandList2_Vtbl {
     #[cfg(not(feature = "Win32_Graphics_Dxgi_Common"))]
     ResolveEncoderOutputMetadata: usize,
 }
+#[cfg(feature = "Win32_Graphics_Direct3D12")]
+unsafe impl Send for ID3D12VideoEncodeCommandList2 {}
+#[cfg(feature = "Win32_Graphics_Direct3D12")]
+unsafe impl Sync for ID3D12VideoEncodeCommandList2 {}
 #[cfg(all(feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait ID3D12VideoEncodeCommandList2_Impl: ID3D12VideoEncodeCommandList1_Impl {
     fn EncodeFrame(&self, pencoder: windows_core::Ref<ID3D12VideoEncoder>, pheap: windows_core::Ref<ID3D12VideoEncoderHeap>, pinputarguments: *const D3D12_VIDEO_ENCODER_ENCODEFRAME_INPUT_ARGUMENTS, poutputarguments: *const D3D12_VIDEO_ENCODER_ENCODEFRAME_OUTPUT_ARGUMENTS);
@@ -11466,10 +11462,6 @@ impl ID3D12VideoEncodeCommandList2_Vtbl {
 }
 #[cfg(all(feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
 impl windows_core::RuntimeName for ID3D12VideoEncodeCommandList2 {}
-#[cfg(all(feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
-unsafe impl Send for ID3D12VideoEncodeCommandList2 {}
-#[cfg(all(feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
-unsafe impl Sync for ID3D12VideoEncodeCommandList2 {}
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
 windows_core::imp::define_interface!(ID3D12VideoEncodeCommandList3, ID3D12VideoEncodeCommandList3_Vtbl, 0x7f027b22_1515_4e85_aa0d_026486580576);
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
@@ -11493,6 +11485,10 @@ pub struct ID3D12VideoEncodeCommandList3_Vtbl {
     pub base__: ID3D12VideoEncodeCommandList2_Vtbl,
     pub Barrier: unsafe extern "system" fn(*mut core::ffi::c_void, u32, *const super::super::Graphics::Direct3D12::D3D12_BARRIER_GROUP),
 }
+#[cfg(feature = "Win32_Graphics_Direct3D12")]
+unsafe impl Send for ID3D12VideoEncodeCommandList3 {}
+#[cfg(feature = "Win32_Graphics_Direct3D12")]
+unsafe impl Sync for ID3D12VideoEncodeCommandList3 {}
 #[cfg(all(feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait ID3D12VideoEncodeCommandList3_Impl: ID3D12VideoEncodeCommandList2_Impl {
     fn Barrier(&self, numbarriergroups: u32, pbarriergroups: *const super::super::Graphics::Direct3D12::D3D12_BARRIER_GROUP);
@@ -11514,10 +11510,6 @@ impl ID3D12VideoEncodeCommandList3_Vtbl {
 }
 #[cfg(all(feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
 impl windows_core::RuntimeName for ID3D12VideoEncodeCommandList3 {}
-#[cfg(all(feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
-unsafe impl Send for ID3D12VideoEncodeCommandList3 {}
-#[cfg(all(feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
-unsafe impl Sync for ID3D12VideoEncodeCommandList3 {}
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
 windows_core::imp::define_interface!(ID3D12VideoEncoder, ID3D12VideoEncoder_Vtbl, 0x2e0d212d_8df9_44a6_a770_bb289b182737);
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
@@ -11569,6 +11561,10 @@ pub struct ID3D12VideoEncoder_Vtbl {
     GetInputFormat: usize,
     pub GetMaxMotionEstimationPrecision: unsafe extern "system" fn(*mut core::ffi::c_void) -> D3D12_VIDEO_ENCODER_MOTION_ESTIMATION_PRECISION_MODE,
 }
+#[cfg(feature = "Win32_Graphics_Direct3D12")]
+unsafe impl Send for ID3D12VideoEncoder {}
+#[cfg(feature = "Win32_Graphics_Direct3D12")]
+unsafe impl Sync for ID3D12VideoEncoder {}
 #[cfg(all(feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait ID3D12VideoEncoder_Impl: super::super::Graphics::Direct3D12::ID3D12Pageable_Impl {
     fn GetNodeMask(&self) -> u32;
@@ -11641,10 +11637,6 @@ impl ID3D12VideoEncoder_Vtbl {
 }
 #[cfg(all(feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
 impl windows_core::RuntimeName for ID3D12VideoEncoder {}
-#[cfg(all(feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
-unsafe impl Send for ID3D12VideoEncoder {}
-#[cfg(all(feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
-unsafe impl Sync for ID3D12VideoEncoder {}
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
 windows_core::imp::define_interface!(ID3D12VideoEncoderHeap, ID3D12VideoEncoderHeap_Vtbl, 0x22b35d96_876a_44c0_b25e_fb8c9c7f1c4a);
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
@@ -11692,6 +11684,10 @@ pub struct ID3D12VideoEncoderHeap_Vtbl {
     pub GetResolutionListCount: unsafe extern "system" fn(*mut core::ffi::c_void) -> u32,
     pub GetResolutionList: unsafe extern "system" fn(*mut core::ffi::c_void, u32, *mut D3D12_VIDEO_ENCODER_PICTURE_RESOLUTION_DESC) -> windows_core::HRESULT,
 }
+#[cfg(feature = "Win32_Graphics_Direct3D12")]
+unsafe impl Send for ID3D12VideoEncoderHeap {}
+#[cfg(feature = "Win32_Graphics_Direct3D12")]
+unsafe impl Sync for ID3D12VideoEncoderHeap {}
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
 pub trait ID3D12VideoEncoderHeap_Impl: super::super::Graphics::Direct3D12::ID3D12Pageable_Impl {
     fn GetNodeMask(&self) -> u32;
@@ -11765,10 +11761,6 @@ impl ID3D12VideoEncoderHeap_Vtbl {
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
 impl windows_core::RuntimeName for ID3D12VideoEncoderHeap {}
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
-unsafe impl Send for ID3D12VideoEncoderHeap {}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-unsafe impl Sync for ID3D12VideoEncoderHeap {}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
 windows_core::imp::define_interface!(ID3D12VideoExtensionCommand, ID3D12VideoExtensionCommand_Vtbl, 0x554e41e8_ae8e_4a8c_b7d2_5b4f274a30e4);
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
 impl core::ops::Deref for ID3D12VideoExtensionCommand {
@@ -11803,6 +11795,10 @@ pub struct ID3D12VideoExtensionCommand_Vtbl {
     pub GetProtectedResourceSession: unsafe extern "system" fn(*mut core::ffi::c_void, *const windows_core::GUID, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
+unsafe impl Send for ID3D12VideoExtensionCommand {}
+#[cfg(feature = "Win32_Graphics_Direct3D12")]
+unsafe impl Sync for ID3D12VideoExtensionCommand {}
+#[cfg(feature = "Win32_Graphics_Direct3D12")]
 pub trait ID3D12VideoExtensionCommand_Impl: super::super::Graphics::Direct3D12::ID3D12Pageable_Impl {
     fn GetDesc(&self) -> D3D12_VIDEO_EXTENSION_COMMAND_DESC;
     fn GetProtectedResourceSession(&self, riid: *const windows_core::GUID, ppprotectedsession: *mut *mut core::ffi::c_void) -> windows_core::Result<()>;
@@ -11834,10 +11830,6 @@ impl ID3D12VideoExtensionCommand_Vtbl {
 }
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
 impl windows_core::RuntimeName for ID3D12VideoExtensionCommand {}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-unsafe impl Send for ID3D12VideoExtensionCommand {}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-unsafe impl Sync for ID3D12VideoExtensionCommand {}
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
 windows_core::imp::define_interface!(ID3D12VideoMotionEstimator, ID3D12VideoMotionEstimator_Vtbl, 0x33fdae0e_098b_428f_87bb_34b695de08f8);
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
@@ -11876,6 +11868,10 @@ pub struct ID3D12VideoMotionEstimator_Vtbl {
     GetDesc: usize,
     pub GetProtectedResourceSession: unsafe extern "system" fn(*mut core::ffi::c_void, *const windows_core::GUID, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
+#[cfg(feature = "Win32_Graphics_Direct3D12")]
+unsafe impl Send for ID3D12VideoMotionEstimator {}
+#[cfg(feature = "Win32_Graphics_Direct3D12")]
+unsafe impl Sync for ID3D12VideoMotionEstimator {}
 #[cfg(all(feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait ID3D12VideoMotionEstimator_Impl: super::super::Graphics::Direct3D12::ID3D12Pageable_Impl {
     fn GetDesc(&self) -> D3D12_VIDEO_MOTION_ESTIMATOR_DESC;
@@ -11908,10 +11904,6 @@ impl ID3D12VideoMotionEstimator_Vtbl {
 }
 #[cfg(all(feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
 impl windows_core::RuntimeName for ID3D12VideoMotionEstimator {}
-#[cfg(all(feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
-unsafe impl Send for ID3D12VideoMotionEstimator {}
-#[cfg(all(feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
-unsafe impl Sync for ID3D12VideoMotionEstimator {}
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
 windows_core::imp::define_interface!(ID3D12VideoMotionVectorHeap, ID3D12VideoMotionVectorHeap_Vtbl, 0x5be17987_743a_4061_834b_23d22daea505);
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
@@ -11950,6 +11942,10 @@ pub struct ID3D12VideoMotionVectorHeap_Vtbl {
     GetDesc: usize,
     pub GetProtectedResourceSession: unsafe extern "system" fn(*mut core::ffi::c_void, *const windows_core::GUID, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
+#[cfg(feature = "Win32_Graphics_Direct3D12")]
+unsafe impl Send for ID3D12VideoMotionVectorHeap {}
+#[cfg(feature = "Win32_Graphics_Direct3D12")]
+unsafe impl Sync for ID3D12VideoMotionVectorHeap {}
 #[cfg(all(feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait ID3D12VideoMotionVectorHeap_Impl: super::super::Graphics::Direct3D12::ID3D12Pageable_Impl {
     fn GetDesc(&self) -> D3D12_VIDEO_MOTION_VECTOR_HEAP_DESC;
@@ -11982,10 +11978,6 @@ impl ID3D12VideoMotionVectorHeap_Vtbl {
 }
 #[cfg(all(feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
 impl windows_core::RuntimeName for ID3D12VideoMotionVectorHeap {}
-#[cfg(all(feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
-unsafe impl Send for ID3D12VideoMotionVectorHeap {}
-#[cfg(all(feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
-unsafe impl Sync for ID3D12VideoMotionVectorHeap {}
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
 windows_core::imp::define_interface!(ID3D12VideoProcessCommandList, ID3D12VideoProcessCommandList_Vtbl, 0xaeb2543a_167f_4682_acc8_d159ed4a6209);
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
@@ -12083,6 +12075,10 @@ pub struct ID3D12VideoProcessCommandList_Vtbl {
     pub ProcessFrames: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *const D3D12_VIDEO_PROCESS_OUTPUT_STREAM_ARGUMENTS, u32, *const D3D12_VIDEO_PROCESS_INPUT_STREAM_ARGUMENTS),
     pub WriteBufferImmediate: unsafe extern "system" fn(*mut core::ffi::c_void, u32, *const super::super::Graphics::Direct3D12::D3D12_WRITEBUFFERIMMEDIATE_PARAMETER, *const super::super::Graphics::Direct3D12::D3D12_WRITEBUFFERIMMEDIATE_MODE),
 }
+#[cfg(feature = "Win32_Graphics_Direct3D12")]
+unsafe impl Send for ID3D12VideoProcessCommandList {}
+#[cfg(feature = "Win32_Graphics_Direct3D12")]
+unsafe impl Sync for ID3D12VideoProcessCommandList {}
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
 pub trait ID3D12VideoProcessCommandList_Impl: super::super::Graphics::Direct3D12::ID3D12CommandList_Impl {
     fn Close(&self) -> windows_core::Result<()>;
@@ -12212,10 +12208,6 @@ impl ID3D12VideoProcessCommandList_Vtbl {
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
 impl windows_core::RuntimeName for ID3D12VideoProcessCommandList {}
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
-unsafe impl Send for ID3D12VideoProcessCommandList {}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-unsafe impl Sync for ID3D12VideoProcessCommandList {}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
 windows_core::imp::define_interface!(ID3D12VideoProcessCommandList1, ID3D12VideoProcessCommandList1_Vtbl, 0x542c5c4d_7596_434f_8c93_4efa6766f267);
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
 impl core::ops::Deref for ID3D12VideoProcessCommandList1 {
@@ -12242,6 +12234,10 @@ pub struct ID3D12VideoProcessCommandList1_Vtbl {
     pub ProcessFrames1: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *const D3D12_VIDEO_PROCESS_OUTPUT_STREAM_ARGUMENTS, u32, *const D3D12_VIDEO_PROCESS_INPUT_STREAM_ARGUMENTS1),
 }
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
+unsafe impl Send for ID3D12VideoProcessCommandList1 {}
+#[cfg(feature = "Win32_Graphics_Direct3D12")]
+unsafe impl Sync for ID3D12VideoProcessCommandList1 {}
+#[cfg(feature = "Win32_Graphics_Direct3D12")]
 pub trait ID3D12VideoProcessCommandList1_Impl: ID3D12VideoProcessCommandList_Impl {
     fn ProcessFrames1(&self, pvideoprocessor: windows_core::Ref<ID3D12VideoProcessor>, poutputarguments: *const D3D12_VIDEO_PROCESS_OUTPUT_STREAM_ARGUMENTS, numinputstreams: u32, pinputarguments: *const D3D12_VIDEO_PROCESS_INPUT_STREAM_ARGUMENTS1);
 }
@@ -12262,10 +12258,6 @@ impl ID3D12VideoProcessCommandList1_Vtbl {
 }
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
 impl windows_core::RuntimeName for ID3D12VideoProcessCommandList1 {}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-unsafe impl Send for ID3D12VideoProcessCommandList1 {}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-unsafe impl Sync for ID3D12VideoProcessCommandList1 {}
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
 windows_core::imp::define_interface!(ID3D12VideoProcessCommandList2, ID3D12VideoProcessCommandList2_Vtbl, 0xdb525ae4_6ad6_473c_baa7_59b2e37082e4);
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
@@ -12307,6 +12299,10 @@ pub struct ID3D12VideoProcessCommandList2_Vtbl {
     pub ExecuteExtensionCommand: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *const core::ffi::c_void, usize),
 }
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
+unsafe impl Send for ID3D12VideoProcessCommandList2 {}
+#[cfg(feature = "Win32_Graphics_Direct3D12")]
+unsafe impl Sync for ID3D12VideoProcessCommandList2 {}
+#[cfg(feature = "Win32_Graphics_Direct3D12")]
 pub trait ID3D12VideoProcessCommandList2_Impl: ID3D12VideoProcessCommandList1_Impl {
     fn SetProtectedResourceSession(&self, pprotectedresourcesession: windows_core::Ref<super::super::Graphics::Direct3D12::ID3D12ProtectedResourceSession>);
     fn InitializeExtensionCommand(&self, pextensioncommand: windows_core::Ref<ID3D12VideoExtensionCommand>, pinitializationparameters: *const core::ffi::c_void, initializationparameterssizeinbytes: usize);
@@ -12347,10 +12343,6 @@ impl ID3D12VideoProcessCommandList2_Vtbl {
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
 impl windows_core::RuntimeName for ID3D12VideoProcessCommandList2 {}
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
-unsafe impl Send for ID3D12VideoProcessCommandList2 {}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-unsafe impl Sync for ID3D12VideoProcessCommandList2 {}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
 windows_core::imp::define_interface!(ID3D12VideoProcessCommandList3, ID3D12VideoProcessCommandList3_Vtbl, 0x1a0a4ca4_9f08_40ce_9558_b411fd2666ff);
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
 impl core::ops::Deref for ID3D12VideoProcessCommandList3 {
@@ -12374,6 +12366,10 @@ pub struct ID3D12VideoProcessCommandList3_Vtbl {
     pub Barrier: unsafe extern "system" fn(*mut core::ffi::c_void, u32, *const super::super::Graphics::Direct3D12::D3D12_BARRIER_GROUP),
 }
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
+unsafe impl Send for ID3D12VideoProcessCommandList3 {}
+#[cfg(feature = "Win32_Graphics_Direct3D12")]
+unsafe impl Sync for ID3D12VideoProcessCommandList3 {}
+#[cfg(feature = "Win32_Graphics_Direct3D12")]
 pub trait ID3D12VideoProcessCommandList3_Impl: ID3D12VideoProcessCommandList2_Impl {
     fn Barrier(&self, numbarriergroups: u32, pbarriergroups: *const super::super::Graphics::Direct3D12::D3D12_BARRIER_GROUP);
 }
@@ -12394,10 +12390,6 @@ impl ID3D12VideoProcessCommandList3_Vtbl {
 }
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
 impl windows_core::RuntimeName for ID3D12VideoProcessCommandList3 {}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-unsafe impl Send for ID3D12VideoProcessCommandList3 {}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-unsafe impl Sync for ID3D12VideoProcessCommandList3 {}
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
 windows_core::imp::define_interface!(ID3D12VideoProcessor, ID3D12VideoProcessor_Vtbl, 0x304fdb32_bede_410a_8545_943ac6a46138);
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
@@ -12445,6 +12437,10 @@ pub struct ID3D12VideoProcessor_Vtbl {
     #[cfg(not(feature = "Win32_Graphics_Dxgi_Common"))]
     GetOutputStreamDesc: usize,
 }
+#[cfg(feature = "Win32_Graphics_Direct3D12")]
+unsafe impl Send for ID3D12VideoProcessor {}
+#[cfg(feature = "Win32_Graphics_Direct3D12")]
+unsafe impl Sync for ID3D12VideoProcessor {}
 #[cfg(all(feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait ID3D12VideoProcessor_Impl: super::super::Graphics::Direct3D12::ID3D12Pageable_Impl {
     fn GetNodeMask(&self) -> u32;
@@ -12493,10 +12489,6 @@ impl ID3D12VideoProcessor_Vtbl {
 }
 #[cfg(all(feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
 impl windows_core::RuntimeName for ID3D12VideoProcessor {}
-#[cfg(all(feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
-unsafe impl Send for ID3D12VideoProcessor {}
-#[cfg(all(feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
-unsafe impl Sync for ID3D12VideoProcessor {}
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
 windows_core::imp::define_interface!(ID3D12VideoProcessor1, ID3D12VideoProcessor1_Vtbl, 0xf3cfe615_553f_425c_86d8_ee8c1b1fb01c);
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
@@ -12523,6 +12515,10 @@ pub struct ID3D12VideoProcessor1_Vtbl {
     pub base__: ID3D12VideoProcessor_Vtbl,
     pub GetProtectedResourceSession: unsafe extern "system" fn(*mut core::ffi::c_void, *const windows_core::GUID, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
+#[cfg(feature = "Win32_Graphics_Direct3D12")]
+unsafe impl Send for ID3D12VideoProcessor1 {}
+#[cfg(feature = "Win32_Graphics_Direct3D12")]
+unsafe impl Sync for ID3D12VideoProcessor1 {}
 #[cfg(all(feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait ID3D12VideoProcessor1_Impl: ID3D12VideoProcessor_Impl {
     fn GetProtectedResourceSession(&self, riid: *const windows_core::GUID, ppprotectedsession: *mut *mut core::ffi::c_void) -> windows_core::Result<()>;
@@ -12544,10 +12540,6 @@ impl ID3D12VideoProcessor1_Vtbl {
 }
 #[cfg(all(feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
 impl windows_core::RuntimeName for ID3D12VideoProcessor1 {}
-#[cfg(all(feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
-unsafe impl Send for ID3D12VideoProcessor1 {}
-#[cfg(all(feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
-unsafe impl Sync for ID3D12VideoProcessor1 {}
 windows_core::imp::define_interface!(IDXVAHD_Device, IDXVAHD_Device_Vtbl, 0x95f12dfd_d77e_49be_815f_57d579634d6d);
 windows_core::imp::interface_hierarchy!(IDXVAHD_Device, windows_core::IUnknown);
 impl IDXVAHD_Device {

--- a/crates/libs/windows/src/Windows/Win32/System/WinRT/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WinRT/mod.rs
@@ -2007,6 +2007,8 @@ pub struct IRestrictedErrorInfo_Vtbl {
     pub GetErrorDetails: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void, *mut windows_core::HRESULT, *mut *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
     pub GetReference: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
+unsafe impl Send for IRestrictedErrorInfo {}
+unsafe impl Sync for IRestrictedErrorInfo {}
 pub trait IRestrictedErrorInfo_Impl: windows_core::IUnknownImpl {
     fn GetErrorDetails(&self, description: *mut windows_core::BSTR, error: *mut windows_core::HRESULT, restricteddescription: *mut windows_core::BSTR, capabilitysid: *mut windows_core::BSTR) -> windows_core::Result<()>;
     fn GetReference(&self) -> windows_core::Result<windows_core::BSTR>;
@@ -2042,8 +2044,6 @@ impl IRestrictedErrorInfo_Vtbl {
     }
 }
 impl windows_core::RuntimeName for IRestrictedErrorInfo {}
-unsafe impl Send for IRestrictedErrorInfo {}
-unsafe impl Sync for IRestrictedErrorInfo {}
 windows_core::imp::define_interface!(IShareWindowCommandEventArgsInterop, IShareWindowCommandEventArgsInterop_Vtbl, 0x6571a721_643d_43d4_aca4_6b6f5f30f1ad);
 windows_core::imp::interface_hierarchy!(IShareWindowCommandEventArgsInterop, windows_core::IUnknown);
 impl IShareWindowCommandEventArgsInterop {

--- a/crates/tests/bindgen/src/interface_cpp_return_udt.rs
+++ b/crates/tests/bindgen/src/interface_cpp_return_udt.rs
@@ -66,6 +66,8 @@ pub struct ID2D1Bitmap_Vtbl {
     CopyFromRenderTarget: usize,
     CopyFromMemory: usize,
 }
+unsafe impl Send for ID2D1Bitmap {}
+unsafe impl Sync for ID2D1Bitmap {}
 pub trait ID2D1Bitmap_Impl: ID2D1Image_Impl {
     fn GetSize(&self) -> D2D_SIZE_F;
     fn GetDpi(&self, dpix: *mut f32, dpiy: *mut f32);
@@ -115,8 +117,6 @@ impl ID2D1Bitmap_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID2D1Bitmap {}
-unsafe impl Send for ID2D1Bitmap {}
-unsafe impl Sync for ID2D1Bitmap {}
 windows_core::imp::define_interface!(
     ID2D1Image,
     ID2D1Image_Vtbl,
@@ -133,6 +133,8 @@ windows_core::imp::interface_hierarchy!(ID2D1Image, windows_core::IUnknown, ID2D
 pub struct ID2D1Image_Vtbl {
     pub base__: ID2D1Resource_Vtbl,
 }
+unsafe impl Send for ID2D1Image {}
+unsafe impl Sync for ID2D1Image {}
 pub trait ID2D1Image_Impl: ID2D1Resource_Impl {}
 impl ID2D1Image_Vtbl {
     pub const fn new<Identity: ID2D1Image_Impl, const OFFSET: isize>() -> Self {
@@ -146,8 +148,6 @@ impl ID2D1Image_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID2D1Image {}
-unsafe impl Send for ID2D1Image {}
-unsafe impl Sync for ID2D1Image {}
 windows_core::imp::define_interface!(
     ID2D1Resource,
     ID2D1Resource_Vtbl,
@@ -159,6 +159,8 @@ pub struct ID2D1Resource_Vtbl {
     pub base__: windows_core::IUnknown_Vtbl,
     GetFactory: usize,
 }
+unsafe impl Send for ID2D1Resource {}
+unsafe impl Sync for ID2D1Resource {}
 pub trait ID2D1Resource_Impl: windows_core::IUnknownImpl {}
 impl ID2D1Resource_Vtbl {
     pub const fn new<Identity: ID2D1Resource_Impl, const OFFSET: isize>() -> Self {
@@ -172,5 +174,3 @@ impl ID2D1Resource_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID2D1Resource {}
-unsafe impl Send for ID2D1Resource {}
-unsafe impl Sync for ID2D1Resource {}

--- a/crates/tests/bindgen/src/struct_with_cpp_interface.rs
+++ b/crates/tests/bindgen/src/struct_with_cpp_interface.rs
@@ -52,6 +52,8 @@ pub struct ID3D12DeviceChild_Vtbl {
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID3D12DeviceChild {}
+unsafe impl Sync for ID3D12DeviceChild {}
 pub trait ID3D12DeviceChild_Impl: ID3D12Object_Impl {
     fn GetDevice(
         &self,
@@ -91,8 +93,6 @@ impl ID3D12DeviceChild_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D12DeviceChild {}
-unsafe impl Send for ID3D12DeviceChild {}
-unsafe impl Sync for ID3D12DeviceChild {}
 windows_core::imp::define_interface!(
     ID3D12Object,
     ID3D12Object_Vtbl,
@@ -187,6 +187,8 @@ pub struct ID3D12Object_Vtbl {
         windows_core::PCWSTR,
     ) -> windows_core::HRESULT,
 }
+unsafe impl Send for ID3D12Object {}
+unsafe impl Sync for ID3D12Object {}
 pub trait ID3D12Object_Impl: windows_core::IUnknownImpl {
     fn GetPrivateData(
         &self,
@@ -293,8 +295,6 @@ impl ID3D12Object_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D12Object {}
-unsafe impl Send for ID3D12Object {}
-unsafe impl Sync for ID3D12Object {}
 windows_core::imp::define_interface!(
     ID3D12Pageable,
     ID3D12Pageable_Vtbl,
@@ -316,6 +316,8 @@ windows_core::imp::interface_hierarchy!(
 pub struct ID3D12Pageable_Vtbl {
     pub base__: ID3D12DeviceChild_Vtbl,
 }
+unsafe impl Send for ID3D12Pageable {}
+unsafe impl Sync for ID3D12Pageable {}
 pub trait ID3D12Pageable_Impl: ID3D12DeviceChild_Impl {}
 impl ID3D12Pageable_Vtbl {
     pub const fn new<Identity: ID3D12Pageable_Impl, const OFFSET: isize>() -> Self {
@@ -330,8 +332,6 @@ impl ID3D12Pageable_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D12Pageable {}
-unsafe impl Send for ID3D12Pageable {}
-unsafe impl Sync for ID3D12Pageable {}
 windows_core::imp::define_interface!(
     ID3D12Resource,
     ID3D12Resource_Vtbl,
@@ -370,6 +370,8 @@ pub struct ID3D12Resource_Vtbl {
     ReadFromSubresource: usize,
     GetHeapProperties: usize,
 }
+unsafe impl Send for ID3D12Resource {}
+unsafe impl Sync for ID3D12Resource {}
 pub trait ID3D12Resource_Impl: ID3D12Pageable_Impl {
     fn GetGPUVirtualAddress(&self) -> u64;
 }
@@ -406,5 +408,3 @@ impl ID3D12Resource_Vtbl {
     }
 }
 impl windows_core::RuntimeName for ID3D12Resource {}
-unsafe impl Send for ID3D12Resource {}
-unsafe impl Sync for ID3D12Resource {}


### PR DESCRIPTION
The `cfg` attribute used for implementations of the interface was being applied to the `Send` and `Sync` implementations rather than the type `cfg` attribute, requiring additional crate features to "unlock" the `Send` and `Sync` implementations. 

Fixes: #3436