### PR TITLE
Generalize support for access rights in `windows-registry`

### DIFF
--- a/crates/libs/registry/readme.md
+++ b/crates/libs/registry/readme.md
@@ -41,9 +41,9 @@ fn main() -> Result<()> {
 
     let key = CURRENT_USER
         .options()
-        .read(true)
-        .write(true)
-        .create(true)
+        .read()
+        .write()
+        .create()
         .transaction(&tx)
         .open("software\\windows-rs")?;
 

--- a/crates/libs/registry/src/key.rs
+++ b/crates/libs/registry/src/key.rs
@@ -8,16 +8,12 @@ pub struct Key(pub(crate) HKEY);
 impl Key {
     /// Creates a registry key. If the key already exists, the function opens it.
     pub fn create<T: AsRef<str>>(&self, path: T) -> Result<Self> {
-        self.options()
-            .read(true)
-            .write(true)
-            .create(true)
-            .open(path)
+        self.options().read().write().create().open(path)
     }
 
     /// Opens a registry key.
     pub fn open<T: AsRef<str>>(&self, path: T) -> Result<Self> {
-        self.options().read(true).open(path)
+        self.options().read().open(path)
     }
 
     /// Creates an `OpenOptions` object for the registry key.

--- a/crates/tests/misc/registry/Cargo.toml
+++ b/crates/tests/misc/registry/Cargo.toml
@@ -24,3 +24,6 @@ features = ["Win32_System_Registry"]
 
 [dependencies.windows-strings]
 workspace = true
+
+[dependencies.regex]
+version = "1.7"

--- a/crates/tests/misc/registry/tests/access.rs
+++ b/crates/tests/misc/registry/tests/access.rs
@@ -1,0 +1,82 @@
+use windows_registry::*;
+use windows_result::*;
+use windows_sys::Win32::{Foundation::*, System::Registry::*};
+
+#[test]
+fn access() {
+    let test_key = "software\\windows-rs\\tests\\access";
+    _ = CURRENT_USER.remove_tree(test_key);
+
+    let key = CURRENT_USER
+        .options()
+        .create()
+        .access(KEY_WRITE)
+        .open(test_key)
+        .unwrap();
+
+    key.set_u64("u64", 123u64).unwrap();
+
+    assert_eq!(
+        key.get_u64("u64").unwrap_err().code(),
+        HRESULT::from_win32(ERROR_ACCESS_DENIED)
+    );
+
+    let key = CURRENT_USER
+        .options()
+        .access(KEY_READ)
+        .open(test_key)
+        .unwrap();
+
+    assert_eq!(key.get_u64("u64").unwrap(), 123u64);
+
+    assert_eq!(
+        key.set_u64("u64", 123u64).unwrap_err().code(),
+        HRESULT::from_win32(ERROR_ACCESS_DENIED)
+    );
+}
+
+#[test]
+fn flags() {
+    // `OpenOptions` defaults to no access
+    let mut options = CURRENT_USER.options();
+    assert_eq!(get_access(&options), 0);
+
+    // `read` and `write` equate to `KEY_READ` and `KEY_WRITE`
+    options.read().write();
+    assert_eq!(get_access(&options), KEY_READ | KEY_WRITE);
+
+    // Combine additional access rights
+    options.access(KEY_WOW64_32KEY);
+    assert_eq!(get_access(&options), KEY_WOW64_32KEY | KEY_READ | KEY_WRITE);
+
+    // Start with specific access rights
+    let mut options = CURRENT_USER.options();
+    options.access(KEY_WOW64_32KEY | KEY_QUERY_VALUE);
+    assert_eq!(get_access(&options), KEY_WOW64_32KEY | KEY_QUERY_VALUE);
+
+    // `read` is additive
+    options.read();
+    assert_eq!(
+        get_access(&options),
+        KEY_WOW64_32KEY | KEY_QUERY_VALUE | KEY_READ
+    );
+
+    // `write` is additive
+    options.write();
+    assert_eq!(
+        get_access(&options),
+        KEY_WOW64_32KEY | KEY_QUERY_VALUE | KEY_READ | KEY_WRITE
+    );
+}
+
+fn get_access(options: &OpenOptions) -> u32 {
+    regex::Regex::new(r#"access:\s*(\d+)"#)
+        .unwrap()
+        .captures(&format!("{options:?}"))
+        .unwrap()
+        .get(1)
+        .unwrap()
+        .as_str()
+        .parse()
+        .unwrap()
+}

--- a/crates/tests/misc/registry/tests/read_write.rs
+++ b/crates/tests/misc/registry/tests/read_write.rs
@@ -1,0 +1,32 @@
+use windows_registry::*;
+use windows_result::*;
+use windows_sys::Win32::Foundation::*;
+
+#[test]
+fn read_write() {
+    let test_key = "software\\windows-rs\\tests\\read_write";
+    _ = CURRENT_USER.remove_tree(test_key);
+
+    let key = CURRENT_USER
+        .options()
+        .create()
+        .write()
+        .open(test_key)
+        .unwrap();
+
+    key.set_u64("u64", 123u64).unwrap();
+
+    assert_eq!(
+        key.get_u64("u64").unwrap_err().code(),
+        HRESULT::from_win32(ERROR_ACCESS_DENIED)
+    );
+
+    let key = CURRENT_USER.options().read().open(test_key).unwrap();
+
+    assert_eq!(key.get_u64("u64").unwrap(), 123u64);
+
+    assert_eq!(
+        key.set_u64("u64", 123u64).unwrap_err().code(),
+        HRESULT::from_win32(ERROR_ACCESS_DENIED)
+    );
+}

--- a/crates/tests/misc/registry/tests/transaction.rs
+++ b/crates/tests/misc/registry/tests/transaction.rs
@@ -13,8 +13,8 @@ fn create_with_transaction() {
     let tx_key = CURRENT_USER
         .options()
         .transaction(&tx)
-        .read(true)
-        .write(true)
+        .read()
+        .write()
         .open(test_key)
         .unwrap();
 


### PR DESCRIPTION
Building on #3461, this update generalizes support for access rights so that a caller can request more than just read/write access. I decided against adding an enum declaring the various known access rights as that just leads to the inevitable confusion around which ones to use, how they might be combined, and which obscure access rights to include in the library. If you're unsure just use `read()` or `write()` and move on. 😊

I also refined the `OpenOptions` to be additive-only to simplify things. So rather than having to say `options.read(true).write(true)` you can simply say `options.read().write()` and so on. 

Fixes: #3474