### PR TITLE
Consolidate type parsing for enums in `windows-rdl`

### DIFF
--- a/crates/libs/rdl/src/reader/enum.rs
+++ b/crates/libs/rdl/src/reader/enum.rs
@@ -24,21 +24,11 @@ pub fn encode_enum(encoder: &mut Encoder, item: &syntax::Enum) -> Result<(), Err
         return encoder.err(item.token, "`repr` attribute not found");
     };
 
-    let Ok(ty) = attribute.parse_args::<syn::Ident>() else {
+    let Ok(ty) = attribute.parse_args::<syn::Path>() else {
         return encoder.err(attribute, "`repr` integer type attribute not found");
     };
 
-    let ty = ty.to_string();
-
-    let ty = match ty.as_str() {
-        "u32" => metadata::Type::U32,
-        "u64" => metadata::Type::U64,
-        "i32" => metadata::Type::I32,
-        "i64" => metadata::Type::I64,
-        _ => {
-            return encoder.err(attribute, "`repr` integer type not supported");
-        }
-    };
+    let ty = encode_path(encoder, &ty)?;
 
     encoder.output.Field(
         "value__",

--- a/crates/libs/rdl/tests/enum.rdl
+++ b/crates/libs/rdl/tests/enum.rdl
@@ -7,4 +7,11 @@ mod Test {
         Error = 3,
         Started = 0,
     }
+    #[repr(i16)]
+    enum I16 {
+        A = -1,
+        B = 0,
+        C = 1,
+        D = 2,
+    }
 }


### PR DESCRIPTION
This update removes a parser restriction for enum representation so that a larger set of types may be used and the type parsing is now consolidated.

Builds on #3861