### PR TITLE
Turn on Clippy testing of all crates and tests

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -29,176 +29,360 @@ jobs:
         with:
           target: x86_64-pc-windows-msvc
       - name: Check cppwinrt
-        run:  cargo clippy -p cppwinrt
+        run:  cargo clippy -p cppwinrt --tests
       - name: Check csharp_client
-        run:  cargo clippy -p csharp_client
+        run:  cargo clippy -p csharp_client --tests
       - name: Check csharp_component
-        run:  cargo clippy -p csharp_component
+        run:  cargo clippy -p csharp_component --tests
       - name: Check helpers
-        run:  cargo clippy -p helpers
+        run:  cargo clippy -p helpers --tests
       - name: Check sample_bits
-        run:  cargo clippy -p sample_bits
+        run:  cargo clippy -p sample_bits --tests
       - name: Check sample_com_uri
-        run:  cargo clippy -p sample_com_uri
+        run:  cargo clippy -p sample_com_uri --tests
       - name: Check sample_consent
-        run:  cargo clippy -p sample_consent
+        run:  cargo clippy -p sample_consent --tests
       - name: Check sample_core_app
-        run:  cargo clippy -p sample_core_app
+        run:  cargo clippy -p sample_core_app --tests
       - name: Check sample_counter
-        run:  cargo clippy -p sample_counter
+        run:  cargo clippy -p sample_counter --tests
       - name: Check sample_counter_sys
-        run:  cargo clippy -p sample_counter_sys
+        run:  cargo clippy -p sample_counter_sys --tests
       - name: Check sample_create_window
-        run:  cargo clippy -p sample_create_window
+        run:  cargo clippy -p sample_create_window --tests
       - name: Check sample_create_window_sys
-        run:  cargo clippy -p sample_create_window_sys
+        run:  cargo clippy -p sample_create_window_sys --tests
       - name: Check sample_credentials
-        run:  cargo clippy -p sample_credentials
+        run:  cargo clippy -p sample_credentials --tests
       - name: Check sample_data_protection
-        run:  cargo clippy -p sample_data_protection
+        run:  cargo clippy -p sample_data_protection --tests
       - name: Check sample_dcomp
-        run:  cargo clippy -p sample_dcomp
+        run:  cargo clippy -p sample_dcomp --tests
       - name: Check sample_delay_load
-        run:  cargo clippy -p sample_delay_load
+        run:  cargo clippy -p sample_delay_load --tests
       - name: Check sample_delay_load_sys
-        run:  cargo clippy -p sample_delay_load_sys
+        run:  cargo clippy -p sample_delay_load_sys --tests
       - name: Check sample_device_watcher
-        run:  cargo clippy -p sample_device_watcher
+        run:  cargo clippy -p sample_device_watcher --tests
       - name: Check sample_direct2d
-        run:  cargo clippy -p sample_direct2d
+        run:  cargo clippy -p sample_direct2d --tests
       - name: Check sample_direct3d12
-        run:  cargo clippy -p sample_direct3d12
+        run:  cargo clippy -p sample_direct3d12 --tests
       - name: Check sample_enum_windows
-        run:  cargo clippy -p sample_enum_windows
+        run:  cargo clippy -p sample_enum_windows --tests
       - name: Check sample_enum_windows_sys
-        run:  cargo clippy -p sample_enum_windows_sys
+        run:  cargo clippy -p sample_enum_windows_sys --tests
       - name: Check sample_file_dialogs
-        run:  cargo clippy -p sample_file_dialogs
+        run:  cargo clippy -p sample_file_dialogs --tests
       - name: Check sample_json_validator
-        run:  cargo clippy -p sample_json_validator
+        run:  cargo clippy -p sample_json_validator --tests
       - name: Check sample_json_validator_client
-        run:  cargo clippy -p sample_json_validator_client
+        run:  cargo clippy -p sample_json_validator_client --tests
       - name: Check sample_json_validator_winrt
-        run:  cargo clippy -p sample_json_validator_winrt
+        run:  cargo clippy -p sample_json_validator_winrt --tests
       - name: Check sample_json_validator_winrt_client
-        run:  cargo clippy -p sample_json_validator_winrt_client
+        run:  cargo clippy -p sample_json_validator_winrt_client --tests
       - name: Check sample_json_validator_winrt_client_cpp
-        run:  cargo clippy -p sample_json_validator_winrt_client_cpp
+        run:  cargo clippy -p sample_json_validator_winrt_client_cpp --tests
       - name: Check sample_kernel_event
-        run:  cargo clippy -p sample_kernel_event
+        run:  cargo clippy -p sample_kernel_event --tests
       - name: Check sample_memory_buffer
-        run:  cargo clippy -p sample_memory_buffer
+        run:  cargo clippy -p sample_memory_buffer --tests
       - name: Check sample_message_box
-        run:  cargo clippy -p sample_message_box
+        run:  cargo clippy -p sample_message_box --tests
       - name: Check sample_message_box_sys
-        run:  cargo clippy -p sample_message_box_sys
+        run:  cargo clippy -p sample_message_box_sys --tests
       - name: Check sample_ocr
-        run:  cargo clippy -p sample_ocr
+        run:  cargo clippy -p sample_ocr --tests
       - name: Check sample_overlapped
-        run:  cargo clippy -p sample_overlapped
+        run:  cargo clippy -p sample_overlapped --tests
       - name: Check sample_privileges
-        run:  cargo clippy -p sample_privileges
+        run:  cargo clippy -p sample_privileges --tests
       - name: Check sample_privileges_sys
-        run:  cargo clippy -p sample_privileges_sys
+        run:  cargo clippy -p sample_privileges_sys --tests
       - name: Check sample_rss
-        run:  cargo clippy -p sample_rss
+        run:  cargo clippy -p sample_rss --tests
       - name: Check sample_service_simple
-        run:  cargo clippy -p sample_service_simple
+        run:  cargo clippy -p sample_service_simple --tests
       - name: Check sample_service_sys
-        run:  cargo clippy -p sample_service_sys
+        run:  cargo clippy -p sample_service_sys --tests
       - name: Check sample_service_thread
-        run:  cargo clippy -p sample_service_thread
+        run:  cargo clippy -p sample_service_thread --tests
       - name: Check sample_service_time
-        run:  cargo clippy -p sample_service_time
+        run:  cargo clippy -p sample_service_time --tests
       - name: Check sample_shell
-        run:  cargo clippy -p sample_shell
+        run:  cargo clippy -p sample_shell --tests
       - name: Check sample_simple
-        run:  cargo clippy -p sample_simple
+        run:  cargo clippy -p sample_simple --tests
       - name: Check sample_spellchecker
-        run:  cargo clippy -p sample_spellchecker
+        run:  cargo clippy -p sample_spellchecker --tests
       - name: Check sample_task_dialog
-        run:  cargo clippy -p sample_task_dialog
+        run:  cargo clippy -p sample_task_dialog --tests
       - name: Check sample_task_dialog_sys
-        run:  cargo clippy -p sample_task_dialog_sys
+        run:  cargo clippy -p sample_task_dialog_sys --tests
       - name: Check sample_thread_pool_work
-        run:  cargo clippy -p sample_thread_pool_work
+        run:  cargo clippy -p sample_thread_pool_work --tests
       - name: Check sample_thread_pool_work_sys
-        run:  cargo clippy -p sample_thread_pool_work_sys
+        run:  cargo clippy -p sample_thread_pool_work_sys --tests
       - name: Check sample_uiautomation
-        run:  cargo clippy -p sample_uiautomation
+        run:  cargo clippy -p sample_uiautomation --tests
       - name: Check sample_wmi
-        run:  cargo clippy -p sample_wmi
+        run:  cargo clippy -p sample_wmi --tests
       - name: Check sample_xml
-        run:  cargo clippy -p sample_xml
+        run:  cargo clippy -p sample_xml --tests
+      - name: Check test_agile
+        run:  cargo clippy -p test_agile --tests
+      - name: Check test_agile_reference
+        run:  cargo clippy -p test_agile_reference --tests
+      - name: Check test_alternate_success_code
+        run:  cargo clippy -p test_alternate_success_code --tests
+      - name: Check test_arch
+        run:  cargo clippy -p test_arch --tests
+      - name: Check test_arch_feature
+        run:  cargo clippy -p test_arch_feature --tests
+      - name: Check test_array
+        run:  cargo clippy -p test_array --tests
+      - name: Check test_bcrypt
+        run:  cargo clippy -p test_bcrypt --tests
+      - name: Check test_bindgen
+        run:  cargo clippy -p test_bindgen --tests
+      - name: Check test_calling_convention
+        run:  cargo clippy -p test_calling_convention --tests
+      - name: Check test_cfg_generic
+        run:  cargo clippy -p test_cfg_generic --tests
+      - name: Check test_class_hierarchy
+        run:  cargo clippy -p test_class_hierarchy --tests
+      - name: Check test_collection_interop
+        run:  cargo clippy -p test_collection_interop --tests
+      - name: Check test_collections
+        run:  cargo clippy -p test_collections --tests
+      - name: Check test_component
+        run:  cargo clippy -p test_component --tests
+      - name: Check test_component_client
+        run:  cargo clippy -p test_component_client --tests
+      - name: Check test_composable
+        run:  cargo clippy -p test_composable --tests
+      - name: Check test_composable_client
+        run:  cargo clippy -p test_composable_client --tests
+      - name: Check test_const_fields
+        run:  cargo clippy -p test_const_fields --tests
+      - name: Check test_const_params
+        run:  cargo clippy -p test_const_params --tests
+      - name: Check test_const_ptrs
+        run:  cargo clippy -p test_const_ptrs --tests
+      - name: Check test_constructors
+        run:  cargo clippy -p test_constructors --tests
+      - name: Check test_constructors_client
+        run:  cargo clippy -p test_constructors_client --tests
+      - name: Check test_core
+        run:  cargo clippy -p test_core --tests
+      - name: Check test_debug
+        run:  cargo clippy -p test_debug --tests
+      - name: Check test_debugger_visualizer
+        run:  cargo clippy -p test_debugger_visualizer --tests
+      - name: Check test_deprecated
+        run:  cargo clippy -p test_deprecated --tests
+      - name: Check test_dispatch
+        run:  cargo clippy -p test_dispatch --tests
+      - name: Check test_does_not_return
+        run:  cargo clippy -p test_does_not_return --tests
+      - name: Check test_enums
+        run:  cargo clippy -p test_enums --tests
+      - name: Check test_error
+        run:  cargo clippy -p test_error --tests
+      - name: Check test_event_core
+        run:  cargo clippy -p test_event_core --tests
+      - name: Check test_events
+        run:  cargo clippy -p test_events --tests
+      - name: Check test_events_client
+        run:  cargo clippy -p test_events_client --tests
+      - name: Check test_extensions
+        run:  cargo clippy -p test_extensions --tests
+      - name: Check test_future
+        run:  cargo clippy -p test_future --tests
+      - name: Check test_handles
+        run:  cargo clippy -p test_handles --tests
+      - name: Check test_implement
+        run:  cargo clippy -p test_implement --tests
+      - name: Check test_implement_core
+        run:  cargo clippy -p test_implement_core --tests
+      - name: Check test_interface
+        run:  cargo clippy -p test_interface --tests
+      - name: Check test_interface_core
+        run:  cargo clippy -p test_interface_core --tests
+      - name: Check test_interop
+        run:  cargo clippy -p test_interop --tests
+      - name: Check test_lib
+        run:  cargo clippy -p test_lib --tests
+      - name: Check test_link
+        run:  cargo clippy -p test_link --tests
+      - name: Check test_linux
+        run:  cargo clippy -p test_linux --tests
+      - name: Check test_literals
+        run:  cargo clippy -p test_literals --tests
+      - name: Check test_marshal
+        run:  cargo clippy -p test_marshal --tests
+      - name: Check test_match
+        run:  cargo clippy -p test_match --tests
+      - name: Check test_metadata
+        run:  cargo clippy -p test_metadata --tests
+      - name: Check test_msrv
+        run:  cargo clippy -p test_msrv --tests
+      - name: Check test_no_std
+        run:  cargo clippy -p test_no_std --tests
+      - name: Check test_no_use
+        run:  cargo clippy -p test_no_use --tests
+      - name: Check test_noexcept
+        run:  cargo clippy -p test_noexcept --tests
+      - name: Check test_not_dll
+        run:  cargo clippy -p test_not_dll --tests
+      - name: Check test_numerics
+        run:  cargo clippy -p test_numerics --tests
+      - name: Check test_overloads
+        run:  cargo clippy -p test_overloads --tests
+      - name: Check test_overloads_client
+        run:  cargo clippy -p test_overloads_client --tests
+      - name: Check test_query_signature
+        run:  cargo clippy -p test_query_signature --tests
+      - name: Check test_readme
+        run:  cargo clippy -p test_readme --tests
+      - name: Check test_ref_params
+        run:  cargo clippy -p test_ref_params --tests
+      - name: Check test_reference
+        run:  cargo clippy -p test_reference --tests
+      - name: Check test_reference_client
+        run:  cargo clippy -p test_reference_client --tests
+      - name: Check test_reference_custom
+        run:  cargo clippy -p test_reference_custom --tests
+      - name: Check test_reference_float
+        run:  cargo clippy -p test_reference_float --tests
+      - name: Check test_reference_no_deps
+        run:  cargo clippy -p test_reference_no_deps --tests
+      - name: Check test_reference_no_windows
+        run:  cargo clippy -p test_reference_no_windows --tests
+      - name: Check test_reference_windows
+        run:  cargo clippy -p test_reference_windows --tests
+      - name: Check test_registry
+        run:  cargo clippy -p test_registry --tests
+      - name: Check test_registry_default
+        run:  cargo clippy -p test_registry_default --tests
+      - name: Check test_reserved
+        run:  cargo clippy -p test_reserved --tests
+      - name: Check test_resources
+        run:  cargo clippy -p test_resources --tests
+      - name: Check test_result
+        run:  cargo clippy -p test_result --tests
+      - name: Check test_return_handle
+        run:  cargo clippy -p test_return_handle --tests
+      - name: Check test_return_struct
+        run:  cargo clippy -p test_return_struct --tests
+      - name: Check test_services
+        run:  cargo clippy -p test_services --tests
+      - name: Check test_standalone
+        run:  cargo clippy -p test_standalone --tests
+      - name: Check test_string_param
+        run:  cargo clippy -p test_string_param --tests
+      - name: Check test_strings
+        run:  cargo clippy -p test_strings --tests
+      - name: Check test_struct_size
+        run:  cargo clippy -p test_struct_size --tests
+      - name: Check test_structs
+        run:  cargo clippy -p test_structs --tests
+      - name: Check test_sys
+        run:  cargo clippy -p test_sys --tests
+      - name: Check test_targets
+        run:  cargo clippy -p test_targets --tests
+      - name: Check test_threading
+        run:  cargo clippy -p test_threading --tests
+      - name: Check test_unions
+        run:  cargo clippy -p test_unions --tests
+      - name: Check test_variant
+        run:  cargo clippy -p test_variant --tests
+      - name: Check test_wdk
+        run:  cargo clippy -p test_wdk --tests
+      - name: Check test_weak
+        run:  cargo clippy -p test_weak --tests
+      - name: Check test_weak_ref
+        run:  cargo clippy -p test_weak_ref --tests
+      - name: Check test_win32
+        run:  cargo clippy -p test_win32 --tests
+      - name: Check test_win32_arrays
+        run:  cargo clippy -p test_win32_arrays --tests
+      - name: Check test_window_long
+        run:  cargo clippy -p test_window_long --tests
+      - name: Check test_windows_std
+        run:  cargo clippy -p test_windows_std --tests
+      - name: Check test_winrt
+        run:  cargo clippy -p test_winrt --tests
       - name: Check tool_bindgen
-        run:  cargo clippy -p tool_bindgen
+        run:  cargo clippy -p tool_bindgen --tests
       - name: Check tool_bindings
-        run:  cargo clippy -p tool_bindings
+        run:  cargo clippy -p tool_bindings --tests
       - name: Check tool_gnu
-        run:  cargo clippy -p tool_gnu
+        run:  cargo clippy -p tool_gnu --tests
       - name: Check tool_license
-        run:  cargo clippy -p tool_license
+        run:  cargo clippy -p tool_license --tests
       - name: Check tool_merge
-        run:  cargo clippy -p tool_merge
+        run:  cargo clippy -p tool_merge --tests
       - name: Check tool_msvc
-        run:  cargo clippy -p tool_msvc
+        run:  cargo clippy -p tool_msvc --tests
       - name: Check tool_standalone
-        run:  cargo clippy -p tool_standalone
+        run:  cargo clippy -p tool_standalone --tests
       - name: Check tool_test_all
-        run:  cargo clippy -p tool_test_all
+        run:  cargo clippy -p tool_test_all --tests
       - name: Check tool_workspace
-        run:  cargo clippy -p tool_workspace
+        run:  cargo clippy -p tool_workspace --tests
       - name: Check tool_yml
-        run:  cargo clippy -p tool_yml
+        run:  cargo clippy -p tool_yml --tests
       - name: Check windows
-        run:  cargo clippy -p windows
+        run:  cargo clippy -p windows --tests
       - name: Check windows-bindgen
-        run:  cargo clippy -p windows-bindgen
+        run:  cargo clippy -p windows-bindgen --tests
       - name: Check windows-collections
-        run:  cargo clippy -p windows-collections
+        run:  cargo clippy -p windows-collections --tests
       - name: Check windows-core
-        run:  cargo clippy -p windows-core
+        run:  cargo clippy -p windows-core --tests
       - name: Check windows-future
-        run:  cargo clippy -p windows-future
+        run:  cargo clippy -p windows-future --tests
       - name: Check windows-implement
-        run:  cargo clippy -p windows-implement
+        run:  cargo clippy -p windows-implement --tests
       - name: Check windows-interface
-        run:  cargo clippy -p windows-interface
+        run:  cargo clippy -p windows-interface --tests
       - name: Check windows-link
-        run:  cargo clippy -p windows-link
+        run:  cargo clippy -p windows-link --tests
       - name: Check windows-metadata
-        run:  cargo clippy -p windows-metadata
+        run:  cargo clippy -p windows-metadata --tests
       - name: Check windows-numerics
-        run:  cargo clippy -p windows-numerics
+        run:  cargo clippy -p windows-numerics --tests
       - name: Check windows-registry
-        run:  cargo clippy -p windows-registry
+        run:  cargo clippy -p windows-registry --tests
       - name: Check windows-result
-        run:  cargo clippy -p windows-result
+        run:  cargo clippy -p windows-result --tests
       - name: Check windows-services
-        run:  cargo clippy -p windows-services
+        run:  cargo clippy -p windows-services --tests
       - name: Check windows-strings
-        run:  cargo clippy -p windows-strings
+        run:  cargo clippy -p windows-strings --tests
       - name: Check windows-sys
-        run:  cargo clippy -p windows-sys
+        run:  cargo clippy -p windows-sys --tests
       - name: Check windows-targets
-        run:  cargo clippy -p windows-targets
+        run:  cargo clippy -p windows-targets --tests
       - name: Check windows-threading
-        run:  cargo clippy -p windows-threading
+        run:  cargo clippy -p windows-threading --tests
       - name: Check windows-version
-        run:  cargo clippy -p windows-version
+        run:  cargo clippy -p windows-version --tests
       - name: Check windows_aarch64_gnullvm
-        run:  cargo clippy -p windows_aarch64_gnullvm
+        run:  cargo clippy -p windows_aarch64_gnullvm --tests
       - name: Check windows_aarch64_msvc
-        run:  cargo clippy -p windows_aarch64_msvc
+        run:  cargo clippy -p windows_aarch64_msvc --tests
       - name: Check windows_i686_gnu
-        run:  cargo clippy -p windows_i686_gnu
+        run:  cargo clippy -p windows_i686_gnu --tests
       - name: Check windows_i686_gnullvm
-        run:  cargo clippy -p windows_i686_gnullvm
+        run:  cargo clippy -p windows_i686_gnullvm --tests
       - name: Check windows_i686_msvc
-        run:  cargo clippy -p windows_i686_msvc
+        run:  cargo clippy -p windows_i686_msvc --tests
       - name: Check windows_x86_64_gnu
-        run:  cargo clippy -p windows_x86_64_gnu
+        run:  cargo clippy -p windows_x86_64_gnu --tests
       - name: Check windows_x86_64_gnullvm
-        run:  cargo clippy -p windows_x86_64_gnullvm
+        run:  cargo clippy -p windows_x86_64_gnullvm --tests
       - name: Check windows_x86_64_msvc
-        run:  cargo clippy -p windows_x86_64_msvc
+        run:  cargo clippy -p windows_x86_64_msvc --tests

--- a/crates/tests/misc/debugger_visualizer/tests/test.rs
+++ b/crates/tests/misc/debugger_visualizer/tests/test.rs
@@ -1,259 +1,259 @@
-#![cfg(target_env = "msvc")]
+// #![cfg(target_env = "msvc")]
 
-use debugger_test::*;
-use windows::core::*;
-use windows::Win32::Foundation::*;
-use windows::Win32::System::Com::*;
+// use debugger_test::*;
+// use windows::core::*;
+// use windows::Win32::Foundation::*;
+// use windows::Win32::System::Com::*;
 
-#[inline(never)]
-fn __break() {}
+// #[inline(never)]
+// fn __break() {}
 
-#[implement(IErrorInfo)]
-struct Test;
+// #[implement(IErrorInfo)]
+// struct Test;
 
-impl IErrorInfo_Impl for Test_Impl {
-    fn GetGUID(&self) -> Result<GUID> {
-        Err(Error::new(E_OUTOFMEMORY, "Out of memory message"))
-    }
-    fn GetSource(&self) -> Result<BSTR> {
-        Err(Error::new(E_INVALIDARG, "Invalid argument message"))
-    }
-    fn GetDescription(&self) -> Result<BSTR> {
-        Ok(BSTR::new())
-    }
-    fn GetHelpFile(&self) -> Result<BSTR> {
-        Ok(BSTR::new())
-    }
-    fn GetHelpContext(&self) -> Result<u32> {
-        Ok(1)
-    }
-}
+// impl IErrorInfo_Impl for Test_Impl {
+//     fn GetGUID(&self) -> Result<GUID> {
+//         Err(Error::new(E_OUTOFMEMORY, "Out of memory message"))
+//     }
+//     fn GetSource(&self) -> Result<BSTR> {
+//         Err(Error::new(E_INVALIDARG, "Invalid argument message"))
+//     }
+//     fn GetDescription(&self) -> Result<BSTR> {
+//         Ok(BSTR::new())
+//     }
+//     fn GetHelpFile(&self) -> Result<BSTR> {
+//         Ok(BSTR::new())
+//     }
+//     fn GetHelpContext(&self) -> Result<u32> {
+//         Ok(1)
+//     }
+// }
 
-#[debugger_test(
-    debugger = "cdb",
-    commands = "
-.nvlist
-dx array
+// #[debugger_test(
+//     debugger = "cdb",
+//     commands = "
+// .nvlist
+// dx array
 
-dx -r2 pstr
-dx -r2 pcstr
-dx -r2 pwstr
-dx -r2 pcwstr
+// dx -r2 pstr
+// dx -r2 pcstr
+// dx -r2 pwstr
+// dx -r2 pcwstr
 
-dx empty
-dx -r2 hstring
+// dx empty
+// dx -r2 hstring
 
-dx out_of_memory_error
-dx invalid_argument_error
-    ",
-    expected_statements = r#"
-array            : { len=0xd } [Type: windows_core::array::Array<u8>]
-    [<Raw View>]     [Type: windows_core::array::Array<u8>]
-    [len]            : 0xd
-    [0]              : 0x48 [Type: unsigned char]
-    [1]              : 0x65 [Type: unsigned char]
-    [2]              : 0x6c [Type: unsigned char]
-    [3]              : 0x6c [Type: unsigned char]
-    [4]              : 0x6f [Type: unsigned char]
-    [5]              : 0x20 [Type: unsigned char]
-    [6]              : 0x57 [Type: unsigned char]
-    [7]              : 0x6f [Type: unsigned char]
-    [8]              : 0x72 [Type: unsigned char]
-    [9]              : 0x6c [Type: unsigned char]
-    [10]             : 0x64 [Type: unsigned char]
-    [11]             : 0x21 [Type: unsigned char]
-    [12]             : 0x0 [Type: unsigned char]
+// dx out_of_memory_error
+// dx invalid_argument_error
+//     ",
+//     expected_statements = r#"
+// array            : { len=0xd } [Type: windows_core::array::Array<u8>]
+//     [<Raw View>]     [Type: windows_core::array::Array<u8>]
+//     [len]            : 0xd
+//     [0]              : 0x48 [Type: unsigned char]
+//     [1]              : 0x65 [Type: unsigned char]
+//     [2]              : 0x6c [Type: unsigned char]
+//     [3]              : 0x6c [Type: unsigned char]
+//     [4]              : 0x6f [Type: unsigned char]
+//     [5]              : 0x20 [Type: unsigned char]
+//     [6]              : 0x57 [Type: unsigned char]
+//     [7]              : 0x6f [Type: unsigned char]
+//     [8]              : 0x72 [Type: unsigned char]
+//     [9]              : 0x6c [Type: unsigned char]
+//     [10]             : 0x64 [Type: unsigned char]
+//     [11]             : 0x21 [Type: unsigned char]
+//     [12]             : 0x0 [Type: unsigned char]
 
-pstr             : "This is a PSTR" [Type: windows_strings::pstr::PSTR]
-    [<Raw View>]     [Type: windows_strings::pstr::PSTR]
-    [len]            : 0xe
-    [chars]
-        [0]              : 84 'T' [Type: char]
-        [1]              : 104 'h' [Type: char]
-        [2]              : 105 'i' [Type: char]
-        [3]              : 115 's' [Type: char]
-        [4]              : 32 ' ' [Type: char]
-        [5]              : 105 'i' [Type: char]
-        [6]              : 115 's' [Type: char]
-        [7]              : 32 ' ' [Type: char]
-        [8]              : 97 'a' [Type: char]
-        [9]              : 32 ' ' [Type: char]
-        [10]             : 80 'P' [Type: char]
-        [11]             : 83 'S' [Type: char]
-        [12]             : 84 'T' [Type: char]
-        [13]             : 82 'R' [Type: char]
+// pstr             : "This is a PSTR" [Type: windows_strings::pstr::PSTR]
+//     [<Raw View>]     [Type: windows_strings::pstr::PSTR]
+//     [len]            : 0xe
+//     [chars]
+//         [0]              : 84 'T' [Type: char]
+//         [1]              : 104 'h' [Type: char]
+//         [2]              : 105 'i' [Type: char]
+//         [3]              : 115 's' [Type: char]
+//         [4]              : 32 ' ' [Type: char]
+//         [5]              : 105 'i' [Type: char]
+//         [6]              : 115 's' [Type: char]
+//         [7]              : 32 ' ' [Type: char]
+//         [8]              : 97 'a' [Type: char]
+//         [9]              : 32 ' ' [Type: char]
+//         [10]             : 80 'P' [Type: char]
+//         [11]             : 83 'S' [Type: char]
+//         [12]             : 84 'T' [Type: char]
+//         [13]             : 82 'R' [Type: char]
 
-pcstr            : "This is a PCSTR" [Type: windows_strings::pcstr::PCSTR]
-    [<Raw View>]     [Type: windows_strings::pcstr::PCSTR]
-    [len]            : 0xf
-    [chars]
-        [0]              : 84 'T' [Type: char]
-        [1]              : 104 'h' [Type: char]
-        [2]              : 105 'i' [Type: char]
-        [3]              : 115 's' [Type: char]
-        [4]              : 32 ' ' [Type: char]
-        [5]              : 105 'i' [Type: char]
-        [6]              : 115 's' [Type: char]
-        [7]              : 32 ' ' [Type: char]
-        [8]              : 97 'a' [Type: char]
-        [9]              : 32 ' ' [Type: char]
-        [10]             : 80 'P' [Type: char]
-        [11]             : 67 'C' [Type: char]
-        [12]             : 83 'S' [Type: char]
-        [13]             : 84 'T' [Type: char]
-        [14]             : 82 'R' [Type: char]
+// pcstr            : "This is a PCSTR" [Type: windows_strings::pcstr::PCSTR]
+//     [<Raw View>]     [Type: windows_strings::pcstr::PCSTR]
+//     [len]            : 0xf
+//     [chars]
+//         [0]              : 84 'T' [Type: char]
+//         [1]              : 104 'h' [Type: char]
+//         [2]              : 105 'i' [Type: char]
+//         [3]              : 115 's' [Type: char]
+//         [4]              : 32 ' ' [Type: char]
+//         [5]              : 105 'i' [Type: char]
+//         [6]              : 115 's' [Type: char]
+//         [7]              : 32 ' ' [Type: char]
+//         [8]              : 97 'a' [Type: char]
+//         [9]              : 32 ' ' [Type: char]
+//         [10]             : 80 'P' [Type: char]
+//         [11]             : 67 'C' [Type: char]
+//         [12]             : 83 'S' [Type: char]
+//         [13]             : 84 'T' [Type: char]
+//         [14]             : 82 'R' [Type: char]
 
-pwstr            : "This is a PWSTR" [Type: windows_strings::pwstr::PWSTR]
-    [<Raw View>]     [Type: windows_strings::pwstr::PWSTR]
-    [len]            : 0xf
-    [chars]
-        [0]              : 0x54 'T' [Type: char16_t]
-        [1]              : 0x68 'h' [Type: char16_t]
-        [2]              : 0x69 'i' [Type: char16_t]
-        [3]              : 0x73 's' [Type: char16_t]
-        [4]              : 0x20 ' ' [Type: char16_t]
-        [5]              : 0x69 'i' [Type: char16_t]
-        [6]              : 0x73 's' [Type: char16_t]
-        [7]              : 0x20 ' ' [Type: char16_t]
-        [8]              : 0x61 'a' [Type: char16_t]
-        [9]              : 0x20 ' ' [Type: char16_t]
-        [10]             : 0x50 'P' [Type: char16_t]
-        [11]             : 0x57 'W' [Type: char16_t]
-        [12]             : 0x53 'S' [Type: char16_t]
-        [13]             : 0x54 'T' [Type: char16_t]
-        [14]             : 0x52 'R' [Type: char16_t]
+// pwstr            : "This is a PWSTR" [Type: windows_strings::pwstr::PWSTR]
+//     [<Raw View>]     [Type: windows_strings::pwstr::PWSTR]
+//     [len]            : 0xf
+//     [chars]
+//         [0]              : 0x54 'T' [Type: char16_t]
+//         [1]              : 0x68 'h' [Type: char16_t]
+//         [2]              : 0x69 'i' [Type: char16_t]
+//         [3]              : 0x73 's' [Type: char16_t]
+//         [4]              : 0x20 ' ' [Type: char16_t]
+//         [5]              : 0x69 'i' [Type: char16_t]
+//         [6]              : 0x73 's' [Type: char16_t]
+//         [7]              : 0x20 ' ' [Type: char16_t]
+//         [8]              : 0x61 'a' [Type: char16_t]
+//         [9]              : 0x20 ' ' [Type: char16_t]
+//         [10]             : 0x50 'P' [Type: char16_t]
+//         [11]             : 0x57 'W' [Type: char16_t]
+//         [12]             : 0x53 'S' [Type: char16_t]
+//         [13]             : 0x54 'T' [Type: char16_t]
+//         [14]             : 0x52 'R' [Type: char16_t]
 
-pcwstr           : "This is a PCWSTR" [Type: windows_strings::pcwstr::PCWSTR]
-    [<Raw View>]     [Type: windows_strings::pcwstr::PCWSTR]
-    [len]            : 0x10
-    [chars]
-        [0]              : 0x54 'T' [Type: char16_t]
-        [1]              : 0x68 'h' [Type: char16_t]
-        [2]              : 0x69 'i' [Type: char16_t]
-        [3]              : 0x73 's' [Type: char16_t]
-        [4]              : 0x20 ' ' [Type: char16_t]
-        [5]              : 0x69 'i' [Type: char16_t]
-        [6]              : 0x73 's' [Type: char16_t]
-        [7]              : 0x20 ' ' [Type: char16_t]
-        [8]              : 0x61 'a' [Type: char16_t]
-        [9]              : 0x20 ' ' [Type: char16_t]
-        [10]             : 0x50 'P' [Type: char16_t]
-        [11]             : 0x43 'C' [Type: char16_t]
-        [12]             : 0x57 'W' [Type: char16_t]
-        [13]             : 0x53 'S' [Type: char16_t]
-        [14]             : 0x54 'T' [Type: char16_t]
-        [15]             : 0x52 'R' [Type: char16_t]
+// pcwstr           : "This is a PCWSTR" [Type: windows_strings::pcwstr::PCWSTR]
+//     [<Raw View>]     [Type: windows_strings::pcwstr::PCWSTR]
+//     [len]            : 0x10
+//     [chars]
+//         [0]              : 0x54 'T' [Type: char16_t]
+//         [1]              : 0x68 'h' [Type: char16_t]
+//         [2]              : 0x69 'i' [Type: char16_t]
+//         [3]              : 0x73 's' [Type: char16_t]
+//         [4]              : 0x20 ' ' [Type: char16_t]
+//         [5]              : 0x69 'i' [Type: char16_t]
+//         [6]              : 0x73 's' [Type: char16_t]
+//         [7]              : 0x20 ' ' [Type: char16_t]
+//         [8]              : 0x61 'a' [Type: char16_t]
+//         [9]              : 0x20 ' ' [Type: char16_t]
+//         [10]             : 0x50 'P' [Type: char16_t]
+//         [11]             : 0x43 'C' [Type: char16_t]
+//         [12]             : 0x57 'W' [Type: char16_t]
+//         [13]             : 0x53 'S' [Type: char16_t]
+//         [14]             : 0x54 'T' [Type: char16_t]
+//         [15]             : 0x52 'R' [Type: char16_t]
 
-empty            : "" [Type: windows_strings::hstring::HSTRING]
-    [<Raw View>]     [Type: windows_strings::hstring::HSTRING]
-    [len]            : 0x0 [Type: unsigned int]
+// empty            : "" [Type: windows_strings::hstring::HSTRING]
+//     [<Raw View>]     [Type: windows_strings::hstring::HSTRING]
+//     [len]            : 0x0 [Type: unsigned int]
 
-hstring          : "This is an HSTRING" [Type: windows_strings::hstring::HSTRING]
-    [<Raw View>]     [Type: windows_strings::hstring::HSTRING]
-    [len]            : 0x12 [Type: unsigned int]
-    [ref_count]      : 1 [Type: windows_strings::ref_count::RefCount]
-    [flags]          : 0x0 [Type: unsigned int]
-    [chars]
-        [0]              : 0x54 'T' [Type: char16_t]
-        [1]              : 0x68 'h' [Type: char16_t]
-        [2]              : 0x69 'i' [Type: char16_t]
-        [3]              : 0x73 's' [Type: char16_t]
-        [4]              : 0x20 ' ' [Type: char16_t]
-        [5]              : 0x69 'i' [Type: char16_t]
-        [6]              : 0x73 's' [Type: char16_t]
-        [7]              : 0x20 ' ' [Type: char16_t]
-        [8]              : 0x61 'a' [Type: char16_t]
-        [9]              : 0x6e 'n' [Type: char16_t]
-        [10]             : 0x20 ' ' [Type: char16_t]
-        [11]             : 0x48 'H' [Type: char16_t]
-        [12]             : 0x53 'S' [Type: char16_t]
-        [13]             : 0x54 'T' [Type: char16_t]
-        [14]             : 0x52 'R' [Type: char16_t]
-        [15]             : 0x49 'I' [Type: char16_t]
-        [16]             : 0x4e 'N' [Type: char16_t]
-        [17]             : 0x47 'G' [Type: char16_t]
+// hstring          : "This is an HSTRING" [Type: windows_strings::hstring::HSTRING]
+//     [<Raw View>]     [Type: windows_strings::hstring::HSTRING]
+//     [len]            : 0x12 [Type: unsigned int]
+//     [ref_count]      : 1 [Type: windows_strings::ref_count::RefCount]
+//     [flags]          : 0x0 [Type: unsigned int]
+//     [chars]
+//         [0]              : 0x54 'T' [Type: char16_t]
+//         [1]              : 0x68 'h' [Type: char16_t]
+//         [2]              : 0x69 'i' [Type: char16_t]
+//         [3]              : 0x73 's' [Type: char16_t]
+//         [4]              : 0x20 ' ' [Type: char16_t]
+//         [5]              : 0x69 'i' [Type: char16_t]
+//         [6]              : 0x73 's' [Type: char16_t]
+//         [7]              : 0x20 ' ' [Type: char16_t]
+//         [8]              : 0x61 'a' [Type: char16_t]
+//         [9]              : 0x6e 'n' [Type: char16_t]
+//         [10]             : 0x20 ' ' [Type: char16_t]
+//         [11]             : 0x48 'H' [Type: char16_t]
+//         [12]             : 0x53 'S' [Type: char16_t]
+//         [13]             : 0x54 'T' [Type: char16_t]
+//         [14]             : 0x52 'R' [Type: char16_t]
+//         [15]             : 0x49 'I' [Type: char16_t]
+//         [16]             : 0x4e 'N' [Type: char16_t]
+//         [17]             : 0x47 'G' [Type: char16_t]
 
-out_of_memory_error : 0x8007000e (Not enough memory resources are available to complete this operation.) [Type: windows_result::error::Error]
-    [<Raw View>]     [Type: windows_result::error::Error]
-    [info]           : Some [Type: enum2$<core::option::Option<windows_result::com::ComPtr> >]
+// out_of_memory_error : 0x8007000e (Not enough memory resources are available to complete this operation.) [Type: windows_result::error::Error]
+//     [<Raw View>]     [Type: windows_result::error::Error]
+//     [info]           : Some [Type: enum2$<core::option::Option<windows_result::com::ComPtr> >]
 
-invalid_argument_error : 0x80070057 (The parameter is incorrect.) [Type: windows_result::error::Error]
-    [<Raw View>]     [Type: windows_result::error::Error]
-    [info]           : Some [Type: enum2$<core::option::Option<windows_result::com::ComPtr> >]
-    "#
-)]
-fn test_debugger_visualizer() {
-    let string = "Hello World!\0".to_string();
-    let mut array = Array::<u8>::with_len(string.len());
-    for (i, ch) in string.as_bytes().iter().enumerate() {
-        array[i] = *ch;
-    }
+// invalid_argument_error : 0x80070057 (The parameter is incorrect.) [Type: windows_result::error::Error]
+//     [<Raw View>]     [Type: windows_result::error::Error]
+//     [info]           : Some [Type: enum2$<core::option::Option<windows_result::com::ComPtr> >]
+//     "#
+// )]
+// fn test_debugger_visualizer() {
+//     let string = "Hello World!\0".to_string();
+//     let mut array = Array::<u8>::with_len(string.len());
+//     for (i, ch) in string.as_bytes().iter().enumerate() {
+//         array[i] = *ch;
+//     }
 
-    // Test debugger visualizations for PSTR
-    let mut pstr_string = "This is a PSTR\0".to_string();
-    let pstr = PSTR::from_raw(pstr_string.as_mut_ptr());
-    unsafe {
-        assert_eq!(
-            &pstr_string.as_bytes()[..(pstr_string.len() - 1)],
-            pstr.as_bytes()
-        );
-    }
+//     // Test debugger visualizations for PSTR
+//     let mut pstr_string = "This is a PSTR\0".to_string();
+//     let pstr = PSTR::from_raw(pstr_string.as_mut_ptr());
+//     unsafe {
+//         assert_eq!(
+//             &pstr_string.as_bytes()[..(pstr_string.len() - 1)],
+//             pstr.as_bytes()
+//         );
+//     }
 
-    // Test debugger visualizations for PCSTR
-    let pcstr_string = "This is a PCSTR\0".to_string();
-    let pcstr = PCSTR::from_raw(pcstr_string.as_ptr());
-    unsafe {
-        assert_eq!(
-            &pcstr_string.as_bytes()[..(pcstr_string.len() - 1)],
-            pcstr.as_bytes()
-        );
-    }
+//     // Test debugger visualizations for PCSTR
+//     let pcstr_string = "This is a PCSTR\0".to_string();
+//     let pcstr = PCSTR::from_raw(pcstr_string.as_ptr());
+//     unsafe {
+//         assert_eq!(
+//             &pcstr_string.as_bytes()[..(pcstr_string.len() - 1)],
+//             pcstr.as_bytes()
+//         );
+//     }
 
-    // Test debugger visualizations for PWSTR
-    let mut pwstr_string: Vec<u16> = vec![
-        84, 104, 105, 115, 32, 105, 115, 32, 97, 32, 80, 87, 83, 84, 82, 0,
-    ];
-    let pwstr = PWSTR::from_raw(pwstr_string.as_mut_ptr());
-    unsafe {
-        assert_eq!(
-            &pwstr_string.as_slice()[..(pwstr_string.len() - 1)],
-            pwstr.as_wide()
-        );
-    }
+//     // Test debugger visualizations for PWSTR
+//     let mut pwstr_string: Vec<u16> = vec![
+//         84, 104, 105, 115, 32, 105, 115, 32, 97, 32, 80, 87, 83, 84, 82, 0,
+//     ];
+//     let pwstr = PWSTR::from_raw(pwstr_string.as_mut_ptr());
+//     unsafe {
+//         assert_eq!(
+//             &pwstr_string.as_slice()[..(pwstr_string.len() - 1)],
+//             pwstr.as_wide()
+//         );
+//     }
 
-    // Test debugger visualizations for PCWSTR
-    let pcwstr_string: Vec<u16> = vec![
-        84, 104, 105, 115, 32, 105, 115, 32, 97, 32, 80, 67, 87, 83, 84, 82, 0,
-    ];
-    let pcwstr = PCWSTR::from_raw(pcwstr_string.as_ptr());
-    unsafe {
-        assert_eq!(
-            &pcwstr_string.as_slice()[..(pcwstr_string.len() - 1)],
-            pcwstr.as_wide()
-        );
-    }
+//     // Test debugger visualizations for PCWSTR
+//     let pcwstr_string: Vec<u16> = vec![
+//         84, 104, 105, 115, 32, 105, 115, 32, 97, 32, 80, 67, 87, 83, 84, 82, 0,
+//     ];
+//     let pcwstr = PCWSTR::from_raw(pcwstr_string.as_ptr());
+//     unsafe {
+//         assert_eq!(
+//             &pcwstr_string.as_slice()[..(pcwstr_string.len() - 1)],
+//             pcwstr.as_wide()
+//         );
+//     }
 
-    // Test debugger visualizations for HSTRING
-    let empty = HSTRING::new();
-    assert!(empty.is_empty());
+//     // Test debugger visualizations for HSTRING
+//     let empty = HSTRING::new();
+//     assert!(empty.is_empty());
 
-    let hstring = HSTRING::from("This is an HSTRING");
-    assert!(!hstring.is_empty());
-    assert!(hstring.len() == 18);
+//     let hstring = HSTRING::from("This is an HSTRING");
+//     assert!(!hstring.is_empty());
+//     assert!(hstring.len() == 18);
 
-    let test: IErrorInfo = Test.into();
+//     let test: IErrorInfo = Test.into();
 
-    unsafe {
-        // Test debugger visualizations for Error
-        let result = test.GetGUID();
-        let out_of_memory_error = result.unwrap_err();
-        assert_eq!(out_of_memory_error.code(), E_OUTOFMEMORY);
-        assert_eq!(out_of_memory_error.message(), "Out of memory message");
+//     unsafe {
+//         // Test debugger visualizations for Error
+//         let result = test.GetGUID();
+//         let out_of_memory_error = result.unwrap_err();
+//         assert_eq!(out_of_memory_error.code(), E_OUTOFMEMORY);
+//         assert_eq!(out_of_memory_error.message(), "Out of memory message");
 
-        let result = test.GetSource();
-        let invalid_argument_error = result.unwrap_err();
-        assert_eq!(invalid_argument_error.code(), E_INVALIDARG);
-        assert_eq!(invalid_argument_error.message(), "Invalid argument message");
-        __break();
-    }
-}
+//         let result = test.GetSource();
+//         let invalid_argument_error = result.unwrap_err();
+//         assert_eq!(invalid_argument_error.code(), E_INVALIDARG);
+//         assert_eq!(invalid_argument_error.message(), "Invalid argument message");
+//         __break();
+//     }
+// }

--- a/crates/tests/misc/debugger_visualizer/tests/test.rs
+++ b/crates/tests/misc/debugger_visualizer/tests/test.rs
@@ -1,259 +1,259 @@
-// #![cfg(target_env = "msvc")]
+#![cfg(target_env = "msvc")]
 
-// use debugger_test::*;
-// use windows::core::*;
-// use windows::Win32::Foundation::*;
-// use windows::Win32::System::Com::*;
+use debugger_test::*;
+use windows::core::*;
+use windows::Win32::Foundation::*;
+use windows::Win32::System::Com::*;
 
-// #[inline(never)]
-// fn __break() {}
+#[inline(never)]
+fn __break() {}
 
-// #[implement(IErrorInfo)]
-// struct Test;
+#[implement(IErrorInfo)]
+struct Test;
 
-// impl IErrorInfo_Impl for Test_Impl {
-//     fn GetGUID(&self) -> Result<GUID> {
-//         Err(Error::new(E_OUTOFMEMORY, "Out of memory message"))
-//     }
-//     fn GetSource(&self) -> Result<BSTR> {
-//         Err(Error::new(E_INVALIDARG, "Invalid argument message"))
-//     }
-//     fn GetDescription(&self) -> Result<BSTR> {
-//         Ok(BSTR::new())
-//     }
-//     fn GetHelpFile(&self) -> Result<BSTR> {
-//         Ok(BSTR::new())
-//     }
-//     fn GetHelpContext(&self) -> Result<u32> {
-//         Ok(1)
-//     }
-// }
+impl IErrorInfo_Impl for Test_Impl {
+    fn GetGUID(&self) -> Result<GUID> {
+        Err(Error::new(E_OUTOFMEMORY, "Out of memory message"))
+    }
+    fn GetSource(&self) -> Result<BSTR> {
+        Err(Error::new(E_INVALIDARG, "Invalid argument message"))
+    }
+    fn GetDescription(&self) -> Result<BSTR> {
+        Ok(BSTR::new())
+    }
+    fn GetHelpFile(&self) -> Result<BSTR> {
+        Ok(BSTR::new())
+    }
+    fn GetHelpContext(&self) -> Result<u32> {
+        Ok(1)
+    }
+}
 
-// #[debugger_test(
-//     debugger = "cdb",
-//     commands = "
-// .nvlist
-// dx array
+#[debugger_test(
+    debugger = "cdb",
+    commands = "
+.nvlist
+dx array
 
-// dx -r2 pstr
-// dx -r2 pcstr
-// dx -r2 pwstr
-// dx -r2 pcwstr
+dx -r2 pstr
+dx -r2 pcstr
+dx -r2 pwstr
+dx -r2 pcwstr
 
-// dx empty
-// dx -r2 hstring
+dx empty
+dx -r2 hstring
 
-// dx out_of_memory_error
-// dx invalid_argument_error
-//     ",
-//     expected_statements = r#"
-// array            : { len=0xd } [Type: windows_core::array::Array<u8>]
-//     [<Raw View>]     [Type: windows_core::array::Array<u8>]
-//     [len]            : 0xd
-//     [0]              : 0x48 [Type: unsigned char]
-//     [1]              : 0x65 [Type: unsigned char]
-//     [2]              : 0x6c [Type: unsigned char]
-//     [3]              : 0x6c [Type: unsigned char]
-//     [4]              : 0x6f [Type: unsigned char]
-//     [5]              : 0x20 [Type: unsigned char]
-//     [6]              : 0x57 [Type: unsigned char]
-//     [7]              : 0x6f [Type: unsigned char]
-//     [8]              : 0x72 [Type: unsigned char]
-//     [9]              : 0x6c [Type: unsigned char]
-//     [10]             : 0x64 [Type: unsigned char]
-//     [11]             : 0x21 [Type: unsigned char]
-//     [12]             : 0x0 [Type: unsigned char]
+dx out_of_memory_error
+dx invalid_argument_error
+    ",
+    expected_statements = r#"
+array            : { len=0xd } [Type: windows_core::array::Array<u8>]
+    [<Raw View>]     [Type: windows_core::array::Array<u8>]
+    [len]            : 0xd
+    [0]              : 0x48 [Type: unsigned char]
+    [1]              : 0x65 [Type: unsigned char]
+    [2]              : 0x6c [Type: unsigned char]
+    [3]              : 0x6c [Type: unsigned char]
+    [4]              : 0x6f [Type: unsigned char]
+    [5]              : 0x20 [Type: unsigned char]
+    [6]              : 0x57 [Type: unsigned char]
+    [7]              : 0x6f [Type: unsigned char]
+    [8]              : 0x72 [Type: unsigned char]
+    [9]              : 0x6c [Type: unsigned char]
+    [10]             : 0x64 [Type: unsigned char]
+    [11]             : 0x21 [Type: unsigned char]
+    [12]             : 0x0 [Type: unsigned char]
 
-// pstr             : "This is a PSTR" [Type: windows_strings::pstr::PSTR]
-//     [<Raw View>]     [Type: windows_strings::pstr::PSTR]
-//     [len]            : 0xe
-//     [chars]
-//         [0]              : 84 'T' [Type: char]
-//         [1]              : 104 'h' [Type: char]
-//         [2]              : 105 'i' [Type: char]
-//         [3]              : 115 's' [Type: char]
-//         [4]              : 32 ' ' [Type: char]
-//         [5]              : 105 'i' [Type: char]
-//         [6]              : 115 's' [Type: char]
-//         [7]              : 32 ' ' [Type: char]
-//         [8]              : 97 'a' [Type: char]
-//         [9]              : 32 ' ' [Type: char]
-//         [10]             : 80 'P' [Type: char]
-//         [11]             : 83 'S' [Type: char]
-//         [12]             : 84 'T' [Type: char]
-//         [13]             : 82 'R' [Type: char]
+pstr             : "This is a PSTR" [Type: windows_strings::pstr::PSTR]
+    [<Raw View>]     [Type: windows_strings::pstr::PSTR]
+    [len]            : 0xe
+    [chars]
+        [0]              : 84 'T' [Type: char]
+        [1]              : 104 'h' [Type: char]
+        [2]              : 105 'i' [Type: char]
+        [3]              : 115 's' [Type: char]
+        [4]              : 32 ' ' [Type: char]
+        [5]              : 105 'i' [Type: char]
+        [6]              : 115 's' [Type: char]
+        [7]              : 32 ' ' [Type: char]
+        [8]              : 97 'a' [Type: char]
+        [9]              : 32 ' ' [Type: char]
+        [10]             : 80 'P' [Type: char]
+        [11]             : 83 'S' [Type: char]
+        [12]             : 84 'T' [Type: char]
+        [13]             : 82 'R' [Type: char]
 
-// pcstr            : "This is a PCSTR" [Type: windows_strings::pcstr::PCSTR]
-//     [<Raw View>]     [Type: windows_strings::pcstr::PCSTR]
-//     [len]            : 0xf
-//     [chars]
-//         [0]              : 84 'T' [Type: char]
-//         [1]              : 104 'h' [Type: char]
-//         [2]              : 105 'i' [Type: char]
-//         [3]              : 115 's' [Type: char]
-//         [4]              : 32 ' ' [Type: char]
-//         [5]              : 105 'i' [Type: char]
-//         [6]              : 115 's' [Type: char]
-//         [7]              : 32 ' ' [Type: char]
-//         [8]              : 97 'a' [Type: char]
-//         [9]              : 32 ' ' [Type: char]
-//         [10]             : 80 'P' [Type: char]
-//         [11]             : 67 'C' [Type: char]
-//         [12]             : 83 'S' [Type: char]
-//         [13]             : 84 'T' [Type: char]
-//         [14]             : 82 'R' [Type: char]
+pcstr            : "This is a PCSTR" [Type: windows_strings::pcstr::PCSTR]
+    [<Raw View>]     [Type: windows_strings::pcstr::PCSTR]
+    [len]            : 0xf
+    [chars]
+        [0]              : 84 'T' [Type: char]
+        [1]              : 104 'h' [Type: char]
+        [2]              : 105 'i' [Type: char]
+        [3]              : 115 's' [Type: char]
+        [4]              : 32 ' ' [Type: char]
+        [5]              : 105 'i' [Type: char]
+        [6]              : 115 's' [Type: char]
+        [7]              : 32 ' ' [Type: char]
+        [8]              : 97 'a' [Type: char]
+        [9]              : 32 ' ' [Type: char]
+        [10]             : 80 'P' [Type: char]
+        [11]             : 67 'C' [Type: char]
+        [12]             : 83 'S' [Type: char]
+        [13]             : 84 'T' [Type: char]
+        [14]             : 82 'R' [Type: char]
 
-// pwstr            : "This is a PWSTR" [Type: windows_strings::pwstr::PWSTR]
-//     [<Raw View>]     [Type: windows_strings::pwstr::PWSTR]
-//     [len]            : 0xf
-//     [chars]
-//         [0]              : 0x54 'T' [Type: char16_t]
-//         [1]              : 0x68 'h' [Type: char16_t]
-//         [2]              : 0x69 'i' [Type: char16_t]
-//         [3]              : 0x73 's' [Type: char16_t]
-//         [4]              : 0x20 ' ' [Type: char16_t]
-//         [5]              : 0x69 'i' [Type: char16_t]
-//         [6]              : 0x73 's' [Type: char16_t]
-//         [7]              : 0x20 ' ' [Type: char16_t]
-//         [8]              : 0x61 'a' [Type: char16_t]
-//         [9]              : 0x20 ' ' [Type: char16_t]
-//         [10]             : 0x50 'P' [Type: char16_t]
-//         [11]             : 0x57 'W' [Type: char16_t]
-//         [12]             : 0x53 'S' [Type: char16_t]
-//         [13]             : 0x54 'T' [Type: char16_t]
-//         [14]             : 0x52 'R' [Type: char16_t]
+pwstr            : "This is a PWSTR" [Type: windows_strings::pwstr::PWSTR]
+    [<Raw View>]     [Type: windows_strings::pwstr::PWSTR]
+    [len]            : 0xf
+    [chars]
+        [0]              : 0x54 'T' [Type: char16_t]
+        [1]              : 0x68 'h' [Type: char16_t]
+        [2]              : 0x69 'i' [Type: char16_t]
+        [3]              : 0x73 's' [Type: char16_t]
+        [4]              : 0x20 ' ' [Type: char16_t]
+        [5]              : 0x69 'i' [Type: char16_t]
+        [6]              : 0x73 's' [Type: char16_t]
+        [7]              : 0x20 ' ' [Type: char16_t]
+        [8]              : 0x61 'a' [Type: char16_t]
+        [9]              : 0x20 ' ' [Type: char16_t]
+        [10]             : 0x50 'P' [Type: char16_t]
+        [11]             : 0x57 'W' [Type: char16_t]
+        [12]             : 0x53 'S' [Type: char16_t]
+        [13]             : 0x54 'T' [Type: char16_t]
+        [14]             : 0x52 'R' [Type: char16_t]
 
-// pcwstr           : "This is a PCWSTR" [Type: windows_strings::pcwstr::PCWSTR]
-//     [<Raw View>]     [Type: windows_strings::pcwstr::PCWSTR]
-//     [len]            : 0x10
-//     [chars]
-//         [0]              : 0x54 'T' [Type: char16_t]
-//         [1]              : 0x68 'h' [Type: char16_t]
-//         [2]              : 0x69 'i' [Type: char16_t]
-//         [3]              : 0x73 's' [Type: char16_t]
-//         [4]              : 0x20 ' ' [Type: char16_t]
-//         [5]              : 0x69 'i' [Type: char16_t]
-//         [6]              : 0x73 's' [Type: char16_t]
-//         [7]              : 0x20 ' ' [Type: char16_t]
-//         [8]              : 0x61 'a' [Type: char16_t]
-//         [9]              : 0x20 ' ' [Type: char16_t]
-//         [10]             : 0x50 'P' [Type: char16_t]
-//         [11]             : 0x43 'C' [Type: char16_t]
-//         [12]             : 0x57 'W' [Type: char16_t]
-//         [13]             : 0x53 'S' [Type: char16_t]
-//         [14]             : 0x54 'T' [Type: char16_t]
-//         [15]             : 0x52 'R' [Type: char16_t]
+pcwstr           : "This is a PCWSTR" [Type: windows_strings::pcwstr::PCWSTR]
+    [<Raw View>]     [Type: windows_strings::pcwstr::PCWSTR]
+    [len]            : 0x10
+    [chars]
+        [0]              : 0x54 'T' [Type: char16_t]
+        [1]              : 0x68 'h' [Type: char16_t]
+        [2]              : 0x69 'i' [Type: char16_t]
+        [3]              : 0x73 's' [Type: char16_t]
+        [4]              : 0x20 ' ' [Type: char16_t]
+        [5]              : 0x69 'i' [Type: char16_t]
+        [6]              : 0x73 's' [Type: char16_t]
+        [7]              : 0x20 ' ' [Type: char16_t]
+        [8]              : 0x61 'a' [Type: char16_t]
+        [9]              : 0x20 ' ' [Type: char16_t]
+        [10]             : 0x50 'P' [Type: char16_t]
+        [11]             : 0x43 'C' [Type: char16_t]
+        [12]             : 0x57 'W' [Type: char16_t]
+        [13]             : 0x53 'S' [Type: char16_t]
+        [14]             : 0x54 'T' [Type: char16_t]
+        [15]             : 0x52 'R' [Type: char16_t]
 
-// empty            : "" [Type: windows_strings::hstring::HSTRING]
-//     [<Raw View>]     [Type: windows_strings::hstring::HSTRING]
-//     [len]            : 0x0 [Type: unsigned int]
+empty            : "" [Type: windows_strings::hstring::HSTRING]
+    [<Raw View>]     [Type: windows_strings::hstring::HSTRING]
+    [len]            : 0x0 [Type: unsigned int]
 
-// hstring          : "This is an HSTRING" [Type: windows_strings::hstring::HSTRING]
-//     [<Raw View>]     [Type: windows_strings::hstring::HSTRING]
-//     [len]            : 0x12 [Type: unsigned int]
-//     [ref_count]      : 1 [Type: windows_strings::ref_count::RefCount]
-//     [flags]          : 0x0 [Type: unsigned int]
-//     [chars]
-//         [0]              : 0x54 'T' [Type: char16_t]
-//         [1]              : 0x68 'h' [Type: char16_t]
-//         [2]              : 0x69 'i' [Type: char16_t]
-//         [3]              : 0x73 's' [Type: char16_t]
-//         [4]              : 0x20 ' ' [Type: char16_t]
-//         [5]              : 0x69 'i' [Type: char16_t]
-//         [6]              : 0x73 's' [Type: char16_t]
-//         [7]              : 0x20 ' ' [Type: char16_t]
-//         [8]              : 0x61 'a' [Type: char16_t]
-//         [9]              : 0x6e 'n' [Type: char16_t]
-//         [10]             : 0x20 ' ' [Type: char16_t]
-//         [11]             : 0x48 'H' [Type: char16_t]
-//         [12]             : 0x53 'S' [Type: char16_t]
-//         [13]             : 0x54 'T' [Type: char16_t]
-//         [14]             : 0x52 'R' [Type: char16_t]
-//         [15]             : 0x49 'I' [Type: char16_t]
-//         [16]             : 0x4e 'N' [Type: char16_t]
-//         [17]             : 0x47 'G' [Type: char16_t]
+hstring          : "This is an HSTRING" [Type: windows_strings::hstring::HSTRING]
+    [<Raw View>]     [Type: windows_strings::hstring::HSTRING]
+    [len]            : 0x12 [Type: unsigned int]
+    [ref_count]      : 1 [Type: windows_strings::ref_count::RefCount]
+    [flags]          : 0x0 [Type: unsigned int]
+    [chars]
+        [0]              : 0x54 'T' [Type: char16_t]
+        [1]              : 0x68 'h' [Type: char16_t]
+        [2]              : 0x69 'i' [Type: char16_t]
+        [3]              : 0x73 's' [Type: char16_t]
+        [4]              : 0x20 ' ' [Type: char16_t]
+        [5]              : 0x69 'i' [Type: char16_t]
+        [6]              : 0x73 's' [Type: char16_t]
+        [7]              : 0x20 ' ' [Type: char16_t]
+        [8]              : 0x61 'a' [Type: char16_t]
+        [9]              : 0x6e 'n' [Type: char16_t]
+        [10]             : 0x20 ' ' [Type: char16_t]
+        [11]             : 0x48 'H' [Type: char16_t]
+        [12]             : 0x53 'S' [Type: char16_t]
+        [13]             : 0x54 'T' [Type: char16_t]
+        [14]             : 0x52 'R' [Type: char16_t]
+        [15]             : 0x49 'I' [Type: char16_t]
+        [16]             : 0x4e 'N' [Type: char16_t]
+        [17]             : 0x47 'G' [Type: char16_t]
 
-// out_of_memory_error : 0x8007000e (Not enough memory resources are available to complete this operation.) [Type: windows_result::error::Error]
-//     [<Raw View>]     [Type: windows_result::error::Error]
-//     [info]           : Some [Type: enum2$<core::option::Option<windows_result::com::ComPtr> >]
+out_of_memory_error : 0x8007000e (Not enough memory resources are available to complete this operation.) [Type: windows_result::error::Error]
+    [<Raw View>]     [Type: windows_result::error::Error]
+    [info]           : Some [Type: enum2$<core::option::Option<windows_result::com::ComPtr> >]
 
-// invalid_argument_error : 0x80070057 (The parameter is incorrect.) [Type: windows_result::error::Error]
-//     [<Raw View>]     [Type: windows_result::error::Error]
-//     [info]           : Some [Type: enum2$<core::option::Option<windows_result::com::ComPtr> >]
-//     "#
-// )]
-// fn test_debugger_visualizer() {
-//     let string = "Hello World!\0".to_string();
-//     let mut array = Array::<u8>::with_len(string.len());
-//     for (i, ch) in string.as_bytes().iter().enumerate() {
-//         array[i] = *ch;
-//     }
+invalid_argument_error : 0x80070057 (The parameter is incorrect.) [Type: windows_result::error::Error]
+    [<Raw View>]     [Type: windows_result::error::Error]
+    [info]           : Some [Type: enum2$<core::option::Option<windows_result::com::ComPtr> >]
+    "#
+)]
+fn test_debugger_visualizer() {
+    let string = "Hello World!\0".to_string();
+    let mut array = Array::<u8>::with_len(string.len());
+    for (i, ch) in string.as_bytes().iter().enumerate() {
+        array[i] = *ch;
+    }
 
-//     // Test debugger visualizations for PSTR
-//     let mut pstr_string = "This is a PSTR\0".to_string();
-//     let pstr = PSTR::from_raw(pstr_string.as_mut_ptr());
-//     unsafe {
-//         assert_eq!(
-//             &pstr_string.as_bytes()[..(pstr_string.len() - 1)],
-//             pstr.as_bytes()
-//         );
-//     }
+    // Test debugger visualizations for PSTR
+    let mut pstr_string = "This is a PSTR\0".to_string();
+    let pstr = PSTR::from_raw(pstr_string.as_mut_ptr());
+    unsafe {
+        assert_eq!(
+            &pstr_string.as_bytes()[..(pstr_string.len() - 1)],
+            pstr.as_bytes()
+        );
+    }
 
-//     // Test debugger visualizations for PCSTR
-//     let pcstr_string = "This is a PCSTR\0".to_string();
-//     let pcstr = PCSTR::from_raw(pcstr_string.as_ptr());
-//     unsafe {
-//         assert_eq!(
-//             &pcstr_string.as_bytes()[..(pcstr_string.len() - 1)],
-//             pcstr.as_bytes()
-//         );
-//     }
+    // Test debugger visualizations for PCSTR
+    let pcstr_string = "This is a PCSTR\0".to_string();
+    let pcstr = PCSTR::from_raw(pcstr_string.as_ptr());
+    unsafe {
+        assert_eq!(
+            &pcstr_string.as_bytes()[..(pcstr_string.len() - 1)],
+            pcstr.as_bytes()
+        );
+    }
 
-//     // Test debugger visualizations for PWSTR
-//     let mut pwstr_string: Vec<u16> = vec![
-//         84, 104, 105, 115, 32, 105, 115, 32, 97, 32, 80, 87, 83, 84, 82, 0,
-//     ];
-//     let pwstr = PWSTR::from_raw(pwstr_string.as_mut_ptr());
-//     unsafe {
-//         assert_eq!(
-//             &pwstr_string.as_slice()[..(pwstr_string.len() - 1)],
-//             pwstr.as_wide()
-//         );
-//     }
+    // Test debugger visualizations for PWSTR
+    let mut pwstr_string: Vec<u16> = vec![
+        84, 104, 105, 115, 32, 105, 115, 32, 97, 32, 80, 87, 83, 84, 82, 0,
+    ];
+    let pwstr = PWSTR::from_raw(pwstr_string.as_mut_ptr());
+    unsafe {
+        assert_eq!(
+            &pwstr_string.as_slice()[..(pwstr_string.len() - 1)],
+            pwstr.as_wide()
+        );
+    }
 
-//     // Test debugger visualizations for PCWSTR
-//     let pcwstr_string: Vec<u16> = vec![
-//         84, 104, 105, 115, 32, 105, 115, 32, 97, 32, 80, 67, 87, 83, 84, 82, 0,
-//     ];
-//     let pcwstr = PCWSTR::from_raw(pcwstr_string.as_ptr());
-//     unsafe {
-//         assert_eq!(
-//             &pcwstr_string.as_slice()[..(pcwstr_string.len() - 1)],
-//             pcwstr.as_wide()
-//         );
-//     }
+    // Test debugger visualizations for PCWSTR
+    let pcwstr_string: Vec<u16> = vec![
+        84, 104, 105, 115, 32, 105, 115, 32, 97, 32, 80, 67, 87, 83, 84, 82, 0,
+    ];
+    let pcwstr = PCWSTR::from_raw(pcwstr_string.as_ptr());
+    unsafe {
+        assert_eq!(
+            &pcwstr_string.as_slice()[..(pcwstr_string.len() - 1)],
+            pcwstr.as_wide()
+        );
+    }
 
-//     // Test debugger visualizations for HSTRING
-//     let empty = HSTRING::new();
-//     assert!(empty.is_empty());
+    // Test debugger visualizations for HSTRING
+    let empty = HSTRING::new();
+    assert!(empty.is_empty());
 
-//     let hstring = HSTRING::from("This is an HSTRING");
-//     assert!(!hstring.is_empty());
-//     assert!(hstring.len() == 18);
+    let hstring = HSTRING::from("This is an HSTRING");
+    assert!(!hstring.is_empty());
+    assert!(hstring.len() == 18);
 
-//     let test: IErrorInfo = Test.into();
+    let test: IErrorInfo = Test.into();
 
-//     unsafe {
-//         // Test debugger visualizations for Error
-//         let result = test.GetGUID();
-//         let out_of_memory_error = result.unwrap_err();
-//         assert_eq!(out_of_memory_error.code(), E_OUTOFMEMORY);
-//         assert_eq!(out_of_memory_error.message(), "Out of memory message");
+    unsafe {
+        // Test debugger visualizations for Error
+        let result = test.GetGUID();
+        let out_of_memory_error = result.unwrap_err();
+        assert_eq!(out_of_memory_error.code(), E_OUTOFMEMORY);
+        assert_eq!(out_of_memory_error.message(), "Out of memory message");
 
-//         let result = test.GetSource();
-//         let invalid_argument_error = result.unwrap_err();
-//         assert_eq!(invalid_argument_error.code(), E_INVALIDARG);
-//         assert_eq!(invalid_argument_error.message(), "Invalid argument message");
-//         __break();
-//     }
-// }
+        let result = test.GetSource();
+        let invalid_argument_error = result.unwrap_err();
+        assert_eq!(invalid_argument_error.code(), E_INVALIDARG);
+        assert_eq!(invalid_argument_error.message(), "Invalid argument message");
+        __break();
+    }
+}

--- a/crates/tests/misc/debugger_visualizer/tests/test.rs
+++ b/crates/tests/misc/debugger_visualizer/tests/test.rs
@@ -1,4 +1,6 @@
 #![cfg(target_env = "msvc")]
+// https://github.com/microsoft/rust_debugger_test/issues/14
+#![allow(unsupported_calling_conventions)]
 
 use debugger_test::*;
 use windows::core::*;

--- a/crates/tools/yml/src/clippy.rs
+++ b/crates/tools/yml/src/clippy.rs
@@ -38,15 +38,11 @@ jobs:
     for package in helpers::crates("crates") {
         let name = &package.name;
 
-        if name.starts_with("test") {
-            continue;
-        }
-
         write!(
             &mut yml,
             r"
       - name: Check {name}
-        run:  cargo clippy -p {name}"
+        run:  cargo clippy -p {name} --tests"
         )
         .unwrap();
     }


### PR DESCRIPTION
Following #3691, this turns on all of the remaining Clippy test coverage. 

I do [expect it to fail](https://github.com/microsoft/windows-rs/pull/3691#issuecomment-3140639900) for the time being, but may highlight other potential issues.

