### PR TITLE
Assume default `readme` fields in `Cargo.toml`

### DIFF
--- a/crates/libs/bindgen/Cargo.toml
+++ b/crates/libs/bindgen/Cargo.toml
@@ -6,7 +6,6 @@ rust-version = "1.82"
 license = "MIT OR Apache-2.0"
 description = "Code generator for Windows metadata"
 repository = "https://github.com/microsoft/windows-rs"
-readme = "readme.md"
 categories = ["os::windows-apis"]
 
 [dependencies]

--- a/crates/libs/collections/Cargo.toml
+++ b/crates/libs/collections/Cargo.toml
@@ -6,7 +6,7 @@ rust-version = "1.82"
 license = "MIT OR Apache-2.0"
 description = "Windows collection types"
 repository = "https://github.com/microsoft/windows-rs"
-readme = "readme.md"
+
 categories = ["os::windows-apis"]
 
 [dependencies]

--- a/crates/libs/core/Cargo.toml
+++ b/crates/libs/core/Cargo.toml
@@ -6,7 +6,7 @@ rust-version = "1.82"
 license = "MIT OR Apache-2.0"
 description = "Core type support for COM and Windows"
 repository = "https://github.com/microsoft/windows-rs"
-readme = "readme.md"
+
 categories = ["os::windows-apis"]
 
 [dependencies]

--- a/crates/libs/cppwinrt/Cargo.toml
+++ b/crates/libs/cppwinrt/Cargo.toml
@@ -6,7 +6,7 @@ rust-version = "1.74"
 license = "MIT OR Apache-2.0"
 description = "C++/WinRT"
 repository = "https://github.com/microsoft/windows-rs"
-readme = "readme.md"
+
 categories = ["os::windows-apis"]
 
 [dependencies]

--- a/crates/libs/future/Cargo.toml
+++ b/crates/libs/future/Cargo.toml
@@ -6,7 +6,7 @@ rust-version = "1.82"
 license = "MIT OR Apache-2.0"
 description = "Windows async types"
 repository = "https://github.com/microsoft/windows-rs"
-readme = "readme.md"
+
 categories = ["os::windows-apis"]
 
 [dependencies]

--- a/crates/libs/implement/Cargo.toml
+++ b/crates/libs/implement/Cargo.toml
@@ -6,7 +6,7 @@ rust-version = "1.74"
 license = "MIT OR Apache-2.0"
 description = "The implement macro for the windows crate"
 repository = "https://github.com/microsoft/windows-rs"
-readme = "readme.md"
+
 categories = ["os::windows-apis"]
 
 [dependencies]

--- a/crates/libs/interface/Cargo.toml
+++ b/crates/libs/interface/Cargo.toml
@@ -7,7 +7,6 @@ license = "MIT OR Apache-2.0"
 description = "The interface macro for the windows crate"
 repository = "https://github.com/microsoft/windows-rs"
 categories = ["os::windows-apis"]
-readme = "readme.md"
 
 [dependencies]
 proc-macro2 = { workspace = true }

--- a/crates/libs/link/Cargo.toml
+++ b/crates/libs/link/Cargo.toml
@@ -7,7 +7,7 @@ rust-version = "1.71"
 license = "MIT OR Apache-2.0"
 description = "Linking for Windows"
 repository = "https://github.com/microsoft/windows-rs"
-readme = "readme.md"
+
 categories = ["os::windows-apis"]
 
 [lints]

--- a/crates/libs/metadata/Cargo.toml
+++ b/crates/libs/metadata/Cargo.toml
@@ -6,5 +6,5 @@ rust-version = "1.82"
 license = "MIT OR Apache-2.0"
 description = "Low-level metadata library for ECMA-335"
 repository = "https://github.com/microsoft/windows-rs"
-readme = "readme.md"
+
 categories = ["os::windows-apis"]

--- a/crates/libs/numerics/Cargo.toml
+++ b/crates/libs/numerics/Cargo.toml
@@ -6,7 +6,7 @@ rust-version = "1.82"
 license = "MIT OR Apache-2.0"
 description = "Windows numeric types"
 repository = "https://github.com/microsoft/windows-rs"
-readme = "readme.md"
+
 categories = ["os::windows-apis"]
 
 [dependencies]

--- a/crates/libs/registry/Cargo.toml
+++ b/crates/libs/registry/Cargo.toml
@@ -6,7 +6,7 @@ rust-version = "1.82"
 license = "MIT OR Apache-2.0"
 description = "Windows registry"
 repository = "https://github.com/microsoft/windows-rs"
-readme = "readme.md"
+
 categories = ["os::windows-apis"]
 
 [dependencies]

--- a/crates/libs/result/Cargo.toml
+++ b/crates/libs/result/Cargo.toml
@@ -6,7 +6,7 @@ rust-version = "1.82"
 license = "MIT OR Apache-2.0"
 description = "Windows error handling"
 repository = "https://github.com/microsoft/windows-rs"
-readme = "readme.md"
+
 categories = ["os::windows-apis"]
 
 [dependencies]

--- a/crates/libs/services/Cargo.toml
+++ b/crates/libs/services/Cargo.toml
@@ -6,7 +6,7 @@ rust-version = "1.82"
 license = "MIT OR Apache-2.0"
 description = "Windows services"
 repository = "https://github.com/microsoft/windows-rs"
-readme = "readme.md"
+
 categories = ["os::windows-apis"]
 
 [dependencies]

--- a/crates/libs/strings/Cargo.toml
+++ b/crates/libs/strings/Cargo.toml
@@ -6,7 +6,7 @@ rust-version = "1.82"
 license = "MIT OR Apache-2.0"
 description = "Windows string types"
 repository = "https://github.com/microsoft/windows-rs"
-readme = "readme.md"
+
 categories = ["os::windows-apis"]
 
 [dependencies]

--- a/crates/libs/sys/Cargo.toml
+++ b/crates/libs/sys/Cargo.toml
@@ -6,7 +6,7 @@ rust-version = "1.60"
 license = "MIT OR Apache-2.0"
 description = "Rust for Windows"
 repository = "https://github.com/microsoft/windows-rs"
-readme = "readme.md"
+
 categories = ["os::windows-apis"]
 
 [dependencies]

--- a/crates/libs/targets/Cargo.toml
+++ b/crates/libs/targets/Cargo.toml
@@ -7,7 +7,7 @@ rust-version = "1.60"
 license = "MIT OR Apache-2.0"
 description = "Import libs for Windows"
 repository = "https://github.com/microsoft/windows-rs"
-readme = "readme.md"
+
 categories = ["os::windows-apis"]
 
 [lints]

--- a/crates/libs/threading/Cargo.toml
+++ b/crates/libs/threading/Cargo.toml
@@ -6,7 +6,7 @@ rust-version = "1.82"
 license = "MIT OR Apache-2.0"
 description = "Windows threading"
 repository = "https://github.com/microsoft/windows-rs"
-readme = "readme.md"
+
 categories = ["os::windows-apis"]
 
 [dependencies]

--- a/crates/libs/version/Cargo.toml
+++ b/crates/libs/version/Cargo.toml
@@ -6,7 +6,7 @@ rust-version = "1.74"
 license = "MIT OR Apache-2.0"
 description = "Windows version information"
 repository = "https://github.com/microsoft/windows-rs"
-readme = "readme.md"
+
 categories = ["os::windows-apis"]
 
 [dependencies]

--- a/crates/libs/windows/Cargo.toml
+++ b/crates/libs/windows/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 description = "Rust for Windows"
 repository = "https://github.com/microsoft/windows-rs"
 documentation = "https://microsoft.github.io/windows-docs-rs/"
-readme = "readme.md"
+
 categories = ["os::windows-apis"]
 exclude = ["features.json"]
 

--- a/crates/targets/aarch64_gnullvm/Cargo.toml
+++ b/crates/targets/aarch64_gnullvm/Cargo.toml
@@ -6,7 +6,7 @@ rust-version = "1.60"
 license = "MIT OR Apache-2.0"
 description = "Import lib for Windows"
 repository = "https://github.com/microsoft/windows-rs"
-readme = "readme.md"
+
 categories = ["os::windows-apis"]
 
 [package.metadata.docs.rs]

--- a/crates/targets/aarch64_msvc/Cargo.toml
+++ b/crates/targets/aarch64_msvc/Cargo.toml
@@ -6,7 +6,7 @@ rust-version = "1.60"
 license = "MIT OR Apache-2.0"
 description = "Import lib for Windows"
 repository = "https://github.com/microsoft/windows-rs"
-readme = "readme.md"
+
 categories = ["os::windows-apis"]
 
 [package.metadata.docs.rs]

--- a/crates/targets/i686_gnu/Cargo.toml
+++ b/crates/targets/i686_gnu/Cargo.toml
@@ -6,7 +6,7 @@ rust-version = "1.60"
 license = "MIT OR Apache-2.0"
 description = "Import lib for Windows"
 repository = "https://github.com/microsoft/windows-rs"
-readme = "readme.md"
+
 categories = ["os::windows-apis"]
 
 [package.metadata.docs.rs]

--- a/crates/targets/i686_gnullvm/Cargo.toml
+++ b/crates/targets/i686_gnullvm/Cargo.toml
@@ -6,7 +6,7 @@ rust-version = "1.60"
 license = "MIT OR Apache-2.0"
 description = "Import lib for Windows"
 repository = "https://github.com/microsoft/windows-rs"
-readme = "readme.md"
+
 categories = ["os::windows-apis"]
 
 [package.metadata.docs.rs]

--- a/crates/targets/i686_msvc/Cargo.toml
+++ b/crates/targets/i686_msvc/Cargo.toml
@@ -6,7 +6,7 @@ rust-version = "1.60"
 license = "MIT OR Apache-2.0"
 description = "Import lib for Windows"
 repository = "https://github.com/microsoft/windows-rs"
-readme = "readme.md"
+
 categories = ["os::windows-apis"]
 
 [package.metadata.docs.rs]

--- a/crates/targets/x86_64_gnu/Cargo.toml
+++ b/crates/targets/x86_64_gnu/Cargo.toml
@@ -6,7 +6,7 @@ rust-version = "1.60"
 license = "MIT OR Apache-2.0"
 description = "Import lib for Windows"
 repository = "https://github.com/microsoft/windows-rs"
-readme = "readme.md"
+
 categories = ["os::windows-apis"]
 
 [package.metadata.docs.rs]

--- a/crates/targets/x86_64_gnullvm/Cargo.toml
+++ b/crates/targets/x86_64_gnullvm/Cargo.toml
@@ -6,7 +6,7 @@ rust-version = "1.60"
 license = "MIT OR Apache-2.0"
 description = "Import lib for Windows"
 repository = "https://github.com/microsoft/windows-rs"
-readme = "readme.md"
+
 categories = ["os::windows-apis"]
 
 [package.metadata.docs.rs]

--- a/crates/targets/x86_64_msvc/Cargo.toml
+++ b/crates/targets/x86_64_msvc/Cargo.toml
@@ -6,7 +6,7 @@ rust-version = "1.60"
 license = "MIT OR Apache-2.0"
 description = "Import lib for Windows"
 repository = "https://github.com/microsoft/windows-rs"
-readme = "readme.md"
+
 categories = ["os::windows-apis"]
 
 [package.metadata.docs.rs]

--- a/crates/tests/misc/package/tests/test.rs
+++ b/crates/tests/misc/package/tests/test.rs
@@ -4,13 +4,13 @@ fn test() {
         println!("package: {}", package.name);
         assert_eq!(package.edition, "2021");
         assert_eq!(package.authors, None);
+        assert_eq!(package.readme, None);
 
         if package.publish == Some(false) {
             // The `version` field is no longer required - remove once MSRV can support it.
             assert_eq!(package.version, "0.0.0");
             assert_eq!(package.license, None);
             assert_eq!(package.repository, None);
-            assert_eq!(package.readme, None);
             assert_eq!(package.categories, None);
             assert_eq!(package.description, None);
         } else {
@@ -19,7 +19,6 @@ fn test() {
                 package.repository,
                 Some("https://github.com/microsoft/windows-rs".to_string())
             );
-            assert_eq!(package.readme, Some("readme.md".to_string()));
             assert_eq!(
                 package.categories,
                 Some(vec!["os::windows-apis".to_string()])


### PR DESCRIPTION
Following on from #3714, I tested crates.io and it does in fact handle readme mismatched case in the package manifest so I can simplify the package metadata even further. 