### PR TITLE
bindgen: add --overrides

### DIFF
--- a/crates/libs/bindgen/src/config/mod.rs
+++ b/crates/libs/bindgen/src/config/mod.rs
@@ -22,6 +22,7 @@ pub struct Config<'a> {
     pub sys: bool,
     pub sys_fn_ptrs: bool,
     pub implement: bool,
+    pub overrides: bool,
     pub specific_deps: bool,
     pub derive: &'a Derive,
     pub link: &'a str,

--- a/crates/libs/bindgen/src/lib.rs
+++ b/crates/libs/bindgen/src/lib.rs
@@ -275,6 +275,7 @@ where
     let mut no_toml = false;
     let mut package = false;
     let mut implement = false;
+    let mut overrides = false;
     let mut specific_deps = false;
     let mut rustfmt = String::new();
     let mut output = String::new();
@@ -305,6 +306,7 @@ where
                 "--sys" => sys = true,
                 "--sys-fn-ptrs" => sys_fn_ptrs = true,
                 "--implement" => implement = true,
+                "--overrides" => overrides = true,
                 "--specific-deps" => specific_deps = true,
                 "--link" => kind = ArgKind::Link,
                 "--index" => index = true,
@@ -440,6 +442,7 @@ where
         sys,
         sys_fn_ptrs,
         implement,
+        overrides,
         specific_deps,
         link: &link,
         warnings: &warnings,

--- a/crates/libs/bindgen/src/types/interface.rs
+++ b/crates/libs/bindgen/src/types/interface.rs
@@ -229,7 +229,7 @@ impl Interface {
                 }
             }
 
-            if !is_exclusive {
+            if !is_exclusive || (config.overrides && type_name.1.contains("Overrides")) {
                 let method_names = &mut MethodNames::new();
                 let virtual_names = &mut MethodNames::new();
                 let mut method_tokens = TokenStream::new();


### PR DESCRIPTION
Fixes: #3801 

...although the issue has been closed.

Related: #3767

Not sure whether you'll like it, but at least it's better than nothing.

This PR adds `--overrides` flag for bindgen to generate method wrappers for `*Overrides` interfaces. It uses `contains` instead of `ends_with` because WinRT adds new interfaces when extending, e.g., `IVirtualizingLayoutContextOverrides2`.

This small change helps me a lot. I have generated new bindings with it for [`winio-winui3`](https://crates.io/crates/winio-winui3), and an example of using it in production (and with composable classes) is here: [backdrop.rs](https://github.com/compio-rs/winio/blob/e857a9a3d42b8b5a2ac5093ca1cb9403bdbad741/winio-ui-winui/src/ui/backdrop.rs#L100-L102).