### PR TITLE
Fix new nightly Clippy warning

### DIFF
--- a/crates/tools/yml/src/test.rs
+++ b/crates/tools/yml/src/test.rs
@@ -70,7 +70,7 @@ jobs:
 
     for (count, package) in helpers::crates("crates").iter().enumerate() {
         let name = &package.name;
-        if count % 50 == 0 {
+        if count.is_multiple_of(50) {
             write!(
                 &mut yml,
                 r"


### PR DESCRIPTION
Looks like Copilot is unable to recover, so I have to fix this new nightly Clippy warning to clear the build (#3648). 