### PR TITLE
Bump actions/checkout from 4 to 5

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: windows-2025
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Update toolchain
         run: rustup update --no-self-update nightly && rustup default nightly-x86_64-pc-windows-msvc
       - name: Add toolchain target

--- a/.github/workflows/cross.yml
+++ b/.github/workflows/cross.yml
@@ -35,7 +35,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Update toolchain
         run: rustup update --no-self-update stable && rustup default stable

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: windows-2025
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Check
         run: cargo doc --no-deps -p windows
 
@@ -27,7 +27,7 @@ jobs:
     runs-on: windows-2025
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Check
         run: cargo doc --no-deps -p windows-sys
 
@@ -35,7 +35,7 @@ jobs:
     runs-on: windows-2025
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Check
         run: >

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Update toolchain
         run: rustup update --no-self-update stable && rustup default stable
       - name: Check

--- a/.github/workflows/gen.yml
+++ b/.github/workflows/gen.yml
@@ -21,7 +21,7 @@ jobs:
         tool: [bindgen, bindings, yml, license, standalone, workspace]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Update toolchain
         run: rustup update --no-self-update stable && rustup default stable
       - name: Run

--- a/.github/workflows/lib.yml
+++ b/.github/workflows/lib.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: windows-2025
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Fix environment
         uses: ./.github/actions/fix-environment

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Update toolchain
         run: rustup update --no-self-update stable && rustup default stable
       - name: Run cargo test

--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: windows-2025
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Update toolchain
         run: rustup update --no-self-update nightly && rustup default nightly-x86_64-pc-windows-msvc
       - name: Add toolchain target

--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: windows-2025
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Rust version
         run: rustup update --no-self-update 1.74 && rustup default 1.74
       - name: Check cppwinrt

--- a/.github/workflows/no-default-features.yml
+++ b/.github/workflows/no-default-features.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: windows-2025
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Update toolchain
         run: rustup update --no-self-update nightly && rustup default nightly-x86_64-pc-windows-msvc
       - name: Add toolchain target

--- a/.github/workflows/no_std.yml
+++ b/.github/workflows/no_std.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: windows-2025
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Prepare
         run: rustup update --no-self-update ${{ matrix.rust }} && rustup default ${{ matrix.rust }}
       - name: Check

--- a/.github/workflows/slim_errors.yml
+++ b/.github/workflows/slim_errors.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ${{ matrix.runs-on }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         
       - name: Update toolchain
         run: rustup update --no-self-update nightly && rustup default nightly-${{ matrix.target }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Update toolchain
         run: rustup update --no-self-update ${{ matrix.version }} && rustup default ${{ matrix.version }}-${{ matrix.host }}
       - name: Add toolchain target

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -17,7 +17,7 @@ jobs:
     if: github.repository == 'microsoft/windows-rs'
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           path: current
 
@@ -35,7 +35,7 @@ jobs:
             ./build.ps1 $site.Name
           }
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: gh-pages
           path: gh-pages

--- a/crates/tools/yml/src/clippy.rs
+++ b/crates/tools/yml/src/clippy.rs
@@ -20,7 +20,7 @@ jobs:
     runs-on: windows-2025
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Update toolchain
         run: rustup update --no-self-update nightly && rustup default nightly-x86_64-pc-windows-msvc
       - name: Add toolchain target

--- a/crates/tools/yml/src/msrv.rs
+++ b/crates/tools/yml/src/msrv.rs
@@ -20,7 +20,7 @@ jobs:
     runs-on: windows-2025
     steps:
       - name: Checkout
-        uses: actions/checkout@v4"
+        uses: actions/checkout@v5"
         .to_string();
 
     for package in helpers::crates("crates/libs") {

--- a/crates/tools/yml/src/no_default_features.rs
+++ b/crates/tools/yml/src/no_default_features.rs
@@ -20,7 +20,7 @@ jobs:
     runs-on: windows-2025
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Update toolchain
         run: rustup update --no-self-update nightly && rustup default nightly-x86_64-pc-windows-msvc
       - name: Add toolchain target

--- a/crates/tools/yml/src/test.rs
+++ b/crates/tools/yml/src/test.rs
@@ -46,7 +46,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Update toolchain
         run: rustup update --no-self-update ${{ matrix.version }} && rustup default ${{ matrix.version }}-${{ matrix.host }}
       - name: Add toolchain target


### PR DESCRIPTION
The bot can't update this automatically as the yml workflows are generated and the generation tool must be updated as well.

Fixes: #3711