### PR TITLE
Remove MacOS testing

### DIFF
--- a/.github/workflows/cross.yml
+++ b/.github/workflows/cross.yml
@@ -30,9 +30,8 @@ jobs:
         # https://github.com/rust-lang/rust/issues/79577
         # https://sourceforge.net/p/mingw-w64/wiki2/Exception%20Handling
         #
-        image: [macos-14, ubuntu-22.04]
         target: [x86_64-pc-windows-gnu, aarch64-pc-windows-gnullvm, x86_64-pc-windows-gnullvm, i686-pc-windows-gnullvm]
-    runs-on: ${{ matrix.image }}
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout
@@ -46,35 +45,31 @@ jobs:
 
       - name: Install gcc-mingw-w64-x86-64
         run: sudo apt-get install -y gcc-mingw-w64-x86-64
-        if: startsWith(matrix.image, 'ubuntu-') && matrix.target == 'x86_64-pc-windows-gnu'
-
-      - name: Install mingw-w64
-        run: brew install mingw-w64
-        if: startsWith(matrix.image, 'macos-') && matrix.target == 'x86_64-pc-windows-gnu'
+        if: matrix.target == 'x86_64-pc-windows-gnu'
 
       - name: LLVM MinGW toolchain cache configuration
         id: cache-llvm-mingw-toolchain
         uses: actions/cache@v4
-        if: startsWith(matrix.image, 'ubuntu-') && contains(matrix.target, 'gnullvm')
+        if: contains(matrix.target, 'gnullvm')
         with:
           path: ${{ env.LLVM-MINGW-TOOLCHAIN-NAME }}
           key: ${{ env.LLVM-MINGW-TOOLCHAIN-NAME }}
 
       - name: Install LLVM MinGW toolchain
-        if: startsWith(matrix.image, 'ubuntu-') && contains(matrix.target, 'gnullvm') && steps.cache-llvm-mingw-toolchain.outputs.cache-hit != 'true'
+        if: contains(matrix.target, 'gnullvm') && steps.cache-llvm-mingw-toolchain.outputs.cache-hit != 'true'
         run: |
           curl -L -o ${{ env.LLVM-MINGW-TOOLCHAIN-NAME }}.tar.xz https://github.com/mstorsjo/llvm-mingw/releases/download/20220906/${{ env.LLVM-MINGW-TOOLCHAIN-NAME }}.tar.xz
           tar -xf ${{ env.LLVM-MINGW-TOOLCHAIN-NAME }}.tar.xz
           echo "${{ env.LLVM-MINGW-TOOLCHAIN-NAME }}/bin" >> $GITHUB_PATH
           
       - name: Add LLVM MinGW toolchain to PATH
-        if: startsWith(matrix.image, 'ubuntu-') && contains(matrix.target, 'gnullvm')
+        if: contains(matrix.target, 'gnullvm')
         run: |
           echo "${{ env.LLVM-MINGW-TOOLCHAIN-NAME }}/bin" >> $GITHUB_PATH
 
       - name: Test
         shell: pwsh
-        if: startsWith(matrix.image, 'ubuntu-') && contains(matrix.target, 'gnullvm') || endsWith(matrix.target, 'gnu')
+        if: contains(matrix.target, 'gnullvm') || endsWith(matrix.target, 'gnu')
         run: |
           cargo test --no-run --target ${{ matrix.target }} -p test_win32
           if (-Not (Resolve-Path "target/*/debug/deps/test_win32-*.exe" | Test-Path)) {


### PR DESCRIPTION
MacOS runners are scarce/slow and delay the build unnecessarily, so this update just limits cross platform validation to the Ubuntu runner.