### PR TITLE
Adds a Windows service example

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -131,6 +131,8 @@ jobs:
         run:  cargo test -p sample_privileges_sys --target ${{ matrix.target }}
       - name: Test sample_rss
         run:  cargo test -p sample_rss --target ${{ matrix.target }}
+      - name: Test sample_service_sys
+        run:  cargo test -p sample_service_sys --target ${{ matrix.target }}
       - name: Test sample_shell
         run:  cargo test -p sample_shell --target ${{ matrix.target }}
       - name: Test sample_simple
@@ -159,10 +161,10 @@ jobs:
         run:  cargo test -p test_alternate_success_code --target ${{ matrix.target }}
       - name: Test test_arch
         run:  cargo test -p test_arch --target ${{ matrix.target }}
-      - name: Test test_arch_feature
-        run:  cargo test -p test_arch_feature --target ${{ matrix.target }}
       - name: Clean
         run:  cargo clean
+      - name: Test test_arch_feature
+        run:  cargo test -p test_arch_feature --target ${{ matrix.target }}
       - name: Test test_array
         run:  cargo test -p test_array --target ${{ matrix.target }}
       - name: Test test_bcrypt
@@ -261,10 +263,10 @@ jobs:
         run:  cargo test -p test_noexcept --target ${{ matrix.target }}
       - name: Test test_not_dll
         run:  cargo test -p test_not_dll --target ${{ matrix.target }}
-      - name: Test test_numerics
-        run:  cargo test -p test_numerics --target ${{ matrix.target }}
       - name: Clean
         run:  cargo clean
+      - name: Test test_numerics
+        run:  cargo test -p test_numerics --target ${{ matrix.target }}
       - name: Test test_overloads
         run:  cargo test -p test_overloads --target ${{ matrix.target }}
       - name: Test test_overloads_client
@@ -363,10 +365,10 @@ jobs:
         run:  cargo test -p windows-core --target ${{ matrix.target }}
       - name: Test windows-ecma335
         run:  cargo test -p windows-ecma335 --target ${{ matrix.target }}
-      - name: Test windows-future
-        run:  cargo test -p windows-future --target ${{ matrix.target }}
       - name: Clean
         run:  cargo clean
+      - name: Test windows-future
+        run:  cargo test -p windows-future --target ${{ matrix.target }}
       - name: Test windows-implement
         run:  cargo test -p windows-implement --target ${{ matrix.target }}
       - name: Test windows-interface

--- a/crates/samples/windows-sys/service/Cargo.toml
+++ b/crates/samples/windows-sys/service/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "sample_service_sys"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[dependencies.windows-sys]
+workspace = true
+features = [
+    "Win32_System_Services",
+    "Win32_Storage_FileSystem",
+    "Win32_Security",
+    "Win32_System_IO",
+]

--- a/crates/samples/windows-sys/service/src/main.rs
+++ b/crates/samples/windows-sys/service/src/main.rs
@@ -1,0 +1,194 @@
+use windows_sys::{
+    core::*, Win32::Foundation::*, Win32::Storage::FileSystem::*, Win32::System::Services::*,
+};
+
+// Sample logs to this file for illustration purposes.
+const LOG_FILE: PCWSTR = w!("D:\\service.txt");
+
+// The service spawns a thread and calls `service_thread` to do some actual work.
+fn service_thread() {
+    for i in 0.. {
+        log(&format!("...{i}\n"));
+
+        // Replace with whatever work the service needs to do.
+        std::thread::sleep(std::time::Duration::from_millis(1000));
+
+        if stop_request() {
+            break;
+        }
+    }
+}
+
+// Minimal state required to support the service sample.
+struct State {
+    // Service handle returned by `RegisterServiceCtrlHandlerW` use to update the service status.
+    handle: SERVICE_STATUS_HANDLE,
+
+    // The join handle used to wait for the service thread to stop.
+    thread: Option<std::thread::JoinHandle<()>>,
+
+    // The reported status and support service bevavior.
+    status: SERVICE_STATUS,
+}
+
+impl State {
+    const fn new() -> Self {
+        Self {
+            handle: std::ptr::null_mut(),
+            thread: None,
+            status: SERVICE_STATUS {
+                dwServiceType: SERVICE_WIN32_OWN_PROCESS,
+                dwCurrentState: SERVICE_STOPPED,
+                dwControlsAccepted: SERVICE_ACCEPT_PAUSE_CONTINUE
+                    | SERVICE_ACCEPT_STOP
+                    | SERVICE_ACCEPT_SHUTDOWN,
+                dwWin32ExitCode: 0,
+                dwServiceSpecificExitCode: 0,
+                dwCheckPoint: 0,
+                dwWaitHint: 0,
+            },
+        }
+    }
+}
+
+unsafe impl Send for State {}
+unsafe impl Sync for State {}
+
+static STATE: std::sync::RwLock<State> = std::sync::RwLock::new(State::new());
+
+fn main() {
+    let table = [
+        SERVICE_TABLE_ENTRYW {
+            lpServiceName: &mut 0,
+            lpServiceProc: Some(service_main),
+        },
+        SERVICE_TABLE_ENTRYW::default(),
+    ];
+
+    unsafe {
+        if StartServiceCtrlDispatcherW(table.as_ptr()) == 0 {
+            println!("Use Service Control Manager to start service.")
+        }
+    }
+}
+
+extern "system" fn service_main(_len: u32, _args: *mut PWSTR) {
+    unsafe {
+        set_handle(RegisterServiceCtrlHandlerW(std::ptr::null(), Some(handler)));
+    }
+
+    set_state(SERVICE_START_PENDING);
+    log("service start pending\n");
+
+    set_thread();
+
+    set_state(SERVICE_RUNNING);
+    log("service running\n");
+}
+
+extern "system" fn handler(control: u32) {
+    match control {
+        SERVICE_CONTROL_CONTINUE => {
+            set_state(SERVICE_CONTINUE_PENDING);
+            log("service continue pending\n");
+
+            set_thread();
+
+            set_state(SERVICE_RUNNING);
+            log("service running\n");
+        }
+        SERVICE_CONTROL_PAUSE => {
+            set_state(SERVICE_PAUSE_PENDING);
+            log("service pause pending\n");
+
+            join_thread();
+
+            set_state(SERVICE_PAUSED);
+            log("service paused\n");
+        }
+        SERVICE_CONTROL_SHUTDOWN | SERVICE_CONTROL_STOP => {
+            if state() == SERVICE_RUNNING {
+                set_state(SERVICE_STOP_PENDING);
+                log("service stop pending\n");
+
+                join_thread();
+            }
+
+            set_state(SERVICE_STOPPED);
+            log("service stopped\n");
+        }
+        _ => {
+            log(&format!("unexpected request {control}\n"));
+        }
+    }
+}
+
+fn set_handle(handle: SERVICE_STATUS_HANDLE) {
+    let mut writer = STATE.write().unwrap();
+    writer.handle = handle;
+}
+
+fn set_state(state: SERVICE_STATUS_CURRENT_STATE) {
+    let mut writer = STATE.write().unwrap();
+    writer.status.dwCurrentState = state;
+
+    // Makes a copy to avoid holding a lock while calling `SetServiceStatus`.
+    let handle = writer.handle;
+    let status = writer.status;
+    drop(writer);
+
+    unsafe {
+        SetServiceStatus(handle, &status);
+    }
+}
+
+fn set_thread() {
+    let thread = std::thread::spawn(service_thread);
+
+    let mut writer = STATE.write().unwrap();
+    writer.thread = Some(thread);
+}
+
+fn state() -> SERVICE_STATUS_CURRENT_STATE {
+    let reader = STATE.read().unwrap();
+    reader.status.dwCurrentState
+}
+
+fn stop_request() -> bool {
+    matches!(state(), SERVICE_PAUSE_PENDING | SERVICE_STOP_PENDING)
+}
+
+fn join_thread() {
+    let mut writer = STATE.write().unwrap();
+
+    // Takes the join handle and drops the lock before calling `join`.
+    let thread = writer.thread.take();
+    drop(writer);
+
+    thread.unwrap().join().unwrap();
+}
+
+// Simply appends the string to the log file.
+fn log(message: &str) {
+    unsafe {
+        let file = CreateFileW(
+            LOG_FILE,
+            FILE_APPEND_DATA,
+            0,
+            std::ptr::null(),
+            OPEN_ALWAYS,
+            FILE_ATTRIBUTE_NORMAL,
+            std::ptr::null_mut(),
+        );
+
+        WriteFile(
+            file,
+            message.as_ptr(),
+            message.len().try_into().unwrap(),
+            &mut 0,
+            std::ptr::null_mut(),
+        );
+
+        CloseHandle(file);
+    }
+}

--- a/crates/samples/windows-sys/service/src/main.rs
+++ b/crates/samples/windows-sys/service/src/main.rs
@@ -141,8 +141,8 @@ fn set_thread() {
     let thread = std::thread::spawn(|| {
         service_thread();
 
-        // The service thread returns without an external request then the service will signal that
-        // it has stopped and will cause the process to terminate normally.
+        // If the service thread returns without an external request, the service will signal that
+        // it has stopped and cause the process to terminate normally.
         if state() == SERVICE_RUNNING {
             set_state(SERVICE_STOPPED);
             log("service stopped\n");


### PR DESCRIPTION
This sample illustrates how to write a Windows service directly using the Service Control Manager (SCM) and with the help of the `windows-sys` crate. Once built, you can install the service (from an admin prompt) as follows:

```
> sc create rust binPath= D:\git\windows-rs\target\debug\sample_service_sys.exe
```

You can then use the various SCM commands to control the services:

```
> sc start rust
> sc pause rust
> sc continue rust
> sc stop rust
```

I do plan to provide a more idiomatic `windows-services` crate but this should help get you started if you need to write a Windows service for the time being. 