### PR TITLE
Add pseudo-type support for `windows-rdl`

### DIFF
--- a/crates/libs/metadata/src/ty.rs
+++ b/crates/libs/metadata/src/ty.rs
@@ -56,3 +56,9 @@ impl Type {
         }
     }
 }
+
+impl From<(&str, &str)> for Type {
+    fn from(value: (&str, &str)) -> Self {
+        Self::named(value.0, value.1)
+    }
+}

--- a/crates/libs/metadata/src/type_name.rs
+++ b/crates/libs/metadata/src/type_name.rs
@@ -16,3 +16,9 @@ impl TypeName {
         }
     }
 }
+
+impl PartialEq<(&str, &str)> for &TypeName {
+    fn eq(&self, other: &(&str, &str)) -> bool {
+        self.namespace == other.0 && self.name == other.1
+    }
+}

--- a/crates/libs/rdl/src/reader/mod.rs
+++ b/crates/libs/rdl/src/reader/mod.rs
@@ -366,6 +366,8 @@ fn encode_path(encoder: &Encoder, ty: &syn::Path) -> Result<metadata::Type, Erro
         "isize" => return Ok(metadata::Type::ISize),
         "usize" => return Ok(metadata::Type::USize),
         "String" => return Ok(metadata::Type::String),
+        "GUID" => return Ok(("System", "Guid").into()),
+        "HRESULT" => return Ok(("Windows.Metadata", "HRESULT").into()),
         _ => {}
     }
 

--- a/crates/libs/rdl/src/writer/mod.rs
+++ b/crates/libs/rdl/src/writer/mod.rs
@@ -306,6 +306,8 @@ fn write_type(namespace: &str, item: &metadata::Type) -> TokenStream {
 
             ty
         }
+        Name(tn) if tn == ("System", "Guid") => quote! { GUID },
+        Name(tn) if tn == ("Windows.Metadata", "HRESULT") => quote! { HRESULT },
         Name(type_name) => {
             let name = format_ident!("{}", &type_name.name);
 

--- a/crates/libs/rdl/tests/pseudo-types.rdl
+++ b/crates/libs/rdl/tests/pseudo-types.rdl
@@ -1,0 +1,5 @@
+#[win32]
+mod Test {
+    #[link(name = "ole32.dll", abi = "system")]
+    fn CoCreateGuid(result: *mut GUID) -> HRESULT;
+}

--- a/crates/libs/rdl/tests/pseudo-types.rs
+++ b/crates/libs/rdl/tests/pseudo-types.rs
@@ -1,0 +1,17 @@
+use windows_rdl::*;
+
+#[test]
+pub fn parse() {
+    Reader::new()
+        .input("tests/pseudo-types.rdl")
+        .output("tests/pseudo-types.winmd")
+        .write()
+        .unwrap();
+
+    Writer::new()
+        .input("tests/pseudo-types.winmd")
+        .output("tests/pseudo-types.rdl")
+        .namespace("Test")
+        .write()
+        .unwrap();
+}


### PR DESCRIPTION
There are a small (closed) set of types that are essential for language projections like `GUID`, `IUnknown`, and `HRESULT`, to name a few. Some of these have "built-in" pseudo type names in ECMA-335 while others do not. The `windows-rdl` library will smooth this over by providing pseudo type names for those essential types that lack first-class ECMA-335 support in the `Windows.Metadata` namespace. We may end up officially defining these types in metadata or .rdl at some point, but for now it suffices that these well-known pseudo type names are "well known" to the parser and the Windows metadata language. 

As an example, you can define the `CoCreateGuid` operating system function as follows:

```rust
#[link(name = "ole32.dll", abi = "system")]
fn CoCreateGuid(result: *mut GUID) -> HRESULT;
```

It will result in the following metadata definition:

```
.method public hidebysig static pinvokeimpl("ole32.dll" nomangle winapi) 
    valuetype [Windows]Windows.Metadata.HRESULT CoCreateGuid (
        [out] valuetype [mscorlib]System.Guid* result
    ) cil managed 
{
}
```

Related to #3861