### PR TITLE
Add `scale` and `skew` functions to `Matrix3x2`

### DIFF
--- a/crates/libs/numerics/src/matrix3x2.rs
+++ b/crates/libs/numerics/src/matrix3x2.rs
@@ -42,6 +42,17 @@ impl Matrix3x2 {
             M32: center.Y - height * center.Y,
         }
     }
+    pub fn skew(angle_x: f32, angle_y: f32) -> Self {
+        Self::skew_around(angle_x, angle_y, Vector2::zero())
+    }
+    pub fn skew_around(angle_x: f32, angle_y: f32, center: Vector2) -> Self {
+        windows_link::link!("d2d1.dll" "system" fn D2D1MakeSkewMatrix(angle_x: f32, angle_y: f32, center: Vector2, matrix: *mut Matrix3x2));
+        let mut matrix = Self::default();
+        unsafe {
+            D2D1MakeSkewMatrix(angle_x, angle_y, center, &mut matrix);
+        }
+        matrix
+    }
     fn impl_add(&self, rhs: &Self) -> Self {
         Self {
             M11: self.M11 + rhs.M11,

--- a/crates/libs/numerics/src/matrix3x2.rs
+++ b/crates/libs/numerics/src/matrix3x2.rs
@@ -21,11 +21,14 @@ impl Matrix3x2 {
             M32: y,
         }
     }
-    pub fn rotation(angle: f32, x: f32, y: f32) -> Self {
+    pub fn rotation(angle: f32) -> Self {
+        Self::rotation_around(angle, Vector2::zero())
+    }
+    pub fn rotation_around(angle: f32, center: Vector2) -> Self {
         windows_link::link!("d2d1.dll" "system" fn D2D1MakeRotateMatrix(angle: f32, center: Vector2, matrix: *mut Matrix3x2));
         let mut matrix = Self::default();
         unsafe {
-            D2D1MakeRotateMatrix(angle, Vector2::new(x, y), &mut matrix);
+            D2D1MakeRotateMatrix(angle, center, &mut matrix);
         }
         matrix
     }

--- a/crates/libs/numerics/src/matrix3x2.rs
+++ b/crates/libs/numerics/src/matrix3x2.rs
@@ -29,17 +29,17 @@ impl Matrix3x2 {
         }
         matrix
     }
-    pub const fn scale(width: f32, height: f32) -> Self {
-        Self::scale_around(width, height, Vector2::zero())
+    pub const fn scale(scale_x: f32, scale_y: f32) -> Self {
+        Self::scale_around(scale_x, scale_y, Vector2::zero())
     }
-    pub const fn scale_around(width: f32, height: f32, center: Vector2) -> Self {
+    pub const fn scale_around(scale_x: f32, scale_y: f32, center: Vector2) -> Self {
         Self {
-            M11: width,
+            M11: scale_x,
             M12: 0.0,
             M21: 0.0,
-            M22: height,
-            M31: center.X - width * center.X,
-            M32: center.Y - height * center.Y,
+            M22: scale_y,
+            M31: center.X - scale_x * center.X,
+            M32: center.Y - scale_y * center.Y,
         }
     }
     pub fn skew(angle_x: f32, angle_y: f32) -> Self {

--- a/crates/libs/numerics/src/matrix3x2.rs
+++ b/crates/libs/numerics/src/matrix3x2.rs
@@ -32,10 +32,10 @@ impl Matrix3x2 {
         }
         matrix
     }
-    pub const fn scale(scale_x: f32, scale_y: f32) -> Self {
+    pub fn scale(scale_x: f32, scale_y: f32) -> Self {
         Self::scale_around(scale_x, scale_y, Vector2::zero())
     }
-    pub const fn scale_around(scale_x: f32, scale_y: f32, center: Vector2) -> Self {
+    pub fn scale_around(scale_x: f32, scale_y: f32, center: Vector2) -> Self {
         Self {
             M11: scale_x,
             M12: 0.0,

--- a/crates/libs/numerics/src/matrix3x2.rs
+++ b/crates/libs/numerics/src/matrix3x2.rs
@@ -29,6 +29,19 @@ impl Matrix3x2 {
         }
         matrix
     }
+    pub const fn scale(width: f32, height: f32) -> Self {
+        Self::scale_around(width, height, Vector2::zero())
+    }
+    pub const fn scale_around(width: f32, height: f32, center: Vector2) -> Self {
+        Self {
+            M11: width,
+            M12: 0.0,
+            M21: 0.0,
+            M22: height,
+            M31: center.X - width * center.X,
+            M32: center.Y - height * center.Y,
+        }
+    }
     fn impl_add(&self, rhs: &Self) -> Self {
         Self {
             M11: self.M11 + rhs.M11,

--- a/crates/libs/numerics/src/vector2.rs
+++ b/crates/libs/numerics/src/vector2.rs
@@ -4,7 +4,7 @@ impl Vector2 {
     pub fn new(X: f32, Y: f32) -> Self {
         Self { X, Y }
     }
-    pub const fn zero() -> Self {
+    pub fn zero() -> Self {
         Self { X: 0f32, Y: 0f32 }
     }
     pub fn one() -> Self {

--- a/crates/libs/numerics/src/vector2.rs
+++ b/crates/libs/numerics/src/vector2.rs
@@ -4,7 +4,7 @@ impl Vector2 {
     pub fn new(X: f32, Y: f32) -> Self {
         Self { X, Y }
     }
-    pub fn zero() -> Self {
+    pub const fn zero() -> Self {
         Self { X: 0f32, Y: 0f32 }
     }
     pub fn one() -> Self {

--- a/crates/samples/windows/direct2d/src/main.rs
+++ b/crates/samples/windows/direct2d/src/main.rs
@@ -241,7 +241,7 @@ impl Window {
         }
 
         unsafe {
-            target.SetTransform(&(Matrix3x2::rotation(angles.second, 0.0, 0.0) * translation));
+            target.SetTransform(&(Matrix3x2::rotation(angles.second) * translation));
 
             target.DrawLine(
                 Vector2::zero(),
@@ -251,7 +251,7 @@ impl Window {
                 &self.style,
             );
 
-            target.SetTransform(&(Matrix3x2::rotation(angles.minute, 0.0, 0.0) * translation));
+            target.SetTransform(&(Matrix3x2::rotation(angles.minute) * translation));
 
             target.DrawLine(
                 Vector2::zero(),
@@ -261,7 +261,7 @@ impl Window {
                 &self.style,
             );
 
-            target.SetTransform(&(Matrix3x2::rotation(angles.hour, 0.0, 0.0) * translation));
+            target.SetTransform(&(Matrix3x2::rotation(angles.hour) * translation));
 
             target.DrawLine(
                 Vector2::zero(),

--- a/crates/tests/misc/matrix3x2/tests/matrix3x2.rs
+++ b/crates/tests/misc/matrix3x2/tests/matrix3x2.rs
@@ -2,7 +2,7 @@ use windows_numerics::{Matrix3x2, Vector2};
 
 #[test]
 fn rotation_test() {
-    _ = Matrix3x2::rotation(0.0, 1.0, 2.0);
+    _ = Matrix3x2::rotation_around(0.0, Vector2::new(1.0, 2.0));
 }
 
 #[test]

--- a/crates/tests/misc/matrix3x2/tests/matrix3x2.rs
+++ b/crates/tests/misc/matrix3x2/tests/matrix3x2.rs
@@ -1,6 +1,11 @@
-use windows_numerics::Matrix3x2;
+use windows_numerics::{Matrix3x2, Vector2};
 
 #[test]
-fn test() {
+fn rotation_test() {
     _ = Matrix3x2::rotation(0.0, 1.0, 2.0);
+}
+
+#[test]
+fn skew_test() {
+    _ = Matrix3x2::skew_around(2.0, 1.0, Vector2::new(1.0, 2.0));
 }


### PR DESCRIPTION
This change copies over the [`Matrix3x2F::Scale`](https://learn.microsoft.com/en-us/windows/win32/api/d2d1helper/nf-d2d1helper-matrix3x2f-scale(d2d1_size_f_d2d1_point_2f)) and [`Matrix3x2F::Skew`](https://learn.microsoft.com/en-us/windows/win32/api/d2d1helper/nf-d2d1helper-matrix3x2f-skew) helpers from `d2d1helper.h`. Additionally, the existing `rotation` helper was changed to align with the pattern created with `scale` and `scale_around`, utilizing `Vector2` for the center.

Finally, tests and samples were updated for these changes. A test was also added to make sure `skew_around` properly linked to `D2D1MakeSkewMatrix`.

Fixes: #2939
