### PR TITLE
Tweaks to support Edition 2024 of Rust in future

### DIFF
--- a/crates/libs/bindgen/src/types/cpp_const.rs
+++ b/crates/libs/bindgen/src/types/cpp_const.rs
@@ -109,7 +109,7 @@ impl CppConst {
             }
         } else if let Some(attribute) = self.field.find_attribute("ConstantAttribute") {
             let args = attribute.args();
-            let Some((_, Value::Str(mut input))) = args.first() else {
+            let Some(&(_, Value::Str(mut input))) = args.first() else {
                 panic!()
             };
 

--- a/crates/libs/implement/src/lib.rs
+++ b/crates/libs/implement/src/lib.rs
@@ -6,7 +6,8 @@
 
 use quote::{quote, ToTokens};
 
-mod gen;
+mod r#gen;
+use r#gen::gen_all;
 
 #[cfg(test)]
 mod tests;
@@ -75,7 +76,7 @@ fn implement_core(
         original_type,
     };
 
-    let items = gen::gen_all(&inputs);
+    let items = gen_all(&inputs);
     let mut tokens = inputs.original_type.into_token_stream();
     for item in items {
         tokens.extend(item.into_token_stream());

--- a/crates/libs/strings/src/literals.rs
+++ b/crates/libs/strings/src/literals.rs
@@ -41,8 +41,7 @@ macro_rules! h {
     ($s:literal) => {{
         const INPUT: &[u8] = $s.as_bytes();
         const OUTPUT_LEN: usize = $crate::utf16_len(INPUT) + 1;
-        #[allow(clippy::declare_interior_mutable_const)]
-        const RESULT: $crate::HSTRING = {
+        static RESULT: $crate::HSTRING = {
             if OUTPUT_LEN == 1 {
                 unsafe { ::core::mem::transmute(::core::ptr::null::<u16>()) }
             } else {
@@ -60,7 +59,6 @@ macro_rules! h {
                 }
             }
         };
-        #[allow(clippy::borrow_interior_mutable_const)]
         &RESULT
     }};
 }

--- a/crates/samples/components/json_validator_winrt_client_cpp/src/lib.rs
+++ b/crates/samples/components/json_validator_winrt_client_cpp/src/lib.rs
@@ -2,7 +2,7 @@
 
 #[test]
 fn test() {
-    extern "system" {
+    unsafe extern "system" {
         fn client();
     }
     unsafe {

--- a/crates/samples/windows/data_protection/src/main.rs
+++ b/crates/samples/windows/data_protection/src/main.rs
@@ -24,9 +24,12 @@ fn main() -> std::io::Result<()> {
 
 unsafe fn as_mut_bytes(buffer: &IBuffer) -> Result<&mut [u8]> {
     let interop = buffer.cast::<IBufferByteAccess>()?;
-    let data = interop.Buffer()?;
-    Ok(std::slice::from_raw_parts_mut(
-        data,
-        buffer.Length()? as usize,
-    ))
+
+    unsafe {
+        let data = interop.Buffer()?;
+        Ok(std::slice::from_raw_parts_mut(
+            data,
+            buffer.Length()? as usize,
+        ))
+    }
 }

--- a/crates/samples/windows/delay_load/src/main.rs
+++ b/crates/samples/windows/delay_load/src/main.rs
@@ -4,20 +4,22 @@ use windows::{core::*, Win32::Foundation::*, Win32::System::LibraryLoader::*};
 ///
 /// The `PCSTR` parameters need to be valid for reads up until and including the next `\0`.
 pub unsafe fn delay_load<T>(library: PCSTR, function: PCSTR) -> Option<T> {
-    let library = LoadLibraryExA(library, None, LOAD_LIBRARY_SEARCH_DEFAULT_DIRS);
+    unsafe {
+        let library = LoadLibraryExA(library, None, LOAD_LIBRARY_SEARCH_DEFAULT_DIRS);
 
-    let Ok(library) = library else {
-        return None;
-    };
+        let Ok(library) = library else {
+            return None;
+        };
 
-    let address = GetProcAddress(library, function);
+        let address = GetProcAddress(library, function);
 
-    if address.is_some() {
-        return Some(std::mem::transmute_copy(&address));
+        if address.is_some() {
+            return Some(std::mem::transmute_copy(&address));
+        }
+
+        _ = FreeLibrary(library);
+        None
     }
-
-    _ = FreeLibrary(library);
-    None
 }
 
 fn main() {

--- a/crates/samples/windows/memory_buffer/src/main.rs
+++ b/crates/samples/windows/memory_buffer/src/main.rs
@@ -10,8 +10,10 @@ unsafe fn as_mut_slice(buffer: &IMemoryBufferReference) -> Result<&mut [u8]> {
     let mut data = std::ptr::null_mut();
     let mut len = 0;
 
-    interop.GetBuffer(&mut data, &mut len)?;
-    Ok(std::slice::from_raw_parts_mut(data, len as usize))
+    unsafe {
+        interop.GetBuffer(&mut data, &mut len)?;
+        Ok(std::slice::from_raw_parts_mut(data, len as usize))
+    }
 }
 
 fn main() -> Result<()> {

--- a/crates/tests/libs/core/tests/unknown.rs
+++ b/crates/tests/libs/core/tests/unknown.rs
@@ -14,7 +14,7 @@ struct Test {
 
 impl ITest_Impl for Test_Impl {
     unsafe fn Test(&self) -> u32 {
-        *self.drop
+        unsafe { *self.drop }
     }
 }
 

--- a/crates/tests/libs/interface/tests/com.rs
+++ b/crates/tests/libs/interface/tests/com.rs
@@ -61,8 +61,10 @@ struct PersistState {
 
 impl ICustomPersist_Impl for Persist_Impl {
     unsafe fn GetClassID(&self, clsid: *mut GUID) -> HRESULT {
-        *clsid = "117fb826-2155-483a-b50d-bc99a2c7cca3".try_into().unwrap();
-        S_OK
+        unsafe {
+            *clsid = "117fb826-2155-483a-b50d-bc99a2c7cca3".try_into().unwrap();
+            S_OK
+        }
     }
 }
 
@@ -79,7 +81,9 @@ impl ICustomPersistMemory_Impl for Persist_Impl {
     unsafe fn Load(&self, input: *const core::ffi::c_void, size: u32) -> HRESULT {
         let mut writer = self.0.write().unwrap();
         if size <= writer.memory.len() as u32 {
-            std::ptr::copy(input, writer.memory.as_mut_ptr() as _, size as usize);
+            unsafe {
+                std::ptr::copy(input, writer.memory.as_mut_ptr() as _, size as usize);
+            }
             writer.dirty = true;
             S_OK
         } else {
@@ -90,7 +94,9 @@ impl ICustomPersistMemory_Impl for Persist_Impl {
     unsafe fn Save(&self, output: *mut core::ffi::c_void, clear_dirty: BOOL, size: u32) -> HRESULT {
         let mut writer = self.0.write().unwrap();
         if size <= writer.memory.len() as u32 {
-            std::ptr::copy(writer.memory.as_mut_ptr() as _, output, size as usize);
+            unsafe {
+                std::ptr::copy(writer.memory.as_mut_ptr() as _, output, size as usize);
+            }
             if clear_dirty.as_bool() {
                 writer.dirty = false;
             }
@@ -102,7 +108,9 @@ impl ICustomPersistMemory_Impl for Persist_Impl {
 
     unsafe fn GetSizeMax(&self, len: *mut u32) -> HRESULT {
         let reader = self.0.read().unwrap();
-        *len = reader.memory.len() as u32;
+        unsafe {
+            *len = reader.memory.len() as u32;
+        }
         S_OK
     }
 

--- a/crates/tests/libs/interface/tests/non_com_new.rs
+++ b/crates/tests/libs/interface/tests/non_com_new.rs
@@ -17,7 +17,7 @@ impl IBase_Impl for Base {
 }
 
 unsafe fn base_value(test: &IBase) -> i32 {
-    test.BaseValue()
+    unsafe { test.BaseValue() }
 }
 
 #[test]

--- a/crates/tests/libs/interface_core/tests/ref.rs
+++ b/crates/tests/libs/interface_core/tests/ref.rs
@@ -40,7 +40,7 @@ impl ITest_Impl for Test_Impl {
         if input.is_none() {
             E_INVALIDARG
         } else {
-            self.interface(input, output)
+            unsafe { self.interface(input, output) }
         }
     }
 
@@ -48,7 +48,7 @@ impl ITest_Impl for Test_Impl {
         if output.is_null() {
             S_FALSE
         } else {
-            self.interface(input, output)
+            unsafe { self.interface(input, output) }
         }
     }
 
@@ -65,7 +65,7 @@ impl ITest_Impl for Test_Impl {
         if input.is_none() {
             E_INVALIDARG.ok()
         } else {
-            self.result_interface(input, output)
+            unsafe { self.result_interface(input, output) }
         }
     }
 }

--- a/crates/tests/libs/interface_core/tests/ref_ok.rs
+++ b/crates/tests/libs/interface_core/tests/ref_ok.rs
@@ -17,7 +17,7 @@ impl ITest_Impl for Test_Impl {
         Ok(())
     }
     unsafe fn TestOther(&self, other: Ref<ITest>, result: &mut i32) -> Result<()> {
-        other.ok()?.Test(result)
+        unsafe { other.ok()?.Test(result) }
     }
 }
 

--- a/crates/tests/libs/strings/tests/literals.rs
+++ b/crates/tests/libs/strings/tests/literals.rs
@@ -9,8 +9,19 @@ fn literals() -> Result<()> {
     const W: PCWSTR = w!("wide");
     assert_eq!(unsafe { W.to_string()? }, "wide");
 
-    const H: &HSTRING = h!("hstring");
-    assert_eq!(H, "hstring");
+    let h: &'static HSTRING = h!("hstring");
+    assert_eq!(h, "hstring");
 
     Ok(())
 }
+
+#[test]
+fn temporary() {
+    expect_pcstr(s!("ansi"));
+    expect_pcwstr(w!("wide"));
+    expect_hstring(h!("hstring"));
+}
+
+fn expect_hstring(_: &'static HSTRING) {}
+fn expect_pcwstr(_: PCWSTR) {}
+fn expect_pcstr(_: PCSTR) {}

--- a/crates/tests/misc/const_params/tests/sys.rs
+++ b/crates/tests/misc/const_params/tests/sys.rs
@@ -5,7 +5,7 @@ extern "C" {
 }
 
 unsafe fn to_string(s: PCWSTR) -> String {
-    String::from_utf16_lossy(std::slice::from_raw_parts(s, wcslen(s)))
+    unsafe { String::from_utf16_lossy(std::slice::from_raw_parts(s, wcslen(s))) }
 }
 
 #[test]


### PR DESCRIPTION
While the 2024 edition of Rust is out, switching isn't so easy since it also requires bumping the MSRV on all crates. Still, making what changes are possible early on does help with eventual transition and can catch problems and blockers early. So I started testing with 2024 and encountered a few notable thigs:

* `extern` blocks must be `unsafe`, but since this is not compatible with 2021 I have to leave that for now. 
* `no_mangle` is considered an unsafe attribute, but that is also incompatible with 2021. 
* Unsafe code within `unsafe` functions must be wrapped in `unsafe` blocks. Since this is compatible with 2021 I've gone ahead and applied this change.
* There are some lifetime changes that restrict lifetime promotion particularly for `const` values. I've gone ahead and fixed those. Notably the `h!` macro cannot return an `HSTRING` reference to a `const` value as Rust thinks the `HSTRING` is a temporary and will be dropped as the expression returns. Making it `static` solves this problem by explicitly promoting to `static` lifetime. This has the downside that the result of `h!` is no longer `const` but that's less of an issue than it not living in static memory which is the whole point. 
