### PR TITLE
Remove workaround for invalid metadata

### DIFF
--- a/crates/libs/bindgen/src/types/cpp_method.rs
+++ b/crates/libs/bindgen/src/types/cpp_method.rs
@@ -103,14 +103,6 @@ impl CppMethod {
                         param_hints[position] = ParamHint::None;
                     }
                 }
-                ParamHint::ArrayFixed(_) => {
-                    if signature.params[position]
-                        .def
-                        .has_attribute("FreeWithAttribute")
-                    {
-                        param_hints[position] = ParamHint::None;
-                    }
-                }
                 _ => {}
             }
         }


### PR DESCRIPTION
Recent updates to the Win32 metadata have addressed this bug. 