### PR TITLE
Address most Clippy warnings in test code

### DIFF
--- a/crates/libs/version/src/lib.rs
+++ b/crates/libs/version/src/lib.rs
@@ -78,6 +78,7 @@ impl OSVERSIONINFOEXW {
 }
 
 #[cfg(test)]
+#[allow(clippy::nonminimal_bool)] // explicit logic is intentionally being tested
 mod test {
     use super::OsVersion;
     use std::sync::RwLock;

--- a/crates/tests/libs/bindgen/tests/deps.rs
+++ b/crates/tests/libs/bindgen/tests/deps.rs
@@ -1,6 +1,7 @@
 use test_bindgen::deps::*;
 
 #[test]
+#[allow(clippy::manual_c_str_literals)] // false positive
 fn test() {
     unsafe {
         let library = LoadLibraryExA(
@@ -11,7 +12,10 @@ fn test() {
 
         assert!(!library.is_null());
         let address = GetProcAddress(library, "GetTickCount\0".as_ptr()).unwrap();
-        let fp = core::mem::transmute::<_, extern "system" fn() -> u32>(address);
+        let fp = core::mem::transmute::<
+            unsafe extern "system" fn() -> isize,
+            extern "system" fn() -> u32,
+        >(address);
         assert_ne!(fp(), 0);
         FreeLibrary(library);
     }

--- a/crates/tests/libs/future/tests/futures.rs
+++ b/crates/tests/libs/future/tests/futures.rs
@@ -45,6 +45,7 @@ fn stream_async() -> Result<()> {
 }
 
 #[test]
+#[allow(clippy::async_yields_async)] // don't want to disturb concurrency testing
 fn switch_context() -> Result<()> {
     use futures::{executor::LocalPool, future, task::SpawnExt};
     use std::future::IntoFuture;

--- a/crates/tests/libs/implement/tests/generic_primitive.rs
+++ b/crates/tests/libs/implement/tests/generic_primitive.rs
@@ -38,7 +38,7 @@ impl IIterable_Impl<i32> for Thing_Impl {
 #[test]
 fn test_implement() -> Result<()> {
     let v: IVectorView<i32> = Thing().into();
-    assert_eq!(012, v.GetAt(012)?);
+    assert_eq!(12, v.GetAt(12)?);
     assert_eq!(123, v.Size()?);
     let mut index = 0;
     assert!(v.IndexOf(456, &mut index)?);

--- a/crates/tests/libs/registry/tests/string.rs
+++ b/crates/tests/libs/registry/tests/string.rs
@@ -3,6 +3,7 @@ use windows_registry::*;
 use windows_strings::*;
 
 #[test]
+#[allow(clippy::unnecessary_to_owned)] // intentionally testing convertible types
 fn string() -> Result<()> {
     let test_key = "software\\windows-rs\\tests\\string";
     _ = CURRENT_USER.remove_tree(test_key);

--- a/crates/tests/libs/strings/tests/bstr.rs
+++ b/crates/tests/libs/strings/tests/bstr.rs
@@ -19,14 +19,14 @@ fn clone() {
 
     let a = BSTR::default();
     assert!(a.is_empty());
-    assert!(a.len() == 0);
+    assert_eq!(a.len(), 0);
     let b = a.clone();
     assert_eq!(a, "");
     assert_eq!(b, "");
 
     let a = BSTR::new();
     assert!(a.is_empty());
-    assert!(a.len() == 0);
+    assert_eq!(a.len(), 0);
     assert_eq!(a.len(), 0);
     assert_eq!(a.len(), 0);
 
@@ -40,11 +40,11 @@ fn clone() {
 
     let a: BSTR = "".into();
     assert!(a.is_empty());
-    assert!(a.len() == 0);
+    assert_eq!(a.len(), 0);
 
     let a: BSTR = unsafe { SysAllocStringLen(None) };
     assert!(a.is_empty());
-    assert!(a.len() == 0);
+    assert_eq!(a.len(), 0);
 
     let a = BSTR::from("a");
     assert_eq!(a, String::from("a"));

--- a/crates/tests/libs/strings/tests/hstring.rs
+++ b/crates/tests/libs/strings/tests/hstring.rs
@@ -2,6 +2,7 @@ use windows::core::Result;
 use windows_strings::*;
 
 #[test]
+#[allow(clippy::cmp_owned)] // intentionally testing how operations work
 fn hstring_works() {
     assert_eq!(std::mem::size_of::<HSTRING>(), std::mem::size_of::<usize>());
     let empty = HSTRING::new();
@@ -321,6 +322,7 @@ extern "C" {
     pub fn wcslen(s: *const u16) -> usize;
 }
 
+#[allow(clippy::upper_case_acronyms)]
 mod sys {
     windows_link::link!("api-ms-win-core-winrt-string-l1-1-0.dll" "system" fn WindowsCreateStringReference(sourcestring: PCWSTR, length: u32, hstringheader: *mut HSTRING_HEADER, string: *mut HSTRING) -> HRESULT);
     windows_link::link!("api-ms-win-core-winrt-string-l1-1-0.dll" "system" fn WindowsDeleteString(string: HSTRING) -> HRESULT);

--- a/crates/tests/libs/targets/tests/symbol.rs
+++ b/crates/tests/libs/targets/tests/symbol.rs
@@ -11,10 +11,7 @@ fn symbol() {
     unsafe {
         use windows::Win32::Security::Authentication::Identity::RtlGenRandom;
         let mut buffer = [0u8; 8];
-        assert_eq!(
-            RtlGenRandom(buffer.as_mut_ptr() as _, buffer.len() as u32),
-            true
-        );
+        assert!(RtlGenRandom(buffer.as_mut_ptr() as _, buffer.len() as u32),);
         assert_ne!(&buffer, &[0u8; 8]);
     }
 }

--- a/crates/tests/misc/arch_feature/tests/sys.rs
+++ b/crates/tests/misc/arch_feature/tests/sys.rs
@@ -1,5 +1,6 @@
 #[test]
 #[cfg(target_arch = "x86_64")]
+#[allow(clippy::unnecessary_literal_unwrap)] // callback type is intentionally being tested
 fn test() {
     use windows_sys::{
         Win32::System::Diagnostics::Debug::CONTEXT,

--- a/crates/tests/misc/arch_feature/tests/win.rs
+++ b/crates/tests/misc/arch_feature/tests/win.rs
@@ -1,5 +1,6 @@
 #[test]
 #[cfg(target_arch = "x86_64")]
+#[allow(clippy::unnecessary_literal_unwrap)] // callback type is intentionally being tested
 fn test() {
     use windows::{
         Win32::System::Diagnostics::Debug::CONTEXT,

--- a/crates/tests/misc/const_fields/tests/win.rs
+++ b/crates/tests/misc/const_fields/tests/win.rs
@@ -1,6 +1,7 @@
 use windows::{Win32::Storage::CloudFilters::*, Win32::System::CorrelationVector::*};
 
 #[test]
+#[allow(clippy::field_reassign_with_default)] // testing unusual field assignment
 fn can_assign_const() {
     let v: CORRELATION_VECTOR = Default::default();
     let mut i: CF_OPERATION_INFO = Default::default();

--- a/crates/tests/misc/enums/tests/win.rs
+++ b/crates/tests/misc/enums/tests/win.rs
@@ -27,6 +27,7 @@ fn nested() {
 }
 
 #[test]
+#[allow(clippy::assertions_on_constants)] // intentionally testing constant
 fn const_pattern() {
     match InputStreamOptions::ReadAhead {
         InputStreamOptions::ReadAhead => assert!(true),

--- a/crates/tests/misc/extensions/tests/bool32.rs
+++ b/crates/tests/misc/extensions/tests/bool32.rs
@@ -1,6 +1,7 @@
 use windows::{core::*, Win32::Foundation::*, Win32::System::Threading::*};
 
 #[test]
+#[allow(clippy::nonminimal_bool)] // explicit logic is intentionally being tested
 fn test() {
     let status = BOOL::default();
     assert_eq!(status.0, 0);

--- a/crates/tests/misc/extensions/tests/ntstatus.rs
+++ b/crates/tests/misc/extensions/tests/ntstatus.rs
@@ -1,6 +1,7 @@
 use windows::{core::*, Win32::Foundation::*, Win32::Security::Cryptography::*};
 
 #[test]
+#[allow(clippy::nonminimal_bool)] // explicit logic is intentionally being tested
 fn test() -> Result<()> {
     let status = NTSTATUS::default();
     assert_eq!(status.0, 0);

--- a/crates/tests/misc/extensions/tests/variant_bool.rs
+++ b/crates/tests/misc/extensions/tests/variant_bool.rs
@@ -1,6 +1,7 @@
 use windows::Win32::Foundation::*;
 
 #[test]
+#[allow(clippy::nonminimal_bool)] // explicit logic is intentionally being tested
 fn test() {
     let status = VARIANT_BOOL::default();
     assert_eq!(status, VARIANT_FALSE);

--- a/crates/tests/misc/handles/tests/win.rs
+++ b/crates/tests/misc/handles/tests/win.rs
@@ -53,6 +53,7 @@ fn hfont() {
 }
 
 #[test]
+#[allow(clippy::assertions_on_constants)] // intentionally testing constant
 fn const_pattern() {
     match HKEY_CLASSES_ROOT {
         HKEY_CLASSES_ROOT => assert!(true),

--- a/crates/tests/misc/no_std/src/lib.rs
+++ b/crates/tests/misc/no_std/src/lib.rs
@@ -32,6 +32,7 @@ fn _test() {
 // This panic handler will cause a build error if an indirect `std` dependency exists as `std`
 // will include its own panic handler and conflict with this one.
 #[cfg_attr(not(test), panic_handler)]
+#[allow(clippy::empty_loop)] // just a test
 fn _panic(_: &core::panic::PanicInfo<'_>) -> ! {
     loop {}
 }

--- a/crates/tests/misc/structs/tests/propertykey.rs
+++ b/crates/tests/misc/structs/tests/propertykey.rs
@@ -6,5 +6,5 @@ fn test_debug_impl() {
         DEVPKEY_Device_BiosDeviceName.fmtid
             == "540B947E-8B40-45BC-A8A2-6A0B894CBDA2".try_into().unwrap()
     );
-    assert!(DEVPKEY_Device_BiosDeviceName.pid == 10);
+    assert_eq!(DEVPKEY_Device_BiosDeviceName.pid, 10);
 }

--- a/crates/tests/misc/weak_ref/tests/race.rs
+++ b/crates/tests/misc/weak_ref/tests/race.rs
@@ -4,6 +4,7 @@ use windows::core::imp::WeakRefCount;
 
 const TARGET: u32 = 100_000;
 const CONCURRENCY: usize = 8;
+#[allow(clippy::declare_interior_mutable_const)] // don't want to disturb concurrency testing
 const ATOMIC_U32_ZERO: AtomicU32 = AtomicU32::new(0);
 static PROGRESS: [AtomicU32; CONCURRENCY] = [ATOMIC_U32_ZERO; CONCURRENCY];
 
@@ -16,6 +17,7 @@ fn run_increment(ref_count: Arc<WeakRefCount>, progress: &AtomicU32) {
 }
 
 #[test]
+#[allow(clippy::needless_range_loop)] // don't want to disturb concurrency testing
 fn test_race() {
     let ref_count = Arc::new(WeakRefCount::new());
     let mut threads = Vec::with_capacity(CONCURRENCY);

--- a/crates/tests/misc/win32/tests/hresult.rs
+++ b/crates/tests/misc/win32/tests/hresult.rs
@@ -6,10 +6,10 @@ fn test_message() {
     helpers::set_thread_ui_language();
 
     let code: HRESULT = ERROR_SUCCESS.into();
-    let message: String = code.message().try_into().unwrap();
+    let message: String = code.message();
     assert_eq!(message, "The operation completed successfully.");
 
     let code: HRESULT = ERROR_IO_PENDING.into();
-    let message: String = code.message().try_into().unwrap();
+    let message: String = code.message();
     assert_eq!(message, "Overlapped I/O operation is in progress.");
 }

--- a/crates/tests/misc/win32/tests/win32.rs
+++ b/crates/tests/misc/win32/tests/win32.rs
@@ -99,10 +99,13 @@ fn size32() {
 
 #[test]
 fn constant() {
-    assert!(WM_KEYUP == 257u32);
-    assert!(D3D12_DEFAULT_BLEND_FACTOR_ALPHA == 1f32);
-    assert!(UIA_ScrollPatternNoScroll == -1f64);
-    assert!(CLSID_D2D1Shadow == GUID::try_from("C67EA361-1863-4e69-89DB-695D3E9A5B6B").unwrap());
+    assert_eq!(WM_KEYUP, 257u32);
+    assert_eq!(D3D12_DEFAULT_BLEND_FACTOR_ALPHA, 1f32);
+    assert_eq!(UIA_ScrollPatternNoScroll, -1f64);
+    assert_eq!(
+        CLSID_D2D1Shadow,
+        GUID::try_from("C67EA361-1863-4e69-89DB-695D3E9A5B6B").unwrap()
+    );
 
     let b: PCSTR = D3DCOMPILER_DLL_A;
     let c: PCWSTR = D3DCOMPILER_DLL_W;
@@ -133,7 +136,7 @@ fn bool_as_error() {
         let error = SetEvent(HANDLE(0 as _)).unwrap_err();
 
         assert_eq!(error.code(), windows::core::HRESULT(-2147024890));
-        let message: String = error.message().try_into().unwrap();
+        let message: String = error.message();
         assert_eq!(message, "The handle is invalid.");
     }
 }
@@ -240,6 +243,7 @@ fn interface() -> windows::core::Result<()> {
 }
 
 #[test]
+#[allow(clippy::unnecessary_literal_unwrap)] // callback type is intentionally being tested
 fn callback() {
     unsafe {
         let a: PROPENUMPROCA = Some(callback_a);

--- a/crates/tests/winrt/old/tests/enum.rs
+++ b/crates/tests/winrt/old/tests/enum.rs
@@ -3,24 +3,24 @@ use windows_future::*;
 
 #[test]
 fn signed_enum() {
-    assert!(AsyncStatus::default().0 == 0);
-    assert!(AsyncStatus::Canceled.0 == 2);
-    assert!(AsyncStatus::Completed.0 == 1);
-    assert!(AsyncStatus::Error.0 == 3);
-    assert!(AsyncStatus::Started.0 == 0);
+    assert_eq!(AsyncStatus::default().0, 0);
+    assert_eq!(AsyncStatus::Canceled.0, 2);
+    assert_eq!(AsyncStatus::Completed.0, 1);
+    assert_eq!(AsyncStatus::Error.0, 3);
+    assert_eq!(AsyncStatus::Started.0, 0);
 }
 
 #[test]
 fn unsigned_enum() {
-    assert!(AppointmentDaysOfWeek::default().0 == 0);
-    assert!(AppointmentDaysOfWeek::None.0 == 0);
-    assert!(AppointmentDaysOfWeek::Sunday.0 == 0x1);
-    assert!(AppointmentDaysOfWeek::Monday.0 == 0x2);
-    assert!(AppointmentDaysOfWeek::Tuesday.0 == 0x4);
-    assert!(AppointmentDaysOfWeek::Wednesday.0 == 0x8);
-    assert!(AppointmentDaysOfWeek::Thursday.0 == 0x10);
-    assert!(AppointmentDaysOfWeek::Friday.0 == 0x20);
-    assert!(AppointmentDaysOfWeek::Saturday.0 == 0x40);
+    assert_eq!(AppointmentDaysOfWeek::default().0, 0);
+    assert_eq!(AppointmentDaysOfWeek::None.0, 0);
+    assert_eq!(AppointmentDaysOfWeek::Sunday.0, 0x1);
+    assert_eq!(AppointmentDaysOfWeek::Monday.0, 0x2);
+    assert_eq!(AppointmentDaysOfWeek::Tuesday.0, 0x4);
+    assert_eq!(AppointmentDaysOfWeek::Wednesday.0, 0x8);
+    assert_eq!(AppointmentDaysOfWeek::Thursday.0, 0x10);
+    assert_eq!(AppointmentDaysOfWeek::Friday.0, 0x20);
+    assert_eq!(AppointmentDaysOfWeek::Saturday.0, 0x40);
 
     // Use as bitflags
     let weekend = AppointmentDaysOfWeek::Sunday | AppointmentDaysOfWeek::Saturday;

--- a/crates/tests/winrt/old/tests/error.rs
+++ b/crates/tests/winrt/old/tests/error.rs
@@ -7,7 +7,7 @@ fn from_hresult() {
     let error: windows::core::Error = windows::core::HRESULT(-2147467260).into();
 
     assert_eq!(error.code(), windows::core::HRESULT(-2147467260));
-    let message: String = error.message().try_into().unwrap();
+    let message: String = error.message();
     assert_eq!(message, "Operation aborted");
 }
 

--- a/crates/tests/winrt/reference_float/src/lib.rs
+++ b/crates/tests/winrt/reference_float/src/lib.rs
@@ -5,6 +5,7 @@ use bindings::*;
 use windows::{core::*, Foundation::*};
 
 #[test]
+#[allow(clippy::field_reassign_with_default)] // testing unusual field assignment
 fn test() -> Result<()> {
     let mut container = RefWithFloat::default();
     container.Value = Some(PropertyValue::CreateSingle(1.23)?.cast()?);


### PR DESCRIPTION
By default, windows-rs does not run Clippy against tests but I have been steadily working on the noisy issues and I think this should be the last batch before I can flip the switch and let the Clippy workflow keep the tests honest. 

This update doesn't change the yml workflow as that will require one test to be disabled or removed. I'll do that separately. 