### PR TITLE
Add fast indexing support to `windows-ecma335`

### DIFF
--- a/crates/libs/ecma335/src/reader/blob.rs
+++ b/crates/libs/ecma335/src/reader/blob.rs
@@ -1,7 +1,8 @@
 use super::*;
 
 pub struct Blob<'a> {
-    file: &'a File,
+    index: &'a Index,
+    file: usize,
     slice: &'a [u8],
 }
 
@@ -26,8 +27,8 @@ impl std::ops::Deref for Blob<'_> {
 }
 
 impl<'a> Blob<'a> {
-    pub fn new(file: &'a File, slice: &'a [u8]) -> Self {
-        Self { file, slice }
+    pub fn new(index: &'a Index, file: usize, slice: &'a [u8]) -> Self {
+        Self { index, file, slice }
     }
 
     fn peek(&self) -> (usize, usize) {
@@ -47,7 +48,7 @@ impl<'a> Blob<'a> {
     }
 
     pub fn decode<D: Decode<'a>>(&mut self) -> D {
-        D::decode(self.file, self.read_compressed())
+        D::decode(self.index, self.file, self.read_compressed())
     }
 
     pub fn try_read(&mut self, expected: usize) -> bool {
@@ -68,7 +69,11 @@ impl<'a> Blob<'a> {
                 break;
             } else {
                 self.offset(offset);
-                mods.push(TypeDefOrRef::decode(self.file, self.read_compressed()))
+                mods.push(TypeDefOrRef::decode(
+                    self.index,
+                    self.file,
+                    self.read_compressed(),
+                ))
             }
         }
         mods

--- a/crates/libs/ecma335/src/reader/codes.rs
+++ b/crates/libs/ecma335/src/reader/codes.rs
@@ -23,7 +23,7 @@ macro_rules! code {
             #[allow(dead_code)]
             pub fn encode(&self) -> usize {
                 match self {
-                    $(Self::$table(row) => (row.index() + 1) << $size | $code,)*
+                    $(Self::$table(row) => (row.pos() + 1) << $size | $code,)*
                 }
             }
         }

--- a/crates/libs/ecma335/src/reader/codes.rs
+++ b/crates/libs/ecma335/src/reader/codes.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 pub trait Decode<'a> {
-    fn decode(file: &'a File, code: usize) -> Self;
+    fn decode(index: &'a Index, file: usize, code: usize) -> Self;
 }
 
 macro_rules! code {
@@ -11,10 +11,10 @@ macro_rules! code {
             $($table($table<'a>),)*
         }
         impl<'a> Decode<'a> for $name<'a> {
-            fn decode(file: &'a File, code: usize) -> Self {
+            fn decode(index: &'a Index, file: usize, code: usize) -> Self {
                 let (kind, row) = (code & ((1 << $size) - 1), (code >> $size) - 1);
                 match kind {
-                    $($code => Self::$table($table(Row::new(file, row))),)*
+                    $($code => Self::$table($table(Row::new(index, file, row))),)*
                     rest => panic!("{rest:?}"),
                 }
             }

--- a/crates/libs/ecma335/src/reader/codes.rs
+++ b/crates/libs/ecma335/src/reader/codes.rs
@@ -109,7 +109,7 @@ code! { TypeOrMethodDef(1)
     (TypeDef, 0)
 }
 
-impl<'a> TypeDefOrRef<'a> {
+impl TypeDefOrRef<'_> {
     pub fn namespace(&self) -> &str {
         match self {
             Self::TypeDef(row) => row.namespace(),

--- a/crates/libs/ecma335/src/reader/file.rs
+++ b/crates/libs/ecma335/src/reader/file.rs
@@ -7,40 +7,6 @@ pub struct File {
     tables: [Table; 17],
 }
 
-impl std::fmt::Debug for File {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        std::write!(f, "{:?}", self.bytes.as_ptr())
-    }
-}
-
-impl std::hash::Hash for File {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.bytes.as_ptr().hash(state);
-    }
-}
-
-impl PartialEq for File {
-    fn eq(&self, other: &Self) -> bool {
-        std::ptr::eq(self.bytes.as_ptr(), other.bytes.as_ptr())
-    }
-}
-
-impl Eq for File {}
-
-impl Ord for File {
-    fn cmp(&self, other: &Self) -> Ordering {
-        self.bytes.as_ptr().cmp(&other.bytes.as_ptr())
-    }
-}
-
-impl PartialOrd for File {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-unsafe impl Sync for File {}
-
 impl File {
     pub fn read<P: AsRef<std::path::Path>>(path: P) -> Option<Self> {
         std::fs::read(path).ok().and_then(Self::new)
@@ -660,11 +626,11 @@ impl File {
         first
     }
 
-    pub fn TypeDef(&self) -> std::ops::Range<usize> {
+    pub(crate) fn TypeDef(&self) -> std::ops::Range<usize> {
         0..self.tables[TypeDef::TABLE].len
     }
 
-    pub fn NestedClass(&self) -> std::ops::Range<usize> {
+    pub(crate) fn NestedClass(&self) -> std::ops::Range<usize> {
         0..self.tables[NestedClass::TABLE].len
     }
 }

--- a/crates/libs/ecma335/src/reader/file.rs
+++ b/crates/libs/ecma335/src/reader/file.rs
@@ -722,8 +722,8 @@ impl View for [u8] {
 
     fn view_as_str(&self, offset: usize) -> Option<&[u8]> {
         let buffer = &self[offset..];
-        let index = buffer.iter().position(|c| *c == b'\0')?;
-        Some(&self[offset..offset + index])
+        let pos = buffer.iter().position(|c| *c == b'\0')?;
+        Some(&self[offset..offset + pos])
     }
 
     fn is_proper_length<T>(&self, offset: usize) -> Option<()> {

--- a/crates/libs/ecma335/src/reader/file.rs
+++ b/crates/libs/ecma335/src/reader/file.rs
@@ -535,7 +535,7 @@ impl File {
         std::str::from_utf8(&bytes[..nul_pos]).expect("expected valid utf-8 C-string")
     }
 
-    pub(crate) fn blob(&self, row: usize, table: usize, column: usize) -> Blob {
+    pub(crate) fn blob(&self, row: usize, table: usize, column: usize) -> &[u8] {
         let offset = self.blobs + self.usize(row, table, column);
         let initial_byte = self.bytes[offset];
 
@@ -553,7 +553,7 @@ impl File {
         }
 
         let offset = offset + blob_size_bytes;
-        Blob::new(self, &self.bytes[offset..offset + blob_size])
+        &self.bytes[offset..offset + blob_size]
     }
 
     pub(crate) fn list(
@@ -660,16 +660,12 @@ impl File {
         first
     }
 
-    pub fn table<'a, R: AsRow<'a>>(&'a self) -> RowIterator<'a, R> {
-        RowIterator::new(self, 0..self.tables[R::TABLE].len)
+    pub fn TypeDef(&self) -> std::ops::Range<usize> {
+        0..self.tables[TypeDef::TABLE].len
     }
 
-    pub fn TypeDef(&self) -> RowIterator<TypeDef> {
-        self.table()
-    }
-
-    pub fn NestedClass<'a>(&'a self) -> RowIterator<'a, NestedClass<'a>> {
-        self.table()
+    pub fn NestedClass(&self) -> std::ops::Range<usize> {
+        0..self.tables[NestedClass::TABLE].len
     }
 }
 

--- a/crates/libs/ecma335/src/reader/index.rs
+++ b/crates/libs/ecma335/src/reader/index.rs
@@ -1,9 +1,9 @@
 use super::*;
 
 pub struct Index {
-    pub(crate) files: Vec<File>,
-    pub(crate) types: HashMap<String, HashMap<String, Vec<(usize, usize)>>>,
-    pub(crate) nested: HashMap<(usize, usize), Vec<(usize, usize)>>,
+    files: Vec<File>,
+    types: HashMap<String, HashMap<String, Vec<(usize, usize)>>>,
+    nested: HashMap<(usize, usize), Vec<usize>>,
 }
 
 impl Index {
@@ -13,7 +13,7 @@ impl Index {
 
     pub fn new(files: Vec<File>) -> Self {
         let mut types: HashMap<String, HashMap<String, Vec<(usize, usize)>>> = HashMap::new();
-        let mut nested: HashMap<(usize, usize), Vec<(usize, usize)>> = HashMap::new();
+        let mut nested: HashMap<(usize, usize), Vec<usize>> = HashMap::new();
 
         for (file_pos, file) in files.iter().enumerate() {
             for def_pos in file.TypeDef() {
@@ -40,7 +40,7 @@ impl Index {
                 nested
                     .entry((file_pos, outer))
                     .or_default()
-                    .push((file_pos, inner));
+                    .push(inner);
             }
         }
 
@@ -51,7 +51,7 @@ impl Index {
         }
     }
 
-    pub fn files(&self, pos: usize) -> &File {
+    pub(crate) fn files(&self, pos: usize) -> &File {
         &self.files[pos]
     }
 
@@ -92,10 +92,10 @@ impl Index {
             .into_iter()
             .flatten()
             .cloned()
-            .map(|(file, pos)| {
+            .map(move |pos| {
                 TypeDef(Row {
                     index: self,
-                    file,
+                    file: ty.0.file,
                     pos,
                 })
             })

--- a/crates/libs/ecma335/src/reader/index.rs
+++ b/crates/libs/ecma335/src/reader/index.rs
@@ -37,10 +37,7 @@ impl Index {
             for map in file.NestedClass() {
                 let inner = file.usize(map, TypeDef::TABLE, 0);
                 let outer = file.usize(map, TypeDef::TABLE, 1);
-                nested
-                    .entry((file_pos, outer))
-                    .or_default()
-                    .push(inner);
+                nested.entry((file_pos, outer)).or_default().push(inner);
             }
         }
 

--- a/crates/libs/ecma335/src/reader/index.rs
+++ b/crates/libs/ecma335/src/reader/index.rs
@@ -7,6 +7,10 @@ pub struct Index {
 }
 
 impl Index {
+    pub fn read<P: AsRef<std::path::Path>>(path: P) -> Option<Self> {
+        Some(Self::new(vec![File::read(path)?]))
+    }
+
     pub fn new(files: Vec<File>) -> Self {
         let mut types: HashMap<String, HashMap<String, Vec<(usize, usize)>>> = HashMap::new();
         let mut nested: HashMap<(usize, usize), Vec<(usize, usize)>> = HashMap::new();
@@ -47,7 +51,7 @@ impl Index {
         }
     }
 
-    pub fn file(&self, pos: usize) -> &File {
+    pub fn files(&self, pos: usize) -> &File {
         &self.files[pos]
     }
 

--- a/crates/libs/ecma335/src/reader/index.rs
+++ b/crates/libs/ecma335/src/reader/index.rs
@@ -1,40 +1,54 @@
 use super::*;
 
-pub struct Index<'a> {
-    types: BTreeMap<&'a str, BTreeMap<&'a str, Vec<TypeDef<'a>>>>,
-    nested: HashMap<TypeDef<'a>, Vec<TypeDef<'a>>>,
+pub struct Index {
+    pub(crate) files: Vec<File>,
+    pub(crate) types: HashMap<String, HashMap<String, Vec<(usize, usize)>>>,
+    pub(crate) nested: HashMap<(usize, usize), Vec<(usize, usize)>>,
 }
 
-impl<'a> Index<'a> {
-    pub fn new(files: &'a [File]) -> Self {
-        let mut types: BTreeMap<&str, BTreeMap<&str, Vec<TypeDef>>> = BTreeMap::new();
-        let mut nested: HashMap<TypeDef, Vec<TypeDef>> = HashMap::new();
+impl Index {
+    pub fn new(files: Vec<File>) -> Self {
+        let mut types: HashMap<String, HashMap<String, Vec<(usize, usize)>>> = HashMap::new();
+        let mut nested: HashMap<(usize, usize), Vec<(usize, usize)>> = HashMap::new();
 
-        for file in files {
-            for def in file.TypeDef() {
-                let namespace = def.namespace();
+        for (file_pos, file) in files.iter().enumerate() {
+            for def_pos in file.TypeDef() {
+                let namespace = file.str(def_pos, TypeDef::TABLE, 2);
 
                 if namespace.is_empty() {
                     // Skips `<Module>` as well as nested types.
                     continue;
                 }
 
+                let name = file.str(def_pos, TypeDef::TABLE, 1);
+
                 types
-                    .entry(namespace)
+                    .entry(namespace.to_string())
                     .or_default()
-                    .entry(trim_tick(def.name()))
+                    .entry(trim_tick(name).to_string())
                     .or_default()
-                    .push(def);
+                    .push((file_pos, def_pos));
             }
 
             for map in file.NestedClass() {
-                let outer = map.outer();
-                let inner = map.inner();
-                nested.entry(outer).or_default().push(inner);
+                let inner = file.usize(map, TypeDef::TABLE, 0);
+                let outer = file.usize(map, TypeDef::TABLE, 1);
+                nested
+                    .entry((file_pos, outer))
+                    .or_default()
+                    .push((file_pos, inner));
             }
         }
 
-        Self { types, nested }
+        Self {
+            files,
+            types,
+            nested,
+        }
+    }
+
+    pub fn file(&self, pos: usize) -> &File {
+        &self.files[pos]
     }
 
     pub fn all(&self) -> impl Iterator<Item = TypeDef> + '_ {
@@ -42,7 +56,7 @@ impl<'a> Index<'a> {
             .values()
             .flat_map(|types| types.values())
             .flatten()
-            .cloned()
+            .map(|(file, pos)| TypeDef(Row::new(self, *file, *pos)))
     }
 
     pub fn get(&self, namespace: &str, name: &str) -> impl Iterator<Item = TypeDef> + '_ {
@@ -51,7 +65,7 @@ impl<'a> Index<'a> {
             .and_then(|types| types.get(name))
             .into_iter()
             .flatten()
-            .cloned()
+            .map(|(file, pos)| TypeDef(Row::new(self, *file, *pos)))
     }
 
     pub fn expect(&self, namespace: &str, name: &str) -> TypeDef {
@@ -68,11 +82,18 @@ impl<'a> Index<'a> {
         }
     }
 
-    pub fn nested(&self, ty: TypeDef<'a>) -> impl Iterator<Item = TypeDef<'a>> + '_ {
+    pub fn nested(&self, ty: TypeDef) -> impl Iterator<Item = TypeDef> + '_ {
         self.nested
-            .get(&ty)
-            .map(|nested| nested.iter())
-            .unwrap_or_else(|| [].iter())
+            .get(&(ty.0.file, ty.0.pos))
+            .into_iter()
+            .flatten()
             .cloned()
+            .map(|(file, pos)| {
+                TypeDef(Row {
+                    index: self,
+                    file,
+                    pos,
+                })
+            })
     }
 }

--- a/crates/libs/ecma335/src/reader/row.rs
+++ b/crates/libs/ecma335/src/reader/row.rs
@@ -3,15 +3,15 @@ use super::*;
 #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, Ord, PartialOrd)]
 pub struct Row<'a> {
     file: &'a File,
-    index: usize,
+    pos: usize,
 }
 
 unsafe impl Send for Row<'_> {}
 unsafe impl Sync for Row<'_> {}
 
 impl<'a> Row<'a> {
-    pub(crate) fn new(file: &'a File, index: usize) -> Self {
-        Self { file, index }
+    pub(crate) fn new(file: &'a File, pos: usize) -> Self {
+        Self { file, pos }
     }
 }
 
@@ -24,16 +24,16 @@ pub trait AsRow<'a>: Copy {
         self.to_row().file
     }
 
-    fn index(&self) -> usize {
-        self.to_row().index
+    fn pos(&self) -> usize {
+        self.to_row().pos
     }
 
     fn usize(&self, column: usize) -> usize {
-        self.file().usize(self.index(), Self::TABLE, column)
+        self.file().usize(self.pos(), Self::TABLE, column)
     }
 
     fn str(&self, column: usize) -> &'a str {
-        self.file().str(self.index(), Self::TABLE, column)
+        self.file().str(self.pos(), Self::TABLE, column)
     }
 
     fn row<R: AsRow<'a>>(&self, column: usize) -> R {
@@ -45,12 +45,12 @@ pub trait AsRow<'a>: Copy {
     }
 
     fn blob(&self, column: usize) -> Blob<'a> {
-        self.file().blob(self.index(), Self::TABLE, column)
+        self.file().blob(self.pos(), Self::TABLE, column)
     }
 
     fn list<R: AsRow<'a>>(&self, column: usize) -> RowIterator<'a, R> {
         let file = self.file();
-        RowIterator::new(file, file.list(self.index(), Self::TABLE, column, R::TABLE))
+        RowIterator::new(file, file.list(self.pos(), Self::TABLE, column, R::TABLE))
     }
 
     fn equal_range<L: AsRow<'a>>(&self, column: usize, value: usize) -> RowIterator<'a, L> {
@@ -62,7 +62,7 @@ pub trait AsRow<'a>: Copy {
     fn parent_row<P: AsRow<'a>>(&'a self, column: usize) -> P {
         let file = self.file();
 
-        P::from_row(Row::new(file, file.parent(self.index(), P::TABLE, column)))
+        P::from_row(Row::new(file, file.parent(self.pos(), P::TABLE, column)))
     }
 }
 

--- a/crates/libs/ecma335/src/reader/row.rs
+++ b/crates/libs/ecma335/src/reader/row.rs
@@ -64,7 +64,7 @@ pub trait AsRow<'a>: Copy {
 
     fn file(&self) -> &'a File {
         let row = self.to_row();
-        row.index.file(row.file)
+        row.index.files(row.file)
     }
 
     fn pos(&self) -> usize {

--- a/crates/libs/ecma335/src/reader/tables/field.rs
+++ b/crates/libs/ecma335/src/reader/tables/field.rs
@@ -24,8 +24,7 @@ impl Field<'_> {
     }
 
     pub fn constant(&self) -> Option<Constant> {
-        self.file()
-            .equal_range(1, HasConstant::Field(*self).encode())
+        self.equal_range(1, HasConstant::Field(*self).encode())
             .next()
     }
 }

--- a/crates/libs/ecma335/src/reader/tables/method_def.rs
+++ b/crates/libs/ecma335/src/reader/tables/method_def.rs
@@ -32,12 +32,11 @@ impl MethodDef<'_> {
     }
 
     pub fn parent(&self) -> MemberRefParent {
-        MemberRefParent::TypeDef(self.file().parent(5, *self))
+        MemberRefParent::TypeDef(self.parent_row(5))
     }
 
     pub fn impl_map(&self) -> Option<ImplMap> {
-        self.file()
-            .equal_range(1, MemberForwarded::MethodDef(*self).encode())
+        self.equal_range(1, MemberForwarded::MethodDef(*self).encode())
             .next()
     }
 

--- a/crates/libs/ecma335/src/reader/tables/nested_class.rs
+++ b/crates/libs/ecma335/src/reader/tables/nested_class.rs
@@ -9,12 +9,12 @@ impl std::fmt::Debug for NestedClass<'_> {
     }
 }
 
-impl<'a> NestedClass<'a> {
-    pub fn inner(&self) -> TypeDef<'a> {
+impl NestedClass<'_> {
+    pub fn inner(&self) -> TypeDef {
         self.row(0)
     }
 
-    pub fn outer(&self) -> TypeDef<'a> {
+    pub fn outer(&self) -> TypeDef {
         self.row(1)
     }
 }

--- a/crates/libs/ecma335/src/reader/tables/type_def.rs
+++ b/crates/libs/ecma335/src/reader/tables/type_def.rs
@@ -6,16 +6,16 @@ impl std::fmt::Debug for TypeDef<'_> {
     }
 }
 
-impl<'a> TypeDef<'a> {
+impl TypeDef<'_> {
     pub fn flags(&self) -> TypeAttributes {
         TypeAttributes(self.usize(0).try_into().unwrap())
     }
 
-    pub fn name(&self) -> &'a str {
+    pub fn name(&self) -> &str {
         self.str(1)
     }
 
-    pub fn namespace(&self) -> &'a str {
+    pub fn namespace(&self) -> &str {
         self.str(2)
     }
 

--- a/crates/libs/ecma335/src/reader/tables/type_def.rs
+++ b/crates/libs/ecma335/src/reader/tables/type_def.rs
@@ -36,16 +36,15 @@ impl<'a> TypeDef<'a> {
     }
 
     pub fn generic_params(&self) -> RowIterator<GenericParam> {
-        self.file()
-            .equal_range(2, TypeOrMethodDef::TypeDef(*self).encode())
+        self.equal_range(2, TypeOrMethodDef::TypeDef(*self).encode())
     }
 
     pub fn interface_impls(&self) -> RowIterator<InterfaceImpl> {
-        self.file().equal_range(0, self.index() + 1)
+        self.equal_range(0, self.index() + 1)
     }
 
     pub fn class_layout(&self) -> Option<ClassLayout> {
-        self.file().equal_range(2, self.index() + 1).next()
+        self.equal_range(2, self.index() + 1).next()
     }
 
     pub fn category(&self) -> TypeCategory {

--- a/crates/libs/ecma335/src/reader/tables/type_def.rs
+++ b/crates/libs/ecma335/src/reader/tables/type_def.rs
@@ -40,11 +40,11 @@ impl<'a> TypeDef<'a> {
     }
 
     pub fn interface_impls(&self) -> RowIterator<InterfaceImpl> {
-        self.equal_range(0, self.index() + 1)
+        self.equal_range(0, self.pos() + 1)
     }
 
     pub fn class_layout(&self) -> Option<ClassLayout> {
-        self.equal_range(2, self.index() + 1).next()
+        self.equal_range(2, self.pos() + 1).next()
     }
 
     pub fn category(&self) -> TypeCategory {

--- a/crates/tests/libs/ecma335/tests/attribute.rs
+++ b/crates/tests/libs/ecma335/tests/attribute.rs
@@ -61,11 +61,7 @@ fn test() {
     std::fs::write("tests/attribute.winmd", bytes).unwrap();
 
     let reader = reader::Index::read("tests/attribute.winmd").unwrap();
-
-    let ty = reader
-        .all()
-        .find(|def| def.name() == "Name")
-        .unwrap();
+    let ty = reader.expect("Namespace", "Name");
 
     let attributes: Vec<_> = ty.attributes().collect();
     assert_eq!(attributes.len(), 1);

--- a/crates/tests/libs/ecma335/tests/attribute.rs
+++ b/crates/tests/libs/ecma335/tests/attribute.rs
@@ -60,10 +60,10 @@ fn test() {
     let bytes = file.into_stream();
     std::fs::write("tests/attribute.winmd", bytes).unwrap();
 
-    let reader = reader::File::read("tests/attribute.winmd").unwrap();
+    let reader = reader::Index::read("tests/attribute.winmd").unwrap();
 
     let ty = reader
-        .table::<reader::TypeDef>()
+        .all()
         .find(|def| def.name() == "Name")
         .unwrap();
 

--- a/crates/tests/libs/ecma335/tests/class.rs
+++ b/crates/tests/libs/ecma335/tests/class.rs
@@ -84,6 +84,5 @@ fn test() {
     std::fs::write("tests/class.winmd", bytes).unwrap();
 
     let reader = reader::Index::read("tests/class.winmd").unwrap();
-
     let _ty = reader.expect("Namespace", "Name");
 }

--- a/crates/tests/libs/ecma335/tests/class.rs
+++ b/crates/tests/libs/ecma335/tests/class.rs
@@ -83,7 +83,7 @@ fn test() {
     let bytes = file.into_stream();
     std::fs::write("tests/class.winmd", bytes).unwrap();
 
-    let reader = reader::File::read("tests/class.winmd").unwrap();
+    let reader = reader::Index::read("tests/class.winmd").unwrap();
 
-    let _ty = reader.TypeDef().find(|def| def.name() == "Name").unwrap();
+    let _ty = reader.expect("Namespace", "Name");
 }

--- a/crates/tests/libs/ecma335/tests/empty.rs
+++ b/crates/tests/libs/ecma335/tests/empty.rs
@@ -6,5 +6,5 @@ fn test() {
     let bytes = file.into_stream();
     std::fs::write("tests/empty.winmd", bytes).unwrap();
 
-    let _reader = reader::File::read("tests/empty.winmd").unwrap();
+    let _reader = reader::Index::read("tests/empty.winmd").unwrap();
 }

--- a/crates/tests/libs/ecma335/tests/interface.rs
+++ b/crates/tests/libs/ecma335/tests/interface.rs
@@ -41,9 +41,8 @@ fn test() {
     let bytes = file.into_stream();
     std::fs::write("tests/interface.winmd", bytes).unwrap();
 
-    let reader = reader::File::read("tests/interface.winmd").unwrap();
-
-    let ty = reader.TypeDef().find(|def| def.name() == "Name").unwrap();
+    let reader = reader::Index::read("tests/interface.winmd").unwrap();
+    let ty = reader.expect("Namespace", "Name");
 
     let methods: Vec<_> = ty.methods().collect();
     assert_eq!(methods.len(), 2);

--- a/crates/tests/libs/ecma335/tests/reader.rs
+++ b/crates/tests/libs/ecma335/tests/reader.rs
@@ -23,10 +23,8 @@ fn test() {
 #[test]
 fn array() {
     let file = reader::Index::read("../../../libs/bindgen/default/Windows.Win32.winmd").unwrap();
-    let def = file
-        .all()
-        .find(|def| def.name() == "VDMCONTEXT")
-        .unwrap();
+    let def = file.all().find(|def| def.name() == "VDMCONTEXT").unwrap();
+    
     let field = def
         .fields()
         .find(|field| field.name() == "ExtendedRegisters")

--- a/crates/tests/libs/ecma335/tests/reader.rs
+++ b/crates/tests/libs/ecma335/tests/reader.rs
@@ -2,9 +2,9 @@ use windows_ecma335::*;
 
 #[test]
 fn test() {
-    let file = reader::File::read("../../../libs/bindgen/default/Windows.winmd").unwrap();
+    let file = reader::Index::read("../../../libs/bindgen/default/Windows.winmd").unwrap();
 
-    let def = file.TypeDef().find(|def| def.name() == "Point").unwrap();
+    let def = file.expect("Windows.Foundation", "Point");
     assert_eq!(def.namespace(), "Windows.Foundation");
     assert_eq!(def.name(), "Point");
 
@@ -22,9 +22,9 @@ fn test() {
 
 #[test]
 fn array() {
-    let file = reader::File::read("../../../libs/bindgen/default/Windows.Win32.winmd").unwrap();
+    let file = reader::Index::read("../../../libs/bindgen/default/Windows.Win32.winmd").unwrap();
     let def = file
-        .TypeDef()
+        .all()
         .find(|def| def.name() == "VDMCONTEXT")
         .unwrap();
     let field = def

--- a/crates/tests/libs/ecma335/tests/reader.rs
+++ b/crates/tests/libs/ecma335/tests/reader.rs
@@ -24,7 +24,7 @@ fn test() {
 fn array() {
     let file = reader::Index::read("../../../libs/bindgen/default/Windows.Win32.winmd").unwrap();
     let def = file.all().find(|def| def.name() == "VDMCONTEXT").unwrap();
-    
+
     let field = def
         .fields()
         .find(|field| field.name() == "ExtendedRegisters")

--- a/crates/tests/libs/ecma335/tests/struct.rs
+++ b/crates/tests/libs/ecma335/tests/struct.rs
@@ -27,8 +27,7 @@ fn test() {
     std::fs::write("tests/struct.winmd", bytes).unwrap();
 
     let reader = reader::Index::read("tests/struct.winmd").unwrap();
-
-    let ty = reader.all().find(|def| def.name() == "Name").unwrap();
+    let ty = reader.expect("Namespace", "Name");
 
     let fields: Vec<_> = ty.fields().collect();
     assert_eq!(fields.len(), 2);

--- a/crates/tests/libs/ecma335/tests/struct.rs
+++ b/crates/tests/libs/ecma335/tests/struct.rs
@@ -26,9 +26,9 @@ fn test() {
     let bytes = file.into_stream();
     std::fs::write("tests/struct.winmd", bytes).unwrap();
 
-    let reader = reader::File::read("tests/struct.winmd").unwrap();
+    let reader = reader::Index::read("tests/struct.winmd").unwrap();
 
-    let ty = reader.TypeDef().find(|def| def.name() == "Name").unwrap();
+    let ty = reader.all().find(|def| def.name() == "Name").unwrap();
 
     let fields: Vec<_> = ty.fields().collect();
     assert_eq!(fields.len(), 2);

--- a/crates/tools/merge/src/main.rs
+++ b/crates/tools/merge/src/main.rs
@@ -50,7 +50,7 @@ fn main() {
 
     let mut writer = writer::File::new(&name);
 
-    let index = reader::Index::new(&input);
+    let index = reader::Index::new(input);
 
     for ty in index.all() {
         write_type(&mut writer, &index, ty, None);


### PR DESCRIPTION
Builds on #3560 to add fast indexing support to the `windows-ecma335` reader so that any row can quickly resolve indexed types. This is necessary for deeper type inspection required by `windows-bindgen`.