### PR TITLE
Properly locate and simplify the `ArrayProxy` type support ABI

### DIFF
--- a/crates/libs/bindgen/src/types/method.rs
+++ b/crates/libs/bindgen/src/types/method.rs
@@ -53,7 +53,7 @@ impl Method {
             } else if param.is_winrt_array() {
                 quote! { core::slice::from_raw_parts_mut(core::mem::transmute_copy(&#name), #abi_size_name as usize) }
             } else if param.is_winrt_array_ref() {
-                quote! { windows_core::ArrayProxy::from_raw_parts(core::mem::transmute_copy(&#name), #abi_size_name).as_array() }
+                quote! { &mut windows_core::imp::array_proxy(core::mem::transmute_copy(&#name), #abi_size_name) }
             } else {
                 quote! { core::mem::transmute_copy(&#name) }
             }

--- a/crates/libs/core/src/array.rs
+++ b/crates/libs/core/src/array.rs
@@ -2,8 +2,8 @@ use super::*;
 
 /// A WinRT array stores elements contiguously in a heap-allocated buffer.
 pub struct Array<T: Type<T>> {
-    data: *mut T::Default,
-    len: u32,
+    pub(crate) data: *mut T::Default,
+    pub(crate) len: u32,
 }
 
 impl<T: Type<T>> Default for Array<T> {
@@ -152,35 +152,5 @@ impl<T: Type<T>> core::ops::DerefMut for Array<T> {
 impl<T: Type<T>> Drop for Array<T> {
     fn drop(&mut self) {
         self.clear();
-    }
-}
-
-#[doc(hidden)]
-pub struct ArrayProxy<T: Type<T>> {
-    data: *mut *mut T::Default,
-    len: *mut u32,
-    temp: core::mem::ManuallyDrop<Array<T>>,
-}
-
-impl<T: Type<T>> ArrayProxy<T> {
-    pub fn from_raw_parts(data: *mut *mut T::Default, len: *mut u32) -> Self {
-        Self {
-            data,
-            len,
-            temp: core::mem::ManuallyDrop::new(Array::new()),
-        }
-    }
-
-    pub fn as_array(&mut self) -> &mut Array<T> {
-        &mut self.temp
-    }
-}
-
-impl<T: Type<T>> Drop for ArrayProxy<T> {
-    fn drop(&mut self) {
-        unsafe {
-            *self.data = self.temp.data;
-            *self.len = self.temp.len;
-        }
     }
 }

--- a/crates/libs/core/src/imp/array_proxy.rs
+++ b/crates/libs/core/src/imp/array_proxy.rs
@@ -1,0 +1,38 @@
+use crate::{Array, Type};
+
+pub struct ArrayProxy<T: Type<T>> {
+    data: *mut *mut T::Default,
+    len: *mut u32,
+    temp: core::mem::ManuallyDrop<Array<T>>,
+}
+
+pub unsafe fn array_proxy<T: Type<T>>(data: *mut *mut T::Default, len: *mut u32) -> ArrayProxy<T> {
+    ArrayProxy {
+        data,
+        len,
+        temp: core::mem::ManuallyDrop::new(Array::new()),
+    }
+}
+
+impl<T: Type<T>> Drop for ArrayProxy<T> {
+    fn drop(&mut self) {
+        unsafe {
+            *self.data = self.temp.data;
+            *self.len = self.temp.len;
+        }
+    }
+}
+
+impl<T: Type<T>> core::ops::Deref for ArrayProxy<T> {
+    type Target = Array<T>;
+
+    fn deref(&self) -> &Array<T> {
+        &self.temp
+    }
+}
+
+impl<T: Type<T>> core::ops::DerefMut for ArrayProxy<T> {
+    fn deref_mut(&mut self) -> &mut Array<T> {
+        &mut self.temp
+    }
+}

--- a/crates/libs/core/src/imp/mod.rs
+++ b/crates/libs/core/src/imp/mod.rs
@@ -1,6 +1,7 @@
 #[cfg(windows)]
 include!("windows.rs");
 
+mod array_proxy;
 mod bindings;
 mod can_into;
 mod com_bindings;
@@ -8,6 +9,7 @@ mod ref_count;
 mod sha1;
 mod weak_ref_count;
 
+pub use array_proxy::*;
 pub use bindings::*;
 pub use can_into::*;
 pub use com_bindings::*;

--- a/crates/libs/core/src/imp/mod.rs
+++ b/crates/libs/core/src/imp/mod.rs
@@ -1,7 +1,6 @@
 #[cfg(windows)]
 include!("windows.rs");
 
-mod array_proxy;
 mod bindings;
 mod can_into;
 mod com_bindings;
@@ -9,7 +8,6 @@ mod ref_count;
 mod sha1;
 mod weak_ref_count;
 
-pub use array_proxy::*;
 pub use bindings::*;
 pub use can_into::*;
 pub use com_bindings::*;

--- a/crates/libs/core/src/imp/windows.rs
+++ b/crates/libs/core/src/imp/windows.rs
@@ -6,3 +6,6 @@ pub use generic_factory::*;
 
 mod marshaler;
 pub use marshaler::*;
+
+mod array_proxy;
+pub use array_proxy::*;

--- a/crates/libs/windows/src/Windows/Foundation/mod.rs
+++ b/crates/libs/windows/src/Windows/Foundation/mod.rs
@@ -1040,115 +1040,115 @@ impl IPropertyValue_Vtbl {
         unsafe extern "system" fn GetUInt8Array<Identity: IPropertyValue_Impl, const OFFSET: isize>(this: *mut core::ffi::c_void, value_array_size: *mut u32, value: *mut *mut u8) -> windows_core::HRESULT {
             unsafe {
                 let this: &Identity = &*((this as *const *const ()).offset(OFFSET) as *const Identity);
-                IPropertyValue_Impl::GetUInt8Array(this, windows_core::ArrayProxy::from_raw_parts(core::mem::transmute_copy(&value), value_array_size).as_array()).into()
+                IPropertyValue_Impl::GetUInt8Array(this, &mut windows_core::imp::array_proxy(core::mem::transmute_copy(&value), value_array_size)).into()
             }
         }
         unsafe extern "system" fn GetInt16Array<Identity: IPropertyValue_Impl, const OFFSET: isize>(this: *mut core::ffi::c_void, value_array_size: *mut u32, value: *mut *mut i16) -> windows_core::HRESULT {
             unsafe {
                 let this: &Identity = &*((this as *const *const ()).offset(OFFSET) as *const Identity);
-                IPropertyValue_Impl::GetInt16Array(this, windows_core::ArrayProxy::from_raw_parts(core::mem::transmute_copy(&value), value_array_size).as_array()).into()
+                IPropertyValue_Impl::GetInt16Array(this, &mut windows_core::imp::array_proxy(core::mem::transmute_copy(&value), value_array_size)).into()
             }
         }
         unsafe extern "system" fn GetUInt16Array<Identity: IPropertyValue_Impl, const OFFSET: isize>(this: *mut core::ffi::c_void, value_array_size: *mut u32, value: *mut *mut u16) -> windows_core::HRESULT {
             unsafe {
                 let this: &Identity = &*((this as *const *const ()).offset(OFFSET) as *const Identity);
-                IPropertyValue_Impl::GetUInt16Array(this, windows_core::ArrayProxy::from_raw_parts(core::mem::transmute_copy(&value), value_array_size).as_array()).into()
+                IPropertyValue_Impl::GetUInt16Array(this, &mut windows_core::imp::array_proxy(core::mem::transmute_copy(&value), value_array_size)).into()
             }
         }
         unsafe extern "system" fn GetInt32Array<Identity: IPropertyValue_Impl, const OFFSET: isize>(this: *mut core::ffi::c_void, value_array_size: *mut u32, value: *mut *mut i32) -> windows_core::HRESULT {
             unsafe {
                 let this: &Identity = &*((this as *const *const ()).offset(OFFSET) as *const Identity);
-                IPropertyValue_Impl::GetInt32Array(this, windows_core::ArrayProxy::from_raw_parts(core::mem::transmute_copy(&value), value_array_size).as_array()).into()
+                IPropertyValue_Impl::GetInt32Array(this, &mut windows_core::imp::array_proxy(core::mem::transmute_copy(&value), value_array_size)).into()
             }
         }
         unsafe extern "system" fn GetUInt32Array<Identity: IPropertyValue_Impl, const OFFSET: isize>(this: *mut core::ffi::c_void, value_array_size: *mut u32, value: *mut *mut u32) -> windows_core::HRESULT {
             unsafe {
                 let this: &Identity = &*((this as *const *const ()).offset(OFFSET) as *const Identity);
-                IPropertyValue_Impl::GetUInt32Array(this, windows_core::ArrayProxy::from_raw_parts(core::mem::transmute_copy(&value), value_array_size).as_array()).into()
+                IPropertyValue_Impl::GetUInt32Array(this, &mut windows_core::imp::array_proxy(core::mem::transmute_copy(&value), value_array_size)).into()
             }
         }
         unsafe extern "system" fn GetInt64Array<Identity: IPropertyValue_Impl, const OFFSET: isize>(this: *mut core::ffi::c_void, value_array_size: *mut u32, value: *mut *mut i64) -> windows_core::HRESULT {
             unsafe {
                 let this: &Identity = &*((this as *const *const ()).offset(OFFSET) as *const Identity);
-                IPropertyValue_Impl::GetInt64Array(this, windows_core::ArrayProxy::from_raw_parts(core::mem::transmute_copy(&value), value_array_size).as_array()).into()
+                IPropertyValue_Impl::GetInt64Array(this, &mut windows_core::imp::array_proxy(core::mem::transmute_copy(&value), value_array_size)).into()
             }
         }
         unsafe extern "system" fn GetUInt64Array<Identity: IPropertyValue_Impl, const OFFSET: isize>(this: *mut core::ffi::c_void, value_array_size: *mut u32, value: *mut *mut u64) -> windows_core::HRESULT {
             unsafe {
                 let this: &Identity = &*((this as *const *const ()).offset(OFFSET) as *const Identity);
-                IPropertyValue_Impl::GetUInt64Array(this, windows_core::ArrayProxy::from_raw_parts(core::mem::transmute_copy(&value), value_array_size).as_array()).into()
+                IPropertyValue_Impl::GetUInt64Array(this, &mut windows_core::imp::array_proxy(core::mem::transmute_copy(&value), value_array_size)).into()
             }
         }
         unsafe extern "system" fn GetSingleArray<Identity: IPropertyValue_Impl, const OFFSET: isize>(this: *mut core::ffi::c_void, value_array_size: *mut u32, value: *mut *mut f32) -> windows_core::HRESULT {
             unsafe {
                 let this: &Identity = &*((this as *const *const ()).offset(OFFSET) as *const Identity);
-                IPropertyValue_Impl::GetSingleArray(this, windows_core::ArrayProxy::from_raw_parts(core::mem::transmute_copy(&value), value_array_size).as_array()).into()
+                IPropertyValue_Impl::GetSingleArray(this, &mut windows_core::imp::array_proxy(core::mem::transmute_copy(&value), value_array_size)).into()
             }
         }
         unsafe extern "system" fn GetDoubleArray<Identity: IPropertyValue_Impl, const OFFSET: isize>(this: *mut core::ffi::c_void, value_array_size: *mut u32, value: *mut *mut f64) -> windows_core::HRESULT {
             unsafe {
                 let this: &Identity = &*((this as *const *const ()).offset(OFFSET) as *const Identity);
-                IPropertyValue_Impl::GetDoubleArray(this, windows_core::ArrayProxy::from_raw_parts(core::mem::transmute_copy(&value), value_array_size).as_array()).into()
+                IPropertyValue_Impl::GetDoubleArray(this, &mut windows_core::imp::array_proxy(core::mem::transmute_copy(&value), value_array_size)).into()
             }
         }
         unsafe extern "system" fn GetChar16Array<Identity: IPropertyValue_Impl, const OFFSET: isize>(this: *mut core::ffi::c_void, value_array_size: *mut u32, value: *mut *mut u16) -> windows_core::HRESULT {
             unsafe {
                 let this: &Identity = &*((this as *const *const ()).offset(OFFSET) as *const Identity);
-                IPropertyValue_Impl::GetChar16Array(this, windows_core::ArrayProxy::from_raw_parts(core::mem::transmute_copy(&value), value_array_size).as_array()).into()
+                IPropertyValue_Impl::GetChar16Array(this, &mut windows_core::imp::array_proxy(core::mem::transmute_copy(&value), value_array_size)).into()
             }
         }
         unsafe extern "system" fn GetBooleanArray<Identity: IPropertyValue_Impl, const OFFSET: isize>(this: *mut core::ffi::c_void, value_array_size: *mut u32, value: *mut *mut bool) -> windows_core::HRESULT {
             unsafe {
                 let this: &Identity = &*((this as *const *const ()).offset(OFFSET) as *const Identity);
-                IPropertyValue_Impl::GetBooleanArray(this, windows_core::ArrayProxy::from_raw_parts(core::mem::transmute_copy(&value), value_array_size).as_array()).into()
+                IPropertyValue_Impl::GetBooleanArray(this, &mut windows_core::imp::array_proxy(core::mem::transmute_copy(&value), value_array_size)).into()
             }
         }
         unsafe extern "system" fn GetStringArray<Identity: IPropertyValue_Impl, const OFFSET: isize>(this: *mut core::ffi::c_void, value_array_size: *mut u32, value: *mut *mut windows_core::HSTRING) -> windows_core::HRESULT {
             unsafe {
                 let this: &Identity = &*((this as *const *const ()).offset(OFFSET) as *const Identity);
-                IPropertyValue_Impl::GetStringArray(this, windows_core::ArrayProxy::from_raw_parts(core::mem::transmute_copy(&value), value_array_size).as_array()).into()
+                IPropertyValue_Impl::GetStringArray(this, &mut windows_core::imp::array_proxy(core::mem::transmute_copy(&value), value_array_size)).into()
             }
         }
         unsafe extern "system" fn GetInspectableArray<Identity: IPropertyValue_Impl, const OFFSET: isize>(this: *mut core::ffi::c_void, value_array_size: *mut u32, value: *mut *mut windows_core::IInspectable) -> windows_core::HRESULT {
             unsafe {
                 let this: &Identity = &*((this as *const *const ()).offset(OFFSET) as *const Identity);
-                IPropertyValue_Impl::GetInspectableArray(this, windows_core::ArrayProxy::from_raw_parts(core::mem::transmute_copy(&value), value_array_size).as_array()).into()
+                IPropertyValue_Impl::GetInspectableArray(this, &mut windows_core::imp::array_proxy(core::mem::transmute_copy(&value), value_array_size)).into()
             }
         }
         unsafe extern "system" fn GetGuidArray<Identity: IPropertyValue_Impl, const OFFSET: isize>(this: *mut core::ffi::c_void, value_array_size: *mut u32, value: *mut *mut windows_core::GUID) -> windows_core::HRESULT {
             unsafe {
                 let this: &Identity = &*((this as *const *const ()).offset(OFFSET) as *const Identity);
-                IPropertyValue_Impl::GetGuidArray(this, windows_core::ArrayProxy::from_raw_parts(core::mem::transmute_copy(&value), value_array_size).as_array()).into()
+                IPropertyValue_Impl::GetGuidArray(this, &mut windows_core::imp::array_proxy(core::mem::transmute_copy(&value), value_array_size)).into()
             }
         }
         unsafe extern "system" fn GetDateTimeArray<Identity: IPropertyValue_Impl, const OFFSET: isize>(this: *mut core::ffi::c_void, value_array_size: *mut u32, value: *mut *mut DateTime) -> windows_core::HRESULT {
             unsafe {
                 let this: &Identity = &*((this as *const *const ()).offset(OFFSET) as *const Identity);
-                IPropertyValue_Impl::GetDateTimeArray(this, windows_core::ArrayProxy::from_raw_parts(core::mem::transmute_copy(&value), value_array_size).as_array()).into()
+                IPropertyValue_Impl::GetDateTimeArray(this, &mut windows_core::imp::array_proxy(core::mem::transmute_copy(&value), value_array_size)).into()
             }
         }
         unsafe extern "system" fn GetTimeSpanArray<Identity: IPropertyValue_Impl, const OFFSET: isize>(this: *mut core::ffi::c_void, value_array_size: *mut u32, value: *mut *mut TimeSpan) -> windows_core::HRESULT {
             unsafe {
                 let this: &Identity = &*((this as *const *const ()).offset(OFFSET) as *const Identity);
-                IPropertyValue_Impl::GetTimeSpanArray(this, windows_core::ArrayProxy::from_raw_parts(core::mem::transmute_copy(&value), value_array_size).as_array()).into()
+                IPropertyValue_Impl::GetTimeSpanArray(this, &mut windows_core::imp::array_proxy(core::mem::transmute_copy(&value), value_array_size)).into()
             }
         }
         unsafe extern "system" fn GetPointArray<Identity: IPropertyValue_Impl, const OFFSET: isize>(this: *mut core::ffi::c_void, value_array_size: *mut u32, value: *mut *mut Point) -> windows_core::HRESULT {
             unsafe {
                 let this: &Identity = &*((this as *const *const ()).offset(OFFSET) as *const Identity);
-                IPropertyValue_Impl::GetPointArray(this, windows_core::ArrayProxy::from_raw_parts(core::mem::transmute_copy(&value), value_array_size).as_array()).into()
+                IPropertyValue_Impl::GetPointArray(this, &mut windows_core::imp::array_proxy(core::mem::transmute_copy(&value), value_array_size)).into()
             }
         }
         unsafe extern "system" fn GetSizeArray<Identity: IPropertyValue_Impl, const OFFSET: isize>(this: *mut core::ffi::c_void, value_array_size: *mut u32, value: *mut *mut Size) -> windows_core::HRESULT {
             unsafe {
                 let this: &Identity = &*((this as *const *const ()).offset(OFFSET) as *const Identity);
-                IPropertyValue_Impl::GetSizeArray(this, windows_core::ArrayProxy::from_raw_parts(core::mem::transmute_copy(&value), value_array_size).as_array()).into()
+                IPropertyValue_Impl::GetSizeArray(this, &mut windows_core::imp::array_proxy(core::mem::transmute_copy(&value), value_array_size)).into()
             }
         }
         unsafe extern "system" fn GetRectArray<Identity: IPropertyValue_Impl, const OFFSET: isize>(this: *mut core::ffi::c_void, value_array_size: *mut u32, value: *mut *mut Rect) -> windows_core::HRESULT {
             unsafe {
                 let this: &Identity = &*((this as *const *const ()).offset(OFFSET) as *const Identity);
-                IPropertyValue_Impl::GetRectArray(this, windows_core::ArrayProxy::from_raw_parts(core::mem::transmute_copy(&value), value_array_size).as_array()).into()
+                IPropertyValue_Impl::GetRectArray(this, &mut windows_core::imp::array_proxy(core::mem::transmute_copy(&value), value_array_size)).into()
             }
         }
         Self {

--- a/crates/tests/libs/bindgen/src/struct_with_generic.rs
+++ b/crates/tests/libs/bindgen/src/struct_with_generic.rs
@@ -665,11 +665,10 @@ impl IPropertyValue_Vtbl {
                     &*((this as *const *const ()).offset(OFFSET) as *const Identity);
                 IPropertyValue_Impl::GetUInt8Array(
                     this,
-                    windows_core::ArrayProxy::from_raw_parts(
+                    &mut windows_core::imp::array_proxy(
                         core::mem::transmute_copy(&value),
                         value_array_size,
-                    )
-                    .as_array(),
+                    ),
                 )
                 .into()
             }
@@ -687,11 +686,10 @@ impl IPropertyValue_Vtbl {
                     &*((this as *const *const ()).offset(OFFSET) as *const Identity);
                 IPropertyValue_Impl::GetInt16Array(
                     this,
-                    windows_core::ArrayProxy::from_raw_parts(
+                    &mut windows_core::imp::array_proxy(
                         core::mem::transmute_copy(&value),
                         value_array_size,
-                    )
-                    .as_array(),
+                    ),
                 )
                 .into()
             }
@@ -709,11 +707,10 @@ impl IPropertyValue_Vtbl {
                     &*((this as *const *const ()).offset(OFFSET) as *const Identity);
                 IPropertyValue_Impl::GetUInt16Array(
                     this,
-                    windows_core::ArrayProxy::from_raw_parts(
+                    &mut windows_core::imp::array_proxy(
                         core::mem::transmute_copy(&value),
                         value_array_size,
-                    )
-                    .as_array(),
+                    ),
                 )
                 .into()
             }
@@ -731,11 +728,10 @@ impl IPropertyValue_Vtbl {
                     &*((this as *const *const ()).offset(OFFSET) as *const Identity);
                 IPropertyValue_Impl::GetInt32Array(
                     this,
-                    windows_core::ArrayProxy::from_raw_parts(
+                    &mut windows_core::imp::array_proxy(
                         core::mem::transmute_copy(&value),
                         value_array_size,
-                    )
-                    .as_array(),
+                    ),
                 )
                 .into()
             }
@@ -753,11 +749,10 @@ impl IPropertyValue_Vtbl {
                     &*((this as *const *const ()).offset(OFFSET) as *const Identity);
                 IPropertyValue_Impl::GetUInt32Array(
                     this,
-                    windows_core::ArrayProxy::from_raw_parts(
+                    &mut windows_core::imp::array_proxy(
                         core::mem::transmute_copy(&value),
                         value_array_size,
-                    )
-                    .as_array(),
+                    ),
                 )
                 .into()
             }
@@ -775,11 +770,10 @@ impl IPropertyValue_Vtbl {
                     &*((this as *const *const ()).offset(OFFSET) as *const Identity);
                 IPropertyValue_Impl::GetInt64Array(
                     this,
-                    windows_core::ArrayProxy::from_raw_parts(
+                    &mut windows_core::imp::array_proxy(
                         core::mem::transmute_copy(&value),
                         value_array_size,
-                    )
-                    .as_array(),
+                    ),
                 )
                 .into()
             }
@@ -797,11 +791,10 @@ impl IPropertyValue_Vtbl {
                     &*((this as *const *const ()).offset(OFFSET) as *const Identity);
                 IPropertyValue_Impl::GetUInt64Array(
                     this,
-                    windows_core::ArrayProxy::from_raw_parts(
+                    &mut windows_core::imp::array_proxy(
                         core::mem::transmute_copy(&value),
                         value_array_size,
-                    )
-                    .as_array(),
+                    ),
                 )
                 .into()
             }
@@ -819,11 +812,10 @@ impl IPropertyValue_Vtbl {
                     &*((this as *const *const ()).offset(OFFSET) as *const Identity);
                 IPropertyValue_Impl::GetSingleArray(
                     this,
-                    windows_core::ArrayProxy::from_raw_parts(
+                    &mut windows_core::imp::array_proxy(
                         core::mem::transmute_copy(&value),
                         value_array_size,
-                    )
-                    .as_array(),
+                    ),
                 )
                 .into()
             }
@@ -841,11 +833,10 @@ impl IPropertyValue_Vtbl {
                     &*((this as *const *const ()).offset(OFFSET) as *const Identity);
                 IPropertyValue_Impl::GetDoubleArray(
                     this,
-                    windows_core::ArrayProxy::from_raw_parts(
+                    &mut windows_core::imp::array_proxy(
                         core::mem::transmute_copy(&value),
                         value_array_size,
-                    )
-                    .as_array(),
+                    ),
                 )
                 .into()
             }
@@ -863,11 +854,10 @@ impl IPropertyValue_Vtbl {
                     &*((this as *const *const ()).offset(OFFSET) as *const Identity);
                 IPropertyValue_Impl::GetChar16Array(
                     this,
-                    windows_core::ArrayProxy::from_raw_parts(
+                    &mut windows_core::imp::array_proxy(
                         core::mem::transmute_copy(&value),
                         value_array_size,
-                    )
-                    .as_array(),
+                    ),
                 )
                 .into()
             }
@@ -885,11 +875,10 @@ impl IPropertyValue_Vtbl {
                     &*((this as *const *const ()).offset(OFFSET) as *const Identity);
                 IPropertyValue_Impl::GetBooleanArray(
                     this,
-                    windows_core::ArrayProxy::from_raw_parts(
+                    &mut windows_core::imp::array_proxy(
                         core::mem::transmute_copy(&value),
                         value_array_size,
-                    )
-                    .as_array(),
+                    ),
                 )
                 .into()
             }
@@ -907,11 +896,10 @@ impl IPropertyValue_Vtbl {
                     &*((this as *const *const ()).offset(OFFSET) as *const Identity);
                 IPropertyValue_Impl::GetStringArray(
                     this,
-                    windows_core::ArrayProxy::from_raw_parts(
+                    &mut windows_core::imp::array_proxy(
                         core::mem::transmute_copy(&value),
                         value_array_size,
-                    )
-                    .as_array(),
+                    ),
                 )
                 .into()
             }
@@ -929,11 +917,10 @@ impl IPropertyValue_Vtbl {
                     &*((this as *const *const ()).offset(OFFSET) as *const Identity);
                 IPropertyValue_Impl::GetInspectableArray(
                     this,
-                    windows_core::ArrayProxy::from_raw_parts(
+                    &mut windows_core::imp::array_proxy(
                         core::mem::transmute_copy(&value),
                         value_array_size,
-                    )
-                    .as_array(),
+                    ),
                 )
                 .into()
             }
@@ -951,11 +938,10 @@ impl IPropertyValue_Vtbl {
                     &*((this as *const *const ()).offset(OFFSET) as *const Identity);
                 IPropertyValue_Impl::GetGuidArray(
                     this,
-                    windows_core::ArrayProxy::from_raw_parts(
+                    &mut windows_core::imp::array_proxy(
                         core::mem::transmute_copy(&value),
                         value_array_size,
-                    )
-                    .as_array(),
+                    ),
                 )
                 .into()
             }

--- a/crates/tests/misc/component/src/bindings.rs
+++ b/crates/tests/misc/component/src/bindings.rs
@@ -404,11 +404,10 @@ impl IClass_Vtbl {
                         core::mem::transmute_copy(&b),
                         b_array_size as usize,
                     ),
-                    windows_core::ArrayProxy::from_raw_parts(
+                    &mut windows_core::imp::array_proxy(
                         core::mem::transmute_copy(&c),
                         c_array_size,
-                    )
-                    .as_array(),
+                    ),
                 ) {
                     Ok(ok__) => {
                         let (ok_data__, ok_data_len__) = ok__.into_abi();
@@ -444,11 +443,10 @@ impl IClass_Vtbl {
                         core::mem::transmute_copy(&b),
                         b_array_size as usize,
                     ),
-                    windows_core::ArrayProxy::from_raw_parts(
+                    &mut windows_core::imp::array_proxy(
                         core::mem::transmute_copy(&c),
                         c_array_size,
-                    )
-                    .as_array(),
+                    ),
                 ) {
                     Ok(ok__) => {
                         let (ok_data__, ok_data_len__) = ok__.into_abi();

--- a/crates/tests/winrt/reference_float/src/bindings.rs
+++ b/crates/tests/winrt/reference_float/src/bindings.rs
@@ -627,11 +627,10 @@ impl IPropertyValue_Vtbl {
                     &*((this as *const *const ()).offset(OFFSET) as *const Identity);
                 IPropertyValue_Impl::GetUInt8Array(
                     this,
-                    windows_core::ArrayProxy::from_raw_parts(
+                    &mut windows_core::imp::array_proxy(
                         core::mem::transmute_copy(&value),
                         value_array_size,
-                    )
-                    .as_array(),
+                    ),
                 )
                 .into()
             }
@@ -649,11 +648,10 @@ impl IPropertyValue_Vtbl {
                     &*((this as *const *const ()).offset(OFFSET) as *const Identity);
                 IPropertyValue_Impl::GetInt16Array(
                     this,
-                    windows_core::ArrayProxy::from_raw_parts(
+                    &mut windows_core::imp::array_proxy(
                         core::mem::transmute_copy(&value),
                         value_array_size,
-                    )
-                    .as_array(),
+                    ),
                 )
                 .into()
             }
@@ -671,11 +669,10 @@ impl IPropertyValue_Vtbl {
                     &*((this as *const *const ()).offset(OFFSET) as *const Identity);
                 IPropertyValue_Impl::GetUInt16Array(
                     this,
-                    windows_core::ArrayProxy::from_raw_parts(
+                    &mut windows_core::imp::array_proxy(
                         core::mem::transmute_copy(&value),
                         value_array_size,
-                    )
-                    .as_array(),
+                    ),
                 )
                 .into()
             }
@@ -693,11 +690,10 @@ impl IPropertyValue_Vtbl {
                     &*((this as *const *const ()).offset(OFFSET) as *const Identity);
                 IPropertyValue_Impl::GetInt32Array(
                     this,
-                    windows_core::ArrayProxy::from_raw_parts(
+                    &mut windows_core::imp::array_proxy(
                         core::mem::transmute_copy(&value),
                         value_array_size,
-                    )
-                    .as_array(),
+                    ),
                 )
                 .into()
             }
@@ -715,11 +711,10 @@ impl IPropertyValue_Vtbl {
                     &*((this as *const *const ()).offset(OFFSET) as *const Identity);
                 IPropertyValue_Impl::GetUInt32Array(
                     this,
-                    windows_core::ArrayProxy::from_raw_parts(
+                    &mut windows_core::imp::array_proxy(
                         core::mem::transmute_copy(&value),
                         value_array_size,
-                    )
-                    .as_array(),
+                    ),
                 )
                 .into()
             }
@@ -737,11 +732,10 @@ impl IPropertyValue_Vtbl {
                     &*((this as *const *const ()).offset(OFFSET) as *const Identity);
                 IPropertyValue_Impl::GetInt64Array(
                     this,
-                    windows_core::ArrayProxy::from_raw_parts(
+                    &mut windows_core::imp::array_proxy(
                         core::mem::transmute_copy(&value),
                         value_array_size,
-                    )
-                    .as_array(),
+                    ),
                 )
                 .into()
             }
@@ -759,11 +753,10 @@ impl IPropertyValue_Vtbl {
                     &*((this as *const *const ()).offset(OFFSET) as *const Identity);
                 IPropertyValue_Impl::GetUInt64Array(
                     this,
-                    windows_core::ArrayProxy::from_raw_parts(
+                    &mut windows_core::imp::array_proxy(
                         core::mem::transmute_copy(&value),
                         value_array_size,
-                    )
-                    .as_array(),
+                    ),
                 )
                 .into()
             }
@@ -781,11 +774,10 @@ impl IPropertyValue_Vtbl {
                     &*((this as *const *const ()).offset(OFFSET) as *const Identity);
                 IPropertyValue_Impl::GetSingleArray(
                     this,
-                    windows_core::ArrayProxy::from_raw_parts(
+                    &mut windows_core::imp::array_proxy(
                         core::mem::transmute_copy(&value),
                         value_array_size,
-                    )
-                    .as_array(),
+                    ),
                 )
                 .into()
             }
@@ -803,11 +795,10 @@ impl IPropertyValue_Vtbl {
                     &*((this as *const *const ()).offset(OFFSET) as *const Identity);
                 IPropertyValue_Impl::GetDoubleArray(
                     this,
-                    windows_core::ArrayProxy::from_raw_parts(
+                    &mut windows_core::imp::array_proxy(
                         core::mem::transmute_copy(&value),
                         value_array_size,
-                    )
-                    .as_array(),
+                    ),
                 )
                 .into()
             }
@@ -825,11 +816,10 @@ impl IPropertyValue_Vtbl {
                     &*((this as *const *const ()).offset(OFFSET) as *const Identity);
                 IPropertyValue_Impl::GetChar16Array(
                     this,
-                    windows_core::ArrayProxy::from_raw_parts(
+                    &mut windows_core::imp::array_proxy(
                         core::mem::transmute_copy(&value),
                         value_array_size,
-                    )
-                    .as_array(),
+                    ),
                 )
                 .into()
             }
@@ -847,11 +837,10 @@ impl IPropertyValue_Vtbl {
                     &*((this as *const *const ()).offset(OFFSET) as *const Identity);
                 IPropertyValue_Impl::GetBooleanArray(
                     this,
-                    windows_core::ArrayProxy::from_raw_parts(
+                    &mut windows_core::imp::array_proxy(
                         core::mem::transmute_copy(&value),
                         value_array_size,
-                    )
-                    .as_array(),
+                    ),
                 )
                 .into()
             }
@@ -869,11 +858,10 @@ impl IPropertyValue_Vtbl {
                     &*((this as *const *const ()).offset(OFFSET) as *const Identity);
                 IPropertyValue_Impl::GetStringArray(
                     this,
-                    windows_core::ArrayProxy::from_raw_parts(
+                    &mut windows_core::imp::array_proxy(
                         core::mem::transmute_copy(&value),
                         value_array_size,
-                    )
-                    .as_array(),
+                    ),
                 )
                 .into()
             }
@@ -891,11 +879,10 @@ impl IPropertyValue_Vtbl {
                     &*((this as *const *const ()).offset(OFFSET) as *const Identity);
                 IPropertyValue_Impl::GetInspectableArray(
                     this,
-                    windows_core::ArrayProxy::from_raw_parts(
+                    &mut windows_core::imp::array_proxy(
                         core::mem::transmute_copy(&value),
                         value_array_size,
-                    )
-                    .as_array(),
+                    ),
                 )
                 .into()
             }
@@ -913,11 +900,10 @@ impl IPropertyValue_Vtbl {
                     &*((this as *const *const ()).offset(OFFSET) as *const Identity);
                 IPropertyValue_Impl::GetGuidArray(
                     this,
-                    windows_core::ArrayProxy::from_raw_parts(
+                    &mut windows_core::imp::array_proxy(
                         core::mem::transmute_copy(&value),
                         value_array_size,
-                    )
-                    .as_array(),
+                    ),
                 )
                 .into()
             }


### PR DESCRIPTION
In preparation for #3369, this moves another implementation type into the `windows-core` crate's `imp` module and streamlines its implementation to make code gen more concise for the `windows-bindgen` crate. 