### PR TITLE
Ensure remaining extensions compile with `no_std`

### DIFF
--- a/crates/libs/windows/src/extensions/Win32/Networking.rs
+++ b/crates/libs/windows/src/extensions/Win32/Networking.rs
@@ -1,2 +1,2 @@
-#[cfg(feature = "Win32_Networking_WinSock")]
+#[cfg(all(feature = "std", feature = "Win32_Networking_WinSock"))]
 mod WinSock;

--- a/crates/tests/misc/no_std/Cargo.toml
+++ b/crates/tests/misc/no_std/Cargo.toml
@@ -42,7 +42,13 @@ path = "../../../libs/windows"
 default-features = false
 features = [
     "Foundation_Collections",
+    "Foundation_Numerics",
     "Win32_Graphics_Direct3D",
+    "Win32_Networking_WinSock",
+    "Win32_System_Com_StructuredStorage",
+    "Win32_System_Ole",
+    "Win32_System_Rpc",
+    "Win32_System_Variant",
 ]
 
 [lints]


### PR DESCRIPTION
Fixes: #3467