### PR TITLE
Add key rename support to the `windows-registry` crate

### DIFF
--- a/crates/libs/registry/src/bindings.rs
+++ b/crates/libs/registry/src/bindings.rs
@@ -23,6 +23,7 @@ windows_link::link!("advapi32.dll" "system" fn RegOpenKeyExW(hkey : HKEY, lpsubk
 windows_link::link!("advapi32.dll" "system" fn RegOpenKeyTransactedW(hkey : HKEY, lpsubkey : PCWSTR, uloptions : u32, samdesired : REG_SAM_FLAGS, phkresult : *mut HKEY, htransaction : HANDLE, pextendedparemeter : *const core::ffi::c_void) -> WIN32_ERROR);
 windows_link::link!("advapi32.dll" "system" fn RegQueryInfoKeyW(hkey : HKEY, lpclass : PWSTR, lpcchclass : *mut u32, lpreserved : *const u32, lpcsubkeys : *mut u32, lpcbmaxsubkeylen : *mut u32, lpcbmaxclasslen : *mut u32, lpcvalues : *mut u32, lpcbmaxvaluenamelen : *mut u32, lpcbmaxvaluelen : *mut u32, lpcbsecuritydescriptor : *mut u32, lpftlastwritetime : *mut FILETIME) -> WIN32_ERROR);
 windows_link::link!("advapi32.dll" "system" fn RegQueryValueExW(hkey : HKEY, lpvaluename : PCWSTR, lpreserved : *const u32, lptype : *mut REG_VALUE_TYPE, lpdata : *mut u8, lpcbdata : *mut u32) -> WIN32_ERROR);
+windows_link::link!("advapi32.dll" "system" fn RegRenameKey(hkey : HKEY, lpsubkeyname : PCWSTR, lpnewkeyname : PCWSTR) -> WIN32_ERROR);
 windows_link::link!("advapi32.dll" "system" fn RegSetValueExW(hkey : HKEY, lpvaluename : PCWSTR, reserved : u32, dwtype : REG_VALUE_TYPE, lpdata : *const u8, cbdata : u32) -> WIN32_ERROR);
 pub type BOOL = i32;
 pub const ERROR_INVALID_DATA: WIN32_ERROR = 13u32;

--- a/crates/libs/registry/src/key.rs
+++ b/crates/libs/registry/src/key.rs
@@ -36,6 +36,12 @@ impl Key {
         self.0
     }
 
+    /// Changes the name of the specified registry key.
+    pub fn rename<F: AsRef<str>, T: AsRef<str>>(&self, from: F, to: T) -> Result<()> {
+        let result = unsafe { RegRenameKey(self.0, pcwstr(from).as_ptr(), pcwstr(to).as_ptr()) };
+        win32_error(result)
+    }
+
     /// Removes the registry keys and values of the specified key recursively.
     pub fn remove_tree<T: AsRef<str>>(&self, path: T) -> Result<()> {
         let result = unsafe { RegDeleteTreeW(self.0, pcwstr(path).as_ptr()) };

--- a/crates/tests/libs/registry/tests/rename.rs
+++ b/crates/tests/libs/registry/tests/rename.rs
@@ -1,0 +1,21 @@
+use windows_registry::*;
+
+#[test]
+fn string() -> Result<()> {
+    let test_key = "software\\windows-rs\\tests\\rename";
+    _ = CURRENT_USER.remove_tree(test_key);
+    let test_key = CURRENT_USER.create(test_key)?;
+
+    let from = test_key.create("from")?;
+    from.set_string("key", "renamed value")?;
+    drop(from);
+
+    test_key.rename("from", "to")?;
+
+    let renamed = test_key.open("to")?;
+    assert_eq!(renamed.get_string("key")?, "renamed value");
+
+    CURRENT_USER.rename("software\\windows-rs\\tests\\rename\\to", "too")?;
+
+    Ok(())
+}

--- a/crates/tools/bindings/src/registry.txt
+++ b/crates/tools/bindings/src/registry.txt
@@ -37,4 +37,5 @@
     RegOpenKeyTransactedW
     RegQueryInfoKeyW
     RegQueryValueExW
+    RegRenameKey
     RegSetValueExW


### PR DESCRIPTION
The new `rename` method changes the name of the specified registry sub key.

The test illustrates how this may be used.

Fixes: #3495