### PR TITLE
Derive `Hash` for `Type` in `windows_registry`

### DIFF
--- a/crates/libs/registry/src/type.rs
+++ b/crates/libs/registry/src/type.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 /// The possible types that a registry value could have.
-#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug, Hash)]
 pub enum Type {
     /// A 32-bit unsigned integer value.
     U32,

--- a/crates/tests/libs/registry/tests/hash.rs
+++ b/crates/tests/libs/registry/tests/hash.rs
@@ -1,4 +1,3 @@
-
 use windows_registry::*;
 
 #[test]

--- a/crates/tests/libs/registry/tests/hash.rs
+++ b/crates/tests/libs/registry/tests/hash.rs
@@ -1,0 +1,8 @@
+
+use windows_registry::*;
+
+#[test]
+fn hash() {
+    let mut set = std::collections::HashSet::<Type>::new();
+    set.insert(Type::U32);
+}


### PR DESCRIPTION
Fixes: #3557