### PR TITLE
Workaround for `integer_to_ptr_transmutes` warning

### DIFF
--- a/crates/libs/core/src/imp/weak_ref_count.rs
+++ b/crates/libs/core/src/imp/weak_ref_count.rs
@@ -155,7 +155,10 @@ impl TearOff {
     }
 
     unsafe fn decode<'a>(value: isize) -> &'a mut Self {
-        unsafe { transmute(value << 1) }
+        #[allow(unknown_lints, integer_to_ptr_transmutes)]
+        unsafe {
+            transmute(value << 1)
+        }
     }
 
     unsafe fn query_interface(&self, iid: *const GUID, interface: *mut *mut c_void) -> HRESULT {


### PR DESCRIPTION
See https://github.com/microsoft/windows-rs/actions/runs/17277596764/job/49038221132?pr=3730

This new warning seems a little painful. 

* I could use `with_exposed_provenance_mut` but that requires a higher MSRV.
* I could allow `integer_to_ptr_transmutes` but that is an unknown lint to the current MSRV.

So I have to allow both `unknown_lints` and `integer_to_ptr_transmutes`. 

That does not seem ideal. 🤔
