### PR TITLE
docs: update README to include guidance on using looser semver ranges for dependencies

### DIFF
--- a/crates/libs/sys/readme.md
+++ b/crates/libs/sys/readme.md
@@ -7,7 +7,7 @@ The `windows-sys` crate is a zero-overhead fallback for the most demanding situa
 - [Releases](https://github.com/microsoft/windows-rs/releases)
 - [Feature search](https://microsoft.github.io/windows-rs/features)
 
-Start by adding the following to your Cargo.toml file:
+Start by adding the following to your Cargo.toml file (see [Dependency Version Ranges](#dependency-version-ranges) for guidance on version specification):
 
 ```toml
 [dependencies.windows-sys]
@@ -36,3 +36,38 @@ unsafe {
     MessageBoxW(0 as _, w!("Wide"), w!("Caption"), MB_OK);
 }
 ```
+
+## Dependency Version Ranges
+
+When adding `windows-sys` as a dependency, consider using looser semver ranges to improve ecosystem compatibility and reduce duplicate dependencies in your build graph. This is especially important for `windows-sys` since it's widely used throughout the Rust ecosystem:
+
+```toml
+# Specific version - may cause duplicate dependencies
+[dependencies.windows-sys]
+version = "0.61"
+
+# Better: Use a wider range for ecosystem compatibility
+[dependencies.windows-sys]
+version = ">=0.59, <=0.61"  # Compatible with multiple versions
+```
+
+**Benefits of wider version ranges:**
+
+- Reduces likelihood of duplicate `windows-sys` versions in dependency graphs
+- Prevents `clippy::multiple-crate-versions` warnings in your consumers
+- Improves compatibility with other crates that also depend on `windows-sys`
+- Allows users more flexibility in dependency resolution
+
+**Important:** When using wider version ranges, be sure to test your code with the minimum supported version. One approach is by using `cargo-minimal-versions`:
+
+```pwsh
+# Install cargo-minimal-versions and cargo-hack
+cargo install --locked cargo-minimal-versions 
+cargo install --locked cargo-hack
+
+# Test with minimal dependency versions
+cargo minimal-versions build
+cargo minimal-versions test
+```
+
+This ensures your crate actually works with the minimum version you specify, not just the latest.

--- a/crates/libs/windows/readme.md
+++ b/crates/libs/windows/readme.md
@@ -7,7 +7,7 @@ The [windows](https://crates.io/crates/windows) and [windows-sys](https://crates
 * [Releases](https://github.com/microsoft/windows-rs/releases)
 * [Feature search](https://microsoft.github.io/windows-rs/features)
 
-Start by adding the following to your Cargo.toml file:
+Start by adding the following to your Cargo.toml file (see [Dependency Version Ranges](#dependency-version-ranges) for guidance on version specification):
 
 ```toml
 [dependencies.windows]
@@ -49,3 +49,38 @@ fn main() -> Result<()> {
     Ok(())
 }
 ```
+
+## Dependency Version Ranges
+
+When adding `windows` as a dependency, consider using looser semver ranges to improve ecosystem compatibility and reduce duplicate dependencies in your build graph. Instead of pinning to a specific version:
+
+```toml
+# Specific version - may cause duplicate dependencies
+[dependencies.windows]
+version = "0.62"
+
+# Better: Use a wider range for ecosystem compatibility
+[dependencies.windows]
+version = ">=0.59, <=0.61"  # Compatible with multiple versions
+```
+
+**Benefits of wider version ranges:**
+
+- Reduces likelihood of duplicate `windows` versions in dependency graphs
+- Prevents `clippy::multiple-crate-versions` warnings in your consumers
+- Improves compatibility with other crates that also depend on `windows`
+- Allows users more flexibility in dependency resolution
+
+**Important:** When using wider version ranges, be sure to test your code with the minimum supported version. One approach is by using `cargo-minimal-versions`:
+
+```pwsh
+# Install cargo-minimal-versions and cargo-hack
+cargo install --locked cargo-minimal-versions 
+cargo install --locked cargo-hack
+
+# Test with minimal dependency versions
+cargo minimal-versions build
+cargo minimal-versions test
+```
+
+This ensures your crate actually works with the minimum version you specify, not just the latest.


### PR DESCRIPTION
This pull request updates the documentation for both the `windows` and `windows-sys` crates to recommend using wider semver dependency ranges in your `Cargo.toml` files. The goal is to improve compatibility across the Rust ecosystem and reduce issues with duplicate crate versions. The documentation now also provides guidance on testing your code against the minimum supported version.

Dependency versioning guidance:

* Added a new "Dependency Version Ranges" section to both `crates/libs/windows/readme.md` and `crates/libs/sys/readme.md`, explaining the benefits of using wider semver ranges for the `windows` and `windows-sys` crates and providing example `Cargo.toml` entries. [[1]](diffhunk://#diff-9bb56b7df2ffea5648b586b558aefa0462b4f0f3ef5f4790b35f34e089550f1eR52-R86) [[2]](diffhunk://#diff-bee298c5e7f8027b48aa32b97c44192396b02661d4bd0668c196ce335c76a3b1R39-R73)
* Updated the initial dependency instructions in both readme files to reference the new guidance section. [[1]](diffhunk://#diff-9bb56b7df2ffea5648b586b558aefa0462b4f0f3ef5f4790b35f34e089550f1eL10-R10) [[2]](diffhunk://#diff-bee298c5e7f8027b48aa32b97c44192396b02661d4bd0668c196ce335c76a3b1L10-R10)

Testing recommendations:

* Included instructions for using `cargo-minimal-versions` and `cargo-hack` to verify your crate works with the minimum supported dependency versions, ensuring better reliability for consumers. [[1]](diffhunk://#diff-9bb56b7df2ffea5648b586b558aefa0462b4f0f3ef5f4790b35f34e089550f1eR52-R86) [[2]](diffhunk://#diff-bee298c5e7f8027b48aa32b97c44192396b02661d4bd0668c196ce335c76a3b1R39-R73)