### PR TITLE
Address new lifetime errors in Rust 1.89

### DIFF
--- a/crates/libs/metadata/src/reader/blob.rs
+++ b/crates/libs/metadata/src/reader/blob.rs
@@ -61,7 +61,7 @@ impl<'a> Blob<'a> {
         }
     }
 
-    pub fn read_modifiers(&mut self) -> Vec<TypeDefOrRef> {
+    pub fn read_modifiers(&mut self) -> Vec<TypeDefOrRef<'a>> {
         let mut mods = vec![];
         loop {
             let (value, offset) = self.peek();

--- a/crates/libs/metadata/src/reader/codes.rs
+++ b/crates/libs/metadata/src/reader/codes.rs
@@ -42,8 +42,8 @@ code! { AttributeType(3)
     (MemberRef, 3)
 }
 
-impl AttributeType<'_> {
-    pub fn parent(&self) -> MemberRefParent {
+impl<'a> AttributeType<'a> {
+    pub fn parent(&self) -> MemberRefParent<'a> {
         match self {
             Self::MethodDef(row) => row.parent(),
             Self::MemberRef(row) => row.parent(),

--- a/crates/libs/metadata/src/reader/item_index.rs
+++ b/crates/libs/metadata/src/reader/item_index.rs
@@ -42,7 +42,7 @@ impl<'a> ItemIndex<'a> {
         Self(members)
     }
 
-    pub fn iter(&self) -> impl Iterator<Item = (&str, &str, &Item)> + '_ {
+    pub fn iter(&self) -> impl Iterator<Item = (&str, &str, &Item<'_>)> + '_ {
         self.0
             .iter()
             .flat_map(|(namespace, items)| {
@@ -55,11 +55,11 @@ impl<'a> ItemIndex<'a> {
             })
     }
 
-    pub fn items(&self) -> impl Iterator<Item = &Item> + '_ {
+    pub fn items(&self) -> impl Iterator<Item = &Item<'_>> + '_ {
         self.0.values().flat_map(|items| items.values()).flatten()
     }
 
-    pub fn get(&self, namespace: &str, name: &str) -> impl Iterator<Item = &Item> + '_ {
+    pub fn get(&self, namespace: &str, name: &str) -> impl Iterator<Item = &Item<'_>> + '_ {
         self.0
             .get(namespace)
             .and_then(|items| items.get(name))
@@ -68,7 +68,7 @@ impl<'a> ItemIndex<'a> {
     }
 
     #[track_caller]
-    pub fn expect(&self, namespace: &str, name: &str) -> &Item {
+    pub fn expect(&self, namespace: &str, name: &str) -> &Item<'_> {
         let mut iter = self.get(namespace, name);
 
         if let Some(item) = iter.next() {

--- a/crates/libs/metadata/src/reader/row.rs
+++ b/crates/libs/metadata/src/reader/row.rs
@@ -117,7 +117,7 @@ pub trait AsRow<'a>: Copy {
         )
     }
 
-    fn parent_row<P: AsRow<'a>>(&'a self, column: usize) -> P {
+    fn parent_row<P: AsRow<'a>>(&self, column: usize) -> P {
         let row = self.to_row();
 
         P::from_row(Row::new(

--- a/crates/libs/metadata/src/reader/tables/attribute.rs
+++ b/crates/libs/metadata/src/reader/tables/attribute.rs
@@ -8,12 +8,12 @@ impl std::fmt::Debug for Attribute<'_> {
     }
 }
 
-impl Attribute<'_> {
-    pub fn parent(&self) -> HasAttribute {
+impl<'a> Attribute<'a> {
+    pub fn parent(&self) -> HasAttribute<'a> {
         self.decode(0)
     }
 
-    pub fn ctor(&self) -> AttributeType {
+    pub fn ctor(&self) -> AttributeType<'a> {
         self.decode(1)
     }
 

--- a/crates/libs/metadata/src/reader/tables/constant.rs
+++ b/crates/libs/metadata/src/reader/tables/constant.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-impl Constant<'_> {
+impl<'a> Constant<'a> {
     pub fn ty(&self) -> Type {
         match self.usize(0).try_into().unwrap() {
             ELEMENT_TYPE_U1 => Type::U8,
@@ -18,7 +18,7 @@ impl Constant<'_> {
         }
     }
 
-    pub fn parent(&self) -> HasConstant {
+    pub fn parent(&self) -> HasConstant<'a> {
         self.decode(1)
     }
 

--- a/crates/libs/metadata/src/reader/tables/field.rs
+++ b/crates/libs/metadata/src/reader/tables/field.rs
@@ -23,7 +23,7 @@ impl<'a> Field<'a> {
         blob.read_type_signature(&[])
     }
 
-    pub fn constant(&self) -> Option<Constant> {
+    pub fn constant(&self) -> Option<Constant<'a>> {
         self.equal_range(1, HasConstant::Field(*self).encode())
             .next()
     }

--- a/crates/libs/metadata/src/reader/tables/generic_param.rs
+++ b/crates/libs/metadata/src/reader/tables/generic_param.rs
@@ -6,7 +6,7 @@ impl std::fmt::Debug for GenericParam<'_> {
     }
 }
 
-impl GenericParam<'_> {
+impl<'a> GenericParam<'a> {
     pub fn sequence(&self) -> u16 {
         self.usize(0).try_into().unwrap()
     }
@@ -15,7 +15,7 @@ impl GenericParam<'_> {
         GenericParamAttributes(self.usize(1).try_into().unwrap())
     }
 
-    pub fn owner(&self) -> TypeOrMethodDef {
+    pub fn owner(&self) -> TypeOrMethodDef<'a> {
         self.decode(2)
     }
 

--- a/crates/libs/metadata/src/reader/tables/impl_map.rs
+++ b/crates/libs/metadata/src/reader/tables/impl_map.rs
@@ -6,7 +6,7 @@ impl std::fmt::Debug for ImplMap<'_> {
     }
 }
 
-impl ImplMap<'_> {
+impl<'a> ImplMap<'a> {
     pub fn flags(&self) -> PInvokeAttributes {
         PInvokeAttributes(self.usize(0).try_into().unwrap())
     }
@@ -15,7 +15,7 @@ impl ImplMap<'_> {
         self.str(2)
     }
 
-    pub fn import_scope(&self) -> ModuleRef {
+    pub fn import_scope(&self) -> ModuleRef<'a> {
         self.row(3)
     }
 }

--- a/crates/libs/metadata/src/reader/tables/interface_impl.rs
+++ b/crates/libs/metadata/src/reader/tables/interface_impl.rs
@@ -6,8 +6,8 @@ impl std::fmt::Debug for InterfaceImpl<'_> {
     }
 }
 
-impl InterfaceImpl<'_> {
-    pub fn class(&self) -> TypeDef {
+impl<'a> InterfaceImpl<'a> {
+    pub fn class(&self) -> TypeDef<'a> {
         self.row(0)
     }
 

--- a/crates/libs/metadata/src/reader/tables/member_ref.rs
+++ b/crates/libs/metadata/src/reader/tables/member_ref.rs
@@ -6,12 +6,12 @@ impl std::fmt::Debug for MemberRef<'_> {
     }
 }
 
-impl MemberRef<'_> {
-    pub fn parent(&self) -> MemberRefParent {
+impl<'a> MemberRef<'a> {
+    pub fn parent(&self) -> MemberRefParent<'a> {
         self.decode(0)
     }
 
-    pub fn name(&self) -> &str {
+    pub fn name(&self) -> &'a str {
         self.str(1)
     }
 

--- a/crates/libs/metadata/src/reader/tables/method_def.rs
+++ b/crates/libs/metadata/src/reader/tables/method_def.rs
@@ -27,15 +27,15 @@ impl<'a> MethodDef<'a> {
         self.blob(4).read_method_signature(generics)
     }
 
-    pub fn params(&self) -> RowIterator<MethodParam> {
+    pub fn params(&self) -> RowIterator<'a, MethodParam<'a>> {
         self.list(5)
     }
 
-    pub fn parent(&self) -> MemberRefParent {
+    pub fn parent(&self) -> MemberRefParent<'a> {
         MemberRefParent::TypeDef(self.parent_row(5))
     }
 
-    pub fn impl_map(&self) -> Option<ImplMap> {
+    pub fn impl_map(&self) -> Option<ImplMap<'a>> {
         self.equal_range(1, MemberForwarded::MethodDef(*self).encode())
             .next()
     }

--- a/crates/libs/metadata/src/reader/tables/nested_class.rs
+++ b/crates/libs/metadata/src/reader/tables/nested_class.rs
@@ -9,12 +9,12 @@ impl std::fmt::Debug for NestedClass<'_> {
     }
 }
 
-impl NestedClass<'_> {
-    pub fn inner(&self) -> TypeDef {
+impl<'a> NestedClass<'a> {
+    pub fn inner(&self) -> TypeDef<'a> {
         self.row(0)
     }
 
-    pub fn outer(&self) -> TypeDef {
+    pub fn outer(&self) -> TypeDef<'a> {
         self.row(1)
     }
 }

--- a/crates/libs/metadata/src/reader/tables/type_def.rs
+++ b/crates/libs/metadata/src/reader/tables/type_def.rs
@@ -19,7 +19,7 @@ impl<'a> TypeDef<'a> {
         self.str(2)
     }
 
-    pub fn extends(&self) -> Option<TypeDefOrRef> {
+    pub fn extends(&self) -> Option<TypeDefOrRef<'a>> {
         if self.usize(3) == 0 {
             return None;
         }
@@ -35,15 +35,15 @@ impl<'a> TypeDef<'a> {
         self.list(5)
     }
 
-    pub fn generic_params(&self) -> RowIterator<GenericParam> {
+    pub fn generic_params(&self) -> RowIterator<'a, GenericParam<'a>> {
         self.equal_range(2, TypeOrMethodDef::TypeDef(*self).encode())
     }
 
-    pub fn interface_impls(&self) -> RowIterator<InterfaceImpl> {
+    pub fn interface_impls(&self) -> RowIterator<'a, InterfaceImpl<'a>> {
         self.equal_range(0, self.pos() + 1)
     }
 
-    pub fn class_layout(&self) -> Option<ClassLayout> {
+    pub fn class_layout(&self) -> Option<ClassLayout<'a>> {
         self.equal_range(2, self.pos() + 1).next()
     }
 

--- a/crates/libs/metadata/src/reader/tables/type_ref.rs
+++ b/crates/libs/metadata/src/reader/tables/type_ref.rs
@@ -6,16 +6,16 @@ impl std::fmt::Debug for TypeRef<'_> {
     }
 }
 
-impl TypeRef<'_> {
-    pub fn scope(&self) -> ResolutionScope {
+impl<'a> TypeRef<'a> {
+    pub fn scope(&self) -> ResolutionScope<'a> {
         self.decode(0)
     }
 
-    pub fn name(&self) -> &str {
+    pub fn name(&self) -> &'a str {
         self.str(1)
     }
 
-    pub fn namespace(&self) -> &str {
+    pub fn namespace(&self) -> &'a str {
         self.str(2)
     }
 }

--- a/crates/libs/metadata/src/reader/type_index.rs
+++ b/crates/libs/metadata/src/reader/type_index.rs
@@ -52,7 +52,7 @@ impl TypeIndex {
         &self.files[pos]
     }
 
-    pub fn iter(&self) -> impl Iterator<Item = (&str, &str, TypeDef)> + '_ {
+    pub fn iter(&self) -> impl Iterator<Item = (&str, &str, TypeDef<'_>)> + '_ {
         self.types
             .iter()
             .flat_map(|(namespace, types)| {
@@ -66,7 +66,7 @@ impl TypeIndex {
             })
     }
 
-    pub fn types(&self) -> impl Iterator<Item = TypeDef> + '_ {
+    pub fn types(&self) -> impl Iterator<Item = TypeDef<'_>> + '_ {
         self.types
             .values()
             .flat_map(|types| types.values())
@@ -74,7 +74,7 @@ impl TypeIndex {
             .map(|(file, pos)| TypeDef(Row::new(self, *file, *pos)))
     }
 
-    pub fn get(&self, namespace: &str, name: &str) -> impl Iterator<Item = TypeDef> + '_ {
+    pub fn get(&self, namespace: &str, name: &str) -> impl Iterator<Item = TypeDef<'_>> + '_ {
         self.types
             .get(namespace)
             .and_then(|types| types.get(name))
@@ -84,7 +84,7 @@ impl TypeIndex {
     }
 
     #[track_caller]
-    pub fn expect(&self, namespace: &str, name: &str) -> TypeDef {
+    pub fn expect(&self, namespace: &str, name: &str) -> TypeDef<'_> {
         let mut iter = self.get(namespace, name);
 
         if let Some(def) = iter.next() {
@@ -98,7 +98,7 @@ impl TypeIndex {
         }
     }
 
-    pub fn nested(&self, ty: TypeDef) -> impl Iterator<Item = TypeDef> + '_ {
+    pub fn nested(&self, ty: TypeDef) -> impl Iterator<Item = TypeDef<'_>> + '_ {
         self.nested
             .get(&(ty.0.file, ty.0.pos))
             .into_iter()


### PR DESCRIPTION
Recently nightly builds have introduced a new warning for supposedly confusing syntax related to lifetime. I'm not sure its that confusing but this update addresses it nonetheless. Here's an example of such a warning:

```
error: lifetime flowing from input to output with different syntax can be confusing
  --> crates\libs\metadata\src\reader\tables\constant.rs:21:19
   |
21 |     pub fn parent(&self) -> HasConstant {
   |                   ^^^^^     ----------- the lifetime gets resolved as `'_`
   |                   |
   |                   this lifetime flows to the output
   |
   = note: `-D mismatched-lifetime-syntaxes` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(mismatched_lifetime_syntaxes)]`
help: one option is to remove the lifetime for references and use the anonymous lifetime for paths
   |
21 |     pub fn parent(&self) -> HasConstant<'_> {
   |                                        ++++
```

