### PR TITLE
Add optional warnings for `windows-bindgen` to improve diagnostics

### DIFF
--- a/crates/libs/bindgen/src/lib.rs
+++ b/crates/libs/bindgen/src/lib.rs
@@ -45,7 +45,7 @@ use type_name::*;
 use type_tree::*;
 use types::*;
 use value::*;
-pub use warnings::Warnings;
+pub use warnings::*;
 use winmd::*;
 use writer::*;
 mod method_names;
@@ -66,6 +66,7 @@ struct Config {
     pub implement: bool,
     pub derive: Derive,
     pub link: String,
+    pub warnings: WarningBuilder,
 }
 
 /// The Windows code generator.
@@ -203,6 +204,7 @@ where
         sys,
         implement,
         link,
+        warnings: WarningBuilder::default(),
     };
 
     let tree = TypeTree::new(&config.types);
@@ -213,7 +215,7 @@ where
     };
 
     writer.write(tree);
-    warnings::get()
+    config.warnings.build()
 }
 
 enum ArgKind {

--- a/crates/libs/bindgen/src/lib.rs
+++ b/crates/libs/bindgen/src/lib.rs
@@ -22,6 +22,7 @@ mod type_name;
 mod type_tree;
 mod types;
 mod value;
+mod warnings;
 mod winmd;
 mod writer;
 
@@ -44,6 +45,7 @@ use type_name::*;
 use type_tree::*;
 use types::*;
 use value::*;
+pub use warnings::Warnings;
 use winmd::*;
 use writer::*;
 mod method_names;
@@ -68,7 +70,7 @@ struct Config {
 
 /// The Windows code generator.
 #[track_caller]
-pub fn bindgen<I, S>(args: I)
+pub fn bindgen<I, S>(args: I) -> Warnings
 where
     I: IntoIterator<Item = S>,
     S: AsRef<str>,
@@ -210,7 +212,8 @@ where
         namespace: "",
     };
 
-    writer.write(tree)
+    writer.write(tree);
+    warnings::get()
 }
 
 enum ArgKind {

--- a/crates/libs/bindgen/src/types/cpp_interface.rs
+++ b/crates/libs/bindgen/src/types/cpp_interface.rs
@@ -38,7 +38,11 @@ impl CppInterface {
                 if method.dependencies.included(writer.config) {
                     CppMethodOrName::Method(method)
                 } else {
-                    warnings::skip_method(method.def, &method.dependencies, writer.config);
+                    writer.config.warnings.skip_method(
+                        method.def,
+                        &method.dependencies,
+                        writer.config,
+                    );
                     CppMethodOrName::Name(method.def)
                 }
             })

--- a/crates/libs/bindgen/src/types/cpp_interface.rs
+++ b/crates/libs/bindgen/src/types/cpp_interface.rs
@@ -38,6 +38,7 @@ impl CppInterface {
                 if method.dependencies.included(writer.config) {
                     CppMethodOrName::Method(method)
                 } else {
+                    warnings::skip_method(method.def, &method.dependencies, writer.config);
                     CppMethodOrName::Name(method.def)
                 }
             })

--- a/crates/libs/bindgen/src/types/interface.rs
+++ b/crates/libs/bindgen/src/types/interface.rs
@@ -61,6 +61,7 @@ impl Interface {
                 if method.dependencies.included(writer.config) {
                     MethodOrName::Method(method)
                 } else {
+                    warnings::skip_method(method.def, &method.dependencies, writer.config);
                     MethodOrName::Name(method.def)
                 }
             })

--- a/crates/libs/bindgen/src/types/interface.rs
+++ b/crates/libs/bindgen/src/types/interface.rs
@@ -61,7 +61,11 @@ impl Interface {
                 if method.dependencies.included(writer.config) {
                     MethodOrName::Method(method)
                 } else {
-                    warnings::skip_method(method.def, &method.dependencies, writer.config);
+                    writer.config.warnings.skip_method(
+                        method.def,
+                        &method.dependencies,
+                        writer.config,
+                    );
                     MethodOrName::Name(method.def)
                 }
             })

--- a/crates/libs/bindgen/src/winmd/codes.rs
+++ b/crates/libs/bindgen/src/winmd/codes.rs
@@ -84,6 +84,13 @@ code! { MemberRefParent(3)
 }
 
 impl MemberRefParent {
+    pub fn type_name(&self) -> TypeName {
+        match self {
+            Self::TypeDef(row) => row.type_name(),
+            Self::TypeRef(row) => row.type_name(),
+        }
+    }
+
     pub fn name(&self) -> &'static str {
         match self {
             Self::TypeDef(row) => row.name(),

--- a/crates/tests/bindgen/tests/panic.rs
+++ b/crates/tests/bindgen/tests/panic.rs
@@ -156,14 +156,27 @@ fn failed_to_write_file() {
 #[should_panic(
     expected = "skipping `Windows.Win32.System.Com.IPersistFile.Load` due to missing dependencies:\n  Windows.Win32.System.Com.STGM"
 )]
-fn skip_method() {
-    bindgen("--out out.txt --filter IPersistFile").unwrap();
+fn skip_cpp_method() {
+    let mut path = std::env::temp_dir();
+    path.push("skip_cpp_method");
+
+    windows_bindgen::bindgen(["--out", &path.to_string_lossy(), "--filter", "IPersistFile"])
+        .unwrap();
 }
 
 #[test]
 #[should_panic(
     expected = "skipping `Windows.Foundation.IMemoryBuffer.CreateReference` due to missing dependencies:\n  Windows.Foundation.IMemoryBufferReference"
 )]
-fn skip_cpp_method() {
-    bindgen("--out out.txt --filter IMemoryBuffer").unwrap();
+fn skip_method() {
+    let mut path = std::env::temp_dir();
+    path.push("skip_method");
+
+    windows_bindgen::bindgen([
+        "--out",
+        &path.to_string_lossy(),
+        "--filter",
+        "IMemoryBuffer",
+    ])
+    .unwrap();
 }

--- a/crates/tests/bindgen/tests/panic.rs
+++ b/crates/tests/bindgen/tests/panic.rs
@@ -1,6 +1,6 @@
 #[track_caller]
-fn bindgen(args: &str) {
-    windows_bindgen::bindgen(args.split_whitespace());
+fn bindgen(args: &str) -> windows_bindgen::Warnings {
+    windows_bindgen::bindgen(args.split_whitespace())
 }
 
 #[test]
@@ -150,4 +150,20 @@ fn failed_to_write_file() {
     std::fs::create_dir_all(&test_path).unwrap();
 
     bindgen(&format!("--out {test_path} --in default --filter POINT",));
+}
+
+#[test]
+#[should_panic(
+    expected = "skipping `Windows.Win32.System.Com.IPersistFile.Load` due to missing dependencies:\n  Windows.Win32.System.Com.STGM"
+)]
+fn skip_method() {
+    bindgen("--out out.txt --filter IPersistFile").unwrap();
+}
+
+#[test]
+#[should_panic(
+    expected = "skipping `Windows.Foundation.IMemoryBuffer.CreateReference` due to missing dependencies:\n  Windows.Foundation.IMemoryBufferReference"
+)]
+fn skip_cpp_method() {
+    bindgen("--out out.txt --filter IMemoryBuffer").unwrap();
 }

--- a/crates/tools/bindings/src/main.rs
+++ b/crates/tools/bindings/src/main.rs
@@ -3,18 +3,19 @@ use windows_bindgen::*;
 fn main() {
     let time = std::time::Instant::now();
 
-    bindgen(["--etc", "crates/tools/bindings/src/async.txt"]);
-    bindgen(["--etc", "crates/tools/bindings/src/async_impl.txt"]);
-    bindgen(["--etc", "crates/tools/bindings/src/collections.txt"]);
-    bindgen(["--etc", "crates/tools/bindings/src/core_com.txt"]);
-    bindgen(["--etc", "crates/tools/bindings/src/core.txt"]);
-    bindgen(["--etc", "crates/tools/bindings/src/metadata.txt"]);
-    bindgen(["--etc", "crates/tools/bindings/src/numerics.txt"]);
-    bindgen(["--etc", "crates/tools/bindings/src/registry.txt"]);
-    bindgen(["--etc", "crates/tools/bindings/src/result.txt"]);
-    bindgen(["--etc", "crates/tools/bindings/src/strings.txt"]);
+    bindgen(["--etc", "crates/tools/bindings/src/async.txt"]).unwrap();
+    bindgen(["--etc", "crates/tools/bindings/src/async_impl.txt"]).unwrap();
+    bindgen(["--etc", "crates/tools/bindings/src/collections.txt"]).unwrap();
+    bindgen(["--etc", "crates/tools/bindings/src/core_com.txt"]).unwrap();
+    bindgen(["--etc", "crates/tools/bindings/src/core.txt"]).unwrap();
+    bindgen(["--etc", "crates/tools/bindings/src/metadata.txt"]).unwrap();
+    bindgen(["--etc", "crates/tools/bindings/src/numerics.txt"]).unwrap();
+    bindgen(["--etc", "crates/tools/bindings/src/registry.txt"]).unwrap();
+    bindgen(["--etc", "crates/tools/bindings/src/result.txt"]).unwrap();
+    bindgen(["--etc", "crates/tools/bindings/src/strings.txt"]).unwrap();
+    bindgen(["--etc", "crates/tools/bindings/src/version.txt"]).unwrap();
+
     bindgen(["--etc", "crates/tools/bindings/src/sys.txt"]);
-    bindgen(["--etc", "crates/tools/bindings/src/version.txt"]);
     bindgen(["--etc", "crates/tools/bindings/src/windows.txt"]);
 
     println!("Finished in {:.2}s", time.elapsed().as_secs_f32());


### PR DESCRIPTION
This adds the ability to retrieve any warnings that the `bindgen` function may decide to collect and return as part of code generation that may or may not be an error depending on the context. For example, let's say you're calling `bindgen` as follows from your build script:

```rust
fn main() {
    windows_bindgen::bindgen([
        "--out",
        "src/bindings.rs",
        "--filter",
        "Windows.Win32.System.Com.IPersistFile",
    ]);
}
```

All goes well until you realize that the `IPersistFile.Load` method was omitted due to a missing dependency. This may or may not be what you wanted. If not, it can be quite tedious to chase down all of the missing dependencies for a larger filter that may span multiple interfaces with many dozens or even hundreds of methods. 

Fortunately, `windows-bindgen` can gather these up and return this information for you:

```rust
fn main() {
    let warnings = windows_bindgen::bindgen([
        "--out",
        "src/bindings.rs",
        "--filter",
        "Windows.Win32.System.Com.IPersistFile",
    ]);

    if !warnings.is_empty() {
        panic!("{warnings}");
    }
}
```

The resulting `Warnings` type is just a collection of strings. It also provides a convenient `unwrap` method to make your build scripts a bit more concise if you prefer:

```rust
fn main() {
    windows_bindgen::bindgen([
        "--out",
        "src/bindings.rs",
        "--filter",
        "Windows.Win32.System.Com.IPersistFile",
    ]).unwrap();
}
```

Either way, here's what the panic message contains:

```
  thread 'main' panicked at build.rs:7:8:
  skipping `Windows.Win32.System.Com.IPersistFile.Load` due to missing dependencies:
    Windows.Win32.System.Com.STGM
```

You can then decide to add `STGM` to your filter and the `Load` method will be generated and the "warning" disappears: 

```rust
fn main() {
    windows_bindgen::bindgen([
        "--out",
        "src/bindings.rs",
        "--filter",
        "Windows.Win32.System.Com.IPersistFile",
        "Windows.Win32.System.Com.STGM",
    ]).unwrap();
}
```

The solution is generic enough that other warnings can conceivably be added in future. And no you can't turn off some warnings. 🙃 Use it for diagnostics and then turn it off if you'd like to skip some but not all methods. For anything more elaborate, feel free to enumerate the warnings yourself. 