### PR TITLE
Add missing `unsafe` on `extern` blocks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ opt-level = 2
 
 [workspace.lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(windows_raw_dylib, windows_slim_errors)'] }
+missing_unsafe_on_extern = "warn"
 
 [workspace.dependencies]
 helpers = { path = "crates/tools/helpers" }

--- a/crates/libs/strings/src/lib.rs
+++ b/crates/libs/strings/src/lib.rs
@@ -41,6 +41,6 @@ pub use pstr::*;
 mod pwstr;
 pub use pwstr::*;
 
-extern "C" {
+unsafe extern "C" {
     fn strlen(s: PCSTR) -> usize;
 }

--- a/crates/libs/strings/src/pcwstr.rs
+++ b/crates/libs/strings/src/pcwstr.rs
@@ -32,7 +32,7 @@ impl PCWSTR {
     ///
     /// The `PCWSTR`'s pointer needs to be valid for reads up until and including the next `\0`.
     pub unsafe fn len(&self) -> usize {
-        extern "C" {
+        unsafe extern "C" {
             fn wcslen(s: *const u16) -> usize;
         }
         unsafe { wcslen(self.0) }

--- a/crates/samples/components/json_validator_client/src/lib.rs
+++ b/crates/samples/components/json_validator_client/src/lib.rs
@@ -2,7 +2,7 @@
 
 #[test]
 fn test() {
-    extern "system" {
+    unsafe extern "system" {
         fn client();
     }
     unsafe {

--- a/crates/samples/windows/bits/src/main.rs
+++ b/crates/samples/windows/bits/src/main.rs
@@ -65,6 +65,6 @@ impl IBackgroundCopyCallback_Impl for Callback_Impl {
     }
 }
 
-extern "C" {
+unsafe extern "C" {
     pub fn getchar() -> i32;
 }

--- a/crates/tests/libs/strings/tests/bstr.rs
+++ b/crates/tests/libs/strings/tests/bstr.rs
@@ -86,6 +86,6 @@ fn deref_as_slice() {
     }
 }
 
-extern "C" {
+unsafe extern "C" {
     pub fn wcslen(s: *const u16) -> usize;
 }

--- a/crates/tests/libs/strings/tests/hstring.rs
+++ b/crates/tests/libs/strings/tests/hstring.rs
@@ -318,7 +318,7 @@ fn deref_as_slice() {
     }
 }
 
-extern "C" {
+unsafe extern "C" {
     pub fn wcslen(s: *const u16) -> usize;
 }
 

--- a/crates/tests/misc/const_params/tests/sys.rs
+++ b/crates/tests/misc/const_params/tests/sys.rs
@@ -1,6 +1,6 @@
 use windows_sys::{core::*, Win32::Foundation::*, Win32::UI::Shell::*};
 
-extern "C" {
+unsafe extern "C" {
     fn wcslen(s: PCWSTR) -> usize;
 }
 

--- a/crates/tests/misc/literals/tests/sys.rs
+++ b/crates/tests/misc/literals/tests/sys.rs
@@ -39,7 +39,7 @@ fn assert_utf16(left: PCWSTR, right: &[u16]) {
     assert_eq!(left, right);
 }
 
-extern "C" {
+unsafe extern "C" {
     pub fn strlen(s: PCSTR) -> usize;
     pub fn wcslen(s: PCWSTR) -> usize;
 }

--- a/crates/tests/misc/literals/tests/win.rs
+++ b/crates/tests/misc/literals/tests/win.rs
@@ -82,7 +82,7 @@ fn assert_hstring(left: &HSTRING, right: &[u16]) {
     assert_eq!(left, right);
 }
 
-extern "C" {
+unsafe extern "C" {
     pub fn strlen(s: PCSTR) -> usize;
     pub fn wcslen(s: PCWSTR) -> usize;
 }

--- a/crates/tests/winrt/collection_interop/src/lib.rs
+++ b/crates/tests/winrt/collection_interop/src/lib.rs
@@ -5,7 +5,7 @@ pub use bindings::*;
 pub use windows_core::*;
 
 pub fn make_cpp() -> Result<ITest> {
-    extern "system" {
+    unsafe extern "system" {
         fn make_cpp(test: *mut *mut std::ffi::c_void) -> HRESULT;
     }
 

--- a/crates/tests/winrt/composable_client/src/lib.rs
+++ b/crates/tests/winrt/composable_client/src/lib.rs
@@ -5,7 +5,7 @@ mod bindings;
 use bindings::*;
 use windows::core::*;
 
-extern "system" {
+unsafe extern "system" {
     fn interop() -> HRESULT;
 }
 

--- a/crates/tests/winrt/constructors_client/src/lib.rs
+++ b/crates/tests/winrt/constructors_client/src/lib.rs
@@ -5,7 +5,7 @@ mod bindings;
 use bindings::*;
 use windows::core::*;
 
-extern "system" {
+unsafe extern "system" {
     fn interop() -> HRESULT;
 }
 

--- a/crates/tests/winrt/noexcept/src/lib.rs
+++ b/crates/tests/winrt/noexcept/src/lib.rs
@@ -5,7 +5,7 @@ pub use bindings::*;
 pub use windows_core::*;
 
 pub fn consume(test: &ITest) -> Result<()> {
-    extern "system" {
+    unsafe extern "system" {
         fn consume(test: Ref<ITest>) -> HRESULT;
     }
 
@@ -13,7 +13,7 @@ pub fn consume(test: &ITest) -> Result<()> {
 }
 
 pub fn produce() -> Result<ITest> {
-    extern "system" {
+    unsafe extern "system" {
         fn produce(test: *mut *mut std::ffi::c_void) -> HRESULT;
     }
 

--- a/crates/tests/winrt/ref_params/src/lib.rs
+++ b/crates/tests/winrt/ref_params/src/lib.rs
@@ -5,7 +5,7 @@ pub use bindings::*;
 pub use windows_core::*;
 
 pub fn consume(test: &ITest) -> Result<()> {
-    extern "system" {
+    unsafe extern "system" {
         fn consume(test: Ref<ITest>) -> HRESULT;
     }
 
@@ -13,7 +13,7 @@ pub fn consume(test: &ITest) -> Result<()> {
 }
 
 pub fn produce() -> Result<ITest> {
-    extern "system" {
+    unsafe extern "system" {
         fn produce(test: *mut *mut std::ffi::c_void) -> HRESULT;
     }
 


### PR DESCRIPTION
Building on #3727, this update enforces the `missing_unsafe_on_extern` lint as that becomes a hard error in Rust edition 2024 and will make eventual upgrade smoother if we get ahead of such changes. 

https://doc.rust-lang.org/beta/rustc/lints/listing/allowed-by-default.html#missing-unsafe-on-extern