### PR TITLE
Remove `rayon` dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,6 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(windows_raw_dylib, windows
 helpers = { path = "crates/tools/helpers" }
 proc-macro2 = { version = "1.0", default-features = false }
 quote = { version = "1.0", default-features = false }
-rayon = { version = "1.10", default-features = false }
 serde = { version = "1.0", default-features = false }
 syn = { version = "2.0", default-features = false }
 toml = { version = "0.8", features = ["parse"] }

--- a/crates/libs/bindgen/Cargo.toml
+++ b/crates/libs/bindgen/Cargo.toml
@@ -9,7 +9,6 @@ repository = "https://github.com/microsoft/windows-rs"
 readme = "readme.md"
 
 [dependencies]
-rayon = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, features = ["std"] }
 

--- a/crates/libs/bindgen/src/config/mod.rs
+++ b/crates/libs/bindgen/src/config/mod.rs
@@ -6,7 +6,6 @@ mod value;
 
 use super::*;
 pub use cfg::*;
-use rayon::prelude::*;
 
 #[derive(Clone)]
 pub struct Config<'a> {
@@ -90,7 +89,7 @@ impl<'a> Config<'a> {
 
         let trees = tree.flatten_trees();
 
-        trees.par_iter().for_each(|tree| {
+        for tree in &trees {
             let directory = format!("{}/src/{}", &self.output, tree.namespace.replace('.', "/"));
 
             let mut tokens = TokenStream::new();
@@ -113,7 +112,7 @@ impl<'a> Config<'a> {
 
             let output = format!("{directory}/mod.rs");
             write_to_file(&output, self.format(&tokens.into_string()));
-        });
+        }
 
         if self.no_toml {
             return;


### PR DESCRIPTION
This is only used to speed up package generation, which is mostly just for the generation of the `windows` and `windows-sys` crates, by parallelizing code generation. Unfortunately, it has proven unreliable on Windows. I'll likely provide a simple parallelizing replacement in the near future. 