### PR TITLE
Document `windows-rdl` function support

### DIFF
--- a/crates/libs/rdl/rdl.md
+++ b/crates/libs/rdl/rdl.md
@@ -179,7 +179,7 @@ interface ISprocket {
 
 #### Functions
 
-Functions declare external function signatures provided by the system. The `#[link]` attribute specifies the library name and ABI.
+Functions declare external function signatures provided by another library. The `#[link]` attribute specifies the library name and ABI.
 
 **Syntax:**
 ```rust


### PR DESCRIPTION
Adds `windows-rdl` documentation for recently added (#3873) external function signatures.