### PR TITLE
0.62.1

### DIFF
--- a/crates/libs/collections/Cargo.toml
+++ b/crates/libs/collections/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "windows-collections"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 rust-version = "1.74"
 license = "MIT OR Apache-2.0"
@@ -16,7 +16,7 @@ default-target = "x86_64-pc-windows-msvc"
 targets = []
 
 [dependencies.windows-core]
-version = "0.60.0"
+version = "0.60.1"
 path = "../core"
 default-features = false
 

--- a/crates/libs/core/Cargo.toml
+++ b/crates/libs/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "windows-core"
-version = "0.60.0"
+version = "0.60.1"
 authors = ["Microsoft"]
 edition = "2021"
 rust-version = "1.74"
@@ -22,12 +22,12 @@ version = "0.1.0"
 path = "../link"
 
 [dependencies.windows-result]
-version = "0.3.0"
+version = "0.3.1"
 path = "../result"
 default-features = false
 
 [dependencies.windows-strings]
-version = "0.3.0"
+version = "0.3.1"
 path = "../strings"
 default-features = false
 

--- a/crates/libs/future/Cargo.toml
+++ b/crates/libs/future/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "windows-future"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 rust-version = "1.74"
 license = "MIT OR Apache-2.0"
@@ -20,7 +20,7 @@ default = ["std"]
 std = []
 
 [dependencies.windows-core]
-version = "0.60.0"
+version = "0.60.1"
 path = "../core"
 default-features = false
 

--- a/crates/libs/numerics/Cargo.toml
+++ b/crates/libs/numerics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "windows-numerics"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 rust-version = "1.74"
 license = "MIT OR Apache-2.0"
@@ -20,7 +20,7 @@ default = ["std"]
 std = []
 
 [dependencies.windows-core]
-version = "0.60.0"
+version = "0.60.1"
 path = "../core"
 default-features = false
 

--- a/crates/libs/registry/Cargo.toml
+++ b/crates/libs/registry/Cargo.toml
@@ -22,12 +22,12 @@ version = "0.1.0"
 path = "../link"
 
 [dependencies.windows-result]
-version = "0.3.0"
+version = "0.3.1"
 path = "../result"
 default-features = false
 
 [dependencies.windows-strings]
-version = "0.3.0"
+version = "0.3.1"
 path = "../strings"
 default-features = false
 

--- a/crates/libs/windows/Cargo.toml
+++ b/crates/libs/windows/Cargo.toml
@@ -27,7 +27,7 @@ targets = []
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies.windows-core]
-version = "0.60.0"
+version = "0.60.1"
 path = "../core"
 default-features = false
 
@@ -36,17 +36,17 @@ version = "0.1.0"
 path = "../link"
 
 [dependencies.windows-collections]
-version = "0.1.0"
+version = "0.1.1"
 path = "../collections"
 default-features = false
 
 [dependencies.windows-numerics]
-version = "0.1.0"
+version = "0.1.1"
 path = "../numerics"
 default-features = false
 
 [dependencies.windows-future]
-version = "0.1.0"
+version = "0.1.1"
 path = "../future"
 default-features = false
 


### PR DESCRIPTION
Minor tweak to [the 0.62.0 release](https://github.com/microsoft/windows-rs/releases/tag/0.62.0) to ensure that the crates explicitly depend on the latest version of the `windows-strings` and `windows-result` crates. Mismatches in major versions are caught by Cargo but minor versions evidently are not. 