### PR TITLE
Release 73

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ windows-future = { version = "0.3.2", path = "crates/libs/future", default-featu
 windows-implement = { version = "0.60.2", path = "crates/libs/implement", default-features = false }
 windows-interface = { version = "0.59.3", path = "crates/libs/interface", default-features = false }
 windows-link = { version = "0.2.1", path = "crates/libs/link", default-features = false }
-windows-metadata = { version = "0.59.0", path = "crates/libs/metadata", default-features = false }
+windows-metadata = { version = "0.60.0", path = "crates/libs/metadata", default-features = false }
 windows-numerics = { version = "0.3.1", path = "crates/libs/numerics", default-features = false }
 windows-rdl = { version = "0.0.0", path = "crates/libs/rdl", default-features = false }
 windows-registry = { version = "0.6.1", path = "crates/libs/registry", default-features = false }

--- a/crates/libs/metadata/Cargo.toml
+++ b/crates/libs/metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "windows-metadata"
-version = "0.59.0"
+version = "0.60.0"
 edition = "2021"
 rust-version = "1.82"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
This release is only for the [windows-metadata](https://crates.io/crates/windows-metadata) crate (0.60.0) and brings nine months worth of updates to the low-level metadata library for ECMA-335. This includes support for nested types (#3799), the ability to articulate and distinguish between mutable and immutable reference and pointer parameter types (#3865), support for union types (#3867), smarter indexing (#3612), and many other small improvements. 

Fixes #3887