### PR TITLE
Fix use-after-free in json_validator sample

### DIFF
--- a/crates/samples/components/json_validator/src/lib.rs
+++ b/crates/samples/components/json_validator/src/lib.rs
@@ -316,8 +316,8 @@ fn sanitized_value() {
         );
         let sanitized = std::slice::from_raw_parts(sanitized_alloc, sanitized_len);
         let sanitized = String::from_utf8_lossy(sanitized);
-        CoTaskMemFree(Some(sanitized_alloc as _));
         assert_eq!(sanitized, r#"{"age":21,"name":"Kenny"}"#);
+        CoTaskMemFree(Some(sanitized_alloc as _));
 
         // Close the validator with the given handle.
         CloseJsonValidator(handle);

--- a/crates/samples/components/json_validator/src/lib.rs
+++ b/crates/samples/components/json_validator/src/lib.rs
@@ -315,9 +315,10 @@ fn sanitized_value() {
             )
         );
         let sanitized = std::slice::from_raw_parts(sanitized_alloc, sanitized_len);
-        let sanitized = String::from_utf8_lossy(sanitized);
-        assert_eq!(sanitized, r#"{"age":21,"name":"Kenny"}"#);
+        
+        let sanitized = String::from_utf8_lossy(sanitized).into_owned();
         CoTaskMemFree(Some(sanitized_alloc as _));
+        assert_eq!(sanitized, r#"{"age":21,"name":"Kenny"}"#);
 
         // Close the validator with the given handle.
         CloseJsonValidator(handle);

--- a/crates/samples/components/json_validator/src/lib.rs
+++ b/crates/samples/components/json_validator/src/lib.rs
@@ -315,7 +315,6 @@ fn sanitized_value() {
             )
         );
         let sanitized = std::slice::from_raw_parts(sanitized_alloc, sanitized_len);
-        
         let sanitized = String::from_utf8_lossy(sanitized).into_owned();
         CoTaskMemFree(Some(sanitized_alloc as _));
         assert_eq!(sanitized, r#"{"age":21,"name":"Kenny"}"#);


### PR DESCRIPTION
`String::from_utf8_lossy` returns a `Cow<'_, str>` that references the original memory when the input is considered valid UTF-8. Calling `.into_owned()` forces allocation of an owned `String`, allowing us to safely free the FFI memory with `CoTaskMemFree`.