### PR TITLE
Fix semver compatibility issue

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,11 +35,11 @@ toml = { version = "0.8", features = ["parse"] }
 serde_json = {version = "1.0", default-features = false }
 # generated dependencies
 cppwinrt = { version = "0.2.2", path = "crates/libs/cppwinrt", default-features = false }
-windows = { version = "0.61.0", path = "crates/libs/windows", default-features = false }
+windows = { version = "0.61.1", path = "crates/libs/windows", default-features = false }
 windows-bindgen = { version = "0.61.0", path = "crates/libs/bindgen", default-features = false }
-windows-collections = { version = "0.1.2", path = "crates/libs/collections", default-features = false }
+windows-collections = { version = "0.2.0", path = "crates/libs/collections", default-features = false }
 windows-core = { version = "0.61.0", path = "crates/libs/core", default-features = false }
-windows-future = { version = "0.1.2", path = "crates/libs/future", default-features = false }
+windows-future = { version = "0.2.0", path = "crates/libs/future", default-features = false }
 windows-implement = { version = "0.60.0", path = "crates/libs/implement", default-features = false }
 windows-interface = { version = "0.59.1", path = "crates/libs/interface", default-features = false }
 windows-link = { version = "0.1.1", path = "crates/libs/link", default-features = false }

--- a/crates/libs/collections/Cargo.toml
+++ b/crates/libs/collections/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "windows-collections"
-version = "0.1.2"
+version = "0.2.0"
 edition = "2021"
 rust-version = "1.74"
 license = "MIT OR Apache-2.0"

--- a/crates/libs/collections/readme.md
+++ b/crates/libs/collections/readme.md
@@ -10,7 +10,7 @@ Start by adding the following to your Cargo.toml file:
 
 ```toml
 [dependencies.windows-collections]
-version = "0.1"
+version = "0.2"
 ```
 
 Use the Windows collection types as needed:

--- a/crates/libs/future/Cargo.toml
+++ b/crates/libs/future/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "windows-future"
-version = "0.1.2"
+version = "0.2.0"
 edition = "2021"
 rust-version = "1.74"
 license = "MIT OR Apache-2.0"

--- a/crates/libs/future/readme.md
+++ b/crates/libs/future/readme.md
@@ -10,7 +10,7 @@ Start by adding the following to your Cargo.toml file:
 
 ```toml
 [dependencies.windows-future]
-version = "0.1"
+version = "0.2"
 ```
 
 Use the Windows async types as needed:

--- a/crates/libs/windows/Cargo.toml
+++ b/crates/libs/windows/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "windows"
-version = "0.61.0"
+version = "0.61.1"
 authors = ["Microsoft"]
 edition = "2021"
 rust-version = "1.74"


### PR DESCRIPTION
[Release 63](https://github.com/microsoft/windows-rs/releases/tag/63) introduced a semver incompatibility. This is limited to the `windows-future` and `windows-collections` crates that depend on a breaking change in the `windows-core` crate. I have yanked the minor updates to both `windows-future` and `windows-collections`. This update introduces major updates to both crates as well as a minor update to the `windows` crate to pick up the latest versions of those dependencies. 

Fixes: #3553
Fixes: #3552