### PR TITLE
Add query for OS revision number to `windows-version` crate

### DIFF
--- a/crates/libs/version/src/bindings.rs
+++ b/crates/libs/version/src/bindings.rs
@@ -1,4 +1,7 @@
+windows_link::link!("advapi32.dll" "system" fn RegGetValueA(hkey : HKEY, lpsubkey : PCSTR, lpvalue : PCSTR, dwflags : REG_ROUTINE_FLAGS, pdwtype : *mut REG_VALUE_TYPE, pvdata : *mut core::ffi::c_void, pcbdata : *mut u32) -> WIN32_ERROR);
 windows_link::link!("ntdll.dll" "system" fn RtlGetVersion(lpversioninformation : *mut OSVERSIONINFOW) -> NTSTATUS);
+pub type HKEY = *mut core::ffi::c_void;
+pub const HKEY_LOCAL_MACHINE: HKEY = -2147483646i32 as _;
 pub type NTSTATUS = i32;
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -35,4 +38,9 @@ impl Default for OSVERSIONINFOW {
         unsafe { core::mem::zeroed() }
     }
 }
+pub type PCSTR = *const u8;
+pub type REG_ROUTINE_FLAGS = u32;
+pub type REG_VALUE_TYPE = u32;
+pub const RRF_RT_REG_DWORD: REG_ROUTINE_FLAGS = 16u32;
 pub const VER_NT_WORKSTATION: u32 = 1u32;
+pub type WIN32_ERROR = u32;

--- a/crates/tools/bindings/src/version.txt
+++ b/crates/tools/bindings/src/version.txt
@@ -1,7 +1,10 @@
 --out crates/libs/version/src/bindings.rs
---flat --sys --no-comment --no-allow
+--flat --sys --no-comment --no-allow --no-deps
 
 --filter
-    Windows.Wdk.System.SystemServices.RtlGetVersion
-    Windows.Win32.System.SystemInformation.OSVERSIONINFOEXW
-    Windows.Win32.System.SystemServices.VER_NT_WORKSTATION
+    RtlGetVersion
+    OSVERSIONINFOEXW
+    VER_NT_WORKSTATION
+    RegGetValueA
+    HKEY_LOCAL_MACHINE
+    RRF_RT_REG_DWORD


### PR DESCRIPTION
The [windows-version](https://crates.io/crates/windows-version) crate provides reliable operating system version information without the need for application manifest files. The `OsVersion` struct provides the traditional OS version information for major, minor, service pack, and build number. Unfortunately, recent Windows versioning conventions have largely dropped the use of minor and service pack versions while adding a new revision number as you can see when you run commands like `winver.exe` or `cmd.exe`. 

This update adds a `revision` function to the `windows-version` crate that lets you reliably get the same version information used by these OS tools. Here's a simple example that mimics what `cmd.exe` displays:

```rust
fn main() {
    let current = windows_version::OsVersion::current();

    let major = current.major;
    let minor = current.minor;
    let build = current.build;
    let revision = windows_version::revision();

    println!("Microsoft Windows [Version {major}.{minor}.{build}.{revision}]");
}
```