### PR TITLE
Harden nested type discovery

### DIFF
--- a/crates/libs/bindgen/src/tables/type_def.rs
+++ b/crates/libs/bindgen/src/tables/type_def.rs
@@ -56,6 +56,10 @@ impl TypeDef {
         self.file().equal_range(2, self.index() + 1).next()
     }
 
+    pub fn nested(&self) -> Option<NestedClass> {
+        self.file().equal_range(0, self.index() + 1).next()
+    }
+
     pub fn underlying_type(&self) -> Type {
         let field = self.fields().next().unwrap();
         if let Some(constant) = field.constant() {

--- a/crates/libs/bindgen/src/winmd/attributes.rs
+++ b/crates/libs/bindgen/src/winmd/attributes.rs
@@ -73,4 +73,8 @@ flags!(TypeAttributes, u32);
 impl TypeAttributes {
     pub const ExplicitLayout: Self = Self(0x10);
     pub const WindowsRuntime: Self = Self(0x4000);
+
+    pub fn is_nested(&self) -> bool {
+        (self.0 & 0x00000006) != 0
+    }
 }

--- a/crates/libs/bindgen/src/winmd/reader.rs
+++ b/crates/libs/bindgen/src/winmd/reader.rs
@@ -29,7 +29,9 @@ impl Reader {
             }
 
             for def in file.table::<TypeDef>() {
-                if def.nested().is_some() {
+                let flags = def.flags();
+
+                if flags.is_nested() || def.nested().is_some() {
                     // This skips the nested types as we've already retrieved them.
                     continue;
                 }
@@ -43,7 +45,7 @@ impl Reader {
                 let types = reader.0.entry(type_name.namespace()).or_default();
                 let category = Category::new(def);
 
-                if def.flags().contains(TypeAttributes::WindowsRuntime) {
+                if flags.contains(TypeAttributes::WindowsRuntime) {
                     let ty = match category {
                         Category::Attribute => continue,
                         Category::Class => Type::Class(Class { def }),

--- a/crates/libs/bindgen/src/winmd/reader.rs
+++ b/crates/libs/bindgen/src/winmd/reader.rs
@@ -29,12 +29,12 @@ impl Reader {
             }
 
             for def in file.table::<TypeDef>() {
-                let type_name = def.type_name();
-
-                if type_name.namespace().is_empty() {
+                if def.nested().is_some() {
                     // This skips the nested types as we've already retrieved them.
                     continue;
                 }
+
+                let type_name = def.type_name();
 
                 if Type::remap(type_name) != Remap::None {
                     continue;
@@ -67,12 +67,12 @@ impl Reader {
                         }
                     };
 
-                    insert(types, type_name.1, ty);
+                    insert(types, type_name.name(), ty);
                 } else {
                     match category {
                         Category::Attribute => continue,
                         Category::Class => {
-                            if type_name.1 == "Apis" {
+                            if type_name.name() == "Apis" {
                                 for method in def.methods() {
                                     if let Some(map) = method.impl_map() {
                                         // Skip inline and ordinal functions.
@@ -88,7 +88,7 @@ impl Reader {
                                         types,
                                         name,
                                         Type::CppFn(CppFn {
-                                            namespace: def.namespace(),
+                                            namespace: type_name.namespace(),
                                             method,
                                         }),
                                     );
@@ -100,7 +100,7 @@ impl Reader {
                                         types,
                                         name,
                                         Type::CppConst(CppConst {
-                                            namespace: def.namespace(),
+                                            namespace: type_name.namespace(),
                                             field,
                                         }),
                                     );
@@ -108,10 +108,14 @@ impl Reader {
                             }
                         }
                         Category::Delegate => {
-                            insert(types, type_name.1, Type::CppDelegate(CppDelegate { def }));
+                            insert(
+                                types,
+                                type_name.name(),
+                                Type::CppDelegate(CppDelegate { def }),
+                            );
                         }
                         Category::Enum => {
-                            insert(types, type_name.1, Type::CppEnum(CppEnum { def }));
+                            insert(types, type_name.name(), Type::CppEnum(CppEnum { def }));
 
                             if !def.has_attribute("ScopedEnumAttribute") {
                                 for field in def.fields() {
@@ -121,7 +125,7 @@ impl Reader {
                                             types,
                                             name,
                                             Type::CppConst(CppConst {
-                                                namespace: def.namespace(),
+                                                namespace: type_name.namespace(),
                                                 field,
                                             }),
                                         );
@@ -130,7 +134,11 @@ impl Reader {
                             }
                         }
                         Category::Interface => {
-                            insert(types, type_name.1, Type::CppInterface(CppInterface { def }));
+                            insert(
+                                types,
+                                type_name.name(),
+                                Type::CppInterface(CppInterface { def }),
+                            );
                         }
                         Category::Struct => {
                             fn make(
@@ -147,10 +155,17 @@ impl Reader {
                                 for (index, def) in
                                     nested.get(&def).into_iter().flatten().enumerate()
                                 {
-                                    ty.nested.insert(
-                                        def.name(),
-                                        make(*def, format!("{}_{index}", ty.name).leak(), nested),
-                                    );
+                                    // Only nested structs are supported. https://github.com/microsoft/windows-rs/issues/3468
+                                    if Category::new(*def) == Category::Struct {
+                                        ty.nested.insert(
+                                            def.name(),
+                                            make(
+                                                *def,
+                                                format!("{}_{index}", ty.name).leak(),
+                                                nested,
+                                            ),
+                                        );
+                                    }
                                 }
 
                                 ty
@@ -158,8 +173,8 @@ impl Reader {
 
                             insert(
                                 types,
-                                type_name.1,
-                                Type::CppStruct(make(def, def.name(), &nested)),
+                                type_name.name(),
+                                Type::CppStruct(make(def, type_name.name(), &nested)),
                             );
                         }
                     };
@@ -189,6 +204,7 @@ impl Reader {
     }
 }
 
+#[derive(PartialEq)]
 enum Category {
     Interface,
     Class,


### PR DESCRIPTION
It turns out that ECMA-335 may include a valid `TypeNamespace` for a nested `TypeDef`. I have never encountered this until #3468 but I can't find anything in the spec to indicate that this is invalid. So I've hardened the reader to check whether a `TypeDef` is nested directly rather than relying on the absence of a `TypeNamespace` value. 

Scanning the `NestedClass` table is slightly slower, but fortunately it is not much slower as this table is sorted and a binary search can be used. I may revisit this further and attempt to index the types in a single pass instead, but for now this solves the issue encountered by #3468 as I can now also reliably exclude nested types that are not structs. Only nested structs are supported by `windows-bindgen`. 

Fixes: #3468