### PR TITLE
Don't link combase.dll on win7 target

### DIFF
--- a/crates/libs/bindgen/src/tables/method_def.rs
+++ b/crates/libs/bindgen/src/tables/method_def.rs
@@ -41,6 +41,12 @@ impl MethodDef {
     }
 
     pub fn module_name(&self) -> String {
+        self.impl_map()
+            .map_or("", |map| map.scope().name())
+            .to_lowercase()
+    }
+
+    pub fn combase_hack(&self) -> bool {
         const combase_functions: [&str; 5] = [
             "CoCreateFreeThreadedMarshaler",
             "CoIncrementMTAUsage",
@@ -49,13 +55,7 @@ impl MethodDef {
             "RoGetAgileReference",
         ];
 
-        if combase_functions.contains(&self.name()) {
-            "combase.dll".to_string()
-        } else {
-            self.impl_map()
-                .map_or("", |map| map.scope().name())
-                .to_lowercase()
-        }
+        combase_functions.contains(&self.name())
     }
 
     pub fn calling_convention(&self) -> &'static str {

--- a/crates/libs/core/src/imp/bindings.rs
+++ b/crates/libs/core/src/imp/bindings.rs
@@ -1,6 +1,15 @@
-windows_link::link!("combase.dll" "system" fn CoIncrementMTAUsage(pcookie : *mut CO_MTA_USAGE_COOKIE) -> HRESULT);
-windows_link::link!("combase.dll" "system" fn CoTaskMemAlloc(cb : usize) -> *mut core::ffi::c_void);
-windows_link::link!("combase.dll" "system" fn CoTaskMemFree(pv : *const core::ffi::c_void));
+#[cfg(target_vendor = "win7")]
+windows_link::link!("ole32.dll" "system" fn CoIncrementMTAUsage ( pcookie : *mut CO_MTA_USAGE_COOKIE) -> HRESULT);
+#[cfg(not(target_vendor = "win7"))]
+windows_link::link ! ( "combase.dll" "system" fn CoIncrementMTAUsage ( pcookie : *mut CO_MTA_USAGE_COOKIE) -> HRESULT);
+#[cfg(target_vendor = "win7")]
+windows_link::link!("ole32.dll" "system" fn CoTaskMemAlloc ( cb : usize) -> *mut core::ffi::c_void);
+#[cfg(not(target_vendor = "win7"))]
+windows_link::link ! ( "combase.dll" "system" fn CoTaskMemAlloc ( cb : usize) -> *mut core::ffi::c_void);
+#[cfg(target_vendor = "win7")]
+windows_link::link!("ole32.dll" "system" fn CoTaskMemFree ( pv : *const core::ffi::c_void));
+#[cfg(not(target_vendor = "win7"))]
+windows_link::link ! ( "combase.dll" "system" fn CoTaskMemFree ( pv : *const core::ffi::c_void));
 windows_link::link!("kernel32.dll" "system" fn EncodePointer(ptr : *const core::ffi::c_void) -> *mut core::ffi::c_void);
 windows_link::link!("kernel32.dll" "system" fn FreeLibrary(hlibmodule : HMODULE) -> BOOL);
 windows_link::link!("kernel32.dll" "system" fn GetProcAddress(hmodule : HMODULE, lpprocname : PCSTR) -> FARPROC);

--- a/crates/libs/core/src/imp/com_bindings.rs
+++ b/crates/libs/core/src/imp/com_bindings.rs
@@ -7,7 +7,10 @@ pub unsafe fn RoGetAgileReference<P2>(
 where
     P2: windows_core::Param<windows_core::IUnknown>,
 {
-    windows_core::link!("combase.dll" "system" fn RoGetAgileReference(options : AgileReferenceOptions, riid : *const windows_core::GUID, punk : * mut core::ffi::c_void, ppagilereference : *mut * mut core::ffi::c_void) -> windows_core::HRESULT);
+    #[cfg(target_vendor = "win7")]
+    windows_core::link!("ole32.dll" "system" fn RoGetAgileReference ( options : AgileReferenceOptions, riid : *const windows_core::GUID, punk : * mut core::ffi::c_void, ppagilereference : *mut * mut core::ffi::c_void) -> windows_core::HRESULT);
+    #[cfg(not(target_vendor = "win7"))]
+    windows_core::link ! ( "combase.dll" "system" fn RoGetAgileReference ( options : AgileReferenceOptions, riid : *const windows_core::GUID, punk : * mut core::ffi::c_void, ppagilereference : *mut * mut core::ffi::c_void) -> windows_core::HRESULT);
     unsafe {
         let mut result__ = core::mem::zeroed();
         RoGetAgileReference(options, riid, punk.param().abi(), &mut result__)

--- a/crates/libs/core/src/imp/marshaler.rs
+++ b/crates/libs/core/src/imp/marshaler.rs
@@ -4,6 +4,9 @@ use core::ffi::c_void;
 use core::mem::{transmute, transmute_copy};
 use core::ptr::null_mut;
 
+#[cfg(target_vendor = "win7")]
+windows_link::link!("ole32.dll" "system" fn CoCreateFreeThreadedMarshaler(punkouter: *mut c_void, ppunkmarshal: *mut *mut c_void) -> HRESULT);
+#[cfg(not(target_vendor = "win7"))]
 windows_link::link!("combase.dll" "system" fn CoCreateFreeThreadedMarshaler(punkouter: *mut c_void, ppunkmarshal: *mut *mut c_void) -> HRESULT);
 
 pub unsafe fn marshaler(outer: IUnknown, result: *mut *mut c_void) -> HRESULT {

--- a/crates/libs/sys/src/Windows/Win32/System/Com/mod.rs
+++ b/crates/libs/sys/src/Windows/Win32/System/Com/mod.rs
@@ -14,7 +14,10 @@ windows_link::link!("ole32.dll" "system" fn CoAllowUnmarshalerCLSID(clsid : *con
 windows_link::link!("ole32.dll" "system" fn CoBuildVersion() -> u32);
 windows_link::link!("ole32.dll" "system" fn CoCancelCall(dwthreadid : u32, ultimeout : u32) -> windows_sys::core::HRESULT);
 windows_link::link!("ole32.dll" "system" fn CoCopyProxy(pproxy : * mut core::ffi::c_void, ppcopy : *mut * mut core::ffi::c_void) -> windows_sys::core::HRESULT);
-windows_link::link!("combase.dll" "system" fn CoCreateFreeThreadedMarshaler(punkouter : * mut core::ffi::c_void, ppunkmarshal : *mut * mut core::ffi::c_void) -> windows_sys::core::HRESULT);
+#[cfg(target_vendor = "win7")]
+windows_link::link!("ole32.dll" "system" fn CoCreateFreeThreadedMarshaler ( punkouter : * mut core::ffi::c_void, ppunkmarshal : *mut * mut core::ffi::c_void) -> windows_sys::core::HRESULT);
+#[cfg(not(target_vendor = "win7"))]
+windows_link::link ! ( "combase.dll" "system" fn CoCreateFreeThreadedMarshaler ( punkouter : * mut core::ffi::c_void, ppunkmarshal : *mut * mut core::ffi::c_void) -> windows_sys::core::HRESULT);
 windows_link::link!("ole32.dll" "system" fn CoCreateGuid(pguid : *mut windows_sys::core::GUID) -> windows_sys::core::HRESULT);
 windows_link::link!("ole32.dll" "system" fn CoCreateInstance(rclsid : *const windows_sys::core::GUID, punkouter : * mut core::ffi::c_void, dwclscontext : CLSCTX, riid : *const windows_sys::core::GUID, ppv : *mut *mut core::ffi::c_void) -> windows_sys::core::HRESULT);
 windows_link::link!("ole32.dll" "system" fn CoCreateInstanceEx(clsid : *const windows_sys::core::GUID, punkouter : * mut core::ffi::c_void, dwclsctx : CLSCTX, pserverinfo : *const COSERVERINFO, dwcount : u32, presults : *mut MULTI_QI) -> windows_sys::core::HRESULT);
@@ -47,7 +50,10 @@ windows_link::link!("ole32.dll" "system" fn CoGetPSClsid(riid : *const windows_s
 windows_link::link!("ole32.dll" "system" fn CoGetSystemSecurityPermissions(comsdtype : COMSD, ppsd : *mut super::super::Security:: PSECURITY_DESCRIPTOR) -> windows_sys::core::HRESULT);
 windows_link::link!("ole32.dll" "system" fn CoGetTreatAsClass(clsidold : *const windows_sys::core::GUID, pclsidnew : *mut windows_sys::core::GUID) -> windows_sys::core::HRESULT);
 windows_link::link!("ole32.dll" "system" fn CoImpersonateClient() -> windows_sys::core::HRESULT);
-windows_link::link!("combase.dll" "system" fn CoIncrementMTAUsage(pcookie : *mut CO_MTA_USAGE_COOKIE) -> windows_sys::core::HRESULT);
+#[cfg(target_vendor = "win7")]
+windows_link::link!("ole32.dll" "system" fn CoIncrementMTAUsage ( pcookie : *mut CO_MTA_USAGE_COOKIE) -> windows_sys::core::HRESULT);
+#[cfg(not(target_vendor = "win7"))]
+windows_link::link ! ( "combase.dll" "system" fn CoIncrementMTAUsage ( pcookie : *mut CO_MTA_USAGE_COOKIE) -> windows_sys::core::HRESULT);
 windows_link::link!("ole32.dll" "system" fn CoInitialize(pvreserved : *const core::ffi::c_void) -> windows_sys::core::HRESULT);
 windows_link::link!("ole32.dll" "system" fn CoInitializeEx(pvreserved : *const core::ffi::c_void, dwcoinit : u32) -> windows_sys::core::HRESULT);
 #[cfg(feature = "Win32_Security")]
@@ -80,8 +86,14 @@ windows_link::link!("ole32.dll" "system" fn CoSetCancelObject(punk : * mut core:
 windows_link::link!("ole32.dll" "system" fn CoSetProxyBlanket(pproxy : * mut core::ffi::c_void, dwauthnsvc : u32, dwauthzsvc : u32, pserverprincname : windows_sys::core::PCWSTR, dwauthnlevel : RPC_C_AUTHN_LEVEL, dwimplevel : RPC_C_IMP_LEVEL, pauthinfo : *const core::ffi::c_void, dwcapabilities : u32) -> windows_sys::core::HRESULT);
 windows_link::link!("ole32.dll" "system" fn CoSuspendClassObjects() -> windows_sys::core::HRESULT);
 windows_link::link!("ole32.dll" "system" fn CoSwitchCallContext(pnewobject : * mut core::ffi::c_void, ppoldobject : *mut * mut core::ffi::c_void) -> windows_sys::core::HRESULT);
-windows_link::link!("combase.dll" "system" fn CoTaskMemAlloc(cb : usize) -> *mut core::ffi::c_void);
-windows_link::link!("combase.dll" "system" fn CoTaskMemFree(pv : *const core::ffi::c_void));
+#[cfg(target_vendor = "win7")]
+windows_link::link!("ole32.dll" "system" fn CoTaskMemAlloc ( cb : usize) -> *mut core::ffi::c_void);
+#[cfg(not(target_vendor = "win7"))]
+windows_link::link ! ( "combase.dll" "system" fn CoTaskMemAlloc ( cb : usize) -> *mut core::ffi::c_void);
+#[cfg(target_vendor = "win7")]
+windows_link::link!("ole32.dll" "system" fn CoTaskMemFree ( pv : *const core::ffi::c_void));
+#[cfg(not(target_vendor = "win7"))]
+windows_link::link ! ( "combase.dll" "system" fn CoTaskMemFree ( pv : *const core::ffi::c_void));
 windows_link::link!("ole32.dll" "system" fn CoTaskMemRealloc(pv : *const core::ffi::c_void, cb : usize) -> *mut core::ffi::c_void);
 windows_link::link!("ole32.dll" "system" fn CoTestCancel() -> windows_sys::core::HRESULT);
 windows_link::link!("ole32.dll" "system" fn CoTreatAsClass(clsidold : *const windows_sys::core::GUID, clsidnew : *const windows_sys::core::GUID) -> windows_sys::core::HRESULT);

--- a/crates/libs/windows/src/Windows/Win32/System/Com/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Com/mod.rs
@@ -99,7 +99,10 @@ pub unsafe fn CoCreateFreeThreadedMarshaler<P0>(punkouter: P0) -> windows_core::
 where
     P0: windows_core::Param<windows_core::IUnknown>,
 {
-    windows_core::link!("combase.dll" "system" fn CoCreateFreeThreadedMarshaler(punkouter : * mut core::ffi::c_void, ppunkmarshal : *mut * mut core::ffi::c_void) -> windows_core::HRESULT);
+    #[cfg(target_vendor = "win7")]
+    windows_core::link!("ole32.dll" "system" fn CoCreateFreeThreadedMarshaler ( punkouter : * mut core::ffi::c_void, ppunkmarshal : *mut * mut core::ffi::c_void) -> windows_core::HRESULT);
+    #[cfg(not(target_vendor = "win7"))]
+    windows_core::link ! ( "combase.dll" "system" fn CoCreateFreeThreadedMarshaler ( punkouter : * mut core::ffi::c_void, ppunkmarshal : *mut * mut core::ffi::c_void) -> windows_core::HRESULT);
     unsafe {
         let mut result__ = core::mem::zeroed();
         CoCreateFreeThreadedMarshaler(punkouter.param().abi(), &mut result__).and_then(|| windows_core::Type::from_abi(result__))
@@ -319,7 +322,10 @@ pub unsafe fn CoImpersonateClient() -> windows_core::Result<()> {
 }
 #[inline]
 pub unsafe fn CoIncrementMTAUsage() -> windows_core::Result<CO_MTA_USAGE_COOKIE> {
-    windows_core::link!("combase.dll" "system" fn CoIncrementMTAUsage(pcookie : *mut CO_MTA_USAGE_COOKIE) -> windows_core::HRESULT);
+    #[cfg(target_vendor = "win7")]
+    windows_core::link!("ole32.dll" "system" fn CoIncrementMTAUsage ( pcookie : *mut CO_MTA_USAGE_COOKIE) -> windows_core::HRESULT);
+    #[cfg(not(target_vendor = "win7"))]
+    windows_core::link ! ( "combase.dll" "system" fn CoIncrementMTAUsage ( pcookie : *mut CO_MTA_USAGE_COOKIE) -> windows_core::HRESULT);
     unsafe {
         let mut result__ = core::mem::zeroed();
         CoIncrementMTAUsage(&mut result__).map(|| result__)
@@ -545,12 +551,18 @@ where
 }
 #[inline]
 pub unsafe fn CoTaskMemAlloc(cb: usize) -> *mut core::ffi::c_void {
-    windows_core::link!("combase.dll" "system" fn CoTaskMemAlloc(cb : usize) -> *mut core::ffi::c_void);
+    #[cfg(target_vendor = "win7")]
+    windows_core::link!("ole32.dll" "system" fn CoTaskMemAlloc ( cb : usize) -> *mut core::ffi::c_void);
+    #[cfg(not(target_vendor = "win7"))]
+    windows_core::link ! ( "combase.dll" "system" fn CoTaskMemAlloc ( cb : usize) -> *mut core::ffi::c_void);
     unsafe { CoTaskMemAlloc(cb) }
 }
 #[inline]
 pub unsafe fn CoTaskMemFree(pv: Option<*const core::ffi::c_void>) {
-    windows_core::link!("combase.dll" "system" fn CoTaskMemFree(pv : *const core::ffi::c_void));
+    #[cfg(target_vendor = "win7")]
+    windows_core::link!("ole32.dll" "system" fn CoTaskMemFree ( pv : *const core::ffi::c_void));
+    #[cfg(not(target_vendor = "win7"))]
+    windows_core::link ! ( "combase.dll" "system" fn CoTaskMemFree ( pv : *const core::ffi::c_void));
     unsafe { CoTaskMemFree(pv.unwrap_or(core::mem::zeroed()) as _) }
 }
 #[inline]

--- a/crates/libs/windows/src/Windows/Win32/System/WinRT/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WinRT/mod.rs
@@ -185,7 +185,10 @@ pub unsafe fn RoGetAgileReference<P2>(options: AgileReferenceOptions, riid: *con
 where
     P2: windows_core::Param<windows_core::IUnknown>,
 {
-    windows_core::link!("combase.dll" "system" fn RoGetAgileReference(options : AgileReferenceOptions, riid : *const windows_core::GUID, punk : * mut core::ffi::c_void, ppagilereference : *mut * mut core::ffi::c_void) -> windows_core::HRESULT);
+    #[cfg(target_vendor = "win7")]
+    windows_core::link!("ole32.dll" "system" fn RoGetAgileReference ( options : AgileReferenceOptions, riid : *const windows_core::GUID, punk : * mut core::ffi::c_void, ppagilereference : *mut * mut core::ffi::c_void) -> windows_core::HRESULT);
+    #[cfg(not(target_vendor = "win7"))]
+    windows_core::link ! ( "combase.dll" "system" fn RoGetAgileReference ( options : AgileReferenceOptions, riid : *const windows_core::GUID, punk : * mut core::ffi::c_void, ppagilereference : *mut * mut core::ffi::c_void) -> windows_core::HRESULT);
     unsafe {
         let mut result__ = core::mem::zeroed();
         RoGetAgileReference(options, riid, punk.param().abi(), &mut result__).and_then(|| windows_core::Type::from_abi(result__))


### PR DESCRIPTION
Since #3743 was merged, win7 builds have been broken due to linking functions from the combase.dll which doesn't exist on win7 (the functions are instead in ole32.dll).

This PR fixes the issue by checking for target_vendor to chose whether to link against ole32 or combase.