### PR TITLE
Simplify dependency tracking

### DIFF
--- a/crates/libs/bindgen/src/signature.rs
+++ b/crates/libs/bindgen/src/signature.rs
@@ -14,10 +14,6 @@ impl Signature {
             .fold(0, |sum, param| sum + std::cmp::max(4, param.size()))
     }
 
-    pub fn dependencies(&self, dependencies: &mut TypeMap) {
-        self.types().for_each(|ty| ty.dependencies(dependencies));
-    }
-
     pub fn types(&self) -> impl Iterator<Item = &Type> + '_ {
         std::iter::once(&self.return_type)
             .chain(self.params.iter().map(|param| &param.ty))
@@ -42,5 +38,11 @@ impl Signature {
         }
 
         false
+    }
+}
+
+impl Dependencies for Signature {
+    fn combine(&self, dependencies: &mut TypeMap) {
+        self.types().for_each(|ty| ty.combine(dependencies));
     }
 }

--- a/crates/libs/bindgen/src/tables/method_def.rs
+++ b/crates/libs/bindgen/src/tables/method_def.rs
@@ -16,7 +16,7 @@ impl MethodDef {
     }
 
     pub fn import_name(&self) -> Option<&'static str> {
-        self.impl_map().map_or(None, |map| {
+        self.impl_map().and_then(|map| {
             let import_name = map.import_name();
             if self.name() != import_name {
                 Some(import_name)

--- a/crates/libs/bindgen/src/tables/method_def.rs
+++ b/crates/libs/bindgen/src/tables/method_def.rs
@@ -15,6 +15,17 @@ impl MethodDef {
         self.str(3)
     }
 
+    pub fn import_name(&self) -> Option<&'static str> {
+        self.impl_map().map_or(None, |map| {
+            let import_name = map.import_name();
+            if self.name() != import_name {
+                Some(import_name)
+            } else {
+                None
+            }
+        })
+    }
+
     pub fn params(&self) -> RowIterator<MethodParam> {
         self.list(5)
     }
@@ -27,6 +38,20 @@ impl MethodDef {
 
     pub fn module_name(&self) -> &'static str {
         self.impl_map().map_or("", |map| map.scope().name())
+    }
+
+    pub fn calling_convention(&self) -> &'static str {
+        self.impl_map().map_or("", |map| {
+            let flags = map.flags();
+
+            if flags.contains(PInvokeAttributes::CallConvPlatformapi) {
+                "system"
+            } else if flags.contains(PInvokeAttributes::CallConvCdecl) {
+                "cdecl"
+            } else {
+                ""
+            }
+        })
     }
 
     #[track_caller]

--- a/crates/libs/bindgen/src/type_map.rs
+++ b/crates/libs/bindgen/src/type_map.rs
@@ -3,6 +3,16 @@ use super::*;
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct TypeMap(HashMap<TypeName, HashSet<Type>>);
 
+pub trait Dependencies {
+    fn combine(&self, dependencies: &mut TypeMap);
+
+    fn dependencies(&self) -> TypeMap {
+        let mut dependencies = TypeMap::new();
+        self.combine(&mut dependencies);
+        dependencies
+    }
+}
+
 impl std::ops::Deref for TypeMap {
     type Target = HashMap<TypeName, HashSet<Type>>;
 
@@ -27,7 +37,7 @@ impl TypeMap {
                         let mut item_dependencies = Self::new();
 
                         for ty in types {
-                            ty.dependencies(&mut item_dependencies);
+                            ty.combine(&mut item_dependencies);
                         }
 
                         if item_dependencies.excluded(filter) {

--- a/crates/libs/bindgen/src/types/class.rs
+++ b/crates/libs/bindgen/src/types/class.rs
@@ -81,7 +81,7 @@ impl Class {
             }
         );
 
-        let factories = required_interfaces.                 iter().filter_map(|interface| match interface.kind {
+        let factories = required_interfaces.iter().filter_map(|interface| match interface.kind {
             InterfaceKind::Static | InterfaceKind::Composable => {
                 if interface.def.methods().next().is_none() {
                     None

--- a/crates/libs/bindgen/src/types/class.rs
+++ b/crates/libs/bindgen/src/types/class.rs
@@ -15,9 +15,7 @@ impl Class {
             return (Cfg::default(), quote! {});
         }
 
-        let mut dependencies = TypeMap::new();
-        self.dependencies(&mut dependencies);
-        let cfg = Cfg::new(self.def, &dependencies);
+        let cfg = Cfg::new(self.def, &self.dependencies());
         let tokens = cfg.write(writer, false);
         (cfg, tokens)
     }
@@ -83,7 +81,7 @@ impl Class {
             }
         );
 
-        let factories = required_interfaces.iter().filter_map(|interface| match interface.kind {
+        let factories = required_interfaces.                 iter().filter_map(|interface| match interface.kind {
             InterfaceKind::Static | InterfaceKind::Composable => {
                 if interface.def.methods().next().is_none() {
                     None
@@ -92,10 +90,7 @@ impl Class {
                         let interface_type = interface.write_name(writer);
 
                         let cfg = if writer.config.package {
-                            let mut dependencies = TypeMap::new();
-                            interface.dependencies(&mut dependencies);
-
-                            class_cfg.difference(interface.def, &dependencies).write(writer, false)
+                            class_cfg.difference(interface.def, &interface.dependencies()).write(writer, false)
                         } else {
                             quote! {}
                         };
@@ -252,12 +247,6 @@ impl Class {
         )
     }
 
-    pub fn dependencies(&self, dependencies: &mut TypeMap) {
-        for interface in self.required_interfaces() {
-            Type::Interface(interface).dependencies(dependencies);
-        }
-    }
-
     fn bases(&self) -> Vec<Self> {
         let mut bases = Vec::new();
         let mut def = self.def;
@@ -354,5 +343,13 @@ impl Class {
                     .iter()
                     .any(|arg| matches!(arg.1, Value::TypeName(_)))
             })
+    }
+}
+
+impl Dependencies for Class {
+    fn combine(&self, dependencies: &mut TypeMap) {
+        for interface in self.required_interfaces() {
+            Type::Interface(interface).combine(dependencies);
+        }
     }
 }

--- a/crates/libs/bindgen/src/types/cpp_const.rs
+++ b/crates/libs/bindgen/src/types/cpp_const.rs
@@ -32,9 +32,7 @@ impl CppConst {
             return quote! {};
         }
 
-        let mut dependencies = TypeMap::new();
-        self.dependencies(&mut dependencies);
-        Cfg::new(self.field, &dependencies).write(writer, false)
+        Cfg::new(self.field, &self.dependencies()).write(writer, false)
     }
 
     pub fn write(&self, writer: &Writer) -> TokenStream {
@@ -137,12 +135,11 @@ impl CppConst {
             panic!()
         }
     }
+}
 
-    pub fn dependencies(&self, dependencies: &mut TypeMap) {
-        self.field
-            .ty(None)
-            .to_const_type()
-            .dependencies(dependencies);
+impl Dependencies for CppConst {
+    fn combine(&self, dependencies: &mut TypeMap) {
+        self.field.ty(None).to_const_type().combine(dependencies);
     }
 }
 

--- a/crates/libs/bindgen/src/types/cpp_delegate.rs
+++ b/crates/libs/bindgen/src/types/cpp_delegate.rs
@@ -38,9 +38,7 @@ impl CppDelegate {
             return quote! {};
         }
 
-        let mut dependencies = TypeMap::new();
-        self.dependencies(&mut dependencies);
-        Cfg::new(self.def, &dependencies).write(writer, false)
+        Cfg::new(self.def, &self.dependencies()).write(writer, false)
     }
 
     pub fn write(&self, writer: &Writer) -> TokenStream {
@@ -65,11 +63,13 @@ impl CppDelegate {
             pub type #name = Option<unsafe extern "system" fn(#params) #return_sig>;
         }
     }
+}
 
-    pub fn dependencies(&self, dependencies: &mut TypeMap) {
+impl Dependencies for CppDelegate {
+    fn combine(&self, dependencies: &mut TypeMap) {
         self.method()
             .signature(self.def.namespace(), &[])
-            .dependencies(dependencies);
+            .combine(dependencies);
     }
 }
 

--- a/crates/libs/bindgen/src/types/cpp_enum.rs
+++ b/crates/libs/bindgen/src/types/cpp_enum.rs
@@ -124,22 +124,24 @@ impl CppEnum {
         }
     }
 
-    pub fn dependencies(&self, dependencies: &mut TypeMap) {
-        if let Some(attribute) = self.def.find_attribute("AlsoUsableForAttribute") {
-            if let Some((_, Value::Str(type_name))) = attribute.args().first() {
-                self.def
-                    .reader()
-                    .unwrap_full_name(self.def.namespace(), type_name)
-                    .dependencies(dependencies);
-            }
-        }
-    }
-
     pub fn size(&self) -> usize {
         self.def.underlying_type().size()
     }
 
     pub fn align(&self) -> usize {
         self.def.underlying_type().align()
+    }
+}
+
+impl Dependencies for CppEnum {
+    fn combine(&self, dependencies: &mut TypeMap) {
+        if let Some(attribute) = self.def.find_attribute("AlsoUsableForAttribute") {
+            if let Some((_, Value::Str(type_name))) = attribute.args().first() {
+                self.def
+                    .reader()
+                    .unwrap_full_name(self.def.namespace(), type_name)
+                    .combine(dependencies);
+            }
+        }
     }
 }

--- a/crates/libs/bindgen/src/types/cpp_method.rs
+++ b/crates/libs/bindgen/src/types/cpp_method.rs
@@ -78,15 +78,12 @@ impl ParamHint {
 impl CppMethod {
     pub fn new(def: MethodDef, namespace: &'static str) -> Self {
         let signature = def.signature(namespace, &[]);
-
+        let dependencies = signature.dependencies();
         let mut param_hints = vec![ParamHint::None; signature.params.len()];
 
         for (position, param) in signature.params.iter().enumerate() {
             param_hints[position] = param.into();
         }
-
-        let mut dependencies = TypeMap::new();
-        signature.dependencies(&mut dependencies);
 
         for position in 0..signature.params.len() {
             // Point len params back to the corresponding ptr params.

--- a/crates/libs/bindgen/src/types/delegate.rs
+++ b/crates/libs/bindgen/src/types/delegate.rs
@@ -16,9 +16,7 @@ impl Delegate {
             return quote! {};
         }
 
-        let mut dependencies = TypeMap::new();
-        self.dependencies(&mut dependencies);
-        Cfg::new(self.def, &dependencies).write(writer, false)
+        Cfg::new(self.def, &self.dependencies()).write(writer, false)
     }
 
     pub fn write(&self, writer: &Writer) -> TokenStream {
@@ -201,15 +199,17 @@ impl Delegate {
         }
     }
 
-    pub fn dependencies(&self, dependencies: &mut TypeMap) {
+    pub fn write_name(&self, writer: &Writer) -> TokenStream {
+        self.type_name().write(writer, &self.generics)
+    }
+}
+
+impl Dependencies for Delegate {
+    fn combine(&self, dependencies: &mut TypeMap) {
         dependencies.combine(&self.method().dependencies);
 
         for ty in &self.generics {
-            ty.dependencies(dependencies);
+            ty.combine(dependencies);
         }
-    }
-
-    pub fn write_name(&self, writer: &Writer) -> TokenStream {
-        self.type_name().write(writer, &self.generics)
     }
 }

--- a/crates/libs/bindgen/src/types/method.rs
+++ b/crates/libs/bindgen/src/types/method.rs
@@ -11,9 +11,7 @@ pub struct Method {
 impl Method {
     pub fn new(def: MethodDef, generics: &[Type]) -> Self {
         let signature = def.signature("", generics);
-
-        let mut dependencies = TypeMap::new();
-        signature.dependencies(&mut dependencies);
+        let dependencies = signature.dependencies();
 
         Self {
             def,

--- a/crates/libs/bindgen/src/types/struct.rs
+++ b/crates/libs/bindgen/src/types/struct.rs
@@ -83,12 +83,6 @@ impl Struct {
         signature
     }
 
-    pub fn dependencies(&self, dependencies: &mut TypeMap) {
-        for field in self.def.fields() {
-            field.ty(None).dependencies(dependencies);
-        }
-    }
-
     pub fn is_copyable(&self) -> bool {
         self.def.fields().all(|field| field.ty(None).is_copyable())
     }
@@ -111,5 +105,13 @@ impl Struct {
             .map(|field| field.ty(None).align())
             .max()
             .unwrap_or(1)
+    }
+}
+
+impl Dependencies for Struct {
+    fn combine(&self, dependencies: &mut TypeMap) {
+        for field in self.def.fields() {
+            field.ty(None).combine(dependencies);
+        }
     }
 }


### PR DESCRIPTION
Collecting and combing dependencies continues to be an important but challenging task. This update introduces the `Dependencies` trait that simplifies this by allowing dependencies to be retrieved with a single simple method call. 