### PR TITLE
Correct minor typos

### DIFF
--- a/crates/libs/future/src/future.rs
+++ b/crates/libs/future/src/future.rs
@@ -24,7 +24,7 @@ pub trait Async: Interface {
     fn set_completed<F: Fn() + Send + 'static>(&self, handler: F) -> Result<()>;
 
     // Calls the given handler with the current object and status.
-    fn invoke_completed(&self, hander: &Self::CompletedHandler, status: AsyncStatus);
+    fn invoke_completed(&self, handler: &Self::CompletedHandler, status: AsyncStatus);
 
     // Returns the value produced on completion. This should only be called when execution completes.
     fn get_results(&self) -> Result<Self::Output>;
@@ -76,7 +76,7 @@ impl<A: Async> Future for AsyncFuture<A> {
         }
 
         if let Some(shared_waker) = &self.waker {
-            // We have a shared waker which means we're either getting polled again or been transfered to
+            // We have a shared waker which means we're either getting polled again or been transferred to
             // another execution context. As we can't tell the difference, we need to update the shared waker
             // to make sure we've got the "current" waker.
             let mut guard = shared_waker.lock().unwrap();

--- a/crates/libs/implement/src/gen.rs
+++ b/crates/libs/implement/src/gen.rs
@@ -8,7 +8,7 @@
 //! item, within the narrowest possible scope. This allows us to detect errors more quickly during
 //! development. If the input to `parse_quote` cannot be parsed, then the macro will panic and
 //! the panic will point to the specific `parse_quote` call, rather than the entire output of the
-//! `implement` proc macro being unparseable. This greatly aids in development.
+//! `implement` proc macro being unparsable. This greatly aids in development.
 
 use super::*;
 use quote::{quote, quote_spanned};
@@ -570,7 +570,7 @@ fn gen_impl_as_impl(
     parse_quote_spanned! {
         interface_chain.implement.span =>
         impl #generics ::windows_core::AsImpl<#original_ident::#generics> for #interface_ident where #constraints {
-            // SAFETY: the offset is guranteed to be in bounds, and the implementation struct
+            // SAFETY: the offset is guaranteed to be in bounds, and the implementation struct
             // is guaranteed to live at least as long as `self`.
             #[inline(always)]
             unsafe fn as_impl_ptr(&self) -> ::core::ptr::NonNull<#original_ident::#generics> {

--- a/crates/libs/interface/src/lib.rs
+++ b/crates/libs/interface/src/lib.rs
@@ -431,7 +431,7 @@ impl Interface {
         }
     }
 
-    /// Gets the parent trait constrait which is nothing if the parent is IUnknown
+    /// Gets the parent trait constraint which is nothing if the parent is IUnknown
     fn parent_trait_constraint(&self) -> proc_macro2::TokenStream {
         if let Some((ident, path)) = self.parent_path().split_last() {
             if ident != "IUnknown" {

--- a/crates/libs/strings/src/hstring_header.rs
+++ b/crates/libs/strings/src/hstring_header.rs
@@ -31,7 +31,7 @@ impl HStringHeader {
         }
 
         unsafe {
-            // Use `ptr::write` (since `header` is unintialized). `HStringHeader` is safe to be all zeros.
+            // Use `ptr::write` (since `header` is uninitialized). `HStringHeader` is safe to be all zeros.
             header.write(core::mem::MaybeUninit::<Self>::zeroed().assume_init());
             (*header).len = len;
             (*header).count = RefCount::new(1);


### PR DESCRIPTION
What's this all about?

- Correct minor typos
  - hander -> handler
  - transfered -> transferred
  - unparseable -> unparsable
  - guranteed -> guaranteed
  - constrait -> constraint
  - unintialized -> uninitialized