### PR TITLE
Add `readme` workaround for `Cargo.toml` files

### DIFF
--- a/crates/libs/bindgen/Cargo.toml
+++ b/crates/libs/bindgen/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT OR Apache-2.0"
 description = "Code generator for Windows metadata"
 repository = "https://github.com/microsoft/windows-rs"
 categories = ["os::windows-apis"]
+readme = "readme.md"
 
 [dependencies]
 windows-threading = { workspace = true }

--- a/crates/libs/collections/Cargo.toml
+++ b/crates/libs/collections/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT OR Apache-2.0"
 description = "Windows collection types"
 repository = "https://github.com/microsoft/windows-rs"
 categories = ["os::windows-apis"]
+readme = "readme.md"
 
 [dependencies]
 windows-core = { workspace = true }

--- a/crates/libs/core/Cargo.toml
+++ b/crates/libs/core/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT OR Apache-2.0"
 description = "Core type support for COM and Windows"
 repository = "https://github.com/microsoft/windows-rs"
 categories = ["os::windows-apis"]
+readme = "readme.md"
 
 [dependencies]
 windows-implement = { workspace = true }

--- a/crates/libs/cppwinrt/Cargo.toml
+++ b/crates/libs/cppwinrt/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT OR Apache-2.0"
 description = "C++/WinRT"
 repository = "https://github.com/microsoft/windows-rs"
 categories = ["os::windows-apis"]
+readme = "readme.md"
 
 [dependencies]
 windows-link = { workspace = true }

--- a/crates/libs/future/Cargo.toml
+++ b/crates/libs/future/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT OR Apache-2.0"
 description = "Windows async types"
 repository = "https://github.com/microsoft/windows-rs"
 categories = ["os::windows-apis"]
+readme = "readme.md"
 
 [dependencies]
 windows-core = { workspace = true }

--- a/crates/libs/implement/Cargo.toml
+++ b/crates/libs/implement/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT OR Apache-2.0"
 description = "The implement macro for the windows crate"
 repository = "https://github.com/microsoft/windows-rs"
 categories = ["os::windows-apis"]
+readme = "readme.md"
 
 [dependencies]
 proc-macro2 = { workspace = true }

--- a/crates/libs/interface/Cargo.toml
+++ b/crates/libs/interface/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT OR Apache-2.0"
 description = "The interface macro for the windows crate"
 repository = "https://github.com/microsoft/windows-rs"
 categories = ["os::windows-apis"]
+readme = "readme.md"
 
 [dependencies]
 proc-macro2 = { workspace = true }

--- a/crates/libs/link/Cargo.toml
+++ b/crates/libs/link/Cargo.toml
@@ -8,6 +8,7 @@ license = "MIT OR Apache-2.0"
 description = "Linking for Windows"
 repository = "https://github.com/microsoft/windows-rs"
 categories = ["os::windows-apis"]
+readme = "readme.md"
 
 [lints]
 workspace = true

--- a/crates/libs/metadata/Cargo.toml
+++ b/crates/libs/metadata/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT OR Apache-2.0"
 description = "Low-level metadata library for ECMA-335"
 repository = "https://github.com/microsoft/windows-rs"
 categories = ["os::windows-apis"]
+readme = "readme.md"
 
 [lints]
 workspace = true

--- a/crates/libs/numerics/Cargo.toml
+++ b/crates/libs/numerics/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT OR Apache-2.0"
 description = "Windows numeric types"
 repository = "https://github.com/microsoft/windows-rs"
 categories = ["os::windows-apis"]
+readme = "readme.md"
 
 [dependencies]
 windows-core = { workspace = true }

--- a/crates/libs/registry/Cargo.toml
+++ b/crates/libs/registry/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT OR Apache-2.0"
 description = "Windows registry"
 repository = "https://github.com/microsoft/windows-rs"
 categories = ["os::windows-apis"]
+readme = "readme.md"
 
 [dependencies]
 windows-link = { workspace = true }

--- a/crates/libs/result/Cargo.toml
+++ b/crates/libs/result/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT OR Apache-2.0"
 description = "Windows error handling"
 repository = "https://github.com/microsoft/windows-rs"
 categories = ["os::windows-apis"]
+readme = "readme.md"
 
 [dependencies]
 windows-link = { workspace = true }

--- a/crates/libs/services/Cargo.toml
+++ b/crates/libs/services/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT OR Apache-2.0"
 description = "Windows services"
 repository = "https://github.com/microsoft/windows-rs"
 categories = ["os::windows-apis"]
+readme = "readme.md"
 
 [dependencies]
 windows-link = { workspace = true }

--- a/crates/libs/strings/Cargo.toml
+++ b/crates/libs/strings/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT OR Apache-2.0"
 description = "Windows string types"
 repository = "https://github.com/microsoft/windows-rs"
 categories = ["os::windows-apis"]
+readme = "readme.md"
 
 [dependencies]
 windows-link = { workspace = true }

--- a/crates/libs/sys/Cargo.toml
+++ b/crates/libs/sys/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT OR Apache-2.0"
 description = "Rust for Windows"
 repository = "https://github.com/microsoft/windows-rs"
 categories = ["os::windows-apis"]
+readme = "readme.md"
 
 [dependencies]
 windows-link = { workspace = true }

--- a/crates/libs/targets/Cargo.toml
+++ b/crates/libs/targets/Cargo.toml
@@ -8,6 +8,7 @@ license = "MIT OR Apache-2.0"
 description = "Import libs for Windows"
 repository = "https://github.com/microsoft/windows-rs"
 categories = ["os::windows-apis"]
+readme = "readme.md"
 
 [lints]
 workspace = true

--- a/crates/libs/threading/Cargo.toml
+++ b/crates/libs/threading/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT OR Apache-2.0"
 description = "Windows threading"
 repository = "https://github.com/microsoft/windows-rs"
 categories = ["os::windows-apis"]
+readme = "readme.md"
 
 [dependencies]
 windows-link = { workspace = true }

--- a/crates/libs/version/Cargo.toml
+++ b/crates/libs/version/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT OR Apache-2.0"
 description = "Windows version information"
 repository = "https://github.com/microsoft/windows-rs"
 categories = ["os::windows-apis"]
+readme = "readme.md"
 
 [dependencies]
 windows-link = { workspace = true }

--- a/crates/libs/windows/Cargo.toml
+++ b/crates/libs/windows/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/microsoft/windows-rs"
 documentation = "https://microsoft.github.io/windows-docs-rs/"
 categories = ["os::windows-apis"]
 exclude = ["features.json"]
+readme = "readme.md"
 
 [hints]
 mostly-unused = true

--- a/crates/targets/aarch64_gnullvm/Cargo.toml
+++ b/crates/targets/aarch64_gnullvm/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT OR Apache-2.0"
 description = "Import lib for Windows"
 repository = "https://github.com/microsoft/windows-rs"
 categories = ["os::windows-apis"]
+readme = "readme.md"
 
 [package.metadata.docs.rs]
 default-target = "x86_64-pc-windows-msvc"

--- a/crates/targets/aarch64_msvc/Cargo.toml
+++ b/crates/targets/aarch64_msvc/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT OR Apache-2.0"
 description = "Import lib for Windows"
 repository = "https://github.com/microsoft/windows-rs"
 categories = ["os::windows-apis"]
+readme = "readme.md"
 
 [package.metadata.docs.rs]
 default-target = "x86_64-pc-windows-msvc"

--- a/crates/targets/i686_gnu/Cargo.toml
+++ b/crates/targets/i686_gnu/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT OR Apache-2.0"
 description = "Import lib for Windows"
 repository = "https://github.com/microsoft/windows-rs"
 categories = ["os::windows-apis"]
+readme = "readme.md"
 
 [package.metadata.docs.rs]
 default-target = "x86_64-pc-windows-msvc"

--- a/crates/targets/i686_gnullvm/Cargo.toml
+++ b/crates/targets/i686_gnullvm/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT OR Apache-2.0"
 description = "Import lib for Windows"
 repository = "https://github.com/microsoft/windows-rs"
 categories = ["os::windows-apis"]
+readme = "readme.md"
 
 [package.metadata.docs.rs]
 default-target = "x86_64-pc-windows-msvc"

--- a/crates/targets/i686_msvc/Cargo.toml
+++ b/crates/targets/i686_msvc/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT OR Apache-2.0"
 description = "Import lib for Windows"
 repository = "https://github.com/microsoft/windows-rs"
 categories = ["os::windows-apis"]
+readme = "readme.md"
 
 [package.metadata.docs.rs]
 default-target = "x86_64-pc-windows-msvc"

--- a/crates/targets/x86_64_gnu/Cargo.toml
+++ b/crates/targets/x86_64_gnu/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT OR Apache-2.0"
 description = "Import lib for Windows"
 repository = "https://github.com/microsoft/windows-rs"
 categories = ["os::windows-apis"]
+readme = "readme.md"
 
 [package.metadata.docs.rs]
 default-target = "x86_64-pc-windows-msvc"

--- a/crates/targets/x86_64_gnullvm/Cargo.toml
+++ b/crates/targets/x86_64_gnullvm/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT OR Apache-2.0"
 description = "Import lib for Windows"
 repository = "https://github.com/microsoft/windows-rs"
 categories = ["os::windows-apis"]
+readme = "readme.md"
 
 [package.metadata.docs.rs]
 default-target = "x86_64-pc-windows-msvc"

--- a/crates/targets/x86_64_msvc/Cargo.toml
+++ b/crates/targets/x86_64_msvc/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT OR Apache-2.0"
 description = "Import lib for Windows"
 repository = "https://github.com/microsoft/windows-rs"
 categories = ["os::windows-apis"]
+readme = "readme.md"
 
 [package.metadata.docs.rs]
 default-target = "x86_64-pc-windows-msvc"

--- a/crates/tests/misc/package/tests/test.rs
+++ b/crates/tests/misc/package/tests/test.rs
@@ -12,7 +12,6 @@ fn test() {
 
         assert_eq!(package.edition, "2021");
         assert_eq!(package.authors, None);
-        assert_eq!(package.readme, None);
 
         if package.publish == Some(false) {
             // The `version` field is no longer required - remove once MSRV can support it.
@@ -21,6 +20,7 @@ fn test() {
             assert_eq!(package.repository, None);
             assert_eq!(package.categories, None);
             assert_eq!(package.description, None);
+            assert_eq!(package.readme, None);
         } else {
             assert_eq!(package.license, Some("MIT OR Apache-2.0".to_string()));
             assert_eq!(
@@ -33,6 +33,7 @@ fn test() {
             );
             assert!(package.description.is_some());
             assert!(!package.description.as_ref().unwrap().is_empty());
+            assert_eq!(package.readme, Some("readme.md".to_string()));
         }
     }
 }


### PR DESCRIPTION
This logically reverts #3721. Note that the `test_package` test crate validates that this is done uniformly. 

Fixes: #3774