### PR TITLE
Avoid memory explosion when stress testing `bindgen`

### DIFF
--- a/crates/libs/bindgen/src/derive_writer.rs
+++ b/crates/libs/bindgen/src/derive_writer.rs
@@ -3,7 +3,7 @@ use super::*;
 pub struct DeriveWriter(BTreeSet<String>);
 
 impl DeriveWriter {
-    pub fn new(writer: &Writer, type_name: TypeName) -> Self {
+    pub fn new(writer: &Writer<'_>, type_name: TypeName) -> Self {
         let mut derive = BTreeSet::new();
         derive.extend(writer.config.derive.get(type_name));
         Self(derive)

--- a/crates/libs/bindgen/src/lib.rs
+++ b/crates/libs/bindgen/src/lib.rs
@@ -181,12 +181,12 @@ where
     }
 
     let reader = Reader::new(expand_input(&input));
-    let filter = Filter::new(reader, &include, &exclude);
-    let references = References::new(reader, references);
-    let types = TypeMap::filter(reader, &filter, &references);
-    let derive = Derive::new(reader, &types, &derive);
+    let filter = Filter::new(&reader, &include, &exclude);
+    let references = References::new(&reader, references);
+    let types = TypeMap::filter(&reader, &filter, &references);
+    let derive = Derive::new(&reader, &types, &derive);
 
-    let config = Box::leak(Box::new(Config {
+    let config = Config {
         types,
         flat,
         references,
@@ -201,12 +201,12 @@ where
         sys,
         implement,
         link,
-    }));
+    };
 
     let tree = TypeTree::new(&config.types);
 
     let writer = Writer {
-        config,
+        config: &config,
         namespace: "",
     };
 

--- a/crates/libs/bindgen/src/libraries.rs
+++ b/crates/libs/bindgen/src/libraries.rs
@@ -12,7 +12,7 @@ pub fn libraries() -> BTreeMap<String, BTreeMap<String, CallingConvention>> {
     let mut libraries = BTreeMap::new();
 
     let reader = Reader::new(expand_input(&["default"]));
-    combine_libraries(reader, &mut libraries);
+    combine_libraries(&reader, &mut libraries);
     libraries
 }
 

--- a/crates/libs/bindgen/src/references.rs
+++ b/crates/libs/bindgen/src/references.rs
@@ -68,7 +68,7 @@ pub struct Reference {
 pub struct References(Vec<Reference>);
 
 impl References {
-    pub fn new(reader: &'static Reader, stage: Vec<ReferenceStage>) -> Self {
+    pub fn new(reader: &Reader, stage: Vec<ReferenceStage>) -> Self {
         Self(
             stage
                 .into_iter()

--- a/crates/libs/bindgen/src/type_map.rs
+++ b/crates/libs/bindgen/src/type_map.rs
@@ -27,7 +27,7 @@ impl TypeMap {
     }
 
     #[track_caller]
-    pub fn filter(reader: &'static Reader, filter: &Filter, references: &References) -> Self {
+    pub fn filter(reader: &Reader, filter: &Filter, references: &References) -> Self {
         let mut dependencies = Self::new();
 
         for namespace in reader.keys() {

--- a/crates/libs/bindgen/src/type_name.rs
+++ b/crates/libs/bindgen/src/type_name.rs
@@ -77,7 +77,7 @@ impl TypeName {
         self.1
     }
 
-    pub fn write(&self, writer: &Writer, generics: &[Type]) -> TokenStream {
+    pub fn write(&self, writer: &Writer<'_>, generics: &[Type]) -> TokenStream {
         let name = to_ident(self.name());
         let namespace = writer.write_namespace(*self);
 

--- a/crates/libs/bindgen/src/types/class.rs
+++ b/crates/libs/bindgen/src/types/class.rs
@@ -10,7 +10,7 @@ impl Class {
         self.def.type_name()
     }
 
-    fn write_cfg(&self, writer: &Writer) -> (Cfg, TokenStream) {
+    fn write_cfg(&self, writer: &Writer<'_>) -> (Cfg, TokenStream) {
         if !writer.config.package {
             return (Cfg::default(), quote! {});
         }
@@ -20,7 +20,7 @@ impl Class {
         (cfg, tokens)
     }
 
-    pub fn write(&self, writer: &Writer) -> TokenStream {
+    pub fn write(&self, writer: &Writer<'_>) -> TokenStream {
         let required_interfaces = self.required_interfaces();
         let type_name = self.def.type_name();
         let name = to_ident(type_name.name());
@@ -227,7 +227,7 @@ impl Class {
         }
     }
 
-    pub fn write_name(&self, writer: &Writer) -> TokenStream {
+    pub fn write_name(&self, writer: &Writer<'_>) -> TokenStream {
         self.type_name().write(writer, &[])
     }
 

--- a/crates/libs/bindgen/src/types/cpp_const.rs
+++ b/crates/libs/bindgen/src/types/cpp_const.rs
@@ -23,11 +23,11 @@ impl CppConst {
         TypeName(self.namespace, self.field.name())
     }
 
-    pub fn write_name(&self, writer: &Writer) -> TokenStream {
+    pub fn write_name(&self, writer: &Writer<'_>) -> TokenStream {
         self.type_name().write(writer, &[])
     }
 
-    pub fn write_cfg(&self, writer: &Writer) -> TokenStream {
+    pub fn write_cfg(&self, writer: &Writer<'_>) -> TokenStream {
         if !writer.config.package {
             return quote! {};
         }
@@ -35,7 +35,7 @@ impl CppConst {
         Cfg::new(self.field, &self.dependencies(), writer).write(writer, false)
     }
 
-    pub fn write(&self, writer: &Writer) -> TokenStream {
+    pub fn write(&self, writer: &Writer<'_>) -> TokenStream {
         let name = to_ident(self.field.name());
 
         if let Some(guid) = self.field.guid_attribute() {

--- a/crates/libs/bindgen/src/types/cpp_delegate.rs
+++ b/crates/libs/bindgen/src/types/cpp_delegate.rs
@@ -22,7 +22,7 @@ impl CppDelegate {
         self.def.type_name()
     }
 
-    pub fn write_name(&self, writer: &Writer) -> TokenStream {
+    pub fn write_name(&self, writer: &Writer<'_>) -> TokenStream {
         self.type_name().write(writer, &[])
     }
 
@@ -33,7 +33,7 @@ impl CppDelegate {
             .unwrap()
     }
 
-    pub fn write_cfg(&self, writer: &Writer) -> TokenStream {
+    pub fn write_cfg(&self, writer: &Writer<'_>) -> TokenStream {
         if !writer.config.package {
             return quote! {};
         }
@@ -41,7 +41,7 @@ impl CppDelegate {
         Cfg::new(self.def, &self.dependencies(), writer).write(writer, false)
     }
 
-    pub fn write(&self, writer: &Writer) -> TokenStream {
+    pub fn write(&self, writer: &Writer<'_>) -> TokenStream {
         let type_name = self.def.type_name();
         let name = to_ident(type_name.name());
         let method = self.method();
@@ -73,7 +73,7 @@ impl Dependencies for CppDelegate {
     }
 }
 
-fn write_param(writer: &Writer, param: &Param) -> TokenStream {
+fn write_param(writer: &Writer<'_>, param: &Param) -> TokenStream {
     let name = param.write_ident();
     let type_name = param.write_name(writer);
 

--- a/crates/libs/bindgen/src/types/cpp_enum.rs
+++ b/crates/libs/bindgen/src/types/cpp_enum.rs
@@ -22,11 +22,11 @@ impl CppEnum {
         self.def.type_name()
     }
 
-    pub fn write_name(&self, writer: &Writer) -> TokenStream {
+    pub fn write_name(&self, writer: &Writer<'_>) -> TokenStream {
         self.type_name().write(writer, &[])
     }
 
-    pub fn write(&self, writer: &Writer) -> TokenStream {
+    pub fn write(&self, writer: &Writer<'_>) -> TokenStream {
         let tn = self.def.type_name();
         let is_scoped = self.def.has_attribute("ScopedEnumAttribute");
 

--- a/crates/libs/bindgen/src/types/cpp_fn.rs
+++ b/crates/libs/bindgen/src/types/cpp_fn.rs
@@ -23,11 +23,11 @@ impl CppFn {
         TypeName(self.namespace, self.method.name())
     }
 
-    pub fn write_name(&self, writer: &Writer) -> TokenStream {
+    pub fn write_name(&self, writer: &Writer<'_>) -> TokenStream {
         self.type_name().write(writer, &[])
     }
 
-    pub fn write_link(&self, writer: &Writer, underlying_types: bool) -> TokenStream {
+    pub fn write_link(&self, writer: &Writer<'_>, underlying_types: bool) -> TokenStream {
         let library = self.method.module_name().to_lowercase();
         let symbol = self.method.import_name();
         let name = to_ident(self.method.name());
@@ -60,7 +60,7 @@ impl CppFn {
         })
     }
 
-    pub fn write_cfg(&self, writer: &Writer) -> TokenStream {
+    pub fn write_cfg(&self, writer: &Writer<'_>) -> TokenStream {
         if !writer.config.package {
             return quote! {};
         }
@@ -68,7 +68,7 @@ impl CppFn {
         Cfg::new(self.method, &self.dependencies(), writer).write(writer, false)
     }
 
-    pub fn write(&self, writer: &Writer) -> TokenStream {
+    pub fn write(&self, writer: &Writer<'_>) -> TokenStream {
         let name = to_ident(self.method.name());
         let signature = self.method.signature(self.namespace, &[]);
 
@@ -273,7 +273,7 @@ impl Dependencies for CppFn {
     }
 }
 
-impl Writer {
+impl Writer<'_> {
     pub fn write_return_sig(
         &self,
         method: MethodDef,

--- a/crates/libs/bindgen/src/types/cpp_interface.rs
+++ b/crates/libs/bindgen/src/types/cpp_interface.rs
@@ -28,7 +28,7 @@ impl CppInterface {
         self.def.type_name()
     }
 
-    pub fn get_methods(&self, writer: &Writer) -> Vec<CppMethodOrName> {
+    pub fn get_methods(&self, writer: &Writer<'_>) -> Vec<CppMethodOrName> {
         let namespace = self.def.namespace();
 
         self.def
@@ -44,7 +44,7 @@ impl CppInterface {
             .collect()
     }
 
-    fn write_cfg(&self, writer: &Writer) -> (Cfg, TokenStream) {
+    fn write_cfg(&self, writer: &Writer<'_>) -> (Cfg, TokenStream) {
         if !writer.config.package {
             return (Cfg::default(), quote! {});
         }
@@ -54,7 +54,7 @@ impl CppInterface {
         (cfg, tokens)
     }
 
-    pub fn write(&self, writer: &Writer) -> TokenStream {
+    pub fn write(&self, writer: &Writer<'_>) -> TokenStream {
         let methods = self.get_methods(writer);
 
         let base_interfaces = self.base_interfaces();
@@ -221,7 +221,11 @@ impl CppInterface {
             let impl_name: TokenStream = format!("{}_Impl", self.def.name()).into();
 
             let cfg = if writer.config.package {
-                fn combine(interface: &CppInterface, dependencies: &mut TypeMap, writer: &Writer) {
+                fn combine(
+                    interface: &CppInterface,
+                    dependencies: &mut TypeMap,
+                    writer: &Writer<'_>,
+                ) {
                     for method in interface.get_methods(writer).iter() {
                         if let CppMethodOrName::Method(method) = method {
                             dependencies.combine(&method.dependencies);
@@ -398,17 +402,17 @@ impl CppInterface {
         }
     }
 
-    pub fn write_name(&self, writer: &Writer) -> TokenStream {
+    pub fn write_name(&self, writer: &Writer<'_>) -> TokenStream {
         self.type_name().write(writer, &[])
     }
 
-    fn write_vtbl_name(&self, writer: &Writer) -> TokenStream {
+    fn write_vtbl_name(&self, writer: &Writer<'_>) -> TokenStream {
         let name: TokenStream = format!("{}_Vtbl", self.def.name()).into();
         let namespace = writer.write_namespace(self.def.type_name());
         quote! { #namespace #name }
     }
 
-    pub fn write_impl_name(&self, writer: &Writer) -> TokenStream {
+    pub fn write_impl_name(&self, writer: &Writer<'_>) -> TokenStream {
         let name: TokenStream = format!("{}_Impl", self.def.name()).into();
         let namespace = writer.write_namespace(self.def.type_name());
         quote! { #namespace #name }

--- a/crates/libs/bindgen/src/types/cpp_method.rs
+++ b/crates/libs/bindgen/src/types/cpp_method.rs
@@ -206,7 +206,7 @@ impl CppMethod {
         }
     }
 
-    pub fn write_cfg(&self, writer: &Writer, parent: &Cfg, not: bool) -> TokenStream {
+    pub fn write_cfg(&self, writer: &Writer<'_>, parent: &Cfg, not: bool) -> TokenStream {
         if !writer.config.package {
             return quote! {};
         }
@@ -229,7 +229,7 @@ impl CppMethod {
         tokens
     }
 
-    pub fn write_where(&self, writer: &Writer, query: bool) -> TokenStream {
+    pub fn write_where(&self, writer: &Writer<'_>, query: bool) -> TokenStream {
         let mut tokens = quote! {};
 
         for (position, param) in self.signature.params.iter().enumerate() {
@@ -253,7 +253,7 @@ impl CppMethod {
 
     pub fn write(
         &self,
-        writer: &Writer,
+        writer: &Writer<'_>,
         method_names: &mut MethodNames,
         virtual_names: &mut MethodNames,
     ) -> TokenStream {
@@ -419,7 +419,7 @@ impl CppMethod {
         }
     }
 
-    pub fn write_impl_signature(&self, writer: &Writer, _named_params: bool) -> TokenStream {
+    pub fn write_impl_signature(&self, writer: &Writer<'_>, _named_params: bool) -> TokenStream {
         let mut params = quote! {};
 
         if self.return_hint == ReturnHint::ResultValue {
@@ -448,7 +448,7 @@ impl CppMethod {
         quote! { (&self, #params) #return_type }
     }
 
-    pub fn write_abi(&self, writer: &Writer, named_params: bool) -> TokenStream {
+    pub fn write_abi(&self, writer: &Writer<'_>, named_params: bool) -> TokenStream {
         let mut params: Vec<_> = self
             .signature
             .params
@@ -491,7 +491,7 @@ impl CppMethod {
         quote! { (#this, #(#params),*) #return_sig }
     }
 
-    pub fn write_params(&self, writer: &Writer) -> TokenStream {
+    pub fn write_params(&self, writer: &Writer<'_>) -> TokenStream {
         let mut tokens = quote! {};
 
         for (position, param) in self.signature.params.iter().enumerate() {
@@ -666,7 +666,7 @@ impl CppMethod {
         tokens
     }
 
-    pub fn write_return(&self, writer: &Writer) -> TokenStream {
+    pub fn write_return(&self, writer: &Writer<'_>) -> TokenStream {
         match &self.signature.return_type {
             Type::Void if self.def.has_attribute("DoesNotReturnAttribute") => quote! {  -> ! },
             Type::Void => quote! {},
@@ -700,7 +700,7 @@ impl CppMethod {
     }
 }
 
-fn write_produce_type(writer: &Writer, param: &Param) -> TokenStream {
+fn write_produce_type(writer: &Writer<'_>, param: &Param) -> TokenStream {
     let name = param.write_ident();
     let kind = param.write_default(writer);
 

--- a/crates/libs/bindgen/src/types/cpp_struct.rs
+++ b/crates/libs/bindgen/src/types/cpp_struct.rs
@@ -38,7 +38,7 @@ impl CppStruct {
         TypeName(self.def.namespace(), self.name)
     }
 
-    pub fn write_name(&self, writer: &Writer) -> TokenStream {
+    pub fn write_name(&self, writer: &Writer<'_>) -> TokenStream {
         self.type_name().write(writer, &[])
     }
 
@@ -46,7 +46,7 @@ impl CppStruct {
         self.def.has_attribute("NativeTypedefAttribute")
     }
 
-    pub fn write_cfg(&self, writer: &Writer) -> TokenStream {
+    pub fn write_cfg(&self, writer: &Writer<'_>) -> TokenStream {
         if !writer.config.package {
             return quote! {};
         }
@@ -54,7 +54,7 @@ impl CppStruct {
         Cfg::new(self.def, &self.dependencies(), writer).write(writer, false)
     }
 
-    pub fn write(&self, writer: &Writer) -> TokenStream {
+    pub fn write(&self, writer: &Writer<'_>) -> TokenStream {
         if self.is_handle() {
             return writer.write_cpp_handle(self.def);
         }
@@ -70,7 +70,7 @@ impl CppStruct {
         self.write_with_cfg(writer, &quote! { #arches #cfg })
     }
 
-    fn write_with_cfg(&self, writer: &Writer, cfg: &TokenStream) -> TokenStream {
+    fn write_with_cfg(&self, writer: &Writer<'_>, cfg: &TokenStream) -> TokenStream {
         let name = to_ident(self.name);
         let flags = self.def.flags();
         let is_union = flags.contains(TypeAttributes::ExplicitLayout);

--- a/crates/libs/bindgen/src/types/delegate.rs
+++ b/crates/libs/bindgen/src/types/delegate.rs
@@ -11,7 +11,7 @@ impl Delegate {
         self.def.type_name()
     }
 
-    pub fn write_cfg(&self, writer: &Writer) -> TokenStream {
+    pub fn write_cfg(&self, writer: &Writer<'_>) -> TokenStream {
         if !writer.config.package {
             return quote! {};
         }
@@ -19,7 +19,7 @@ impl Delegate {
         Cfg::new(self.def, &self.dependencies(), writer).write(writer, false)
     }
 
-    pub fn write(&self, writer: &Writer) -> TokenStream {
+    pub fn write(&self, writer: &Writer<'_>) -> TokenStream {
         let name = self.write_name(writer);
         //let vtbl_name = self.write_vtbl_name(writer);
         let vtbl_name: TokenStream = format!("{}_Vtbl", self.def.name()).into();
@@ -199,7 +199,7 @@ impl Delegate {
         }
     }
 
-    pub fn write_name(&self, writer: &Writer) -> TokenStream {
+    pub fn write_name(&self, writer: &Writer<'_>) -> TokenStream {
         self.type_name().write(writer, &self.generics)
     }
 }

--- a/crates/libs/bindgen/src/types/enum.rs
+++ b/crates/libs/bindgen/src/types/enum.rs
@@ -10,11 +10,11 @@ impl Enum {
         self.def.type_name()
     }
 
-    pub fn write_name(&self, writer: &Writer) -> TokenStream {
+    pub fn write_name(&self, writer: &Writer<'_>) -> TokenStream {
         self.type_name().write(writer, &[])
     }
 
-    pub fn write(&self, writer: &Writer) -> TokenStream {
+    pub fn write(&self, writer: &Writer<'_>) -> TokenStream {
         let name = to_ident(self.def.name());
         let underlying_type = self.def.underlying_type();
 

--- a/crates/libs/bindgen/src/types/interface.rs
+++ b/crates/libs/bindgen/src/types/interface.rs
@@ -53,7 +53,7 @@ impl Interface {
         self.def.type_name()
     }
 
-    pub fn get_methods(&self, writer: &Writer) -> Vec<MethodOrName> {
+    pub fn get_methods(&self, writer: &Writer<'_>) -> Vec<MethodOrName> {
         self.def
             .methods()
             .map(|def| {
@@ -67,7 +67,7 @@ impl Interface {
             .collect()
     }
 
-    fn write_cfg(&self, writer: &Writer) -> (Cfg, TokenStream) {
+    fn write_cfg(&self, writer: &Writer<'_>) -> (Cfg, TokenStream) {
         if !writer.config.package {
             return (Cfg::default(), quote! {});
         }
@@ -77,7 +77,7 @@ impl Interface {
         (cfg, tokens)
     }
 
-    pub fn write(&self, writer: &Writer) -> TokenStream {
+    pub fn write(&self, writer: &Writer<'_>) -> TokenStream {
         let type_name = self.def.type_name();
         let methods = self.get_methods(writer);
 
@@ -335,7 +335,11 @@ impl Interface {
                 let runtime_name = format!("{type_name}");
 
                 let cfg = if writer.config.package {
-                    fn combine(interface: &Interface, dependencies: &mut TypeMap, writer: &Writer) {
+                    fn combine(
+                        interface: &Interface,
+                        dependencies: &mut TypeMap,
+                        writer: &Writer<'_>,
+                    ) {
                         for method in interface.get_methods(writer).iter() {
                             if let MethodOrName::Method(method) = method {
                                 dependencies.combine(&method.dependencies);
@@ -499,11 +503,11 @@ impl Interface {
         }
     }
 
-    pub fn write_name(&self, writer: &Writer) -> TokenStream {
+    pub fn write_name(&self, writer: &Writer<'_>) -> TokenStream {
         self.type_name().write(writer, &self.generics)
     }
 
-    fn write_vtbl_name(&self, writer: &Writer) -> TokenStream {
+    fn write_vtbl_name(&self, writer: &Writer<'_>) -> TokenStream {
         let name: TokenStream = format!("{}_Vtbl", self.def.name()).into();
 
         if self.generics.is_empty() {
@@ -514,7 +518,7 @@ impl Interface {
         }
     }
 
-    pub fn write_impl_name(&self, writer: &Writer) -> TokenStream {
+    pub fn write_impl_name(&self, writer: &Writer<'_>) -> TokenStream {
         let name: TokenStream = format!("{}_Impl", self.def.name()).into();
         let namespace = writer.write_namespace(self.def.type_name());
 

--- a/crates/libs/bindgen/src/types/method.rs
+++ b/crates/libs/bindgen/src/types/method.rs
@@ -20,7 +20,7 @@ impl Method {
         }
     }
 
-    pub fn write_cfg(&self, writer: &Writer, parent: &Cfg, not: bool) -> TokenStream {
+    pub fn write_cfg(&self, writer: &Writer<'_>, parent: &Cfg, not: bool) -> TokenStream {
         if !writer.config.package {
             return quote! {};
         }
@@ -136,7 +136,7 @@ impl Method {
 
     pub fn write_impl_signature(
         &self,
-        writer: &Writer,
+        writer: &Writer<'_>,
         named_params: bool,
         has_this: bool,
     ) -> TokenStream {
@@ -211,7 +211,7 @@ impl Method {
         }
     }
 
-    pub fn write_abi(&self, writer: &Writer, named_params: bool) -> TokenStream {
+    pub fn write_abi(&self, writer: &Writer<'_>, named_params: bool) -> TokenStream {
         let args = self.signature.params.iter().map(|param| {
             let name = param.write_ident();
             let abi = param.write_abi(writer);
@@ -287,7 +287,7 @@ impl Method {
 
     pub fn write(
         &self,
-        writer: &Writer,
+        writer: &Writer<'_>,
         interface: Option<&Interface>,
         kind: InterfaceKind,
         method_names: &mut MethodNames,

--- a/crates/libs/bindgen/src/types/mod.rs
+++ b/crates/libs/bindgen/src/types/mod.rs
@@ -364,7 +364,7 @@ impl Type {
         )
     }
 
-    pub fn write_name(&self, writer: &Writer) -> TokenStream {
+    pub fn write_name(&self, writer: &Writer<'_>) -> TokenStream {
         if writer.config.sys && self.is_interface() {
             return quote! { *mut core::ffi::c_void };
         }
@@ -470,7 +470,7 @@ impl Type {
         }
     }
 
-    pub fn write_default(&self, writer: &Writer) -> TokenStream {
+    pub fn write_default(&self, writer: &Writer<'_>) -> TokenStream {
         if writer.config.sys {
             return self.write_name(writer);
         }
@@ -490,7 +490,7 @@ impl Type {
         }
     }
 
-    pub fn write_impl_name(&self, writer: &Writer) -> TokenStream {
+    pub fn write_impl_name(&self, writer: &Writer<'_>) -> TokenStream {
         match self {
             Self::IUnknown | Self::Object => {
                 let name = writer.write_core();
@@ -502,7 +502,7 @@ impl Type {
         }
     }
 
-    pub fn write_abi(&self, writer: &Writer) -> TokenStream {
+    pub fn write_abi(&self, writer: &Writer<'_>) -> TokenStream {
         if writer.config.sys {
             return self.write_name(writer);
         }
@@ -789,7 +789,7 @@ impl Type {
         }
     }
 
-    fn write_no_deps(&self, writer: &Writer) -> TokenStream {
+    fn write_no_deps(&self, writer: &Writer<'_>) -> TokenStream {
         if !writer.config.no_deps || !writer.config.sys {
             return quote! {};
         }
@@ -845,7 +845,7 @@ impl Type {
         }
     }
 
-    pub fn write(&self, writer: &Writer) -> TokenStream {
+    pub fn write(&self, writer: &Writer<'_>) -> TokenStream {
         match self {
             Self::Struct(ty) => ty.write(writer),
             Self::Enum(ty) => ty.write(writer),

--- a/crates/libs/bindgen/src/types/struct.rs
+++ b/crates/libs/bindgen/src/types/struct.rs
@@ -10,11 +10,11 @@ impl Struct {
         self.def.type_name()
     }
 
-    pub fn write_name(&self, writer: &Writer) -> TokenStream {
+    pub fn write_name(&self, writer: &Writer<'_>) -> TokenStream {
         self.type_name().write(writer, &[])
     }
 
-    pub fn write(&self, writer: &Writer) -> TokenStream {
+    pub fn write(&self, writer: &Writer<'_>) -> TokenStream {
         let name = to_ident(self.def.name());
 
         let fields: Vec<_> = self

--- a/crates/libs/bindgen/src/winmd/row.rs
+++ b/crates/libs/bindgen/src/winmd/row.rs
@@ -2,9 +2,12 @@ use super::*;
 
 #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, Ord, PartialOrd)]
 pub struct Row {
-    file: &'static File,
+    file: *const File,
     index: usize,
 }
+
+unsafe impl Send for Row {}
+unsafe impl Sync for Row {}
 
 impl Row {
     pub(crate) fn new(file: &'static File, index: usize) -> Self {
@@ -18,7 +21,7 @@ pub trait AsRow: Copy {
     fn from_row(row: Row) -> Self;
 
     fn file(&self) -> &'static File {
-        self.to_row().file
+        unsafe { &*self.to_row().file }
     }
 
     fn reader(&self) -> &'static Reader {

--- a/crates/libs/bindgen/src/writer/cfg.rs
+++ b/crates/libs/bindgen/src/writer/cfg.rs
@@ -38,7 +38,7 @@ pub struct Cfg {
 }
 
 impl Cfg {
-    pub fn new<R: HasAttributes>(row: R, dependencies: &TypeMap, writer: &Writer) -> Self {
+    pub fn new<R: HasAttributes>(row: R, dependencies: &TypeMap, writer: &Writer<'_>) -> Self {
         let features: BTreeSet<&'static str> = dependencies
             .keys()
             .filter_map(|tn| {
@@ -60,7 +60,7 @@ impl Cfg {
         &self,
         row: R,
         dependencies: &TypeMap,
-        writer: &Writer,
+        writer: &Writer<'_>,
     ) -> Self {
         let mut difference = Self::new(row, dependencies, writer);
 
@@ -72,7 +72,7 @@ impl Cfg {
         difference
     }
 
-    pub fn write(&self, writer: &Writer, not: bool) -> TokenStream {
+    pub fn write(&self, writer: &Writer<'_>, not: bool) -> TokenStream {
         if !writer.config.package {
             return quote! {};
         }

--- a/crates/libs/bindgen/src/writer/cpp_handle.rs
+++ b/crates/libs/bindgen/src/writer/cpp_handle.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-impl Writer {
+impl Writer<'_> {
     pub fn write_cpp_handle(&self, def: TypeDef) -> TokenStream {
         let tn = def.type_name();
         let name = to_ident(def.name());

--- a/crates/libs/bindgen/src/writer/format.rs
+++ b/crates/libs/bindgen/src/writer/format.rs
@@ -1,7 +1,7 @@
 use super::*;
 use std::io::Write;
 
-impl Writer {
+impl Writer<'_> {
     pub fn format(&self, tokens: &str) -> String {
         let preamble = if self.config.no_comment {
             String::new()

--- a/crates/libs/bindgen/src/writer/mod.rs
+++ b/crates/libs/bindgen/src/writer/mod.rs
@@ -9,12 +9,12 @@ pub use cfg::*;
 use rayon::prelude::*;
 
 #[derive(Clone)]
-pub struct Writer {
-    pub config: &'static Config,
+pub struct Writer<'a> {
+    pub config: &'a Config,
     pub namespace: &'static str,
 }
 
-impl Writer {
+impl Writer<'_> {
     fn with_namespace(&self, namespace: &'static str) -> Self {
         let mut clone = self.clone();
         clone.namespace = namespace;

--- a/crates/libs/bindgen/src/writer/names.rs
+++ b/crates/libs/bindgen/src/writer/names.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-impl Writer {
+impl Writer<'_> {
     pub fn write_core(&self) -> TokenStream {
         if self.config.sys {
             if self.config.package || !self.config.no_deps {

--- a/crates/libs/bindgen/src/writer/value.rs
+++ b/crates/libs/bindgen/src/writer/value.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-impl Writer {
+impl Writer<'_> {
     pub fn write_cpp_const_guid(&self, name: TokenStream, value: &GUID) -> TokenStream {
         let crate_name = self.write_core();
         let value = self.write_guid_u128(value);


### PR DESCRIPTION
The `windows-bindgen` crate's `bindgen` method is meant to be called once per build but during stress testing, it can be called numerous times from the same process leading to an explosion of memory usage. The winmd reader does an awkward dance with the winmd files to avoid a complex lifetime model. I hope to improve this over time but at least with this change the internal lifetime of the reader and files are scoped to the `bindgen` function call and thus greatly reduces memory usage during build validation. 