### PR TITLE
Improve path `super` support for `windows-rdl`

### DIFF
--- a/crates/libs/rdl/src/reader/mod.rs
+++ b/crates/libs/rdl/src/reader/mod.rs
@@ -427,9 +427,24 @@ fn encode_type_path(encoder: &Encoder, ty: &syn::TypePath) -> Result<metadata::T
 
 fn encode_path(encoder: &Encoder, ty: &syn::Path) -> Result<metadata::Type, Error> {
     let mut name = String::new();
+    let mut supers = 0;
 
     for segment in &ty.segments {
-        if !name.is_empty() {
+        if segment.ident == "super" {
+            supers += 1;
+            continue;
+        }
+
+        if supers > 0 {
+            let relative: Vec<&str> = encoder.namespace.split('.').collect();
+
+            for segment in &relative[..relative.len() - supers] {
+                name.push_str(segment);
+                name.push('.');
+            }
+        }
+
+        if !name.is_empty() && !name.ends_with('.') {
             name.push('.');
         }
 
@@ -467,6 +482,7 @@ fn encode_path(encoder: &Encoder, ty: &syn::Path) -> Result<metadata::Type, Erro
         "isize" => return Ok(metadata::Type::ISize),
         "usize" => return Ok(metadata::Type::USize),
         "String" => return Ok(metadata::Type::String),
+        "Object" => return Ok(metadata::Type::Object),
         "GUID" => return Ok(("System", "Guid").into()),
         "HRESULT" => return Ok(("Windows.Metadata", "HRESULT").into()),
         _ => {}

--- a/crates/libs/rdl/src/writer/attribute.rs
+++ b/crates/libs/rdl/src/writer/attribute.rs
@@ -1,0 +1,9 @@
+use super::*;
+
+pub fn write_attribute(item: &metadata::reader::TypeDef) -> TokenStream {
+    let name = write_ident(item.name());
+
+    quote! {
+        class #name : Attribute {}
+    }
+}

--- a/crates/libs/rdl/src/writer/mod.rs
+++ b/crates/libs/rdl/src/writer/mod.rs
@@ -1,3 +1,4 @@
+mod attribute;
 mod class;
 mod delegate;
 mod r#enum;
@@ -6,6 +7,7 @@ mod layout;
 mod r#struct;
 
 use super::*;
+use attribute::*;
 use class::*;
 use delegate::*;
 use interface::*;
@@ -201,7 +203,7 @@ fn write_type_def(item: &metadata::reader::TypeDef) -> TokenStream {
         metadata::reader::TypeCategory::Interface => write_interface(item),
         metadata::reader::TypeCategory::Class => write_class(item),
         metadata::reader::TypeCategory::Delegate => write_delegate(item),
-        rest => todo!("{rest:?}"),
+        metadata::reader::TypeCategory::Attribute => write_attribute(item),
     }
 }
 

--- a/crates/libs/rdl/tests/path-output.rdl
+++ b/crates/libs/rdl/tests/path-output.rdl
@@ -1,12 +1,55 @@
-#[winrt]
-mod ModForB {
-    struct AlsoInB {
-        a1: u8,
+mod Test {
+    #[winrt]
+    mod ModForA {
+        struct A {
+            a1: u8,
+            a2: u32,
+        }
     }
-    struct B {
-        a: ModForA::A,
-        b: AlsoInB,
-        c: Windows::Foundation::IStringable,
-        d: NestedMod::D,
+    mod ModForB {
+        #[winrt]
+        mod NestedMod {
+            struct D {
+                a1: u8,
+            }
+        }
+    }
+    #[winrt]
+    mod ModForB {
+        struct AlsoInB {
+            a1: u8,
+        }
+        struct B {
+            a: super::ModForA::A,
+            b: AlsoInB,
+            c: Windows::Foundation::IStringable,
+            d: NestedMod::D,
+        }
+    }
+    mod N0 {
+        mod N1 {
+            mod N2 {
+                #[winrt]
+                mod N3 {
+                    struct S3 {
+                        a: super::super::super::S0,
+                        b: super::super::S1,
+                        c: super::S2,
+                    }
+                }
+            }
+            #[winrt]
+            mod N2 {
+                struct S2 {}
+            }
+        }
+        #[winrt]
+        mod N1 {
+            struct S1 {}
+        }
+    }
+    #[winrt]
+    mod N0 {
+        struct S0 {}
     }
 }

--- a/crates/libs/rdl/tests/path.rdl
+++ b/crates/libs/rdl/tests/path.rdl
@@ -1,27 +1,48 @@
 #[winrt]
-mod ModForA {
-    struct A {
-        a1: u8,
-        a2: u32,
-    } 
-}
-
-#[winrt]
-mod ModForB {
-    struct B {
-        a: ModForA::A,
-        b: AlsoInB,
-        c: Windows::Foundation::IStringable,
-        d: NestedMod::D,
+mod Test {
+    mod ModForA {
+        struct A {
+            a1: u8,
+            a2: u32,
+        } 
     }
 
-    struct AlsoInB {
-        a1: u8,
+    mod ModForB {
+        struct B {
+            a: Test::ModForA::A,
+            b: AlsoInB,
+            c: Windows::Foundation::IStringable,
+            d: NestedMod::D,
+        }
+
+        struct AlsoInB {
+            a1: u8,
+        }
+
+        mod NestedMod {
+            struct D {
+                a1: u8
+            }
+        }
     }
 
-    mod NestedMod {
-        struct D {
-            a1: u8
+    mod N0 {
+        struct S0{}
+
+        mod N1 {
+            struct S1 {}
+
+            mod N2 {
+                struct S2 {}
+
+                mod N3 {
+                    struct S3 {
+                        a: super::super::super::S0,
+                        b: super::super::S1,
+                        c: super::S2,
+                    }
+                }
+            }
         }
     }
 }

--- a/crates/libs/rdl/tests/path.rs
+++ b/crates/libs/rdl/tests/path.rs
@@ -12,7 +12,8 @@ pub fn parse() {
     Writer::new()
         .input("tests/path.winmd")
         .output("tests/path-output.rdl")
-        .namespace("ModForB")
+        .namespace("Test")
+        .recursive()
         .write()
         .unwrap();
 }


### PR DESCRIPTION
As I push toward roundtripping support, there will be a number of small improvements such as this where I have improved the reader to properly handle relative paths with `super`. This was previously handled by the writer but not the reader. This update also fleshed out the basics of attribute generation, but more is required to handle attribute authoring and parsing in general.

Builds on #3861

