### PR TITLE
Remove `cast` from `implement` macro

### DIFF
--- a/crates/libs/core/src/com_object.rs
+++ b/crates/libs/core/src/com_object.rs
@@ -1,5 +1,5 @@
 use crate::imp::Box;
-use crate::{AsImpl, IUnknown, IUnknownImpl, Interface, InterfaceRef};
+use crate::{IUnknown, IUnknownImpl, Interface, InterfaceRef};
 use core::any::Any;
 use core::borrow::Borrow;
 use core::ops::Deref;
@@ -245,10 +245,7 @@ impl<T: ComObjectInner> Clone for ComObject<T> {
     }
 }
 
-impl<T: ComObjectInner> AsRef<T> for ComObject<T>
-where
-    IUnknown: From<T> + AsImpl<T>,
-{
+impl<T: ComObjectInner> AsRef<T> for ComObject<T> {
     #[inline(always)]
     fn as_ref(&self) -> &T {
         self.get()

--- a/crates/libs/implement/src/lib.rs
+++ b/crates/libs/implement/src/lib.rs
@@ -36,7 +36,6 @@ pub fn implement(
     original_type: proc_macro::TokenStream,
 ) -> proc_macro::TokenStream {
     let attributes = syn::parse_macro_input!(attributes as ImplementAttributes);
-    let interfaces_len = proc_macro2::Literal::usize_unsuffixed(attributes.implement.len());
 
     let identity_type = if let Some(first) = attributes.implement.first() {
         first.to_ident()
@@ -325,22 +324,6 @@ pub fn implement(
             }
 
             const INNER_OFFSET_IN_POINTERS: usize = #offset_of_this_in_pointers_token;
-        }
-
-        impl #generics #original_ident::#generics where #constraints {
-            /// Try casting as the provided interface
-            ///
-            /// # Safety
-            ///
-            /// This function can only be safely called if `self` has been heap allocated and pinned using
-            /// the mechanisms provided by `implement` macro.
-            #[inline(always)]
-            unsafe fn cast<I: ::windows_core::Interface>(&self) -> ::windows_core::Result<I> {
-                let boxed = (self as *const _ as *const *mut ::core::ffi::c_void).sub(1 + #interfaces_len) as *mut #impl_ident::#generics;
-                let mut result = ::core::ptr::null_mut();
-                _ = <#impl_ident::#generics as ::windows_core::IUnknownImpl>::QueryInterface(&*boxed, &I::IID, &mut result);
-                ::windows_core::Type::from_abi(result)
-            }
         }
 
         impl #generics ::core::convert::From<#original_ident::#generics> for ::windows_core::IUnknown where #constraints {

--- a/crates/tests/libs/implement/tests/from_raw_borrowed.rs
+++ b/crates/tests/libs/implement/tests/from_raw_borrowed.rs
@@ -23,10 +23,8 @@ impl IServiceProvider_Impl for Borrowed_Impl {
         iid: *const GUID,
         object: *mut *mut std::ffi::c_void,
     ) -> Result<()> {
-        unsafe {
-            let unknown: IUnknown = self.cast()?;
-            unknown.query(iid, object).ok()
-        }
+        let unknown = self.as_interface::<IUnknown>();
+        unsafe { unknown.query(iid, object).ok() }
     }
 }
 

--- a/crates/tests/libs/implement/tests/into_impl.rs
+++ b/crates/tests/libs/implement/tests/into_impl.rs
@@ -66,7 +66,7 @@ where
     <T as Type<T>>::Default: PartialEq,
 {
     fn First(&self) -> Result<IIterator<T>> {
-        Ok(Iterator::<T>((unsafe { self.cast()? }, 0).into()).into())
+        Ok(Iterator::<T>((self.to_interface::<IIterable<T>>(), 0).into()).into())
     }
 }
 

--- a/crates/tests/libs/implement/tests/vector.rs
+++ b/crates/tests/libs/implement/tests/vector.rs
@@ -75,7 +75,7 @@ where
         self.Size()
     }
     fn GetView(&self) -> Result<IVectorView<T>> {
-        unsafe { self.cast() }
+        Ok(self.to_interface())
     }
     fn IndexOf(&self, value: Ref<T>, result: &mut u32) -> Result<bool> {
         self.IndexOf(value, result)


### PR DESCRIPTION
This is a cleanup item for my PR #3055.  That PR (and many others that I submitted around the same time) greatly improved support for creating COM objects.  This PR cleans up a few minor things from that work.

First, this PR deletes the generated `cast` method on types marked with `#[implement]`.  The `cast` method was an older mechanism for casting from an object to one of its interfaces.  It is extremely dangerous because it relies on memory constraints that are not verifiable (which is why it is marked `unsafe`).  My previous PRs provided much better ways to handle the need for this, with the `to_interface`, `as_interface` etc. methods.  So `cast` is dangerous and unneeded; let's just remove it.  This is a breaking change, but it's needed.

Second, the PR removes an incorrect type bound on a method in `ComObject`.  This is harmless.