### PR TITLE
Fix nightly clippy warnings

### DIFF
--- a/crates/libs/bindgen/src/lib.rs
+++ b/crates/libs/bindgen/src/lib.rs
@@ -199,7 +199,7 @@ where
     config.write(tree);
 
     if index {
-        index::write(&types, &format!("{}/features.json", output));
+        index::write(&types, &format!("{output}/features.json"));
     }
 
     warnings.build()

--- a/crates/libs/bindgen/src/types/cpp_const.rs
+++ b/crates/libs/bindgen/src/types/cpp_const.rs
@@ -82,7 +82,7 @@ impl CppConst {
                 if underlying_ty == constant_ty {
                     if is_signed_error(&field_ty) {
                         if let Value::I32(signed) = constant.value() {
-                            value = format!("0x{:X}_u32 as _", signed).into();
+                            value = format!("0x{signed:X}_u32 as _").into();
                         }
                     }
                 } else if field_ty == Type::Bool {

--- a/crates/libs/core/src/imp/sha1.rs
+++ b/crates/libs/core/src/imp/sha1.rs
@@ -474,7 +474,7 @@ impl Digest {
 impl core::fmt::Display for Digest {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         for i in self.data.iter() {
-            write!(f, "{:08x}", i)?;
+            write!(f, "{i:08x}")?;
         }
         Ok(())
     }

--- a/crates/libs/result/src/hresult.rs
+++ b/crates/libs/result/src/hresult.rs
@@ -149,6 +149,6 @@ impl core::fmt::Display for HRESULT {
 
 impl core::fmt::Debug for HRESULT {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.write_fmt(format_args!("HRESULT({})", self))
+        f.write_fmt(format_args!("HRESULT({self})"))
     }
 }

--- a/crates/libs/strings/src/bstr.rs
+++ b/crates/libs/strings/src/bstr.rs
@@ -127,7 +127,7 @@ impl core::fmt::Display for BSTR {
 
 impl core::fmt::Debug for BSTR {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::write!(f, "{}", self)
+        core::write!(f, "{self}")
     }
 }
 

--- a/crates/libs/strings/src/hstring.rs
+++ b/crates/libs/strings/src/hstring.rs
@@ -122,7 +122,7 @@ impl core::fmt::Display for HSTRING {
 
 impl core::fmt::Debug for HSTRING {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        write!(f, "\"{}\"", self)
+        write!(f, "\"{self}\"")
     }
 }
 

--- a/crates/tools/msvc/src/main.rs
+++ b/crates/tools/msvc/src/main.rs
@@ -149,7 +149,7 @@ EXPORTS
 
     path.pop();
     path.push(format!("{library}.exp"));
-    std::fs::remove_file(&path).unwrap_or_else(|_| panic!("{:?}", path));
+    std::fs::remove_file(&path).unwrap_or_else(|_| panic!("{path:?}"));
 
     path.pop();
     path.push(format!("{library}.obj"));


### PR DESCRIPTION
Fixes for `clippy::uninlined-format-args`: 
https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args