### PR TITLE
[DRAFT] Prototyping windows-sys fn ptr types

### DIFF
--- a/crates/libs/bindgen/src/types/cpp_fn.rs
+++ b/crates/libs/bindgen/src/types/cpp_fn.rs
@@ -27,6 +27,35 @@ impl CppFn {
         self.type_name().write(config, &[])
     }
 
+    pub fn write_fn_ptr(&self, config: &Config<'_>, underlying_types: bool) -> TokenStream {
+        let ptr_name = self.method.name().to_string() + "Fn";
+        let name = to_ident(&ptr_name);
+        let abi = self.method.calling_convention();
+        let signature = self.method.signature(self.namespace, &[]);
+
+        let params = signature.params.iter().map(|param| {
+            let name = param.write_ident();
+            let ty = if underlying_types {
+                param.underlying_type().write_abi(config)
+            } else {
+                param.write_abi(config)
+            };
+            quote! { #name: #ty }
+        });
+
+        let return_sig = config.write_return_sig(self.method, &signature, underlying_types);
+
+        let vararg = if config.sys && signature.call_flags.contains(MethodCallAttributes::VARARG) {
+            quote! { , ... }
+        } else {
+            quote! {}
+        };
+
+        link_fmt(quote! {
+            pub type #name = unsafe extern #abi fn(#(#params),* #vararg) #return_sig;
+        })
+    }
+
     pub fn write_link(&self, config: &Config<'_>, underlying_types: bool) -> TokenStream {
         let library = self.method.module_name().to_lowercase();
         let symbol = self.method.import_name();
@@ -71,6 +100,7 @@ impl CppFn {
         let name = to_ident(self.method.name());
         let signature = self.method.signature(self.namespace, &[]);
 
+        let ptr = self.write_fn_ptr(config, false);
         let link = self.write_link(config, false);
         let arches = write_arches(self.method);
         let cfg = self.write_cfg(config);
@@ -79,6 +109,9 @@ impl CppFn {
 
         if config.sys {
             return quote! {
+                #cfg
+                #ptr
+                #window_long
                 #cfg
                 #link
                 #window_long

--- a/crates/samples/services/time/src/bindings.rs
+++ b/crates/samples/services/time/src/bindings.rs
@@ -8,7 +8,11 @@
     clippy::all
 )]
 
+pub type FileTimeToLocalFileTimeFn =
+    unsafe extern "system" fn(lpfiletime: *const FILETIME, lplocalfiletime: *mut FILETIME) -> BOOL;
 windows_link::link!("kernel32.dll" "system" fn FileTimeToLocalFileTime(lpfiletime : *const FILETIME, lplocalfiletime : *mut FILETIME) -> BOOL);
+pub type FileTimeToSystemTimeFn =
+    unsafe extern "system" fn(lpfiletime: *const FILETIME, lpsystemtime: *mut SYSTEMTIME) -> BOOL;
 windows_link::link!("kernel32.dll" "system" fn FileTimeToSystemTime(lpfiletime : *const FILETIME, lpsystemtime : *mut SYSTEMTIME) -> BOOL);
 pub type BOOL = i32;
 #[repr(C)]


### PR DESCRIPTION
Prototype solution for #3781

This is not ready for review, I haven't run any tests or built anything more than a local project, I just want to have something to point to in #3781 that provides a rough idea of what I think is a direction to go in for solving that issue.

For reference, I used code built on this to generate the following bindings: https://github.com/jonesnl/pluginrust/blob/master/bindings/src/bindings.rs

```rust
        pub type EXPERIMENTAL_WebAuthNDecodeGetAssertionRequestFn = unsafe extern "system" fn(cbencoded : u32, pbencoded : *const u8, ppgetassertionrequest : *mut *mut _EXPERIMENTAL_WEBAUTHN_CTAPCBOR_GET_ASSERTION_REQUEST) -> windows_sys::core::HRESULT ;
        windows_link::link!("webauthn.dll" "system" fn EXPERIMENTAL_WebAuthNDecodeGetAssertionRequest(cbencoded : u32, pbencoded : *const u8, ppgetassertionrequest : *mut *mut _EXPERIMENTAL_WEBAUTHN_CTAPCBOR_GET_ASSERTION_REQUEST) -> windows_sys::core::HRESULT);
```