### PR TITLE
Deduplicate required interfaces

### DIFF
--- a/crates/libs/bindgen/src/types/class.rs
+++ b/crates/libs/bindgen/src/types/class.rs
@@ -21,8 +21,7 @@ impl Class {
     }
 
     pub fn write(&self, writer: &Writer) -> TokenStream {
-        let mut required_interfaces = self.required_interfaces();
-        required_interfaces.sort();
+        let required_interfaces = self.required_interfaces();
         let type_name = self.def.type_name();
         let name = to_ident(type_name.name());
         let (class_cfg, cfg) = self.write_cfg(writer);
@@ -330,6 +329,8 @@ impl Class {
             }
         }
 
+        set.sort();
+        set.dedup();
         set
     }
 

--- a/crates/libs/bindgen/src/types/interface.rs
+++ b/crates/libs/bindgen/src/types/interface.rs
@@ -81,9 +81,7 @@ impl Interface {
         let type_name = self.def.type_name();
         let methods = self.get_methods(writer);
 
-        let mut required_interfaces = self.required_interfaces();
-        required_interfaces.sort();
-
+        let required_interfaces = self.required_interfaces();
         let name = self.write_name(writer);
 
         let vtbl_name = self.write_vtbl_name(writer);
@@ -555,6 +553,9 @@ impl Interface {
         }
         let mut set = vec![];
         walk(self, &mut set);
+
+        set.sort();
+        set.dedup();
         set
     }
 }


### PR DESCRIPTION
Ran into some internal OS metadata where a class mistakenly set the same interface as both a `Static` and `Activatable` factory interface. Dealing with this edge case is the last step in fully supporting internal OS metadata. 