### PR TITLE
Add specific test coverage for activation

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -130,6 +130,10 @@ jobs:
         run:  cargo clippy -p sample_wmi --tests
       - name: Check sample_xml
         run:  cargo clippy -p sample_xml --tests
+      - name: Check test_activation
+        run:  cargo clippy -p test_activation --tests
+      - name: Check test_activation_client
+        run:  cargo clippy -p test_activation_client --tests
       - name: Check test_agile
         run:  cargo clippy -p test_agile --tests
       - name: Check test_agile_reference

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -159,6 +159,10 @@ jobs:
         run:  cargo clean
       - name: Test sample_xml
         run:  cargo test -p sample_xml --target ${{ matrix.target }}
+      - name: Test test_activation
+        run:  cargo test -p test_activation --target ${{ matrix.target }}
+      - name: Test test_activation_client
+        run:  cargo test -p test_activation_client --target ${{ matrix.target }}
       - name: Test test_agile
         run:  cargo test -p test_agile --target ${{ matrix.target }}
       - name: Test test_agile_reference
@@ -253,12 +257,12 @@ jobs:
         run:  cargo test -p test_match --target ${{ matrix.target }}
       - name: Test test_metadata
         run:  cargo test -p test_metadata --target ${{ matrix.target }}
+      - name: Clean
+        run:  cargo clean
       - name: Test test_msrv
         run:  cargo test -p test_msrv --target ${{ matrix.target }}
       - name: Test test_no_std
         run:  cargo test -p test_no_std --target ${{ matrix.target }}
-      - name: Clean
-        run:  cargo clean
       - name: Test test_no_use
         run:  cargo test -p test_no_use --target ${{ matrix.target }}
       - name: Test test_noexcept
@@ -355,12 +359,12 @@ jobs:
         run:  cargo test -p tool_merge --target ${{ matrix.target }}
       - name: Test tool_msvc
         run:  cargo test -p tool_msvc --target ${{ matrix.target }}
+      - name: Clean
+        run:  cargo clean
       - name: Test tool_standalone
         run:  cargo test -p tool_standalone --target ${{ matrix.target }}
       - name: Test tool_test_all
         run:  cargo test -p tool_test_all --target ${{ matrix.target }}
-      - name: Clean
-        run:  cargo clean
       - name: Test tool_workspace
         run:  cargo test -p tool_workspace --target ${{ matrix.target }}
       - name: Test tool_yml

--- a/crates/libs/core/src/imp/factory_cache.rs
+++ b/crates/libs/core/src/imp/factory_cache.rs
@@ -102,10 +102,6 @@ pub fn load_factory<C: crate::RuntimeName, I: Interface>() -> crate::Result<I> {
         return Ok(factory);
     }
 
-    // If not, first capture the error information from the failure above so that we
-    // can ultimately return this error information if all else fails.
-    let original: crate::Error = code.into();
-
     // Reg-free activation should only be attempted if the class is not registered.
     // It should not be attempted if the class is registered but fails to activate.
     if code == REGDB_E_CLASSNOTREG {
@@ -117,7 +113,7 @@ pub fn load_factory<C: crate::RuntimeName, I: Interface>() -> crate::Result<I> {
         }
     }
 
-    Err(original)
+    Err(crate::Error::from_hresult(code))
 }
 
 // Remove the suffix until a match is found appending `.dll\0` at the end

--- a/crates/tests/winrt/activation/Cargo.toml
+++ b/crates/tests/winrt/activation/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "test_activation"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+doc = false
+doctest = false
+
+[build-dependencies.windows-bindgen]
+workspace = true
+
+[dependencies.windows-core]
+workspace = true
+
+[dependencies.windows]
+workspace = true
+features = [
+    "Foundation",
+    "Win32_System_WinRT",
+]

--- a/crates/tests/winrt/activation/build.rs
+++ b/crates/tests/winrt/activation/build.rs
@@ -1,0 +1,35 @@
+fn main() {
+    let mut command = std::process::Command::new("midlrt.exe");
+
+    command.args([
+        "/winrt",
+        "/nomidl",
+        "/h",
+        "nul",
+        "/metadata_dir",
+        "../../../libs/bindgen/default",
+        "/reference",
+        "../../../libs/bindgen/default/Windows.winmd",
+        "/winmd",
+        "metadata.winmd",
+        "src/metadata.idl",
+    ]);
+
+    if !command.status().unwrap().success() {
+        panic!("Failed to run midlrt");
+    }
+
+    windows_bindgen::bindgen([
+        "--in",
+        "metadata.winmd",
+        "default",
+        "--out",
+        "src/bindings.rs",
+        "--filter",
+        "test_activation",
+        "--implement",
+        "--no-comment",
+        "--flat",
+    ])
+    .unwrap();
+}

--- a/crates/tests/winrt/activation/src/bindings.rs
+++ b/crates/tests/winrt/activation/src/bindings.rs
@@ -1,0 +1,264 @@
+#![allow(
+    non_snake_case,
+    non_upper_case_globals,
+    non_camel_case_types,
+    dead_code,
+    clippy::all
+)]
+
+windows_core::imp::define_interface!(
+    IInstance,
+    IInstance_Vtbl,
+    0x4cc554b9_8483_54a9_8490_1467dfd7078f
+);
+impl windows_core::RuntimeType for IInstance {
+    const SIGNATURE: windows_core::imp::ConstBuffer =
+        windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
+impl windows_core::RuntimeName for IInstance {
+    const NAME: &'static str = "test_activation.One.IInstance";
+}
+pub trait IInstance_Impl: windows_core::IUnknownImpl {
+    fn Property(&self) -> windows_core::Result<i32>;
+}
+impl IInstance_Vtbl {
+    pub const fn new<Identity: IInstance_Impl, const OFFSET: isize>() -> Self {
+        unsafe extern "system" fn Property<Identity: IInstance_Impl, const OFFSET: isize>(
+            this: *mut core::ffi::c_void,
+            result__: *mut i32,
+        ) -> windows_core::HRESULT {
+            unsafe {
+                let this: &Identity =
+                    &*((this as *const *const ()).offset(OFFSET) as *const Identity);
+                match IInstance_Impl::Property(this) {
+                    Ok(ok__) => {
+                        result__.write(core::mem::transmute_copy(&ok__));
+                        windows_core::HRESULT(0)
+                    }
+                    Err(err) => err.into(),
+                }
+            }
+        }
+        Self {
+            base__: windows_core::IInspectable_Vtbl::new::<Identity, IInstance, OFFSET>(),
+            Property: Property::<Identity, OFFSET>,
+        }
+    }
+    pub fn matches(iid: &windows_core::GUID) -> bool {
+        iid == &<IInstance as windows_core::Interface>::IID
+    }
+}
+#[repr(C)]
+#[doc(hidden)]
+pub struct IInstance_Vtbl {
+    pub base__: windows_core::IInspectable_Vtbl,
+    pub Property:
+        unsafe extern "system" fn(*mut core::ffi::c_void, *mut i32) -> windows_core::HRESULT,
+}
+windows_core::imp::define_interface!(
+    IMissing,
+    IMissing_Vtbl,
+    0xad54a92f_16de_537c_b6c0_5099534ee12e
+);
+impl windows_core::RuntimeType for IMissing {
+    const SIGNATURE: windows_core::imp::ConstBuffer =
+        windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
+impl windows_core::RuntimeName for IMissing {
+    const NAME: &'static str = "test_activation.One.IMissing";
+}
+pub trait IMissing_Impl: windows_core::IUnknownImpl {
+    fn Method(&self) -> windows_core::Result<()>;
+}
+impl IMissing_Vtbl {
+    pub const fn new<Identity: IMissing_Impl, const OFFSET: isize>() -> Self {
+        unsafe extern "system" fn Method<Identity: IMissing_Impl, const OFFSET: isize>(
+            this: *mut core::ffi::c_void,
+        ) -> windows_core::HRESULT {
+            unsafe {
+                let this: &Identity =
+                    &*((this as *const *const ()).offset(OFFSET) as *const Identity);
+                IMissing_Impl::Method(this).into()
+            }
+        }
+        Self {
+            base__: windows_core::IInspectable_Vtbl::new::<Identity, IMissing, OFFSET>(),
+            Method: Method::<Identity, OFFSET>,
+        }
+    }
+    pub fn matches(iid: &windows_core::GUID) -> bool {
+        iid == &<IMissing as windows_core::Interface>::IID
+    }
+}
+#[repr(C)]
+#[doc(hidden)]
+pub struct IMissing_Vtbl {
+    pub base__: windows_core::IInspectable_Vtbl,
+    pub Method: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
+}
+windows_core::imp::define_interface!(
+    IStaticStatics,
+    IStaticStatics_Vtbl,
+    0x530ccab2_1b46_5dba_a8bb_a857df3dc803
+);
+impl windows_core::RuntimeType for IStaticStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer =
+        windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
+impl windows_core::RuntimeName for IStaticStatics {
+    const NAME: &'static str = "test_activation.One.Two.Three.Four.IStaticStatics";
+}
+pub trait IStaticStatics_Impl: windows_core::IUnknownImpl {
+    fn Property(&self) -> windows_core::Result<i32>;
+}
+impl IStaticStatics_Vtbl {
+    pub const fn new<Identity: IStaticStatics_Impl, const OFFSET: isize>() -> Self {
+        unsafe extern "system" fn Property<Identity: IStaticStatics_Impl, const OFFSET: isize>(
+            this: *mut core::ffi::c_void,
+            result__: *mut i32,
+        ) -> windows_core::HRESULT {
+            unsafe {
+                let this: &Identity =
+                    &*((this as *const *const ()).offset(OFFSET) as *const Identity);
+                match IStaticStatics_Impl::Property(this) {
+                    Ok(ok__) => {
+                        result__.write(core::mem::transmute_copy(&ok__));
+                        windows_core::HRESULT(0)
+                    }
+                    Err(err) => err.into(),
+                }
+            }
+        }
+        Self {
+            base__: windows_core::IInspectable_Vtbl::new::<Identity, IStaticStatics, OFFSET>(),
+            Property: Property::<Identity, OFFSET>,
+        }
+    }
+    pub fn matches(iid: &windows_core::GUID) -> bool {
+        iid == &<IStaticStatics as windows_core::Interface>::IID
+    }
+}
+#[repr(C)]
+#[doc(hidden)]
+pub struct IStaticStatics_Vtbl {
+    pub base__: windows_core::IInspectable_Vtbl,
+    pub Property:
+        unsafe extern "system" fn(*mut core::ffi::c_void, *mut i32) -> windows_core::HRESULT,
+}
+#[repr(transparent)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Instance(windows_core::IUnknown);
+windows_core::imp::interface_hierarchy!(
+    Instance,
+    windows_core::IUnknown,
+    windows_core::IInspectable
+);
+impl Instance {
+    pub fn new() -> windows_core::Result<Self> {
+        Self::IActivationFactory(|f| f.ActivateInstance::<Self>())
+    }
+    fn IActivationFactory<
+        R,
+        F: FnOnce(&windows_core::imp::IGenericFactory) -> windows_core::Result<R>,
+    >(
+        callback: F,
+    ) -> windows_core::Result<R> {
+        static SHARED: windows_core::imp::FactoryCache<
+            Instance,
+            windows_core::imp::IGenericFactory,
+        > = windows_core::imp::FactoryCache::new();
+        SHARED.call(callback)
+    }
+    pub fn Property(&self) -> windows_core::Result<i32> {
+        let this = self;
+        unsafe {
+            let mut result__ = core::mem::zeroed();
+            (windows_core::Interface::vtable(this).Property)(
+                windows_core::Interface::as_raw(this),
+                &mut result__,
+            )
+            .map(|| result__)
+        }
+    }
+}
+impl windows_core::RuntimeType for Instance {
+    const SIGNATURE: windows_core::imp::ConstBuffer =
+        windows_core::imp::ConstBuffer::for_class::<Self, IInstance>();
+}
+unsafe impl windows_core::Interface for Instance {
+    type Vtable = <IInstance as windows_core::Interface>::Vtable;
+    const IID: windows_core::GUID = <IInstance as windows_core::Interface>::IID;
+}
+impl windows_core::RuntimeName for Instance {
+    const NAME: &'static str = "test_activation.One.Instance";
+}
+unsafe impl Send for Instance {}
+unsafe impl Sync for Instance {}
+#[repr(transparent)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Missing(windows_core::IUnknown);
+windows_core::imp::interface_hierarchy!(
+    Missing,
+    windows_core::IUnknown,
+    windows_core::IInspectable
+);
+impl Missing {
+    pub fn new() -> windows_core::Result<Self> {
+        Self::IActivationFactory(|f| f.ActivateInstance::<Self>())
+    }
+    fn IActivationFactory<
+        R,
+        F: FnOnce(&windows_core::imp::IGenericFactory) -> windows_core::Result<R>,
+    >(
+        callback: F,
+    ) -> windows_core::Result<R> {
+        static SHARED: windows_core::imp::FactoryCache<
+            Missing,
+            windows_core::imp::IGenericFactory,
+        > = windows_core::imp::FactoryCache::new();
+        SHARED.call(callback)
+    }
+    pub fn Method(&self) -> windows_core::Result<()> {
+        let this = self;
+        unsafe {
+            (windows_core::Interface::vtable(this).Method)(windows_core::Interface::as_raw(this))
+                .ok()
+        }
+    }
+}
+impl windows_core::RuntimeType for Missing {
+    const SIGNATURE: windows_core::imp::ConstBuffer =
+        windows_core::imp::ConstBuffer::for_class::<Self, IMissing>();
+}
+unsafe impl windows_core::Interface for Missing {
+    type Vtable = <IMissing as windows_core::Interface>::Vtable;
+    const IID: windows_core::GUID = <IMissing as windows_core::Interface>::IID;
+}
+impl windows_core::RuntimeName for Missing {
+    const NAME: &'static str = "test_activation.One.Missing";
+}
+unsafe impl Send for Missing {}
+unsafe impl Sync for Missing {}
+pub struct Static;
+impl Static {
+    pub fn Property() -> windows_core::Result<i32> {
+        Self::IStaticStatics(|this| unsafe {
+            let mut result__ = core::mem::zeroed();
+            (windows_core::Interface::vtable(this).Property)(
+                windows_core::Interface::as_raw(this),
+                &mut result__,
+            )
+            .map(|| result__)
+        })
+    }
+    fn IStaticStatics<R, F: FnOnce(&IStaticStatics) -> windows_core::Result<R>>(
+        callback: F,
+    ) -> windows_core::Result<R> {
+        static SHARED: windows_core::imp::FactoryCache<Static, IStaticStatics> =
+            windows_core::imp::FactoryCache::new();
+        SHARED.call(callback)
+    }
+}
+impl windows_core::RuntimeName for Static {
+    const NAME: &'static str = "test_activation.One.Two.Three.Four.Static";
+}

--- a/crates/tests/winrt/activation/src/lib.rs
+++ b/crates/tests/winrt/activation/src/lib.rs
@@ -1,0 +1,51 @@
+mod bindings;
+
+use windows::{core::*, Win32::Foundation::*, Win32::System::WinRT::*};
+
+#[no_mangle]
+unsafe extern "system" fn DllGetActivationFactory(
+    name: Ref<HSTRING>,
+    factory: OutRef<IActivationFactory>,
+) -> HRESULT {
+    if *name == "test_activation.One.Instance" {
+        factory.write(Some(InstanceFactory.into())).into()
+    } else if *name == "test_activation.One.Two.Three.Four.Static" {
+        factory.write(Some(StaticFactory.into())).into()
+    } else {
+        _ = factory.write(None);
+        CLASS_E_CLASSNOTAVAILABLE
+    }
+}
+
+#[implement(IActivationFactory)]
+struct InstanceFactory;
+
+impl IActivationFactory_Impl for InstanceFactory_Impl {
+    fn ActivateInstance(&self) -> Result<IInspectable> {
+        Ok(Instance.into())
+    }
+}
+
+#[implement(bindings::Instance)]
+struct Instance;
+
+impl bindings::IInstance_Impl for Instance_Impl {
+    fn Property(&self) -> Result<i32> {
+        Ok(123)
+    }
+}
+
+#[implement(IActivationFactory, bindings::IStaticStatics)]
+struct StaticFactory;
+
+impl IActivationFactory_Impl for StaticFactory_Impl {
+    fn ActivateInstance(&self) -> Result<IInspectable> {
+        Err(Error::from_hresult(E_NOTIMPL))
+    }
+}
+
+impl bindings::IStaticStatics_Impl for StaticFactory_Impl {
+    fn Property(&self) -> Result<i32> {
+        Ok(456)
+    }
+}

--- a/crates/tests/winrt/activation/src/metadata.idl
+++ b/crates/tests/winrt/activation/src/metadata.idl
@@ -1,0 +1,32 @@
+namespace test_activation
+{
+    namespace One
+    {
+        runtimeclass Instance
+        {
+            Instance();
+            Int32 Property { get; };
+        }
+
+        runtimeclass Missing
+        {
+            Missing();
+            void Method();
+        }
+
+        namespace Two
+        {
+            namespace Three
+            {
+                namespace Four
+                {
+                    runtimeclass Static
+                    {
+                        static Int32 Property { get; };
+                    }
+                }
+            }
+        }
+    }
+
+}

--- a/crates/tests/winrt/activation_client/Cargo.toml
+++ b/crates/tests/winrt/activation_client/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "test_activation_client"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+doc = false
+doctest = false
+
+[build-dependencies]
+windows-bindgen = { workspace = true }
+
+[dependencies]
+windows-core = { workspace = true }
+windows = { workspace = true, features = ["Foundation", "Win32_Foundation"] }
+test_activation = { path = "../activation" }

--- a/crates/tests/winrt/activation_client/build.rs
+++ b/crates/tests/winrt/activation_client/build.rs
@@ -1,0 +1,14 @@
+fn main() {
+    windows_bindgen::bindgen([
+        "--in",
+        "../activation/metadata.winmd",
+        "default",
+        "--out",
+        "src/bindings.rs",
+        "--filter",
+        "test_activation",
+        "--no-comment",
+        "--flat",
+    ])
+    .unwrap();
+}

--- a/crates/tests/winrt/activation_client/src/bindings.rs
+++ b/crates/tests/winrt/activation_client/src/bindings.rs
@@ -1,0 +1,172 @@
+#![allow(
+    non_snake_case,
+    non_upper_case_globals,
+    non_camel_case_types,
+    dead_code,
+    clippy::all
+)]
+
+windows_core::imp::define_interface!(
+    IInstance,
+    IInstance_Vtbl,
+    0x4cc554b9_8483_54a9_8490_1467dfd7078f
+);
+impl windows_core::RuntimeType for IInstance {
+    const SIGNATURE: windows_core::imp::ConstBuffer =
+        windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
+#[repr(C)]
+#[doc(hidden)]
+pub struct IInstance_Vtbl {
+    pub base__: windows_core::IInspectable_Vtbl,
+    pub Property:
+        unsafe extern "system" fn(*mut core::ffi::c_void, *mut i32) -> windows_core::HRESULT,
+}
+windows_core::imp::define_interface!(
+    IMissing,
+    IMissing_Vtbl,
+    0xad54a92f_16de_537c_b6c0_5099534ee12e
+);
+impl windows_core::RuntimeType for IMissing {
+    const SIGNATURE: windows_core::imp::ConstBuffer =
+        windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
+#[repr(C)]
+#[doc(hidden)]
+pub struct IMissing_Vtbl {
+    pub base__: windows_core::IInspectable_Vtbl,
+    pub Method: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
+}
+windows_core::imp::define_interface!(
+    IStaticStatics,
+    IStaticStatics_Vtbl,
+    0x530ccab2_1b46_5dba_a8bb_a857df3dc803
+);
+impl windows_core::RuntimeType for IStaticStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer =
+        windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
+#[repr(C)]
+#[doc(hidden)]
+pub struct IStaticStatics_Vtbl {
+    pub base__: windows_core::IInspectable_Vtbl,
+    pub Property:
+        unsafe extern "system" fn(*mut core::ffi::c_void, *mut i32) -> windows_core::HRESULT,
+}
+#[repr(transparent)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Instance(windows_core::IUnknown);
+windows_core::imp::interface_hierarchy!(
+    Instance,
+    windows_core::IUnknown,
+    windows_core::IInspectable
+);
+impl Instance {
+    pub fn new() -> windows_core::Result<Self> {
+        Self::IActivationFactory(|f| f.ActivateInstance::<Self>())
+    }
+    fn IActivationFactory<
+        R,
+        F: FnOnce(&windows_core::imp::IGenericFactory) -> windows_core::Result<R>,
+    >(
+        callback: F,
+    ) -> windows_core::Result<R> {
+        static SHARED: windows_core::imp::FactoryCache<
+            Instance,
+            windows_core::imp::IGenericFactory,
+        > = windows_core::imp::FactoryCache::new();
+        SHARED.call(callback)
+    }
+    pub fn Property(&self) -> windows_core::Result<i32> {
+        let this = self;
+        unsafe {
+            let mut result__ = core::mem::zeroed();
+            (windows_core::Interface::vtable(this).Property)(
+                windows_core::Interface::as_raw(this),
+                &mut result__,
+            )
+            .map(|| result__)
+        }
+    }
+}
+impl windows_core::RuntimeType for Instance {
+    const SIGNATURE: windows_core::imp::ConstBuffer =
+        windows_core::imp::ConstBuffer::for_class::<Self, IInstance>();
+}
+unsafe impl windows_core::Interface for Instance {
+    type Vtable = <IInstance as windows_core::Interface>::Vtable;
+    const IID: windows_core::GUID = <IInstance as windows_core::Interface>::IID;
+}
+impl windows_core::RuntimeName for Instance {
+    const NAME: &'static str = "test_activation.One.Instance";
+}
+unsafe impl Send for Instance {}
+unsafe impl Sync for Instance {}
+#[repr(transparent)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Missing(windows_core::IUnknown);
+windows_core::imp::interface_hierarchy!(
+    Missing,
+    windows_core::IUnknown,
+    windows_core::IInspectable
+);
+impl Missing {
+    pub fn new() -> windows_core::Result<Self> {
+        Self::IActivationFactory(|f| f.ActivateInstance::<Self>())
+    }
+    fn IActivationFactory<
+        R,
+        F: FnOnce(&windows_core::imp::IGenericFactory) -> windows_core::Result<R>,
+    >(
+        callback: F,
+    ) -> windows_core::Result<R> {
+        static SHARED: windows_core::imp::FactoryCache<
+            Missing,
+            windows_core::imp::IGenericFactory,
+        > = windows_core::imp::FactoryCache::new();
+        SHARED.call(callback)
+    }
+    pub fn Method(&self) -> windows_core::Result<()> {
+        let this = self;
+        unsafe {
+            (windows_core::Interface::vtable(this).Method)(windows_core::Interface::as_raw(this))
+                .ok()
+        }
+    }
+}
+impl windows_core::RuntimeType for Missing {
+    const SIGNATURE: windows_core::imp::ConstBuffer =
+        windows_core::imp::ConstBuffer::for_class::<Self, IMissing>();
+}
+unsafe impl windows_core::Interface for Missing {
+    type Vtable = <IMissing as windows_core::Interface>::Vtable;
+    const IID: windows_core::GUID = <IMissing as windows_core::Interface>::IID;
+}
+impl windows_core::RuntimeName for Missing {
+    const NAME: &'static str = "test_activation.One.Missing";
+}
+unsafe impl Send for Missing {}
+unsafe impl Sync for Missing {}
+pub struct Static;
+impl Static {
+    pub fn Property() -> windows_core::Result<i32> {
+        Self::IStaticStatics(|this| unsafe {
+            let mut result__ = core::mem::zeroed();
+            (windows_core::Interface::vtable(this).Property)(
+                windows_core::Interface::as_raw(this),
+                &mut result__,
+            )
+            .map(|| result__)
+        })
+    }
+    fn IStaticStatics<R, F: FnOnce(&IStaticStatics) -> windows_core::Result<R>>(
+        callback: F,
+    ) -> windows_core::Result<R> {
+        static SHARED: windows_core::imp::FactoryCache<Static, IStaticStatics> =
+            windows_core::imp::FactoryCache::new();
+        SHARED.call(callback)
+    }
+}
+impl windows_core::RuntimeName for Static {
+    const NAME: &'static str = "test_activation.One.Two.Three.Four.Static";
+}

--- a/crates/tests/winrt/activation_client/src/lib.rs
+++ b/crates/tests/winrt/activation_client/src/lib.rs
@@ -1,0 +1,42 @@
+#![cfg(test)]
+
+mod bindings;
+use bindings::*;
+use windows::{
+    core::factory,
+    Win32::Foundation::{E_NOINTERFACE, REGDB_E_CLASSNOTREG},
+    Win32::System::WinRT::IActivationFactory,
+};
+
+// Test of an activation factory with a "default constructor" via `IActivationFactory`.
+#[test]
+fn instance_class() {
+    let instance = Instance::new().unwrap();
+    assert_eq!(instance.Property().unwrap(), 123);
+}
+
+// Test of a missing activation factory returns the original error returned by `RoGetActivationFactory`.
+#[test]
+fn missing_class() {
+    let error = Missing::new().unwrap_err();
+    assert_eq!(error.code(), REGDB_E_CLASSNOTREG);
+}
+
+// Test of an activation factory that does not support default construction.
+#[test]
+fn static_class() {
+    let value = Static::Property().unwrap();
+    assert_eq!(value, 456);
+}
+
+// Test for direct factory construction.
+#[test]
+fn get_factory() {
+    factory::<Instance, IActivationFactory>().unwrap();
+
+    let error = factory::<Instance, IInstance>().unwrap_err();
+    assert_eq!(error.code(), E_NOINTERFACE);
+
+    let error = factory::<Missing, IActivationFactory>().unwrap_err();
+    assert_eq!(error.code(), REGDB_E_CLASSNOTREG);
+}


### PR DESCRIPTION
This update adds specific test coverage for component and factory activation. While activation is tested indirectly in various ways, having a specific test suite makes it clear that this is about testing activation itself and lets us provide targeted tests for edge cases not otherwise covered by other test scenarios in a meaningful way. Some specifics:

* The only actual behavior change here is that the activation support in `windows-core` is changed to only preserve the `HRESULT` returned by `RoGetActivationFactory` as apposed to whatever COM error object is currently on the thread. The logic here is that `RoGetActivationFactory` does not produce a COM error object but merely returns an `HRESULT` so this is unnecessary. I am also trying to move away from the overuse of COM error objects as much as possible. I originally copied this behavior from C++/WinRT which assumes COM error objects everywhere. I implemented it that way because that is the norm for WinRT. 

* Specific activation success and failure tests are included with deliberate coverage of the search path fallback logic.

* Specific tests for the `factory` helper function are also provided. Previously this was only "tested" via the `sample_consent` sample crate.


