### PR TITLE
Improve workspace dependency management

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -72,5 +72,7 @@ jobs:
         run:  cargo clippy -p tool_msvc
       - name: Check tool_standalone
         run:  cargo clippy -p tool_standalone
+      - name: Check tool_workspace
+        run:  cargo clippy -p tool_workspace
       - name: Check tool_yml
         run:  cargo clippy -p tool_yml

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -72,6 +72,8 @@ jobs:
         run:  cargo clippy -p tool_msvc
       - name: Check tool_standalone
         run:  cargo clippy -p tool_standalone
+      - name: Check tool_test_all
+        run:  cargo clippy -p tool_test_all
       - name: Check tool_workspace
         run:  cargo clippy -p tool_workspace
       - name: Check tool_yml

--- a/.github/workflows/gen.yml
+++ b/.github/workflows/gen.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        tool: [bindgen, bindings, yml, license, standalone]
+        tool: [bindgen, bindings, yml, license, standalone, workspace]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -339,6 +339,8 @@ jobs:
         run:  cargo test -p tool_msvc --target ${{ matrix.target }} ${{ matrix.etc }}
       - name: Test tool_standalone
         run:  cargo test -p tool_standalone --target ${{ matrix.target }} ${{ matrix.etc }}
+      - name: Test tool_workspace
+        run:  cargo test -p tool_workspace --target ${{ matrix.target }} ${{ matrix.etc }}
       - name: Test tool_yml
         run:  cargo test -p tool_yml --target ${{ matrix.target }} ${{ matrix.etc }}
       - name: Test windows
@@ -359,10 +361,10 @@ jobs:
         run:  cargo test -p windows-link --target ${{ matrix.target }} ${{ matrix.etc }}
       - name: Test windows-numerics
         run:  cargo test -p windows-numerics --target ${{ matrix.target }} ${{ matrix.etc }}
-      - name: Test windows-registry
-        run:  cargo test -p windows-registry --target ${{ matrix.target }} ${{ matrix.etc }}
       - name: Clean
         run:  cargo clean
+      - name: Test windows-registry
+        run:  cargo test -p windows-registry --target ${{ matrix.target }} ${{ matrix.etc }}
       - name: Test windows-result
         run:  cargo test -p windows-result --target ${{ matrix.target }} ${{ matrix.etc }}
       - name: Test windows-strings

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -339,6 +339,8 @@ jobs:
         run:  cargo test -p tool_msvc --target ${{ matrix.target }} ${{ matrix.etc }}
       - name: Test tool_standalone
         run:  cargo test -p tool_standalone --target ${{ matrix.target }} ${{ matrix.etc }}
+      - name: Test tool_test_all
+        run:  cargo test -p tool_test_all --target ${{ matrix.target }} ${{ matrix.etc }}
       - name: Test tool_workspace
         run:  cargo test -p tool_workspace --target ${{ matrix.target }} ${{ matrix.etc }}
       - name: Test tool_yml
@@ -359,10 +361,10 @@ jobs:
         run:  cargo test -p windows-interface --target ${{ matrix.target }} ${{ matrix.etc }}
       - name: Test windows-link
         run:  cargo test -p windows-link --target ${{ matrix.target }} ${{ matrix.etc }}
-      - name: Test windows-numerics
-        run:  cargo test -p windows-numerics --target ${{ matrix.target }} ${{ matrix.etc }}
       - name: Clean
         run:  cargo clean
+      - name: Test windows-numerics
+        run:  cargo test -p windows-numerics --target ${{ matrix.target }} ${{ matrix.etc }}
       - name: Test windows-registry
         run:  cargo test -p windows-registry --target ${{ matrix.target }} ${{ matrix.etc }}
       - name: Test windows-result

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,18 +28,29 @@ unsafe_op_in_unsafe_fn = "warn"
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(windows_raw_dylib, windows_debugger_visualizer, windows_slim_errors)'] }
 
 [workspace.dependencies]
-cppwinrt = { path = "crates/libs/cppwinrt" }
-windows = { path = "crates/libs/windows" }
-windows-bindgen = { path = "crates/libs/bindgen" }
-windows-collections = { path = "crates/libs/collections" }
-windows-core = { path = "crates/libs/core" }
-windows-future = { path = "crates/libs/future" }
-windows-link = { path = "crates/libs/link" }
-windows-numerics = { path = "crates/libs/numerics" }
-windows-registry = { path = "crates/libs/registry" }
-windows-result = { path = "crates/libs/result" }
-windows-strings = { path = "crates/libs/strings" }
-windows-sys = { path = "crates/libs/sys" }
-windows-targets = { path = "crates/libs/targets" }
-windows-version = { path = "crates/libs/version" }
 helpers = { path = "crates/tools/helpers" }
+proc-macro2 = { version = "1.0", default-features = false }
+quote = { version = "1.0", default-features = false }
+rayon = { version = "1.10", default-features = false }
+serde = { version = "1.0", default-features = false, features = ["derive"] }
+syn = { version = "2.0", default-features = false, features = ["parsing", "proc-macro", "printing", "full", "clone-impls"] }
+toml = { version = "0.8", features = ["parse"] }
+jsonschema = { version = "0.23", default-features = false }
+serde_json = {version = "1.0" }
+# generated dependencies
+cppwinrt = { version = "0.2.1", path = "crates/libs/cppwinrt", default-features = false }
+windows = { version = "0.60.0", path = "crates/libs/windows", default-features = false }
+windows-bindgen = { version = "0.60.0", path = "crates/libs/bindgen", default-features = false }
+windows-collections = { version = "0.1.1", path = "crates/libs/collections", default-features = false }
+windows-core = { version = "0.60.1", path = "crates/libs/core", default-features = false }
+windows-future = { version = "0.1.1", path = "crates/libs/future", default-features = false }
+windows-implement = { version = "0.59.0", path = "crates/libs/implement", default-features = false }
+windows-interface = { version = "0.59.0", path = "crates/libs/interface", default-features = false }
+windows-link = { version = "0.1.0", path = "crates/libs/link", default-features = false }
+windows-numerics = { version = "0.1.1", path = "crates/libs/numerics", default-features = false }
+windows-registry = { version = "0.5.0", path = "crates/libs/registry", default-features = false }
+windows-result = { version = "0.3.1", path = "crates/libs/result", default-features = false }
+windows-strings = { version = "0.3.1", path = "crates/libs/strings", default-features = false }
+windows-sys = { version = "0.59.0", path = "crates/libs/sys", default-features = false }
+windows-targets = { version = "0.53.0", path = "crates/libs/targets", default-features = false }
+windows-version = { version = "0.1.3", path = "crates/libs/version", default-features = false }

--- a/crates/libs/bindgen/Cargo.toml
+++ b/crates/libs/bindgen/Cargo.toml
@@ -8,14 +8,14 @@ description = "Code generator for Windows metadata"
 repository = "https://github.com/microsoft/windows-rs"
 readme = "readme.md"
 
+[dependencies]
+rayon = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+
 [lints]
 workspace = true
 
 [package.metadata.docs.rs]
 default-target = "x86_64-pc-windows-msvc"
 targets = []
-
-[dependencies]
-rayon = "1.10"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"

--- a/crates/libs/collections/Cargo.toml
+++ b/crates/libs/collections/Cargo.toml
@@ -8,22 +8,20 @@ description = "Windows collection types"
 repository = "https://github.com/microsoft/windows-rs"
 readme = "readme.md"
 
+[dependencies]
+windows-core = { workspace = true }
+
+[dev-dependencies]
+windows-result = { workspace = true }
+windows-strings = { workspace = true }
+
+[features]
+default = ["std"]
+std = []
+
 [lints]
 workspace = true
 
 [package.metadata.docs.rs]
 default-target = "x86_64-pc-windows-msvc"
 targets = []
-
-[dependencies.windows-core]
-version = "0.60.1"
-path = "../core"
-default-features = false
-
-[features]
-default = ["std"]
-std = []
-
-[dev-dependencies]
-windows-result = { path = "../result" }
-windows-strings = { path = "../strings" }

--- a/crates/libs/core/Cargo.toml
+++ b/crates/libs/core/Cargo.toml
@@ -10,31 +10,20 @@ repository = "https://github.com/microsoft/windows-rs"
 readme = "readme.md"
 categories = ["os::windows-apis"]
 
+[dependencies]
+windows-implement = { workspace = true }
+windows-interface = { workspace = true }
+windows-link = { workspace = true }
+windows-result = { workspace = true }
+windows-strings = { workspace = true }
+
+[features]
+default = ["std"]
+std = ["windows-result/std", "windows-strings/std"]
+
 [lints]
 workspace = true
 
 [package.metadata.docs.rs]
 default-target = "x86_64-pc-windows-msvc"
 targets = []
-
-[dependencies.windows-link]
-version = "0.1.0"
-path = "../link"
-
-[dependencies.windows-result]
-version = "0.3.1"
-path = "../result"
-default-features = false
-
-[dependencies.windows-strings]
-version = "0.3.1"
-path = "../strings"
-default-features = false
-
-[dependencies]
-windows-implement = { path = "../implement",  version = "0.59.0" }
-windows-interface = { path = "../interface",  version = "0.59.0" }
-
-[features]
-default = ["std"]
-std = ["windows-result/std", "windows-strings/std"]

--- a/crates/libs/cppwinrt/Cargo.toml
+++ b/crates/libs/cppwinrt/Cargo.toml
@@ -10,13 +10,12 @@ repository = "https://github.com/microsoft/windows-rs"
 readme = "readme.md"
 categories = ["os::windows-apis"]
 
+[dependencies]
+windows-link = { workspace = true }
+
 [lints]
 workspace = true
 
 [package.metadata.docs.rs]
 default-target = "x86_64-pc-windows-msvc"
 targets = []
-
-[dependencies.windows-link]
-version = "0.1.0"
-path = "../link"

--- a/crates/libs/future/Cargo.toml
+++ b/crates/libs/future/Cargo.toml
@@ -8,25 +8,20 @@ description = "Windows async types"
 repository = "https://github.com/microsoft/windows-rs"
 readme = "readme.md"
 
+[dependencies]
+windows-core = { workspace = true }
+windows-link = { workspace = true }
+
+[dev-dependencies]
+windows-result = { workspace = true }
+
+[features]
+default = ["std"]
+std = []
+
 [lints]
 workspace = true
 
 [package.metadata.docs.rs]
 default-target = "x86_64-pc-windows-msvc"
 targets = []
-
-[features]
-default = ["std"]
-std = []
-
-[dependencies.windows-core]
-version = "0.60.1"
-path = "../core"
-default-features = false
-
-[dependencies.windows-link]
-version = "0.1.0"
-path = "../link"
-
-[dev-dependencies]
-windows-result = { path = "../result" }

--- a/crates/libs/implement/Cargo.toml
+++ b/crates/libs/implement/Cargo.toml
@@ -8,6 +8,14 @@ license = "MIT OR Apache-2.0"
 description = "The implement macro for the windows crate"
 repository = "https://github.com/microsoft/windows-rs"
 
+[dependencies]
+proc-macro2 = { workspace = true }
+quote = { workspace = true }
+syn = { workspace = true }
+
+[dev-dependencies]
+windows-core = { workspace = true }
+
 [lints]
 workspace = true
 
@@ -17,11 +25,3 @@ targets = []
 
 [lib]
 proc-macro = true
-
-[dependencies]
-syn = { version = "2.0", default-features = false, features = ["parsing", "proc-macro", "printing", "full", "derive"] }
-quote = "1.0"
-proc-macro2 = "1.0"
-
-[dev-dependencies]
-windows-core = { path = "../core" }

--- a/crates/libs/interface/Cargo.toml
+++ b/crates/libs/interface/Cargo.toml
@@ -8,6 +8,14 @@ license = "MIT OR Apache-2.0"
 description = "The interface macro for the windows crate"
 repository = "https://github.com/microsoft/windows-rs"
 
+[dependencies]
+proc-macro2 = { workspace = true }
+quote = { workspace = true }
+syn = { workspace = true }
+
+[dev-dependencies]
+windows-core = { workspace = true }
+
 [lints]
 workspace = true
 
@@ -17,11 +25,3 @@ targets = []
 
 [lib]
 proc-macro = true
-
-[dependencies]
-syn = { version = "2.0", default-features = false, features = ["parsing", "proc-macro", "printing", "full", "derive", "clone-impls"] }
-quote = "1.0"
-proc-macro2 = "1.0"
-
-[dev-dependencies]
-windows-core = { path = "../core" }

--- a/crates/libs/numerics/Cargo.toml
+++ b/crates/libs/numerics/Cargo.toml
@@ -8,22 +8,17 @@ description = "Windows numeric types"
 repository = "https://github.com/microsoft/windows-rs"
 readme = "readme.md"
 
+[dependencies]
+windows-core = { workspace = true }
+windows-link = { workspace = true }
+
+[features]
+default = ["std"]
+std = []
+
 [lints]
 workspace = true
 
 [package.metadata.docs.rs]
 default-target = "x86_64-pc-windows-msvc"
 targets = []
-
-[features]
-default = ["std"]
-std = []
-
-[dependencies.windows-core]
-version = "0.60.1"
-path = "../core"
-default-features = false
-
-[dependencies.windows-link]
-version = "0.1.0"
-path = "../link"

--- a/crates/libs/registry/Cargo.toml
+++ b/crates/libs/registry/Cargo.toml
@@ -10,27 +10,18 @@ repository = "https://github.com/microsoft/windows-rs"
 readme = "readme.md"
 categories = ["os::windows-apis"]
 
+[dependencies]
+windows-link = { workspace = true }
+windows-result = { workspace = true }
+windows-strings = { workspace = true }
+
+[features]
+default = ["std"]
+std = ["windows-result/std", "windows-strings/std"]
+
 [lints]
 workspace = true
 
 [package.metadata.docs.rs]
 default-target = "x86_64-pc-windows-msvc"
 targets = []
-
-[dependencies.windows-link]
-version = "0.1.0"
-path = "../link"
-
-[dependencies.windows-result]
-version = "0.3.1"
-path = "../result"
-default-features = false
-
-[dependencies.windows-strings]
-version = "0.3.1"
-path = "../strings"
-default-features = false
-
-[features]
-default = ["std"]
-std = ["windows-result/std", "windows-strings/std"]

--- a/crates/libs/result/Cargo.toml
+++ b/crates/libs/result/Cargo.toml
@@ -10,6 +10,9 @@ repository = "https://github.com/microsoft/windows-rs"
 readme = "readme.md"
 categories = ["os::windows-apis"]
 
+[dependencies]
+windows-link = { workspace = true }
+
 [features]
 default = ["std"]
 std = []
@@ -20,7 +23,3 @@ workspace = true
 [package.metadata.docs.rs]
 default-target = "x86_64-pc-windows-msvc"
 targets = []
-
-[dependencies.windows-link]
-version = "0.1.0"
-path = "../link"

--- a/crates/libs/strings/Cargo.toml
+++ b/crates/libs/strings/Cargo.toml
@@ -10,6 +10,13 @@ repository = "https://github.com/microsoft/windows-rs"
 readme = "readme.md"
 categories = ["os::windows-apis"]
 
+[dependencies]
+windows-link = { workspace = true }
+
+[features]
+default = ["std"]
+std = []
+
 [lints]
 workspace = true
 
@@ -17,10 +24,3 @@ workspace = true
 default-target = "x86_64-pc-windows-msvc"
 targets = []
 
-[dependencies.windows-link]
-version = "0.1.0"
-path = "../link"
-
-[features]
-default = ["std"]
-std = []

--- a/crates/libs/sys/Cargo.toml
+++ b/crates/libs/sys/Cargo.toml
@@ -10,6 +10,9 @@ repository = "https://github.com/microsoft/windows-rs"
 readme = "readme.md"
 categories = ["os::windows-apis"]
 
+[dependencies]
+windows-targets = { workspace = true }
+
 [lib]
 # This crate does not contain tests. All tests are in separate crates.
 test = false
@@ -22,10 +25,6 @@ workspace = true
 default-target = "x86_64-pc-windows-msvc"
 targets = []
 all-features = true
-
-[dependencies.windows-targets]
-version = "0.53.0"
-path = "../targets"
 
 [features]
 default = []

--- a/crates/libs/version/Cargo.toml
+++ b/crates/libs/version/Cargo.toml
@@ -10,13 +10,12 @@ repository = "https://github.com/microsoft/windows-rs"
 readme = "readme.md"
 categories = ["os::windows-apis"]
 
+[dependencies]
+windows-link = { workspace = true }
+
 [lints]
 workspace = true
 
 [package.metadata.docs.rs]
 default-target = "x86_64-pc-windows-msvc"
 targets = []
-
-[dependencies.windows-link]
-version = "0.1.0"
-path = "../link"

--- a/crates/libs/windows/Cargo.toml
+++ b/crates/libs/windows/Cargo.toml
@@ -13,6 +13,13 @@ readme = "readme.md"
 categories = ["os::windows-apis"]
 exclude = ["features.json"]
 
+[dependencies]
+windows-collections = { workspace = true }
+windows-core = { workspace = true }
+windows-future = { workspace = true }
+windows-link = { workspace = true }
+windows-numerics = { workspace = true }
+
 [lib]
 # This crate does not contain tests. All tests are in separate crates.
 test = false
@@ -25,30 +32,6 @@ workspace = true
 default-target = "x86_64-pc-windows-msvc"
 targets = []
 rustdoc-args = ["--cfg", "docsrs"]
-
-[dependencies.windows-core]
-version = "0.60.1"
-path = "../core"
-default-features = false
-
-[dependencies.windows-link]
-version = "0.1.0"
-path = "../link"
-
-[dependencies.windows-collections]
-version = "0.1.1"
-path = "../collections"
-default-features = false
-
-[dependencies.windows-numerics]
-version = "0.1.1"
-path = "../numerics"
-default-features = false
-
-[dependencies.windows-future]
-version = "0.1.1"
-path = "../future"
-default-features = false
 
 [features]
 default = ["std"]

--- a/crates/samples/windows/data_protection/Cargo.toml
+++ b/crates/samples/windows/data_protection/Cargo.toml
@@ -7,6 +7,7 @@ publish = false
 [dependencies.windows]
 workspace = true
 features = [
+    "std",
     "Storage_Streams",
     "Security_Cryptography_DataProtection",
     "Win32_System_WinRT",

--- a/crates/tests/libs/collections/Cargo.toml
+++ b/crates/tests/libs/collections/Cargo.toml
@@ -21,3 +21,4 @@ workspace = true
 
 [dependencies.windows-collections]
 workspace = true
+features = ["std"]

--- a/crates/tests/libs/future/Cargo.toml
+++ b/crates/tests/libs/future/Cargo.toml
@@ -18,6 +18,7 @@ features = [
 
 [dependencies.windows-future]
 workspace = true
+features = ["std"]
 
 [dev-dependencies]
 futures = "0.3"

--- a/crates/tests/libs/strings/Cargo.toml
+++ b/crates/tests/libs/strings/Cargo.toml
@@ -10,6 +10,7 @@ doctest = false
 
 [dependencies.windows-strings]
 workspace = true
+features = ["std"]
 
 [dependencies.windows-link]
 workspace = true

--- a/crates/tests/misc/error/Cargo.toml
+++ b/crates/tests/misc/error/Cargo.toml
@@ -11,6 +11,7 @@ doctest = false
 [dependencies.windows]
 workspace = true
 features = [
+    "std",
     "Foundation",
     "Win32_System_Rpc",
 ]

--- a/crates/tests/misc/readme/Cargo.toml
+++ b/crates/tests/misc/readme/Cargo.toml
@@ -44,9 +44,11 @@ workspace = true
 
 [dev-dependencies.windows-future]
 workspace = true
+features = ["std"]
 
 [dev-dependencies.cppwinrt]
 workspace = true
 
 [dev-dependencies.windows-collections]
 workspace = true
+features = ["std"]

--- a/crates/tests/misc/registry_default/Cargo.toml
+++ b/crates/tests/misc/registry_default/Cargo.toml
@@ -10,3 +10,4 @@ doctest = false
 
 [dependencies.windows-registry]
 workspace = true
+features = ["std"]

--- a/crates/tests/misc/win32/Cargo.toml
+++ b/crates/tests/misc/win32/Cargo.toml
@@ -11,6 +11,7 @@ doctest = false
 [dependencies.windows]
 workspace = true
 features = [
+    "std",
     "Win32_Gaming",
     "Win32_Graphics_Direct2D",
     "Win32_Graphics_Direct3D",

--- a/crates/tests/winrt/collection_interop/Cargo.toml
+++ b/crates/tests/winrt/collection_interop/Cargo.toml
@@ -13,6 +13,7 @@ workspace = true
 
 [dependencies.windows-collections]
 workspace = true
+features = ["std"]
 
 [build-dependencies.windows-bindgen]
 workspace = true

--- a/crates/tests/winrt/event_core/Cargo.toml
+++ b/crates/tests/winrt/event_core/Cargo.toml
@@ -11,6 +11,7 @@ doctest = false
 [dependencies.windows]
 workspace = true
 features = [
+    "std",
     "Foundation",
     "Win32_System_WinRT",
 ]

--- a/crates/tests/winrt/events/Cargo.toml
+++ b/crates/tests/winrt/events/Cargo.toml
@@ -18,6 +18,7 @@ workspace = true
 [dependencies.windows]
 workspace = true
 features = [
+    "std",
     "Foundation",
     "Win32_System_WinRT",
 ]

--- a/crates/tests/winrt/old/Cargo.toml
+++ b/crates/tests/winrt/old/Cargo.toml
@@ -20,6 +20,7 @@ workspace = true
 [dependencies.windows]
 workspace = true
 features = [
+    "std",
     "AI_MachineLearning",
     "ApplicationModel_Activation",
     "ApplicationModel_Appointments",

--- a/crates/tools/test_all/Cargo.toml
+++ b/crates/tools/test_all/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "tool_test_all"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+helpers = { workspace = true }

--- a/crates/tools/test_all/src/main.rs
+++ b/crates/tools/test_all/src/main.rs
@@ -1,0 +1,12 @@
+fn main() {
+    for package in helpers::crates("crates") {
+        let mut command = std::process::Command::new("cargo.exe");
+        command.args(["test", "-p", &package.name]);
+
+        if command.status().unwrap().success() {
+            println!("{}", package.name);
+        } else {
+            panic!("Failed: cargo test -p {}", package.name);
+        }
+    }
+}

--- a/crates/tools/workspace/Cargo.toml
+++ b/crates/tools/workspace/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "tool_workspace"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+helpers = { workspace = true }

--- a/crates/tools/workspace/src/main.rs
+++ b/crates/tools/workspace/src/main.rs
@@ -1,0 +1,32 @@
+use std::fmt::Write;
+use std::io::BufRead;
+
+fn main() {
+    let mut toml = String::new();
+
+    let file = std::fs::File::open("Cargo.toml").unwrap();
+    let file = std::io::BufReader::new(file);
+
+    for line in file.lines() {
+        let line = line.unwrap();
+        toml.push_str(&line);
+        toml.push('\n');
+
+        if line == "# generated dependencies" {
+            break;
+        }
+    }
+
+    for package in helpers::crates("crates/libs") {
+        writeln!(
+            &mut toml,
+            r#"{} = {{ version = "{}", path = "crates/libs/{}", default-features = false }}"#,
+            package.name,
+            package.version,
+            package.name.trim_start_matches("windows-")
+        )
+        .unwrap();
+    }
+
+    std::fs::write("Cargo.toml", toml).unwrap();
+}


### PR DESCRIPTION
In preparation for #3541, I'm improving the way dependencies are managed across the `windows-rs` repo by leveraging the workspace `Cargo.toml` to define all dependencies. This way, any time a crate's version is updated, it doesn't require that change to be repeated throughout the repo. 

Cargo still requires that the crate's version be specified in both the crate's `Cargo.toml` file as well as the workspace `Cargo.toml` file, but the latter is now updated automatically by `tool_workspace`. This should make release management far less error-prone.

This update also introduces `tool_test_all` for locally testing all crates individually. `cargo test --all` does a great job in general. The problem is that Cargo will try and optimize the build by aggregating all of the features required by all crates and thus does not catch the case when a particular crate depends on a feature that was not explicitly requested by that crate. Running `tool_test_all` will catch those. This is already done by the `test.yml` but `tool_test_all` just makes it easier to catch such mistakes locally before creating a PR. 