### PR TITLE
Forward `link` macro for `raw-dylib` support

### DIFF
--- a/crates/libs/targets/Cargo.toml
+++ b/crates/libs/targets/Cargo.toml
@@ -13,6 +13,9 @@ readme = "readme.md"
 [lints]
 workspace = true
 
+[target.'cfg(windows_raw_dylib)'.dependencies]
+windows-link = { workspace = true }
+
 [target.'cfg(all(target_arch = "x86", target_env = "msvc", not(windows_raw_dylib)))'.dependencies]
 windows_i686_msvc = { path = "../../targets/i686_msvc", version = "0.53.0" }
 

--- a/crates/libs/targets/src/lib.rs
+++ b/crates/libs/targets/src/lib.rs
@@ -1,31 +1,8 @@
 #![doc = include_str!("../readme.md")]
 #![no_std]
 
-/// Defines an external function to import.
-#[cfg(all(windows_raw_dylib, target_arch = "x86"))]
-#[macro_export]
-macro_rules! link {
-    ($library:literal $abi:literal $($link_name:literal)? fn $($function:tt)*) => (
-        #[link(name = $library, kind = "raw-dylib", modifiers = "+verbatim", import_name_type = "undecorated")]
-        extern $abi {
-            $(#[link_name=$link_name])?
-            pub fn $($function)*;
-        }
-    )
-}
-
-/// Defines an external function to import.
-#[cfg(all(windows_raw_dylib, not(target_arch = "x86")))]
-#[macro_export]
-macro_rules! link {
-    ($library:literal $abi:literal $($link_name:literal)? fn $($function:tt)*) => (
-        #[link(name = $library, kind = "raw-dylib", modifiers = "+verbatim")]
-        extern "C" {
-            $(#[link_name=$link_name])?
-            pub fn $($function)*;
-        }
-    )
-}
+#[cfg(windows_raw_dylib)]
+pub use windows_link::link;
 
 /// Defines an external function to import.
 #[cfg(all(windows, not(windows_raw_dylib)))]


### PR DESCRIPTION
The `windows-targets` crate behaves exactly like the newer `windows-link` crate when `windows_raw_dylib` is defined. This update just forwards the implementation rather than duplicating the implementation to avoid having to maintain two copies of this tricky code. This shouldn't have much impact in practice since the `windows_raw_dylib` is rarely used. 