### PR TITLE
Apply clippy workflow to all but tests

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -28,6 +28,126 @@ jobs:
         uses: ./.github/actions/fix-environment
       - name: Check cppwinrt
         run:  cargo clippy -p cppwinrt
+      - name: Check csharp_client
+        run:  cargo clippy -p csharp_client
+      - name: Check csharp_component
+        run:  cargo clippy -p csharp_component
+      - name: Check helpers
+        run:  cargo clippy -p helpers
+      - name: Check sample_bits
+        run:  cargo clippy -p sample_bits
+      - name: Check sample_com_uri
+        run:  cargo clippy -p sample_com_uri
+      - name: Check sample_consent
+        run:  cargo clippy -p sample_consent
+      - name: Check sample_core_app
+        run:  cargo clippy -p sample_core_app
+      - name: Check sample_counter
+        run:  cargo clippy -p sample_counter
+      - name: Check sample_counter_sys
+        run:  cargo clippy -p sample_counter_sys
+      - name: Check sample_create_window
+        run:  cargo clippy -p sample_create_window
+      - name: Check sample_create_window_sys
+        run:  cargo clippy -p sample_create_window_sys
+      - name: Check sample_credentials
+        run:  cargo clippy -p sample_credentials
+      - name: Check sample_data_protection
+        run:  cargo clippy -p sample_data_protection
+      - name: Check sample_dcomp
+        run:  cargo clippy -p sample_dcomp
+      - name: Check sample_delay_load
+        run:  cargo clippy -p sample_delay_load
+      - name: Check sample_delay_load_sys
+        run:  cargo clippy -p sample_delay_load_sys
+      - name: Check sample_device_watcher
+        run:  cargo clippy -p sample_device_watcher
+      - name: Check sample_direct2d
+        run:  cargo clippy -p sample_direct2d
+      - name: Check sample_direct3d12
+        run:  cargo clippy -p sample_direct3d12
+      - name: Check sample_enum_windows
+        run:  cargo clippy -p sample_enum_windows
+      - name: Check sample_enum_windows_sys
+        run:  cargo clippy -p sample_enum_windows_sys
+      - name: Check sample_file_dialogs
+        run:  cargo clippy -p sample_file_dialogs
+      - name: Check sample_json_validator
+        run:  cargo clippy -p sample_json_validator
+      - name: Check sample_json_validator_client
+        run:  cargo clippy -p sample_json_validator_client
+      - name: Check sample_json_validator_winrt
+        run:  cargo clippy -p sample_json_validator_winrt
+      - name: Check sample_json_validator_winrt_client
+        run:  cargo clippy -p sample_json_validator_winrt_client
+      - name: Check sample_json_validator_winrt_client_cpp
+        run:  cargo clippy -p sample_json_validator_winrt_client_cpp
+      - name: Check sample_kernel_event
+        run:  cargo clippy -p sample_kernel_event
+      - name: Check sample_memory_buffer
+        run:  cargo clippy -p sample_memory_buffer
+      - name: Check sample_message_box
+        run:  cargo clippy -p sample_message_box
+      - name: Check sample_message_box_sys
+        run:  cargo clippy -p sample_message_box_sys
+      - name: Check sample_ocr
+        run:  cargo clippy -p sample_ocr
+      - name: Check sample_overlapped
+        run:  cargo clippy -p sample_overlapped
+      - name: Check sample_privileges
+        run:  cargo clippy -p sample_privileges
+      - name: Check sample_privileges_sys
+        run:  cargo clippy -p sample_privileges_sys
+      - name: Check sample_rss
+        run:  cargo clippy -p sample_rss
+      - name: Check sample_service_simple
+        run:  cargo clippy -p sample_service_simple
+      - name: Check sample_service_sys
+        run:  cargo clippy -p sample_service_sys
+      - name: Check sample_service_thread
+        run:  cargo clippy -p sample_service_thread
+      - name: Check sample_service_time
+        run:  cargo clippy -p sample_service_time
+      - name: Check sample_shell
+        run:  cargo clippy -p sample_shell
+      - name: Check sample_simple
+        run:  cargo clippy -p sample_simple
+      - name: Check sample_spellchecker
+        run:  cargo clippy -p sample_spellchecker
+      - name: Check sample_task_dialog
+        run:  cargo clippy -p sample_task_dialog
+      - name: Check sample_task_dialog_sys
+        run:  cargo clippy -p sample_task_dialog_sys
+      - name: Check sample_thread_pool_work
+        run:  cargo clippy -p sample_thread_pool_work
+      - name: Check sample_thread_pool_work_sys
+        run:  cargo clippy -p sample_thread_pool_work_sys
+      - name: Check sample_uiautomation
+        run:  cargo clippy -p sample_uiautomation
+      - name: Check sample_wmi
+        run:  cargo clippy -p sample_wmi
+      - name: Check sample_xml
+        run:  cargo clippy -p sample_xml
+      - name: Check tool_bindgen
+        run:  cargo clippy -p tool_bindgen
+      - name: Check tool_bindings
+        run:  cargo clippy -p tool_bindings
+      - name: Check tool_gnu
+        run:  cargo clippy -p tool_gnu
+      - name: Check tool_license
+        run:  cargo clippy -p tool_license
+      - name: Check tool_merge
+        run:  cargo clippy -p tool_merge
+      - name: Check tool_msvc
+        run:  cargo clippy -p tool_msvc
+      - name: Check tool_standalone
+        run:  cargo clippy -p tool_standalone
+      - name: Check tool_test_all
+        run:  cargo clippy -p tool_test_all
+      - name: Check tool_workspace
+        run:  cargo clippy -p tool_workspace
+      - name: Check tool_yml
+        run:  cargo clippy -p tool_yml
       - name: Check windows
         run:  cargo clippy -p windows
       - name: Check windows-bindgen
@@ -64,25 +184,19 @@ jobs:
         run:  cargo clippy -p windows-threading
       - name: Check windows-version
         run:  cargo clippy -p windows-version
-      - name: Check helpers
-        run:  cargo clippy -p helpers
-      - name: Check tool_bindgen
-        run:  cargo clippy -p tool_bindgen
-      - name: Check tool_bindings
-        run:  cargo clippy -p tool_bindings
-      - name: Check tool_gnu
-        run:  cargo clippy -p tool_gnu
-      - name: Check tool_license
-        run:  cargo clippy -p tool_license
-      - name: Check tool_merge
-        run:  cargo clippy -p tool_merge
-      - name: Check tool_msvc
-        run:  cargo clippy -p tool_msvc
-      - name: Check tool_standalone
-        run:  cargo clippy -p tool_standalone
-      - name: Check tool_test_all
-        run:  cargo clippy -p tool_test_all
-      - name: Check tool_workspace
-        run:  cargo clippy -p tool_workspace
-      - name: Check tool_yml
-        run:  cargo clippy -p tool_yml
+      - name: Check windows_aarch64_gnullvm
+        run:  cargo clippy -p windows_aarch64_gnullvm
+      - name: Check windows_aarch64_msvc
+        run:  cargo clippy -p windows_aarch64_msvc
+      - name: Check windows_i686_gnu
+        run:  cargo clippy -p windows_i686_gnu
+      - name: Check windows_i686_gnullvm
+        run:  cargo clippy -p windows_i686_gnullvm
+      - name: Check windows_i686_msvc
+        run:  cargo clippy -p windows_i686_msvc
+      - name: Check windows_x86_64_gnu
+        run:  cargo clippy -p windows_x86_64_gnu
+      - name: Check windows_x86_64_gnullvm
+        run:  cargo clippy -p windows_x86_64_gnullvm
+      - name: Check windows_x86_64_msvc
+        run:  cargo clippy -p windows_x86_64_msvc

--- a/crates/samples/windows/data_protection/src/main.rs
+++ b/crates/samples/windows/data_protection/src/main.rs
@@ -22,6 +22,7 @@ fn main() -> std::io::Result<()> {
     Ok(())
 }
 
+#[allow(clippy::mut_from_ref)]
 unsafe fn as_mut_bytes(buffer: &IBuffer) -> Result<&mut [u8]> {
     let interop = buffer.cast::<IBufferByteAccess>()?;
 

--- a/crates/samples/windows/memory_buffer/src/main.rs
+++ b/crates/samples/windows/memory_buffer/src/main.rs
@@ -5,6 +5,7 @@ use windows::{core::*, Foundation::*, Win32::System::WinRT::IMemoryBufferByteAcc
 // this function does not perform borrow/lifetime checking. The caller must ensure that the
 // IMemoryBufferReference remains alive and that that buffer is not shared across threads.
 
+#[allow(clippy::mut_from_ref)]
 unsafe fn as_mut_slice(buffer: &IMemoryBufferReference) -> Result<&mut [u8]> {
     let interop = buffer.cast::<IMemoryBufferByteAccess>()?;
     let mut data = std::ptr::null_mut();

--- a/crates/tools/yml/src/clippy.rs
+++ b/crates/tools/yml/src/clippy.rs
@@ -33,11 +33,12 @@ jobs:
 
     // This unrolling is required since "cargo clippy --all" consumes too much memory for the GitHub hosted runners.
 
-    for package in helpers::crates("crates/libs")
-        .iter()
-        .chain(helpers::crates("crates/tools").iter())
-    {
+    for package in helpers::crates("crates") {
         let name = &package.name;
+
+        if name.starts_with("test") {
+            continue;
+        }
 
         write!(
             &mut yml,


### PR DESCRIPTION
Right now the clippy workflow only validates libraries and tools. This means that a lot of samples and test crates go unchecked. Although all crates are tested, clippy still points out some more pedantic but often valuable suggestions. Clippy cannot be run on tests at this time as there are too many false positives but I think it should be doable to validate everything else. 