### PR TITLE
Add `Debug` implementation for `HStringBuilder`

### DIFF
--- a/crates/libs/strings/src/hstring_builder.rs
+++ b/crates/libs/strings/src/hstring_builder.rs
@@ -98,3 +98,13 @@ impl Drop for HStringBuilder {
         }
     }
 }
+
+impl core::fmt::Debug for HStringBuilder {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(
+            f,
+            "\"{}\"",
+            Decode(|| core::char::decode_utf16(self.iter().cloned()))
+        )
+    }
+}

--- a/crates/tests/libs/strings/tests/hstring_builder.rs
+++ b/crates/tests/libs/strings/tests/hstring_builder.rs
@@ -49,3 +49,11 @@ fn hstring_builder() {
     let b = HStringBuilder::new(5);
     assert_eq!(*b, [0, 0, 0, 0, 0]);
 }
+
+#[test]
+fn debug() {
+    const HELLO: [u16; 5] = [0x48, 0x65, 0x6C, 0x6C, 0x6F];
+    let mut b = HStringBuilder::new(5);
+    b.copy_from_slice(&HELLO);
+    assert_eq!(format!("{b:?}"), "\"Hello\"");
+}


### PR DESCRIPTION
Ideally all public types implement `Debug` to simplify debugging. 

In future, I would like to enable the `missing_debug_implementations` lint on the workspace to enforce this. 