### PR TITLE
Replace rand crate with BCryptGenRandom in dcomp sample

### DIFF
--- a/crates/samples/windows/dcomp/Cargo.toml
+++ b/crates/samples/windows/dcomp/Cargo.toml
@@ -4,9 +4,6 @@ version = "0.0.0"
 edition = "2021"
 publish = false
 
-[dependencies]
-rand = "0.9"
-
 [dependencies.windows]
 workspace = true
 features = [
@@ -18,6 +15,7 @@ features = [
     "Win32_Graphics_Dxgi_Common",
     "Win32_Graphics_Gdi",
     "Win32_Graphics_Imaging_D2D",
+    "Win32_Security_Cryptography",
     "Win32_System_Com",
     "Win32_System_LibraryLoader",
     "Win32_System_Performance",


### PR DESCRIPTION
Updates the random number generation in `sample_dcomp` by removing the dependency on the external `rand` crate and switching to the Windows-native `BCryptGenRandom` function.