### PR TITLE
Optimize external packages

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,12 @@ exclude = [
     "crates/targets/baseline",
 ]
 
+# This compiles external dependencies (outside crates) with full optimization.
+# This can improve run time while iterating on development (testing, etc.).
+# This has NO EFFECT on end users using windows-* crates.
+[profile.dev.package."*"]
+opt-level = 2
+
 [workspace.lints.rust]
 rust_2018_idioms = { level = "warn", priority = -1 }
 missing_docs = "warn"


### PR DESCRIPTION
This is a tiny improvement in development efficiency. When compiling code directly in the Windows-rs repository, this change enables optimizations for external packages. This slightly improves run times for tests.

This has no effect on compilation when `windows-*` crates are pulled from Crates.io.  This only affects code compiled directly within this repository.