### PR TITLE
Major release of `windows-services`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ windows-metadata = { version = "0.59.0", path = "crates/libs/metadata", default-
 windows-numerics = { version = "0.2.0", path = "crates/libs/numerics", default-features = false }
 windows-registry = { version = "0.5.3", path = "crates/libs/registry", default-features = false }
 windows-result = { version = "0.3.4", path = "crates/libs/result", default-features = false }
-windows-services = { version = "0.24.0", path = "crates/libs/services", default-features = false }
+windows-services = { version = "0.25.0", path = "crates/libs/services", default-features = false }
 windows-strings = { version = "0.4.2", path = "crates/libs/strings", default-features = false }
 windows-sys = { version = "0.60.2", path = "crates/libs/sys", default-features = false }
 windows-targets = { version = "0.53.3", path = "crates/libs/targets", default-features = false }

--- a/crates/libs/services/Cargo.toml
+++ b/crates/libs/services/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "windows-services"
-version = "0.24.0"
+version = "0.25.0"
 authors = ["Microsoft"]
 edition = "2021"
 rust-version = "1.75"

--- a/crates/libs/services/readme.md
+++ b/crates/libs/services/readme.md
@@ -10,7 +10,7 @@ Start by adding the following to your Cargo.toml file:
 
 ```toml
 [dependencies.windows-services]
-version = "0.24"
+version = "0.25"
 ```
 
 Use the Windows services support as needed. Here is how you might write a simple Windows services process:


### PR DESCRIPTION
This is a major update to the [windows-services](https://crates.io/crates/windows-services) crate that introduces a range of powerful updates for supporting different hosting, testing, fallback, and extended commands (#3662). 