### PR TITLE
Remove `IUnknownImpl::from_inner_ref` as no longer needed

### DIFF
--- a/crates/libs/core/src/unknown.rs
+++ b/crates/libs/core/src/unknown.rs
@@ -117,16 +117,6 @@ pub trait IUnknownImpl {
     /// Gets the trust level of the current object.
     unsafe fn GetTrustLevel(&self, value: *mut i32) -> HRESULT;
 
-    /// Given a reference to an inner type, returns a reference to the outer shared type.
-    ///
-    /// # Safety
-    ///
-    /// This function should only be called from methods that implement COM interfaces, i.e.
-    /// implementations of methods on `IFoo_Impl` traits.
-    // TODO: This can be made safe, if IFoo_Impl are moved to the Object_Impl types.
-    // That requires some substantial redesign, though.
-    unsafe fn from_inner_ref(inner: &Self::Impl) -> &Self;
-
     /// Gets a borrowed reference to an interface that is implemented by this ComObject.
     ///
     /// The returned reference does not have an additional reference count.
@@ -158,10 +148,6 @@ pub trait IUnknownImpl {
     fn to_object(&self) -> ComObject<Self::Impl>
     where
         Self::Impl: ComObjectInner<Outer = Self>;
-
-    /// The distance from the start of `<Foo>_Impl` to the `this` field within it, measured in
-    /// pointer-sized elements. The `this` field contains the `MyApp` instance.
-    const INNER_OFFSET_IN_POINTERS: usize;
 }
 
 impl IUnknown_Vtbl {

--- a/crates/libs/implement/src/lib.rs
+++ b/crates/libs/implement/src/lib.rs
@@ -117,11 +117,6 @@ pub fn implement(
         quote!()
     };
 
-    // The distance from the beginning of the generated type to the 'this' field, in units of pointers (not bytes).
-    let offset_of_this_in_pointers = 1 + attributes.implement.len();
-    let offset_of_this_in_pointers_token =
-        proc_macro2::Literal::usize_unsuffixed(offset_of_this_in_pointers);
-
     let trust_level = proc_macro2::Literal::usize_unsuffixed(attributes.trust_level);
 
     let conversions = attributes.implement.iter().enumerate().map(|(enumerate, implement)| {
@@ -309,11 +304,6 @@ pub fn implement(
                 ::windows_core::HRESULT(0)
             }
 
-            unsafe fn from_inner_ref(inner: &Self::Impl) -> &Self {
-                &*((inner as *const Self::Impl as *const *const ::core::ffi::c_void)
-                    .sub(#offset_of_this_in_pointers_token) as *const Self)
-            }
-
             fn to_object(&self) -> ::windows_core::ComObject<Self::Impl> {
                 self.count.add_ref();
                 unsafe {
@@ -322,8 +312,6 @@ pub fn implement(
                     )
                 }
             }
-
-            const INNER_OFFSET_IN_POINTERS: usize = #offset_of_this_in_pointers_token;
         }
 
         impl #generics ::core::convert::From<#original_ident::#generics> for ::windows_core::IUnknown where #constraints {

--- a/crates/tests/libs/implement_core/src/com_object.rs
+++ b/crates/tests/libs/implement_core/src/com_object.rs
@@ -47,8 +47,7 @@ impl IFoo_Impl for MyApp_Impl {
     }
 
     unsafe fn get_self_as_bar(&self) -> IBar {
-        let outer = MyApp_Impl::from_inner_ref(self);
-        outer.to_interface()
+        self.to_interface()
     }
 
     unsafe fn common(&self) -> u32 {


### PR DESCRIPTION
This PR cleans up part of #3055, which improved COM object support.

The `IUnknownImpl::from_inner_ref` method predates the new `ComObject` API. It allows unsafe code to cast from `&T` to `&T_Impl`. This is a very dangerous operation because it "widens" the pointer; it requires that `&T` point to a `T` that is embedded within a `T_Impl`.

This was necessary for some situations before the new `ComObject` API, but is is completely unnecessary now.  The new `ComObject` API provides safe ways to do the same thing.  Also, this cast is unnecessary because all COM interface trait implementations are done on `T_Impl` types, not on `T`, so this method is unnecessary.
