### PR TITLE
Optimize `Iterator` for `IIterator<T>`

### DIFF
--- a/crates/libs/bindgen/src/types/interface.rs
+++ b/crates/libs/bindgen/src/types/interface.rs
@@ -461,7 +461,11 @@ impl Interface {
                         type Item = T;
 
                         fn next(&mut self) -> Option<Self::Item> {
-                            let result = self.Current().ok();
+                            let result = if self.HasCurrent().unwrap_or(false) {
+                                self.Current().ok()
+                            } else {
+                                None
+                            };
 
                             if result.is_some() {
                                 self.MoveNext().ok()?;

--- a/crates/libs/windows/src/Windows/Foundation/Collections/mod.rs
+++ b/crates/libs/windows/src/Windows/Foundation/Collections/mod.rs
@@ -228,7 +228,7 @@ where
 impl<T: windows_core::RuntimeType> Iterator for IIterator<T> {
     type Item = T;
     fn next(&mut self) -> Option<Self::Item> {
-        let result = self.Current().ok();
+        let result = if self.HasCurrent().unwrap_or(false) { self.Current().ok() } else { None };
         if result.is_some() {
             self.MoveNext().ok()?;
         }

--- a/crates/tests/bindgen/src/class_dep.rs
+++ b/crates/tests/bindgen/src/class_dep.rs
@@ -332,7 +332,11 @@ where
 impl<T: windows_core::RuntimeType> Iterator for IIterator<T> {
     type Item = T;
     fn next(&mut self) -> Option<Self::Item> {
-        let result = self.Current().ok();
+        let result = if self.HasCurrent().unwrap_or(false) {
+            self.Current().ok()
+        } else {
+            None
+        };
         if result.is_some() {
             self.MoveNext().ok()?;
         }

--- a/crates/tests/bindgen/src/interface_iterable.rs
+++ b/crates/tests/bindgen/src/interface_iterable.rs
@@ -332,7 +332,11 @@ where
 impl<T: windows_core::RuntimeType> Iterator for IIterator<T> {
     type Item = T;
     fn next(&mut self) -> Option<Self::Item> {
-        let result = self.Current().ok();
+        let result = if self.HasCurrent().unwrap_or(false) {
+            self.Current().ok()
+        } else {
+            None
+        };
         if result.is_some() {
             self.MoveNext().ok()?;
         }


### PR DESCRIPTION
C++/WinRT uses exceptions for error propagation and unfortunately exceptions continue to be very slow. I hadn't realized how much slower until a customer shared some logs.  I decided to take a fresh look and compare [the Rust implementation](https://github.com/microsoft/windows-rs/blob/1a3f15bee39e1557f8fa24c240d5ee6d87dfd9b9/crates/libs/windows/src/extensions/Foundation/Collections/Iterable.rs#L45) of `IIterator<T>::Current` returning `E_BOUNDS` to C++/WinRT's [implementation that throws](https://github.com/microsoft/cppwinrt/blob/153e838a32c8bf5dfe87fbb908942387e9ad0233/strings/base_collections_base.h#L169) before returning `E_BOUNDS`. For a million calls:

* Rust: 0.01s
* C++/WinRT: 18.93s
* C++/WinRT (without call to `RoOriginate`):  3.95s

So that's quite a difference. Ideally we can get C++/WinRT to avoid exceptions but this probably merits a tweak in Rust to avoid this pathological case as changing C++ is hard. 

This change tweaks the `Iterator` trait implementation on the Rust side to use `HasCurrent` to avoid calls to `Current` and thus avoid those exceptions. With this change, the cost of iteration for C++ implementations approaches that of Rust. 

Thanks to @jamesmcnellis for prodding me to look into this a bit more closely. He also gave a [great talk on how exceptions work](https://www.youtube.com/watch?v=COEv2kq_Ht8) that you should definitely check out. 