### PR TITLE
Add basic Miri testing

### DIFF
--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -1,0 +1,28 @@
+name: miri
+
+on:
+  pull_request:
+    paths-ignore:
+      - '.github/ISSUE_TEMPLATE/**'
+      - 'web/**'
+  push:
+    paths-ignore:
+      - '.github/ISSUE_TEMPLATE/**'
+      - 'web/**'
+    branches:
+      - master
+
+jobs:
+  check:
+    runs-on: windows-2022
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Update toolchain
+        run: rustup update --no-self-update nightly && rustup default nightly-x86_64-pc-windows-msvc
+      - name: Add toolchain target
+        run: rustup target add x86_64-pc-windows-msvc
+      - name: Add miri
+        run: rustup toolchain install nightly --component miri
+      - name: Check string literals
+        run:  cargo miri test -p test_strings --test literals

--- a/crates/libs/strings/src/literals.rs
+++ b/crates/libs/strings/src/literals.rs
@@ -52,6 +52,8 @@ macro_rules! h {
                     padding1: 0,
                     padding2: 0,
                     ptr: OUTPUT.as_ptr(),
+                    padding3: 0,
+                    padding4: 0,
                 };
                 // SAFETY: an `HSTRING` is exactly equivalent to a pointer to an `HSTRING_HEADER`
                 unsafe {
@@ -136,6 +138,8 @@ pub struct HSTRING_HEADER {
     pub padding1: u32,
     pub padding2: u32,
     pub ptr: *const u16,
+    pub padding3: i32,
+    pub padding4: u16,
 }
 
 #[doc(hidden)]


### PR DESCRIPTION
Adds a basic [Miri](https://github.com/rust-lang/miri) test workflow to the repository. As Miri cannot make OS calls, this is pretty limited. Right now it only tests string literals in the `windows-strings` crate. 

Fixes: #3534