### PR TITLE
Remap the Win32 definition of `EventRegistrationToken`

### DIFF
--- a/crates/libs/bindgen/src/type_name.rs
+++ b/crates/libs/bindgen/src/type_name.rs
@@ -25,6 +25,8 @@ impl TypeName {
 
     pub const HResult: Self = Self("Windows.Foundation", "HResult");
     pub const EventRegistrationToken: Self = Self("Windows.Foundation", "EventRegistrationToken");
+    pub const EventRegistrationToken2: Self =
+        Self("Windows.Win32.System.WinRT", "EventRegistrationToken");
 
     pub const IAsyncAction: Self = Self("Windows.Foundation", "IAsyncAction");
     pub const IAsyncActionWithProgress: Self =

--- a/crates/libs/bindgen/src/types/mod.rs
+++ b/crates/libs/bindgen/src/types/mod.rs
@@ -172,6 +172,7 @@ impl Type {
             TypeName::IUnknown => Remap::Type(Self::IUnknown),
             TypeName::Type => Remap::Type(Self::Type),
             TypeName::EventRegistrationToken => Remap::Type(Type::I64),
+            TypeName::EventRegistrationToken2 => Remap::Type(Type::I64),
 
             TypeName::D2D_MATRIX_3X2_F => Remap::Name(TypeName::Matrix3x2),
             TypeName::D3DMATRIX => Remap::Name(TypeName::Matrix4x4),

--- a/crates/libs/windows/src/Windows/Win32/System/WinRT/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WinRT/mod.rs
@@ -560,16 +560,6 @@ impl Default for DispatcherQueueOptions {
         unsafe { core::mem::zeroed() }
     }
 }
-#[repr(C)]
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub struct EventRegistrationToken {
-    pub value: i64,
-}
-impl Default for EventRegistrationToken {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
 pub const FullTrust: TrustLevel = TrustLevel(2i32);
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]


### PR DESCRIPTION
Building on #3382, the Win32 metadata should not be defining its own version of `EventRegistrationToken` but there it is. Hopefully we can [clean up the metadata](https://github.com/microsoft/win32metadata/issues/2046) at some point. This at least ensures that windows-rs doesn't have two competing definitions for the same thing. 

Previously in #3382, the original WinRT version of this type was remapped to `i64`. This update just ensures that both definitions are remapped consistently avoid an unnecessary type dependency. 