### PR TITLE
Simplify yml generation

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -32,6 +32,7 @@ jobs:
         uses: ./.github/actions/fix-environment
         with:
           target: x86_64-pc-windows-msvc
+# generated - run `cargo run -p tool_yml` to update
       - name: Check cppwinrt
         run:  cargo clippy -p cppwinrt --tests
       - name: Check csharp_client

--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -20,6 +20,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+# generated - run `cargo run -p tool_yml` to update
       - name: Rust version
         run: rustup update --no-self-update 1.74 && rustup default 1.74
       - name: Check cppwinrt

--- a/.github/workflows/no-default-features.yml
+++ b/.github/workflows/no-default-features.yml
@@ -28,6 +28,7 @@ jobs:
         uses: ./.github/actions/fix-environment
         with:
           target: x86_64-pc-windows-msvc
+# generated - run `cargo run -p tool_yml` to update
       - name: Check cppwinrt
         run:  cargo check -p cppwinrt --no-default-features
       - name: Check windows

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,6 +55,7 @@ jobs:
         uses: ./.github/actions/fix-environment
         with:
           target: ${{ matrix.target }}
+# generated - run `cargo run -p tool_yml` to update
       - name: Clean
         run:  cargo clean
       - name: Test cppwinrt
@@ -434,3 +435,4 @@ jobs:
         run: |
           git add -N .
           git diff --exit-code || (echo 'Tests changed code in the repo.'; exit 1)
+

--- a/crates/tools/yml/src/clippy.rs
+++ b/crates/tools/yml/src/clippy.rs
@@ -1,55 +1,17 @@
 use super::*;
 
 pub fn yml() {
-    let mut yml = r"name: clippy
+    write_yml(".github/workflows/clippy.yml", |yml| {
+        // This unrolling is required since "cargo clippy --all" consumes too much memory for the GitHub hosted runners.
+        for manifest in helpers::crates("crates") {
+            let name = manifest.package.name;
 
-on:
-  pull_request:
-    paths-ignore:
-      - '.github/ISSUE_TEMPLATE/**'
-      - '.github/workflows/web.yml'
-      - 'web/**'
-  push:
-    paths-ignore:
-      - '.github/ISSUE_TEMPLATE/**'
-      - '.github/workflows/web.yml'
-      - 'web/**'
-    branches:
-      - master
-
-jobs:
-  clippy:
-    runs-on: windows-2025
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v5
-      - name: Update toolchain
-        run: rustup update --no-self-update nightly && rustup default nightly-x86_64-pc-windows-msvc
-      - name: Add toolchain target
-        run: rustup target add x86_64-pc-windows-msvc
-      - name: Install clippy
-        run: rustup component add clippy
-      - name: Install rustfmt
-        run: rustup component add rustfmt
-      - name: Fix environment
-        uses: ./.github/actions/fix-environment
-        with:
-          target: x86_64-pc-windows-msvc"
-        .to_string();
-
-    // This unrolling is required since "cargo clippy --all" consumes too much memory for the GitHub hosted runners.
-
-    for manifest in helpers::crates("crates") {
-        let name = manifest.package.name;
-
-        write!(
-            &mut yml,
-            r"
-      - name: Check {name}
+            writeln!(
+                yml,
+                r"      - name: Check {name}
         run:  cargo clippy -p {name} --tests"
-        )
-        .unwrap();
-    }
-
-    std::fs::write(".github/workflows/clippy.yml", yml.as_bytes()).unwrap();
+            )
+            .unwrap();
+        }
+    });
 }

--- a/crates/tools/yml/src/main.rs
+++ b/crates/tools/yml/src/main.rs
@@ -4,10 +4,34 @@ mod no_default_features;
 mod test;
 
 use std::fmt::Write;
+use std::io::BufRead;
 
 fn main() {
     test::yml();
     clippy::yml();
     no_default_features::yml();
     msrv::yml();
+}
+
+#[track_caller]
+fn write_yml<F>(path: &str, f: F)
+where
+    F: FnOnce(&mut String),
+{
+    let mut yml = String::new();
+    let file = std::fs::File::open(path).unwrap();
+    let file = std::io::BufReader::new(file);
+
+    for line in file.lines() {
+        let line = line.unwrap();
+        yml.push_str(&line);
+        yml.push('\n');
+
+        if line.starts_with("# generated") {
+            break;
+        }
+    }
+
+    f(&mut yml);
+    std::fs::write(path, yml.as_bytes()).unwrap();
 }

--- a/crates/tools/yml/src/msrv.rs
+++ b/crates/tools/yml/src/msrv.rs
@@ -1,52 +1,27 @@
 use super::*;
 
 pub fn yml() {
-    let mut yml = r"name: msrv
+    write_yml(".github/workflows/msrv.yml", |yml| {
+        for manifest in helpers::crates("crates/libs") {
+            let name = manifest.package.name;
+            let version = manifest.package.rust_version.expect("rust-version");
 
-on:
-  pull_request:
-    paths-ignore:
-      - '.github/ISSUE_TEMPLATE/**'
-      - '.github/workflows/web.yml'
-      - 'web/**'
-  push:
-    paths-ignore:
-      - '.github/ISSUE_TEMPLATE/**'
-      - '.github/workflows/web.yml'
-      - 'web/**'
-    branches:
-      - master
+            let features = if name == "windows" {
+                // We can't use `--all-features` for the `windows` crate as that would exhaust the available
+                // memory on GitHub VMs so this is just a smoke test for representative Win32 and WinRT APIs.
+                " --features Globalization,Win32_Graphics_Direct2D"
+            } else {
+                " --all-features"
+            };
 
-jobs:
-  msrv:
-    runs-on: windows-2025
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v5"
-        .to_string();
-
-    for manifest in helpers::crates("crates/libs") {
-        let name = manifest.package.name;
-        let version = manifest.package.rust_version.expect("rust-version");
-
-        let features = if name == "windows" {
-            // We can't use `--all-features` for the `windows` crate as that would exhaust the available
-            // memory on GitHub VMs so this is just a smoke test for representative Win32 and WinRT APIs.
-            " --features Globalization,Win32_Graphics_Direct2D"
-        } else {
-            " --all-features"
-        };
-
-        write!(
-            &mut yml,
-            r"
-      - name: Rust version
+            writeln!(
+                yml,
+                r"      - name: Rust version
         run: rustup update --no-self-update {version} && rustup default {version}
       - name: Check {name}
         run:  cargo check -p {name}{features}"
-        )
-        .unwrap();
-    }
-
-    std::fs::write(".github/workflows/msrv.yml", yml.as_bytes()).unwrap();
+            )
+            .unwrap();
+        }
+    });
 }

--- a/crates/tools/yml/src/no_default_features.rs
+++ b/crates/tools/yml/src/no_default_features.rs
@@ -1,48 +1,15 @@
 use super::*;
 
 pub fn yml() {
-    let mut yml = r"name: no-default-features
-
-on:
-  pull_request:
-    paths-ignore:
-      - '.github/ISSUE_TEMPLATE/**'
-      - '.github/workflows/web.yml'
-      - 'web/**'
-  push:
-    paths-ignore:
-      - '.github/ISSUE_TEMPLATE/**'
-      - '.github/workflows/web.yml'
-      - 'web/**'
-    branches:
-      - master
-
-jobs:
-  no-default-features:
-    runs-on: windows-2025
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v5
-      - name: Update toolchain
-        run: rustup update --no-self-update nightly && rustup default nightly-x86_64-pc-windows-msvc
-      - name: Add toolchain target
-        run: rustup target add x86_64-pc-windows-msvc
-      - name: Fix environment
-        uses: ./.github/actions/fix-environment
-        with:
-          target: x86_64-pc-windows-msvc"
-        .to_string();
-
-    for manifest in helpers::crates("crates/libs") {
-        let name = manifest.package.name;
-        write!(
-            &mut yml,
-            r"
-      - name: Check {name}
+    write_yml(".github/workflows/no-default-features.yml", |yml| {
+        for manifest in helpers::crates("crates/libs") {
+            let name = manifest.package.name;
+            writeln!(
+                yml,
+                r"      - name: Check {name}
         run:  cargo check -p {name} --no-default-features"
-        )
-        .unwrap();
-    }
-
-    std::fs::write(".github/workflows/no-default-features.yml", yml.as_bytes()).unwrap();
+            )
+            .unwrap();
+        }
+    });
 }

--- a/crates/tools/yml/src/test.rs
+++ b/crates/tools/yml/src/test.rs
@@ -1,101 +1,37 @@
 use super::*;
 
 pub fn yml() {
-    let mut yml =
-        r#"name: test
-
-on:
-  pull_request:
-    paths-ignore:
-      - '.github/ISSUE_TEMPLATE/**'
-      - '.github/workflows/web.yml'
-      - 'web/**'
-  push:
-    paths-ignore:
-      - '.github/ISSUE_TEMPLATE/**'
-      - '.github/workflows/web.yml'
-      - 'web/**'
-    branches:
-      - master
-
-jobs:
-  test:
-    strategy:
-      matrix:
-        include:
-          - version: stable
-            host: x86_64-pc-windows-msvc
-            target: x86_64-pc-windows-msvc
-            runner: windows-2025
-          - version: nightly
-            host: x86_64-pc-windows-msvc
-            target: i686-pc-windows-msvc
-            runner: windows-2025
-          - version: nightly
-            host: x86_64-pc-windows-gnu
-            target: x86_64-pc-windows-gnu
-            runner: windows-2025
-          - version: stable
-            host: x86_64-pc-windows-gnu
-            target: i686-pc-windows-gnu
-            runner: windows-2025
-          - version: stable
-            host: aarch64-pc-windows-msvc
-            target: aarch64-pc-windows-msvc
-            runner: windows-11-arm
-
-    runs-on: ${{ matrix.runner }}
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v5
-      - name: Update toolchain
-        run: rustup update --no-self-update ${{ matrix.version }} && rustup default ${{ matrix.version }}-${{ matrix.host }}
-      - name: Add toolchain target
-        run: rustup target add ${{ matrix.target }}
-      - name: Install fmt, clippy
-        run: rustup component add clippy rustfmt
-      - name: Fix environment
-        uses: ./.github/actions/fix-environment
-        with:
-          target: ${{ matrix.target }}"#
-    .to_string();
-
-    // This unrolling is required since "cargo test --all" consumes too much memory for the GitHub hosted runners
-    // and the occasional "cargo clean" is required to avoid running out of disk space in the same runners.
-
-    for (count, manifest) in helpers::crates("crates").iter().enumerate() {
-        let name = &manifest.package.name;
-        if count.is_multiple_of(50) {
-            write!(
-                &mut yml,
-                r"
-      - name: Clean
+    write_yml(".github/workflows/test.yml", |yml| {
+        // This unrolling is required since "cargo test --all" consumes too much memory for the GitHub hosted runners
+        // and the occasional "cargo clean" is required to avoid running out of disk space in the same runners.
+        for (count, manifest) in helpers::crates("crates").iter().enumerate() {
+            let name = &manifest.package.name;
+            if count.is_multiple_of(50) {
+                writeln!(
+                    yml,
+                    r"      - name: Clean
         run:  cargo clean"
+                )
+                .unwrap();
+            }
+
+            writeln!(
+                yml,
+                r"      - name: Test {name}
+        run:  cargo test -p {name} --target ${{{{ matrix.target }}}}"
             )
             .unwrap();
         }
 
-        write!(
-            &mut yml,
-            r"
-      - name: Test {name}
-        run:  cargo test -p {name} --target ${{{{ matrix.target }}}}"
-        )
-        .unwrap();
-    }
-
-    write!(
-        &mut yml,
-        r"
-      - name: Check diff
+        writeln!(
+            yml,
+            r"      - name: Check diff
         shell: bash
         run: |
           git add -N .
           git diff --exit-code || (echo 'Tests changed code in the repo.'; exit 1)
 "
-    )
-    .unwrap();
-
-    std::fs::write(".github/workflows/test.yml", yml.as_bytes()).unwrap();
+        )
+        .unwrap();
+    });
 }


### PR DESCRIPTION
This update streamlines how the yml workflows are generated so that the boilerplate bits can still be updated by hand and only the repetitive parts are updated by the tool. This should also make it possible for bots to update the dependencies as in #3819.