### PR TITLE
Fix circular dependency 

### DIFF
--- a/crates/libs/implement/Cargo.toml
+++ b/crates/libs/implement/Cargo.toml
@@ -14,7 +14,7 @@ quote = { workspace = true }
 syn = { workspace = true, features = ["parsing", "proc-macro", "printing", "full", "clone-impls"] }
 
 [dev-dependencies]
-windows-core = { workspace = true }
+windows-core = { path = "../core" }
 
 [lints]
 workspace = true

--- a/crates/libs/interface/Cargo.toml
+++ b/crates/libs/interface/Cargo.toml
@@ -14,7 +14,7 @@ quote = { workspace = true }
 syn = { workspace = true, features = ["parsing", "proc-macro", "printing", "full", "clone-impls"] }
 
 [dev-dependencies]
-windows-core = { workspace = true }
+windows-core = { path = "../core" }
 
 [lints]
 workspace = true


### PR DESCRIPTION
#3546 introduced a circular dependency between `windows-core` and `windows-implement`/`windows-interface` so that those crates could not be published as they depended on each other. This PR fixes the circular dependency by changing the `windows-core` dependency to use a path instead of a workspace reference in the `Cargo.toml` files. This was a problem because the workspace dependencies include versions. This is reasonable as it is only used as a dev dependency for documentation testing. 