### PR TITLE
Add `await` sample

### DIFF
--- a/crates/samples/windows/rss/Cargo.toml
+++ b/crates/samples/windows/rss/Cargo.toml
@@ -7,8 +7,12 @@ publish = false
 [dependencies.windows]
 workspace = true
 features = [
+    "std",
     "Web_Syndication",
 ]
+
+[dependencies]
+futures = "0.3"
 
 [lints]
 workspace = true

--- a/crates/samples/windows/rss/src/main.rs
+++ b/crates/samples/windows/rss/src/main.rs
@@ -1,6 +1,6 @@
 use windows::{core::*, Foundation::Uri, Web::Syndication::SyndicationClient};
 
-fn main() -> Result<()> {
+async fn main_async() -> Result<()> {
     let uri = Uri::CreateUri(h!("https://blogs.windows.com/feed"))?;
     let client = SyndicationClient::new()?;
 
@@ -9,11 +9,15 @@ fn main() -> Result<()> {
         h!("Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; WOW64; Trident/6.0)"),
     )?;
 
-    let feed = client.RetrieveFeedAsync(&uri)?.join()?;
+    let feed = client.RetrieveFeedAsync(&uri)?.await?;
 
     for item in feed.Items()? {
         println!("{:?}", item.Title()?.Text()?);
     }
 
     Ok(())
+}
+
+fn main() -> Result<()> {
+    futures::executor::block_on(main_async())
 }


### PR DESCRIPTION
I had a few `async` samples back in the day but they were removed at some point, probably when the `Future` work was being stabilized in the Standard Library. This just adds a small tweak to one of the samples to illustrate how to marry WinRT async with Rust async.