### PR TITLE
Add option to disable default agility for COM `implement` macro

### DIFF
--- a/crates/libs/implement/src/gen.rs
+++ b/crates/libs/implement/src/gen.rs
@@ -306,19 +306,32 @@ fn gen_query_interface(inputs: &ImplementInputs) -> syn::ImplItemFn {
         quote!()
     };
 
-    let identity_query = quote! {
-        if iid == <::windows_core::IUnknown as ::windows_core::Interface>::IID
-        || iid == <::windows_core::IInspectable as ::windows_core::Interface>::IID
-        || iid == <::windows_core::imp::IAgileObject as ::windows_core::Interface>::IID {
-            break 'found &self.identity as *const _ as *const ::core::ffi::c_void;
+    let identity_query = if inputs.agile {
+        quote! {
+            if iid == <::windows_core::IUnknown as ::windows_core::Interface>::IID
+            || iid == <::windows_core::IInspectable as ::windows_core::Interface>::IID
+            || iid == <::windows_core::imp::IAgileObject as ::windows_core::Interface>::IID {
+                break 'found &self.identity as *const _ as *const ::core::ffi::c_void;
+            }
+        }
+    } else {
+        quote! {
+            if iid == <::windows_core::IUnknown as ::windows_core::Interface>::IID
+            || iid == <::windows_core::IInspectable as ::windows_core::Interface>::IID {
+                break 'found &self.identity as *const _ as *const ::core::ffi::c_void;
+            }
         }
     };
 
-    let marshal_query = quote! {
-        #[cfg(windows)]
-        if iid == <::windows_core::imp::IMarshal as ::windows_core::Interface>::IID {
-            return ::windows_core::imp::marshaler(self.to_interface(), interface);
+    let marshal_query = if inputs.agile {
+        quote! {
+            #[cfg(windows)]
+            if iid == <::windows_core::imp::IMarshal as ::windows_core::Interface>::IID {
+                return ::windows_core::imp::marshaler(self.to_interface(), interface);
+            }
         }
+    } else {
+        quote! {}
     };
 
     let tear_off_query = quote! {

--- a/crates/libs/implement/src/lib.rs
+++ b/crates/libs/implement/src/lib.rs
@@ -161,8 +161,10 @@ struct ImplementAttributes {
 
 impl syn::parse::Parse for ImplementAttributes {
     fn parse(cursor: syn::parse::ParseStream) -> syn::parse::Result<Self> {
-        let mut input = Self::default();
-        input.agile = true;
+        let mut input = Self {
+            agile: true,
+            ..Default::default()
+        };
 
         while !cursor.is_empty() {
             input.parse_implement(cursor)?;
@@ -315,10 +317,10 @@ impl syn::parse::Parse for UseTree2 {
                         )),
                     }
                 } else {
-                    return Err(syn::parse::Error::new(
+                    Err(syn::parse::Error::new(
                         ident.span(),
                         "Unrecognized key-value pair",
-                    ));
+                    ))
                 }
             } else {
                 let generics = if input.peek(syn::Token![<]) {

--- a/crates/libs/implement/src/lib.rs
+++ b/crates/libs/implement/src/lib.rs
@@ -57,6 +57,7 @@ fn implement_core(
         original_ident: original_type.ident.clone(),
         interface_chains: convert_implements_to_interface_chains(attributes.implement),
         trust_level: attributes.trust_level,
+        agile: attributes.agile,
         impl_ident: quote::format_ident!("{}_Impl", &original_type.ident),
         constraints: {
             if let Some(where_clause) = &original_type.generics.where_clause {
@@ -98,6 +99,9 @@ struct ImplementInputs {
 
     /// The "trust level", which is returned by `IInspectable::GetTrustLevel`.
     trust_level: usize,
+
+    /// Determines whether `IAgileObject` and `IMarshal` are implemented automatically.
+    agile: bool,
 
     /// The identifier of the `Foo_Impl` type.
     impl_ident: syn::Ident,
@@ -152,11 +156,13 @@ impl ImplementType {
 struct ImplementAttributes {
     pub implement: Vec<ImplementType>,
     pub trust_level: usize,
+    pub agile: bool,
 }
 
 impl syn::parse::Parse for ImplementAttributes {
     fn parse(cursor: syn::parse::ParseStream) -> syn::parse::Result<Self> {
         let mut input = Self::default();
+        input.agile = true;
 
         while !cursor.is_empty() {
             input.parse_implement(cursor)?;
@@ -201,6 +207,7 @@ impl ImplementAttributes {
                 }
             }
             UseTree2::TrustLevel(input) => self.trust_level = *input,
+            UseTree2::Agile(agile) => self.agile = *agile,
         }
 
         Ok(())
@@ -212,6 +219,7 @@ enum UseTree2 {
     Name(UseName2),
     Group(UseGroup2),
     TrustLevel(usize),
+    Agile(bool),
 }
 
 impl UseTree2 {
@@ -282,22 +290,35 @@ impl syn::parse::Parse for UseTree2 {
                     tree: Box::new(input.parse()?),
                 }))
             } else if input.peek(syn::Token![=]) {
-                if ident != "TrustLevel" {
+                if ident == "TrustLevel" {
+                    input.parse::<syn::Token![=]>()?;
+                    let span = input.span();
+                    let value = input.call(syn::Ident::parse_any)?;
+                    match value.to_string().as_str() {
+                        "Partial" => Ok(Self::TrustLevel(1)),
+                        "Full" => Ok(Self::TrustLevel(2)),
+                        _ => Err(syn::parse::Error::new(
+                            span,
+                            "`TrustLevel` must be `Partial` or `Full`",
+                        )),
+                    }
+                } else if ident == "Agile" {
+                    input.parse::<syn::Token![=]>()?;
+                    let span = input.span();
+                    let value = input.call(syn::Ident::parse_any)?;
+                    match value.to_string().as_str() {
+                        "true" => Ok(Self::Agile(true)),
+                        "false" => Ok(Self::Agile(false)),
+                        _ => Err(syn::parse::Error::new(
+                            span,
+                            "`Agile` must be `true` or `false`",
+                        )),
+                    }
+                } else {
                     return Err(syn::parse::Error::new(
                         ident.span(),
                         "Unrecognized key-value pair",
                     ));
-                }
-                input.parse::<syn::Token![=]>()?;
-                let span = input.span();
-                let value = input.call(syn::Ident::parse_any)?;
-                match value.to_string().as_str() {
-                    "Partial" => Ok(Self::TrustLevel(1)),
-                    "Full" => Ok(Self::TrustLevel(2)),
-                    _ => Err(syn::parse::Error::new(
-                        span,
-                        "`TrustLevel` must be `Partial` or `Full`",
-                    )),
                 }
             } else {
                 let generics = if input.peek(syn::Token![<]) {

--- a/crates/tests/libs/implement/tests/agile.rs
+++ b/crates/tests/libs/implement/tests/agile.rs
@@ -1,0 +1,54 @@
+use windows::core::*;
+use windows::Win32::System::Com::{Marshal::*, *};
+
+#[interface("e9f8ddc5-7006-4c7f-9c1e-5a08e240cb13")]
+unsafe trait ITest: IUnknown {}
+
+#[implement(ITest)]
+struct DefaultAgile;
+impl ITest_Impl for DefaultAgile_Impl {}
+
+#[implement(ITest, Agile = false)]
+struct AgileFalse;
+impl ITest_Impl for AgileFalse_Impl {}
+
+#[implement(ITest, Agile = true)]
+struct AgileTrue;
+impl ITest_Impl for AgileTrue_Impl {}
+
+#[implement(ITest, Agile = false, IAgileObject)]
+struct ExplicitAgile;
+impl ITest_Impl for ExplicitAgile_Impl {}
+impl IAgileObject_Impl for ExplicitAgile_Impl {}
+
+#[test]
+fn test_default() {
+    let test: ITest = DefaultAgile.into();
+    test.cast::<ITest>().unwrap();
+    test.cast::<IAgileObject>().unwrap();
+    test.cast::<IMarshal>().unwrap();
+}
+
+#[test]
+fn test_agile_false() {
+    let test: ITest = AgileFalse.into();
+    test.cast::<ITest>().unwrap();
+    test.cast::<IAgileObject>().unwrap_err();
+    test.cast::<IMarshal>().unwrap_err();
+}
+
+#[test]
+fn test_agile_true() {
+    let test: ITest = DefaultAgile.into();
+    test.cast::<ITest>().unwrap();
+    test.cast::<IAgileObject>().unwrap();
+    test.cast::<IMarshal>().unwrap();
+}
+
+#[test]
+fn test_explicit_agile() {
+    let test: ITest = ExplicitAgile.into();
+    test.cast::<ITest>().unwrap();
+    test.cast::<IAgileObject>().unwrap();
+    test.cast::<IMarshal>().unwrap_err();
+}


### PR DESCRIPTION
COM object implementations are agile and indicate this by implementing both `IAgileObject` and `IMarshal`. This is the default and suitable for the vast majority of implementations, whether or not you need support for COM apartments.

For [C++/WinRT](https://github.com/microsoft/cppwinrt) I provided a `non_agile` marker type that indicated that the object would not provide an implementation of `IAgileObject` or `IMarshal` directly. You are then free to implement them yourself or not at all. This supports the few cases where you need more control over the apartment model of the caller and callee. 

The `implement` macro now provides an equivalent option to control the agility directly. Here is an example from the accompanying test:

```rust
// IAgileObject and IMarshal are implemented
#[implement(ITest)]
struct DefaultAgile;

// IAgileObject and IMarshal are *not* implemented
#[implement(ITest, Agile = false)]
struct AgileFalse;

// IAgileObject and IMarshal are implemented
#[implement(ITest, Agile = true)]
struct AgileTrue;

// IAgileObject is implemented while IMarshal is not
#[implement(ITest, Agile = false, IAgileObject)]
struct ExplicitAgile;
```

Fixes: #3768