### PR TITLE
Restrict `allow` to bindings in `windows-threading` crate

### DIFF
--- a/crates/libs/threading/src/bindings.rs
+++ b/crates/libs/threading/src/bindings.rs
@@ -1,3 +1,11 @@
+#![allow(
+    non_snake_case,
+    non_upper_case_globals,
+    non_camel_case_types,
+    dead_code,
+    clippy::all
+)]
+
 windows_link::link!("kernel32.dll" "system" fn CloseThreadpool(ptpp : PTP_POOL));
 windows_link::link!("kernel32.dll" "system" fn CloseThreadpoolCleanupGroup(ptpcg : PTP_CLEANUP_GROUP));
 windows_link::link!("kernel32.dll" "system" fn CloseThreadpoolCleanupGroupMembers(ptpcg : PTP_CLEANUP_GROUP, fcancelpendingcallbacks : BOOL, pvcleanupcontext : *mut core::ffi::c_void));

--- a/crates/libs/threading/src/lib.rs
+++ b/crates/libs/threading/src/lib.rs
@@ -1,9 +1,3 @@
-#![allow(
-    non_snake_case,
-    non_camel_case_types,
-    non_upper_case_globals,
-    clippy::all
-)]
 #![doc = include_str!("../readme.md")]
 #![cfg(windows)]
 #![no_std]

--- a/crates/tools/bindings/src/threading.txt
+++ b/crates/tools/bindings/src/threading.txt
@@ -1,7 +1,6 @@
 --out crates/libs/threading/src/bindings.rs
 --flat
 --no-comment
---no-allow
 --sys
 --no-deps
 


### PR DESCRIPTION
Minor cleanup following #3595 as the crate as a whole does not need to allow all of these potential warnings. 