### PR TITLE
Encourage using raw strings in registry docs

### DIFF
--- a/crates/libs/registry/readme.md
+++ b/crates/libs/registry/readme.md
@@ -19,7 +19,7 @@ Read and write registry keys and values as needed:
 use windows_registry::*;
 
 fn main() -> Result<()> {
-    let key = CURRENT_USER.create("software\\windows-rs")?;
+    let key = CURRENT_USER.create(r"software\windows-rs")?;
 
     key.set_u32("number", 123)?;
     key.set_string("name", "Rust")?;
@@ -45,7 +45,7 @@ fn main() -> Result<()> {
         .write()
         .create()
         .transaction(&tx)
-        .open("software\\windows-rs")?;
+        .open(r"software\windows-rs")?;
 
     key.set_u32("name", 123)?;
 


### PR DESCRIPTION
This is a bit of a nitpick on how to write strings when they contain Windows-like paths. Generally, I think that raw strings are preferable in this scenario because

- It's a bit easier to read and more familiar (it looks like what you would write in `cmd.exe`).
- It prevents accidentally escaping a character by writing `\` instead of `\\`. I think that characters like newlines (`\n`), tabs (`\t`), etc. are rare enough in paths that this is a reasonable trade-off.

---

I noticed *a lot* of other places where there were strings with `\\` that could be converted to raw strings. If this stylistic change makes sense, I can convert all of those if wanted. Right now I was just focusing on the documentation that I was reading.
