### PR TITLE
Fix for new warnings 

### DIFF
--- a/crates/tests/libs/sys/tests/simple.rs
+++ b/crates/tests/libs/sys/tests/simple.rs
@@ -43,8 +43,8 @@ fn callback() {
             0
         }
 
-        let mut wc: WNDCLASSA = std::mem::zeroed();
-        wc.lpfnWndProc = None;
-        wc.lpfnWndProc = Some(wndproc);
+        let mut _wc: WNDCLASSA = std::mem::zeroed();
+        _wc.lpfnWndProc = None;
+        _wc.lpfnWndProc = Some(wndproc);
     }
 }

--- a/crates/tests/misc/const_fields/tests/sys.rs
+++ b/crates/tests/misc/const_fields/tests/sys.rs
@@ -4,9 +4,9 @@ use windows_sys::{Win32::Storage::CloudFilters::*, Win32::System::CorrelationVec
 fn can_assign_const() {
     unsafe {
         let v: CORRELATION_VECTOR = std::mem::zeroed();
-        let mut i: CF_OPERATION_INFO = std::mem::zeroed();
+        let mut _i: CF_OPERATION_INFO = std::mem::zeroed();
 
         // Note that the rhs expression does not need to be mutable.
-        i.CorrelationVector = &v;
+        _i.CorrelationVector = &v;
     }
 }

--- a/crates/tests/misc/const_fields/tests/win.rs
+++ b/crates/tests/misc/const_fields/tests/win.rs
@@ -4,8 +4,8 @@ use windows::{Win32::Storage::CloudFilters::*, Win32::System::CorrelationVector:
 #[expect(clippy::field_reassign_with_default)] // testing unusual field assignment
 fn can_assign_const() {
     let v: CORRELATION_VECTOR = Default::default();
-    let mut i: CF_OPERATION_INFO = Default::default();
+    let mut _i: CF_OPERATION_INFO = Default::default();
 
     // Note that the rhs expression does not need to be mutable.
-    i.CorrelationVector = &v;
+    _i.CorrelationVector = &v;
 }


### PR DESCRIPTION
Rust nightly warnings are now issued for variable that are assigned to but never used.