### PR TITLE
Add specific yml job names

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -13,7 +13,7 @@ on:
       - master
 
 jobs:
-  check:
+  clippy:
     runs-on: windows-2025
     steps:
       - name: Checkout

--- a/.github/workflows/cross.yml
+++ b/.github/workflows/cross.yml
@@ -16,7 +16,7 @@ env:
   LLVM-MINGW-TOOLCHAIN-NAME: llvm-mingw-20220906-ucrt-ubuntu-18.04-x86_64
 
 jobs:
-  check:
+  cross:
     strategy:
       matrix:
         #

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -13,7 +13,7 @@ on:
       - master
 
 jobs:
-  check:
+  fmt:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout

--- a/.github/workflows/gen.yml
+++ b/.github/workflows/gen.yml
@@ -13,7 +13,7 @@ on:
       - master
 
 jobs:
-  check:
+  gen:
     name: tool_${{ matrix.tool }}
     runs-on: ubuntu-22.04
     strategy:

--- a/.github/workflows/lib.yml
+++ b/.github/workflows/lib.yml
@@ -13,7 +13,7 @@ on:
       - master
 
 jobs:
-  check:
+  lib:
     runs-on: windows-2025
     steps:
       - name: Checkout

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -13,7 +13,7 @@ on:
       - master
 
 jobs:
-  check:
+  linux:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout

--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -13,7 +13,7 @@ on:
       - master
 
 jobs:
-  check:
+  miri:
     runs-on: windows-2025
     steps:
       - name: Checkout

--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -13,7 +13,7 @@ on:
       - master
 
 jobs:
-  check:
+  msrv:
     runs-on: windows-2025
     steps:
       - name: Checkout

--- a/.github/workflows/no-default-features.yml
+++ b/.github/workflows/no-default-features.yml
@@ -13,7 +13,7 @@ on:
       - master
 
 jobs:
-  check:
+  no-default-features:
     runs-on: windows-2025
     steps:
       - name: Checkout

--- a/.github/workflows/no_std.yml
+++ b/.github/workflows/no_std.yml
@@ -13,7 +13,7 @@ on:
       - master
 
 jobs:
-  check:
+  no_std:
     strategy:
       matrix:
         rust: [stable, nightly]

--- a/.github/workflows/slim_errors.yml
+++ b/.github/workflows/slim_errors.yml
@@ -16,7 +16,7 @@ env:
   RUSTFLAGS: --cfg windows_slim_errors
 
 jobs:
-  check:
+  slim_errors:
     strategy:
       matrix:
         include:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ on:
       - master
 
 jobs:
-  check:
+  test:
     strategy:
       matrix:
         include:

--- a/crates/tools/yml/src/clippy.rs
+++ b/crates/tools/yml/src/clippy.rs
@@ -16,7 +16,7 @@ on:
       - master
 
 jobs:
-  check:
+  clippy:
     runs-on: windows-2025
     steps:
       - name: Checkout

--- a/crates/tools/yml/src/msrv.rs
+++ b/crates/tools/yml/src/msrv.rs
@@ -16,7 +16,7 @@ on:
       - master
 
 jobs:
-  check:
+  msrv:
     runs-on: windows-2025
     steps:
       - name: Checkout

--- a/crates/tools/yml/src/no_default_features.rs
+++ b/crates/tools/yml/src/no_default_features.rs
@@ -16,7 +16,7 @@ on:
       - master
 
 jobs:
-  check:
+  no-default-features:
     runs-on: windows-2025
     steps:
       - name: Checkout

--- a/crates/tools/yml/src/test.rs
+++ b/crates/tools/yml/src/test.rs
@@ -17,7 +17,7 @@ on:
       - master
 
 jobs:
-  check:
+  test:
     strategy:
       matrix:
         include:


### PR DESCRIPTION
The GitHub UX is a little confusing when it comes to workflow and job names, making the job name far more prominent than the workflow name. This hopefully just makes that a little clearer for investigating build runs.