### PR TITLE
Fix nightly Clippy warning 

### DIFF
--- a/crates/libs/core/src/imp/sha1.rs
+++ b/crates/libs/core/src/imp/sha1.rs
@@ -16,6 +16,12 @@ pub struct ConstBuffer {
     head: usize,
 }
 
+impl Default for ConstBuffer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl ConstBuffer {
     pub const fn for_class<C: crate::RuntimeName, I: crate::RuntimeType>() -> Self {
         Self::new()


### PR DESCRIPTION
Fixes an issue with the CI validation in #3662 caused by a new Nightly Clippy warning about a missing `Default` implementation for the internal `ConstBuffer` struct. 