### PR TITLE
Revert ABI changes to the `link` macros

### DIFF
--- a/crates/libs/link/src/lib.rs
+++ b/crates/libs/link/src/lib.rs
@@ -32,7 +32,7 @@ macro_rules! link {
 #[macro_export]
 macro_rules! link {
     ($library:literal $abi:literal $($link_name:literal)? fn $($function:tt)*) => (
-        extern "C" {
+        extern $abi {
             pub fn $($function)*;
         }
     )

--- a/crates/libs/targets/src/lib.rs
+++ b/crates/libs/targets/src/lib.rs
@@ -28,7 +28,7 @@ macro_rules! link {
 }
 
 /// Defines an external function to import.
-#[cfg(all(windows, not(windows_raw_dylib), target_arch = "x86"))]
+#[cfg(all(windows, not(windows_raw_dylib)))]
 #[macro_export]
 macro_rules! link {
     ($library:literal $abi:literal $($link_name:literal)? fn $($function:tt)*) => (
@@ -41,24 +41,11 @@ macro_rules! link {
 }
 
 /// Defines an external function to import.
-#[cfg(all(windows, not(windows_raw_dylib), not(target_arch = "x86")))]
-#[macro_export]
-macro_rules! link {
-    ($library:literal $abi:literal $($link_name:literal)? fn $($function:tt)*) => (
-        #[link(name = "windows.0.53.0")]
-        extern "C" {
-            $(#[link_name=$link_name])?
-            pub fn $($function)*;
-        }
-    )
-}
-
-/// Defines an external function to import.
 #[cfg(all(not(windows), not(windows_raw_dylib)))]
 #[macro_export]
 macro_rules! link {
     ($library:literal $abi:literal $($link_name:literal)? fn $($function:tt)*) => (
-        extern "C" {
+        extern $abi {
             pub fn $($function)*;
         }
     )


### PR DESCRIPTION
This simply reverts the changes to the `link` macros made in https://github.com/microsoft/windows-rs/pull/3622. A future version of these crates could change how linking works but let's not do that now.

Fixes: #3626
