### PR TITLE
Release 67

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ windows-interface = { version = "0.59.1", path = "crates/libs/interface", defaul
 windows-link = { version = "0.1.3", path = "crates/libs/link", default-features = false }
 windows-metadata = { version = "0.59.0", path = "crates/libs/metadata", default-features = false }
 windows-numerics = { version = "0.2.0", path = "crates/libs/numerics", default-features = false }
-windows-registry = { version = "0.5.2", path = "crates/libs/registry", default-features = false }
+windows-registry = { version = "0.5.3", path = "crates/libs/registry", default-features = false }
 windows-result = { version = "0.3.4", path = "crates/libs/result", default-features = false }
 windows-services = { version = "0.24.0", path = "crates/libs/services", default-features = false }
 windows-strings = { version = "0.4.2", path = "crates/libs/strings", default-features = false }

--- a/crates/libs/registry/Cargo.toml
+++ b/crates/libs/registry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "windows-registry"
-version = "0.5.2"
+version = "0.5.3"
 authors = ["Microsoft"]
 edition = "2021"
 rust-version = "1.74"


### PR DESCRIPTION
As [requested here](https://github.com/microsoft/windows-rs/issues/3635), this minor update to the [windows-registry](https://crates.io/crates/windows-registry) crate adds support for volatile registry keys (#3632).
