### PR TITLE
Add `void` and other special names for `windows-rdl`

### DIFF
--- a/crates/libs/rdl/src/reader/mod.rs
+++ b/crates/libs/rdl/src/reader/mod.rs
@@ -576,11 +576,14 @@ fn encode_path(encoder: &Encoder, ty: &syn::Path) -> Result<metadata::Type, Erro
             "f64" => return Ok(metadata::Type::F64),
             "isize" => return Ok(metadata::Type::ISize),
             "usize" => return Ok(metadata::Type::USize),
-            "String" => return Ok(metadata::Type::String),
+
+            "void" => return Ok(metadata::Type::Void),
+            "HSTRING" => return Ok(metadata::Type::String),
+            "IInspectable" => return Ok(metadata::Type::Object),
             "Type" => return Ok(metadata::Type::named("System", "Type")),
-            "Object" => return Ok(metadata::Type::Object),
             "GUID" => return Ok(("System", "Guid").into()),
-            "HRESULT" => return Ok(("Windows.Metadata", "HRESULT").into()),
+            "HRESULT" => return Ok(("Windows.Foundation", "HResult").into()),
+
             _ => {}
         }
     }

--- a/crates/libs/rdl/src/writer/mod.rs
+++ b/crates/libs/rdl/src/writer/mod.rs
@@ -338,7 +338,6 @@ fn write_type_ref(namespace: &str, item: &metadata::reader::TypeDefOrRef) -> Tok
 fn write_type(namespace: &str, item: &metadata::Type) -> TokenStream {
     use metadata::Type::*;
     match item {
-        Void => quote! { core::ffi::c_void },
         Bool => quote! { bool },
         Char => quote! { u16 },
         I8 => quote! { i8 },
@@ -353,8 +352,14 @@ fn write_type(namespace: &str, item: &metadata::Type) -> TokenStream {
         F64 => quote! { f64 },
         ISize => quote! { isize },
         USize => quote! { usize },
-        String => quote! { String },
-        Object => quote! { Object },
+
+        Void => quote! { void },
+        String => quote! { HSTRING },
+        Object => quote! { IInspectable },
+        Name(tn) if tn == ("System", "Type") => quote! { Type },
+        Name(tn) if tn == ("System", "Guid") => quote! { GUID },
+        Name(tn) if tn == ("Windows.Foundation", "HResult") => quote! { HRESULT },
+
         Array(ty) => {
             let ty = write_type(namespace, ty);
             quote! { [#ty] }
@@ -390,9 +395,6 @@ fn write_type(namespace: &str, item: &metadata::Type) -> TokenStream {
 
             ty
         }
-        Name(tn) if tn == ("System", "Type") => quote! { Type },
-        Name(tn) if tn == ("System", "Guid") => quote! { GUID },
-        Name(tn) if tn == ("Windows.Metadata", "HRESULT") => quote! { HRESULT },
         Name(type_name) => {
             let name = write_ident(&type_name.name);
 

--- a/crates/libs/rdl/tests/attribute.rdl
+++ b/crates/libs/rdl/tests/attribute.rdl
@@ -2,10 +2,10 @@
 mod Test {
     attribute ActivatableAttribute {
         fn(version: u32);
-        fn(version: u32, r#type: String);
+        fn(version: u32, r#type: HSTRING);
         fn(version: u32, platform: Platform);
         fn(r#type: Type, version: u32);
-        fn(r#type: Type, version: u32, contractName: String);
+        fn(r#type: Type, version: u32, contractName: HSTRING);
         fn(r#type: Type, version: u32, platform: Platform);
     }
     #[repr(i32)]

--- a/crates/libs/rdl/tests/signature.rdl
+++ b/crates/libs/rdl/tests/signature.rdl
@@ -1,7 +1,7 @@
 #[winrt]
 mod Test {
     interface ITest {
-        fn ToString(&self) -> String;
+        fn ToString(&self) -> HSTRING;
         fn Close(&self);
         fn Add(&self, a: u8, b: u16) -> u32;
         fn RefMut(&self, p: &mut u32);

--- a/crates/libs/rdl/tests/special.rdl
+++ b/crates/libs/rdl/tests/special.rdl
@@ -1,0 +1,4 @@
+#[win32]
+mod Test {
+    delegate fn Special(vm: *mut void, vc: *const void, h: HSTRING, i: IInspectable, t: Type, g: GUID, h: HRESULT);
+}

--- a/crates/libs/rdl/tests/special.rs
+++ b/crates/libs/rdl/tests/special.rs
@@ -1,0 +1,17 @@
+use windows_rdl::*;
+
+#[test]
+pub fn parse() {
+    Reader::new()
+        .input("tests/special.rdl")
+        .output("tests/special.winmd")
+        .write()
+        .unwrap();
+
+    Writer::new()
+        .input("tests/special.winmd")
+        .output("tests/special.rdl")
+        .namespace("Test")
+        .write()
+        .unwrap();
+}


### PR DESCRIPTION
There are a few unavoidable special type names when expressing Windows APIs and metadata. These use their traditional type names to avoid introducing new names and for the sake of clarity. 

* `void` represents C's type by the same name and is used as a pointer only. It is encoded as `ELEMENT_TYPE_VOID` in metadata.

* `HSTRING` is a reference-counted and immutable UTF-16 string type. It is encoded as `ELEMENT_TYPE_STRING` in metadata.

* `IInspectable` is the parent interface for all WinRT interface and class types. It is encoded as `ELEMENT_TYPE_OBJECT` in metadata.

* `Type` is used by metadata attributes to accept a type name as an argument. It is encoded as `System.Type` in metadata.


* `GUID` is typically used to identify COM and WinRT interface and class types. It is encoded as `System.Guid` in metadata.

* `HRESULT` is a common error type typically used as a function's return type. It is encoded as `Windows.Foundation.HResult` in metadata.

Here's an example:

```rust
#[win32]
mod Test {
    delegate fn Special(
        vm: *mut void, 
        vc: *const void, 
        h: HSTRING, 
        i: IInspectable, 
        t: Type, 
        g: GUID, 
        h: HRESULT);
}
```

The IL representation is as follows:

```
.class public auto ansi sealed Test.Special
	extends [mscorlib]System.MulticastDelegate
{
	.method public hidebysig newslot abstract virtual 
		void Invoke (
			[out] void* vm,
			[in] void* modreq([mscorlib]System.Runtime.CompilerServices.IsConst) vc,
			[in] string h,
			[in] object i,
			[in] class [mscorlib]System.Type t,
			[in] valuetype [mscorlib]System.Guid g,
			[in] class [Windows]Windows.Foundation.HResult h
		) cil managed 
	{
	}
}
```

And the C#/ILSpy representation is as follows:

```C#
public unsafe delegate void Special([Out] void* vm, [In] void* vc, [In] string h, [In] object i, [In] Type t, [In] Guid g, [In] HResult h);
```

Builds on #3861 