### PR TITLE
Use the given ABI in `link!`

### DIFF
--- a/crates/libs/link/src/lib.rs
+++ b/crates/libs/link/src/lib.rs
@@ -5,6 +5,10 @@
 #[cfg(all(windows, target_arch = "x86"))]
 #[macro_export]
 macro_rules! link {
+    // Avoid future-compat lint if bindings are still using the old "cdecl" form of the bindings.
+    ($library:literal "cdecl" $($link_name:literal)? fn $($function:tt)*) => (
+        $crate::link!($library "C" $($link_name)? fn $($function)*);
+    );
     ($library:literal $abi:literal $($link_name:literal)? fn $($function:tt)*) => (
         #[link(name = $library, kind = "raw-dylib", modifiers = "+verbatim", import_name_type = "undecorated")]
         extern $abi {
@@ -18,9 +22,13 @@ macro_rules! link {
 #[cfg(all(windows, not(target_arch = "x86")))]
 #[macro_export]
 macro_rules! link {
+    // Avoid future-compat lint if bindings are still using the old "cdecl" form of the bindings.
+    ($library:literal "cdecl" $($link_name:literal)? fn $($function:tt)*) => (
+        $crate::link!($library "C" $($link_name)? fn $($function)*);
+    );
     ($library:literal $abi:literal $($link_name:literal)? fn $($function:tt)*) => (
         #[link(name = $library, kind = "raw-dylib", modifiers = "+verbatim")]
-        extern "C" {
+        extern $abi {
             $(#[link_name=$link_name])?
             pub fn $($function)*;
         }
@@ -31,8 +39,12 @@ macro_rules! link {
 #[cfg(not(windows))]
 #[macro_export]
 macro_rules! link {
+    // Avoid future-compat lint if bindings are still using the old "cdecl" form of the bindings.
+    ($library:literal "cdecl" $($link_name:literal)? fn $($function:tt)*) => (
+        $crate::link!($library "C" $($link_name)? fn $($function)*);
+    );
     ($library:literal $abi:literal $($link_name:literal)? fn $($function:tt)*) => (
-        extern "C" {
+        extern $abi {
             pub fn $($function)*;
         }
     )

--- a/crates/libs/targets/src/lib.rs
+++ b/crates/libs/targets/src/lib.rs
@@ -5,6 +5,10 @@
 #[cfg(all(windows_raw_dylib, target_arch = "x86"))]
 #[macro_export]
 macro_rules! link {
+    // Avoid future-compat lint if bindings are still using the old "cdecl" form of the bindings.
+    ($library:literal "cdecl" $($link_name:literal)? fn $($function:tt)*) => (
+        $crate::link!($library "C" $($link_name)? fn $($function)*);
+    );
     ($library:literal $abi:literal $($link_name:literal)? fn $($function:tt)*) => (
         #[link(name = $library, kind = "raw-dylib", modifiers = "+verbatim", import_name_type = "undecorated")]
         extern $abi {
@@ -18,9 +22,13 @@ macro_rules! link {
 #[cfg(all(windows_raw_dylib, not(target_arch = "x86")))]
 #[macro_export]
 macro_rules! link {
+    // Avoid future-compat lint if bindings are still using the old "cdecl" form of the bindings.
+    ($library:literal "cdecl" $($link_name:literal)? fn $($function:tt)*) => (
+        $crate::link!($library "C" $($link_name)? fn $($function)*);
+    );
     ($library:literal $abi:literal $($link_name:literal)? fn $($function:tt)*) => (
         #[link(name = $library, kind = "raw-dylib", modifiers = "+verbatim")]
-        extern "C" {
+        extern $abi {
             $(#[link_name=$link_name])?
             pub fn $($function)*;
         }
@@ -28,9 +36,13 @@ macro_rules! link {
 }
 
 /// Defines an external function to import.
-#[cfg(all(windows, not(windows_raw_dylib), target_arch = "x86"))]
+#[cfg(all(windows, not(windows_raw_dylib)))]
 #[macro_export]
 macro_rules! link {
+    // Avoid future-compat lint if bindings are still using the old "cdecl" form of the bindings.
+    ($library:literal "cdecl" $($link_name:literal)? fn $($function:tt)*) => (
+        $crate::link!($library "C" $($link_name)? fn $($function)*);
+    );
     ($library:literal $abi:literal $($link_name:literal)? fn $($function:tt)*) => (
         #[link(name = "windows.0.53.0")]
         extern $abi {
@@ -41,24 +53,15 @@ macro_rules! link {
 }
 
 /// Defines an external function to import.
-#[cfg(all(windows, not(windows_raw_dylib), not(target_arch = "x86")))]
-#[macro_export]
-macro_rules! link {
-    ($library:literal $abi:literal $($link_name:literal)? fn $($function:tt)*) => (
-        #[link(name = "windows.0.53.0")]
-        extern "C" {
-            $(#[link_name=$link_name])?
-            pub fn $($function)*;
-        }
-    )
-}
-
-/// Defines an external function to import.
 #[cfg(all(not(windows), not(windows_raw_dylib)))]
 #[macro_export]
 macro_rules! link {
+    // Avoid future-compat lint if bindings are still using the old "cdecl" form of the bindings.
+    ($library:literal "cdecl" $($link_name:literal)? fn $($function:tt)*) => (
+        $crate::link!($library "C" $($link_name)? fn $($function)*);
+    );
     ($library:literal $abi:literal $($link_name:literal)? fn $($function:tt)*) => (
-        extern "C" {
+        extern $abi {
             pub fn $($function)*;
         }
     )


### PR DESCRIPTION
What's this all about?

Fixes: #3626

Varargs should not be a problem because they are already `extern "C"`.