### PR TITLE
implement: Add Identity=IUnknown and Agile=false options to #[implement] macro

### DIFF
--- a/crates/tests/libs/implement/tests/identity_opts.rs
+++ b/crates/tests/libs/implement/tests/identity_opts.rs
@@ -1,0 +1,34 @@
+use windows_core::*;
+
+#[interface("e2a0713e-6f6b-4b0c-9a2f-9a0b4a7a2b88")]
+unsafe trait ITest: IUnknown {
+    unsafe fn Ping(&self) -> HRESULT;
+}
+
+#[implement(ITest, Identity = IUnknown, Agile = false)]
+struct UnknownOnly;
+
+impl ITest_Impl for UnknownOnly_Impl {
+    unsafe fn Ping(&self) -> HRESULT {
+        HRESULT(0)
+    }
+}
+
+#[test]
+fn identity_iunknown_no_inspectable_no_agile() {
+    unsafe {
+        // Create object implementing ITest, with IUnknown identity and without IAgileObject.
+        let test: ITest = UnknownOnly.into();
+
+        // IInspectable should not be supported.
+        assert!(test.cast::<IInspectable>().is_err());
+
+        // IAgileObject should not be supported.
+        assert!(test.cast::<windows_core::imp::IAgileObject>().is_err());
+
+        // IUnknown should always work (already true by interface hierarchy).
+        let _base: IUnknown = test.clone().into();
+        let _ = _base; // silence unused warning
+    }
+}
+


### PR DESCRIPTION
Motivation:
- Addresses #3768: allow pure COM implementations that must not expose IInspectable or IAgileObject. Default #[implement] always exposes both; this adds opt-outs.

What’s new:
- Identity = IInspectable | IUnknown (default IInspectable)
  - Choose identity interface; IUnknown removes WinRT identity.
- Agile = true | false (default true)
  - Toggle IAgileObject exposure via QueryInterface.
- Defaults preserve current behavior.

Implementation:
- Identity field and VTABLE_IDENTITY types depend on Identity.
- QueryInterface branches conditional for IInspectable and IAgileObject.
- From<T> for IInspectable and ComObjectInterface<IInspectable> emitted only when Identity=IInspectable.

Tests:
- New: crates/tests/libs/implement/tests/identity_opts.rs
  - #[implement(ITest, Identity = IUnknown, Agile = false)]
  - Asserts cast::<IInspectable>() and cast::<imp::IAgileObject>() fail; IUnknown still valid.

Backwards compatibility:
- No behavior change unless options are specified.

Example:
- #[implement(IMyComInterface, Identity = IUnknown, Agile = false)]