### PR TITLE
Support metadata with `MethodDef` constructor parent resolution

### DIFF
--- a/crates/libs/bindgen/src/tables/attribute.rs
+++ b/crates/libs/bindgen/src/tables/attribute.rs
@@ -12,14 +12,11 @@ impl Attribute {
     }
 
     pub fn name(&self) -> &'static str {
-        let AttributeType::MemberRef(ctor) = self.ty();
-        let MemberRefParent::TypeRef(ty) = ctor.parent();
-        ty.name()
+        self.ty().parent().name()
     }
 
     pub fn args(&self) -> Vec<(&'static str, Value)> {
-        let AttributeType::MemberRef(member) = self.ty();
-        let mut sig = member.blob(2);
+        let mut sig = self.ty().signature();
         let mut values = self.blob(2);
         let prolog = values.read_u16();
         std::debug_assert_eq!(prolog, 1);

--- a/crates/libs/bindgen/src/tables/method_def.rs
+++ b/crates/libs/bindgen/src/tables/method_def.rs
@@ -30,6 +30,10 @@ impl MethodDef {
         self.list(5)
     }
 
+    pub fn parent(&self) -> MemberRefParent {
+        MemberRefParent::TypeDef(self.file().parent(5, *self))
+    }
+
     pub fn impl_map(&self) -> Option<ImplMap> {
         self.file()
             .equal_range(1, MemberForwarded::MethodDef(*self).encode())

--- a/crates/libs/bindgen/src/winmd/codes.rs
+++ b/crates/libs/bindgen/src/winmd/codes.rs
@@ -38,7 +38,24 @@ macro_rules! code {
 }
 
 code! { AttributeType(3)
+    (MethodDef, 2)
     (MemberRef, 3)
+}
+
+impl AttributeType {
+    pub fn parent(&self) -> MemberRefParent {
+        match self {
+            Self::MethodDef(row) => row.parent(),
+            Self::MemberRef(row) => row.parent(),
+        }
+    }
+
+    pub fn signature(&self) -> Blob {
+        match self {
+            Self::MethodDef(row) => row.blob(4),
+            Self::MemberRef(row) => row.blob(2),
+        }
+    }
 }
 
 code! { HasAttribute(5)
@@ -62,7 +79,17 @@ code! { MemberForwarded(1)
 }
 
 code! { MemberRefParent(3)
+    (TypeDef, 0)
     (TypeRef, 1)
+}
+
+impl MemberRefParent {
+    pub fn name(&self) -> &'static str {
+        match self {
+            Self::TypeDef(row) => row.name(),
+            Self::TypeRef(row) => row.name(),
+        }
+    }
 }
 
 code! { TypeDefOrRef(2)

--- a/crates/libs/bindgen/src/winmd/file.rs
+++ b/crates/libs/bindgen/src/winmd/file.rs
@@ -608,6 +608,19 @@ impl File {
         RowIterator::new(self, first..last)
     }
 
+    pub(crate) fn parent<P: AsRow, C: AsRow>(&'static self, column: usize, child: C) -> P {
+        P::from_row(Row::new(
+            self,
+            self.upper_bound_of(
+                P::TABLE,
+                0,
+                self.tables[P::TABLE].len,
+                column,
+                child.index() + 1,
+            ) - 1,
+        ))
+    }
+
     fn lower_bound_of(
         &self,
         table: usize,


### PR DESCRIPTION
Some, typically unmerged, metadata may present `MethodDef` constructors for attributes type resolution. This is unusual and thus hard to test but I have manually tested this against some internal metadata to confirm that it covers this edge case in ECMA-335 parsing. 