### PR TITLE
Add Windows 10 testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,10 @@ jobs:
           - version: stable
             host: x86_64-pc-windows-msvc
             target: x86_64-pc-windows-msvc
+            runner: windows-2019
+          - version: stable
+            host: x86_64-pc-windows-msvc
+            target: x86_64-pc-windows-msvc
             runner: windows-2025
           - version: nightly
             host: x86_64-pc-windows-msvc

--- a/crates/tools/yml/src/test.rs
+++ b/crates/tools/yml/src/test.rs
@@ -26,6 +26,10 @@ jobs:
           - version: stable
             host: x86_64-pc-windows-msvc
             target: x86_64-pc-windows-msvc
+            runner: windows-2019
+          - version: stable
+            host: x86_64-pc-windows-msvc
+            target: x86_64-pc-windows-msvc
             runner: windows-2025
           - version: nightly
             host: x86_64-pc-windows-msvc


### PR DESCRIPTION
The GitHub runner known as `windows-2025` are basically Windows 11 VMs but Rust still supports Windows 10 and I'm hoping that we can use the `windows-2019` runner to provide some Windows 10 coverage. Unfortunately, [the repo for the runner images](https://github.com/actions/runner-images) has `windows-2919` marked as "deprecated" so we'll see...