### PR TITLE
Add delegate support for `windows-rdl`

### DIFF
--- a/crates/libs/rdl/src/reader/delegate.rs
+++ b/crates/libs/rdl/src/reader/delegate.rs
@@ -1,0 +1,61 @@
+use super::*;
+
+pub fn encode_delegate(encoder: &mut Encoder, item: &syntax::Delegate) -> Result<(), Error> {
+    let extends = encoder.output.TypeRef("System", "MulticastDelegate");
+
+    let mut flags = metadata::TypeAttributes::Public | metadata::TypeAttributes::Sealed;
+
+    if item.winrt {
+        flags |= metadata::TypeAttributes::WindowsRuntime;
+    }
+
+    let name = item.sig.ident.to_string();
+
+    encoder.output.TypeDef(
+        encoder.namespace,
+        &name,
+        metadata::writer::TypeDefOrRef::TypeRef(extends),
+        flags,
+    );
+
+    let flags = metadata::MethodAttributes::Public
+        | metadata::MethodAttributes::HideBySig
+        | metadata::MethodAttributes::Abstract
+        | metadata::MethodAttributes::NewSlot
+        | metadata::MethodAttributes::Virtual;
+
+    let mut params = vec![];
+
+    for arg in &item.sig.inputs {
+        match arg {
+            syn::FnArg::Receiver(receiver) => {
+                return encoder.err(receiver, "`unexpected `self` parameter");
+            }
+            syn::FnArg::Typed(pt) => {
+                params.push(param(encoder, pt)?);
+            }
+        }
+    }
+
+    let types = params.iter().map(|param| param.ty.clone()).collect();
+
+    let signature = metadata::Signature {
+        flags: Default::default(),
+        return_type: encode_return_type(encoder, &item.sig.output)?,
+        types,
+    };
+
+    encoder
+        .output
+        .MethodDef("Invoke", &signature, flags, Default::default());
+
+    for (sequence, param) in params.iter().enumerate() {
+        encoder.output.Param(
+            &param.name,
+            (sequence + 1).try_into().unwrap(),
+            param.attributes,
+        );
+    }
+
+    Ok(())
+}

--- a/crates/libs/rdl/src/reader/mod.rs
+++ b/crates/libs/rdl/src/reader/mod.rs
@@ -1,5 +1,6 @@
 mod class;
 mod r#const;
+mod delegate;
 mod r#enum;
 mod r#fn;
 mod index;
@@ -10,6 +11,7 @@ mod union;
 
 use super::*;
 use class::*;
+use delegate::*;
 use index::*;
 use interface::*;
 use param::*;
@@ -111,6 +113,9 @@ fn resolve_winrt(
             item.winrt = read_winrt_expected(source_file, &item.token, &item.attrs, parent)?;
         }
         syntax::Item::Struct(item) => {
+            item.winrt = read_winrt_expected(source_file, &item.token, &item.attrs, parent)?;
+        }
+        syntax::Item::Delegate(item) => {
             item.winrt = read_winrt_expected(source_file, &item.token, &item.attrs, parent)?;
         }
         syntax::Item::Module(item) => {
@@ -294,6 +299,7 @@ fn encode_item(
         syntax::Item::Fn(ty) => encode_fn(encoder, ty),
         syntax::Item::Const(ty) => encode_const(encoder, ty),
         syntax::Item::Class(ty) => encode_class(encoder, ty),
+        syntax::Item::Delegate(ty) => encode_delegate(encoder, ty),
         rest => todo!("{rest:?}"),
     }
 }

--- a/crates/libs/rdl/src/syntax/delegate.rs
+++ b/crates/libs/rdl/src/syntax/delegate.rs
@@ -1,0 +1,25 @@
+syn::custom_keyword!(delegate);
+
+#[derive(Debug)]
+pub struct Delegate {
+    pub attrs: Vec<syn::Attribute>,
+    pub token: delegate,
+    pub sig: syn::Signature,
+    pub winrt: bool,
+}
+
+impl syn::parse::Parse for Delegate {
+    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+        let attrs = input.call(syn::Attribute::parse_outer)?;
+        let token = input.parse()?;
+        let sig = input.parse()?;
+        input.parse::<syn::Token![;]>()?;
+
+        Ok(Self {
+            attrs,
+            token,
+            sig,
+            winrt: false,
+        })
+    }
+}

--- a/crates/libs/rdl/src/syntax/item.rs
+++ b/crates/libs/rdl/src/syntax/item.rs
@@ -5,7 +5,7 @@ pub enum Item {
     // WinRT/Win32 types
     // Attribute(ItemAttribute)
     Class(Class),
-    // Delegate(ItemDelegate),
+    Delegate(Delegate),
     Enum(Enum),
     Interface(Interface),
     Struct(Struct),
@@ -31,6 +31,7 @@ impl Item {
             | Self::Interface(Interface { attrs, .. })
             | Self::Module(Module { attrs, .. })
             | Self::Struct(Struct { attrs, .. })
+            | Self::Delegate(Delegate { attrs, .. })
             | Self::Union(Union { attrs, .. }) => std::mem::replace(attrs, new),
         }
     }
@@ -45,6 +46,7 @@ impl std::fmt::Display for Item {
             Self::Class(item) => item.name.fmt(f),
             Self::Interface(item) => item.name.fmt(f),
             Self::Struct(item) => item.name.fmt(f),
+            Self::Delegate(item) => item.sig.ident.fmt(f),
             Self::Module(item) => item.name.fmt(f),
             Self::Union(item) => item.name.fmt(f),
         }
@@ -70,6 +72,8 @@ impl syn::parse::Parse for Item {
             input.parse().map(Item::Fn)
         } else if lookahead.peek(syn::Token![const]) {
             input.parse().map(Item::Const)
+        } else if lookahead.peek(delegate) {
+            input.parse().map(Item::Delegate)
         } else if lookahead.peek(class) {
             input.parse().map(Item::Class)
         } else {

--- a/crates/libs/rdl/src/syntax/mod.rs
+++ b/crates/libs/rdl/src/syntax/mod.rs
@@ -1,5 +1,6 @@
 mod class;
 mod r#const;
+mod delegate;
 mod r#enum;
 mod file;
 mod r#fn;
@@ -11,6 +12,7 @@ mod r#struct;
 mod union;
 
 pub use class::*;
+pub use delegate::*;
 pub use file::*;
 pub use interface::*;
 pub use item::*;

--- a/crates/libs/rdl/src/writer/delegate.rs
+++ b/crates/libs/rdl/src/writer/delegate.rs
@@ -1,0 +1,32 @@
+use super::*;
+
+pub fn write_delegate(item: &metadata::reader::TypeDef) -> TokenStream {
+    let namespace = item.namespace();
+    let name = format_ident!("{}", item.name());
+
+    let method = item
+        .methods()
+        .find(|method| method.name() == "Invoke")
+        .expect("delegates are expected to have this named method");
+
+    let signature = method.signature(&[]);
+
+    let return_type = if signature.return_type == metadata::Type::Void {
+        quote! {}
+    } else {
+        let ty = write_type(namespace, &signature.return_type);
+        quote! { -> #ty }
+    };
+
+    let params = method.params().filter(|param| param.sequence() != 0);
+
+    let params = params.zip(signature.types).map(|(param, ty)| {
+        let name = format_ident!("{}", param.name());
+        let ty = write_type(namespace, &ty);
+        quote! { #name: #ty, }
+    });
+
+    quote! {
+        delegate fn #name(#(#params)*) #return_type;
+    }
+}

--- a/crates/libs/rdl/src/writer/mod.rs
+++ b/crates/libs/rdl/src/writer/mod.rs
@@ -1,4 +1,5 @@
 mod class;
+mod delegate;
 mod r#enum;
 mod interface;
 mod layout;
@@ -6,6 +7,7 @@ mod r#struct;
 
 use super::*;
 use class::*;
+use delegate::*;
 use interface::*;
 use layout::*;
 use metadata::HasAttributes;
@@ -194,6 +196,7 @@ fn write_type_def(item: &metadata::reader::TypeDef) -> TokenStream {
         metadata::reader::TypeCategory::Enum => write_enum(item),
         metadata::reader::TypeCategory::Interface => write_interface(item),
         metadata::reader::TypeCategory::Class => write_class(item),
+        metadata::reader::TypeCategory::Delegate => write_delegate(item),
         rest => todo!("{rest:?}"),
     }
 }

--- a/crates/libs/rdl/tests/delegate.rdl
+++ b/crates/libs/rdl/tests/delegate.rdl
@@ -1,0 +1,8 @@
+#[winrt]
+mod Test {
+    delegate fn Handler(arg: i32) -> u32;
+}
+#[win32]
+mod Test {
+    delegate fn Callback(arg: i64) -> u64;
+}

--- a/crates/libs/rdl/tests/delegate.rs
+++ b/crates/libs/rdl/tests/delegate.rs
@@ -1,0 +1,17 @@
+use windows_rdl::*;
+
+#[test]
+pub fn parse() {
+    Reader::new()
+        .input("tests/delegate.rdl")
+        .output("tests/delegate.winmd")
+        .write()
+        .unwrap();
+
+    Writer::new()
+        .input("tests/delegate.winmd")
+        .output("tests/delegate.rdl")
+        .namespace("Test")
+        .write()
+        .unwrap();
+}


### PR DESCRIPTION
Building on #3861, this update adds support for Win32 function pointer types (callbacks) and WinRT delegate types collectively called delegates in .rdl and ECMA-335. 

```rust
#[winrt]
mod Test {
    delegate fn Handler(arg: i32) -> u32;
}

#[win32]
mod Test {
    delegate fn Callback(arg: i64) -> u64;
}
```

These are typically used to define WinRT event handlers like `AsyncActionCompletedHandler` and Win32 callback functions like `WNDENUMPROC`. The example above will produce the following ECMA-335 representation:

```
.namespace Test
{
	.class public auto ansi sealed Test.Callback
		extends [mscorlib]System.MulticastDelegate
	{
		.method public hidebysig newslot abstract virtual 
			uint64 Invoke (
				[in] int64 arg
			) cil managed 
		{
		}
	}

	.class public auto ansi sealed windowsruntime Test.Handler
		extends [mscorlib]System.MulticastDelegate
	{
		.method public hidebysig newslot abstract virtual 
			uint32 Invoke (
				[in] int32 arg
			) cil managed 
		{
		}

	}
}

```