### PR TITLE
Simplify construction of `Ref` and `OutRef` directly

### DIFF
--- a/crates/libs/core/src/out_ref.rs
+++ b/crates/libs/core/src/out_ref.rs
@@ -29,3 +29,9 @@ impl<'a, T: Type<T>> From<&'a mut T::Default> for OutRef<'a, T> {
         unsafe { core::mem::transmute(from) }
     }
 }
+
+impl<T: Type<T>> Default for OutRef<'_, T> {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}

--- a/crates/libs/core/src/ref.rs
+++ b/crates/libs/core/src/ref.rs
@@ -46,6 +46,12 @@ impl<T: Type<T>> Ref<'_, T> {
     }
 }
 
+impl<T: Type<T>> Default for Ref<'_, T> {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+
 impl<T: Type<T>> core::ops::Deref for Ref<'_, T> {
     type Target = T::Default;
     fn deref(&self) -> &Self::Target {
@@ -53,8 +59,30 @@ impl<T: Type<T>> core::ops::Deref for Ref<'_, T> {
     }
 }
 
-impl<'a, T: Type<T>> From<&'a T::Default> for Ref<'a, T> {
-    fn from(from: &'a T::Default) -> Self {
+impl<'a, T: Type<T, InterfaceType>> From<&'a Option<T>> for Ref<'a, T>
+where
+    T: TypeKind<TypeKind = InterfaceType>,
+{
+    fn from(from: &'a Option<T>) -> Self {
+        unsafe { core::mem::transmute_copy(from) }
+    }
+}
+
+impl<'a, T: Type<T, InterfaceType>> From<Option<&'a T>> for Ref<'a, T>
+where
+    T: TypeKind<TypeKind = InterfaceType>,
+{
+    fn from(from: Option<&'a T>) -> Self {
+        if let Some(from) = from {
+            unsafe { core::mem::transmute_copy(from) }
+        } else {
+            unsafe { core::mem::zeroed() }
+        }
+    }
+}
+
+impl<'a, T: Type<T>> From<&'a T> for Ref<'a, T> {
+    fn from(from: &'a T) -> Self {
         unsafe { core::mem::transmute_copy(from) }
     }
 }

--- a/crates/tests/libs/core/tests/ref.rs
+++ b/crates/tests/libs/core/tests/ref.rs
@@ -1,0 +1,106 @@
+#![allow(non_camel_case_types)]
+
+use windows::Win32::Foundation::E_POINTER;
+use windows_core::*;
+
+#[interface("6120f260-090f-4b55-a09f-3cce3ffb35a4")]
+unsafe trait ITest: IUnknown {
+    fn get(&self) -> usize;
+}
+
+#[implement(ITest)]
+struct Test(usize);
+
+impl Drop for Test {
+    fn drop(&mut self) {
+        println!("Drop for Test({})", self.0);
+    }
+}
+
+impl ITest_Impl for Test_Impl {
+    unsafe fn get(&self) -> usize {
+        self.0
+    }
+}
+
+fn call_hstring(input: Ref<HSTRING>) -> HSTRING {
+    input.clone()
+}
+
+fn call_object(input: Ref<ITest>) -> Option<ITest> {
+    input.clone()
+}
+
+#[test]
+fn test_ref() {
+    assert_eq!(call_hstring(h!("test").into()), "test");
+
+    // Drop lifetime test
+    {
+        let test: ITest = Test(12).into();
+        let clone = call_object((&test).into());
+        drop(test);
+        assert_eq!(unsafe { clone.unwrap().get() }, 12);
+    }
+
+    // Inline test (`get` is the only unsafe call)
+    unsafe {
+        assert_eq!(
+            call_object((&ITest::from(Test(23))).into()).unwrap().get(),
+            23
+        );
+    }
+
+    // From &T
+    {
+        let test: ITest = Test(34).into();
+        let test = call_object((&test).into());
+        assert_eq!(unsafe { test.unwrap().get() }, 34);
+    }
+
+    // From &Option<T>
+    {
+        let test: Option<ITest> = Some(Test(45).into());
+        let test = call_object((&test).into());
+        assert_eq!(unsafe { test.unwrap().get() }, 45);
+    }
+
+    // From Option<&T>
+    {
+        let test: ITest = Test(56).into();
+        let test = call_object(Some(&test).into());
+        assert_eq!(unsafe { test.unwrap().get() }, 56);
+    }
+}
+
+fn return_hstring(input: Ref<HSTRING>, output: OutRef<HSTRING>) -> Result<()> {
+    output.write(input.clone())
+}
+
+fn return_object(input: Ref<ITest>, output: OutRef<ITest>) -> Result<()> {
+    output.write(input.clone())
+}
+
+#[test]
+fn test_out_ref() {
+    let mut result = HSTRING::new();
+    return_hstring(h!("test").into(), (&mut result).into()).unwrap();
+    assert_eq!(result, "test");
+
+    // input and output
+    let input: ITest = Test(11).into();
+    let mut output = None;
+    return_object((&input).into(), (&mut output).into()).unwrap();
+    drop(input);
+    assert!(output.is_some());
+    assert_eq!(unsafe { output.unwrap().get() }, 11);
+
+    // "None" input and output
+    let mut output = None;
+    return_object((&None).into(), (&mut output).into()).unwrap();
+    assert!(output.is_none());
+
+    // default (optional) input and output
+    let error = return_object(Ref::default(), OutRef::default()).unwrap_err();
+    assert_eq!(error.code(), E_POINTER);
+}

--- a/crates/tests/winrt/noexcept/src/lib.rs
+++ b/crates/tests/winrt/noexcept/src/lib.rs
@@ -9,17 +9,17 @@ pub fn consume(test: &ITest) -> Result<()> {
         fn consume(test: Ref<ITest>) -> HRESULT;
     }
 
-    unsafe { consume(std::mem::transmute_copy(test)).ok() }
+    unsafe { consume(test.into()).ok() }
 }
 
 pub fn produce() -> Result<ITest> {
     unsafe extern "system" {
-        fn produce(test: *mut *mut std::ffi::c_void) -> HRESULT;
+        fn produce(test: OutRef<ITest>) -> HRESULT;
     }
 
     unsafe {
         let mut test = None;
-        produce(&mut test as *mut _ as *mut _).ok()?;
+        produce((&mut test).into()).ok()?;
         Type::from_default(&test)
     }
 }

--- a/crates/tests/winrt/ref_params/src/lib.rs
+++ b/crates/tests/winrt/ref_params/src/lib.rs
@@ -9,17 +9,17 @@ pub fn consume(test: &ITest) -> Result<()> {
         fn consume(test: Ref<ITest>) -> HRESULT;
     }
 
-    unsafe { consume(std::mem::transmute_copy(test)).ok() }
+    unsafe { consume(test.into()).ok() }
 }
 
 pub fn produce() -> Result<ITest> {
     unsafe extern "system" {
-        fn produce(test: *mut *mut std::ffi::c_void) -> HRESULT;
+        fn produce(test: OutRef<ITest>) -> HRESULT;
     }
 
     unsafe {
         let mut test = None;
-        produce(&mut test as *mut _ as *mut _).ok()?;
+        produce((&mut test).into()).ok()?;
         Type::from_default(&test)
     }
 }


### PR DESCRIPTION
#3025 added the the `Ref` and `OutRef` types that represent borrowed types, providing the same memory layout but also offer lifetime management and conveniences to make dealing with in and out parameters safe and convenient:

```Rust
unsafe extern "system" fn DllGetActivationFactory(
    name: Ref<HSTRING>,
    factory: OutRef<IActivationFactory>,
) -> HRESULT
```

This made it much simpler to implement ABIs like `DllGetActivationFactory` but didn't provide much in the way of calling functions with those same ABI types. The thinking was that these would typically be called from some other language like C++, which is typically the case. 

In order to make it easier to define ABI boundaries directly in Rust that might be called from Rust itself, this update adds some conveniences to safely construct `Ref` and `OutRef` types from local Rust types again with the same memory layout and lifetime. This is mainly just adding more convenient `From` implementations for `Ref` and `Default` implementations for both. The tests illustrate how this might be used. 

