### PR TITLE
Fix parallel build reliability with `build-dependencies`

### DIFF
--- a/crates/samples/components/json_validator_winrt_client/Cargo.toml
+++ b/crates/samples/components/json_validator_winrt_client/Cargo.toml
@@ -10,6 +10,4 @@ windows = { workspace = true, features = ["Win32_Foundation"] }
 
 [build-dependencies]
 windows-bindgen = { workspace = true }
-
-[dependencies]
 sample_json_validator_winrt = { path = "../json_validator_winrt" }

--- a/crates/tests/misc/component_client/Cargo.toml
+++ b/crates/tests/misc/component_client/Cargo.toml
@@ -8,10 +8,10 @@ publish = false
 doc = false
 doctest = false
 
-[build-dependencies.windows-bindgen]
-workspace = true
+[build-dependencies]
+windows-bindgen = { workspace = true }
+test_component = { path = "../component" }
 
 [dependencies]
 windows-core = { workspace = true }
 windows = { workspace = true, features = ["Foundation", "Win32_Foundation"] }
-test_component = { path = "../component" }

--- a/crates/tests/winrt/composable_client/Cargo.toml
+++ b/crates/tests/winrt/composable_client/Cargo.toml
@@ -12,8 +12,8 @@ doctest = false
 cc = "1.0"
 windows-bindgen = { workspace = true }
 cppwinrt = { workspace = true }
+test_composable = { path = "../composable" }
 
 [dependencies]
 windows-core = { workspace = true }
 windows = { workspace = true, features = ["Foundation", "Win32_Foundation"] }
-test_composable = { path = "../composable" }

--- a/crates/tests/winrt/constructors_client/Cargo.toml
+++ b/crates/tests/winrt/constructors_client/Cargo.toml
@@ -12,8 +12,8 @@ doctest = false
 cc = "1.0"
 windows-bindgen = { workspace = true }
 cppwinrt = { workspace = true }
+test_constructors = { path = "../constructors" }
 
 [dependencies]
 windows-core = { workspace = true }
 windows = { workspace = true, features = ["Foundation", "Win32_Foundation"] }
-test_constructors = { path = "../constructors" }

--- a/crates/tests/winrt/events_client/Cargo.toml
+++ b/crates/tests/winrt/events_client/Cargo.toml
@@ -10,8 +10,8 @@ doctest = false
 
 [build-dependencies]
 windows-bindgen = { workspace = true }
+test_events = { path = "../events" }
 
 [dependencies]
 windows-core = { workspace = true }
 windows = { workspace = true, features = ["Foundation", "Win32_Foundation"] }
-test_events = { path = "../events" }

--- a/crates/tests/winrt/overloads_client/Cargo.toml
+++ b/crates/tests/winrt/overloads_client/Cargo.toml
@@ -10,8 +10,8 @@ doctest = false
 
 [build-dependencies]
 windows-bindgen = { workspace = true }
+test_overloads = { path = "../overloads" }
 
 [dependencies]
 windows-core = { workspace = true }
 windows = { workspace = true, features = ["Foundation", "Win32_Foundation"] }
-test_overloads = { path = "../overloads" }

--- a/crates/tests/winrt/reference_client/Cargo.toml
+++ b/crates/tests/winrt/reference_client/Cargo.toml
@@ -10,8 +10,8 @@ doctest = false
 
 [build-dependencies]
 windows-bindgen = { workspace = true }
+test_reference = { path = "../reference" }
 
 [dependencies]
 windows-core = { workspace = true }
 windows = { workspace = true, features = ["Foundation", "Win32_Foundation"] }
-test_reference = { path = "../reference" }


### PR DESCRIPTION
Many of the binary (DLL) component tests depend on sibling crates that don't actually need a crate dependency but need predictable build order to ensure that the component's winmd is generated. Cargo isn't very good at this in general but I did notice that some of my test crates were relying on `dependencies` rather than `build-dependencies` resulting in frequent parallel build failures as the build scripts routinely ran before the crate dependency's build script resulting in frequent "missing winmd" errors.

While not foolproof, this should make it a lot easier to quickly run "cargo check --all" or "cargo clippy --all" and get more of the many many crates in this repo to compile successfully in parallel. 