### PR TITLE
Remove `AttributeEnum` from `windows-metadata`

### DIFF
--- a/crates/libs/bindgen/src/types/mod.rs
+++ b/crates/libs/bindgen/src/types/mod.rs
@@ -366,7 +366,6 @@ impl Type {
                 )),
                 _ => Self::from_metadata_type(inner, enclosing, generics, reader),
             },
-            rest => panic!("{rest:?}"),
         }
     }
 

--- a/crates/libs/metadata/src/reader/blob.rs
+++ b/crates/libs/metadata/src/reader/blob.rs
@@ -204,7 +204,6 @@ impl<'a> Blob<'a> {
                     generics: ty_generics,
                 })
             }
-            0x55 => Type::AttributeEnum,
             rest => panic!("{rest:?}"),
         }
     }

--- a/crates/libs/metadata/src/reader/tables/attribute.rs
+++ b/crates/libs/metadata/src/reader/tables/attribute.rs
@@ -32,10 +32,8 @@ impl<'a> Attribute<'a> {
         debug_assert_eq!(prolog, 1);
 
         for ty in &signature.types {
-            let mut name = String::new();
-            let value = read_value(&mut blob, ty, &mut name);
-            debug_assert!(name.is_empty());
-            values.push((name, value));
+            let value = read_value(&mut blob, ty);
+            values.push((String::new(), value));
         }
 
         let named_arg_count = blob.read_u16();
@@ -45,8 +43,8 @@ impl<'a> Attribute<'a> {
             let _id = blob.read_u8();
             // TODO: what's ID?
             let ty = blob.read_type_code(&[]);
-            let mut name = blob.read_utf8();
-            let value = read_value(&mut blob, &ty, &mut name);
+            let name = blob.read_utf8();
+            let value = read_value(&mut blob, &ty);
             values.push((name, value));
         }
 
@@ -55,7 +53,7 @@ impl<'a> Attribute<'a> {
     }
 }
 
-fn read_value(blob: &mut Blob, ty: &Type, name: &mut String) -> Value {
+fn read_value(blob: &mut Blob, ty: &Type) -> Value {
     match ty {
         Type::Bool => Value::Bool(blob.read_bool()),
         Type::I8 => Value::I8(blob.read_i8()),
@@ -78,11 +76,6 @@ fn read_value(blob: &mut Blob, ty: &Type, name: &mut String) -> Value {
             } else {
                 Value::I32(blob.read_i32())
             }
-        }
-        Type::AttributeEnum => {
-            let enum_name = name.clone();
-            *name = blob.read_utf8();
-            Value::AttributeEnum(enum_name, blob.read_i32())
         }
         rest => panic!("{rest:?}"),
     }

--- a/crates/libs/metadata/src/ty.rs
+++ b/crates/libs/metadata/src/ty.rs
@@ -19,7 +19,6 @@ pub enum Type {
     USize,
     String,
     Object,
-    AttributeEnum, // 0x55 is an unnamed ELEMENT_TYPE used by attributes to specify an enum
     Name(TypeName),
     Array(Box<Self>),             // ELEMENT_TYPE_SZARRAY
     Generic(String, u16),         // ELEMENT_TYPE_VAR
@@ -49,7 +48,6 @@ impl Type {
             Self::F32 => ELEMENT_TYPE_R4,
             Self::F64 => ELEMENT_TYPE_R8,
             Self::String => ELEMENT_TYPE_STRING,
-            Self::AttributeEnum => 0x55,
             rest => panic!("{rest:?}"),
         }
     }

--- a/crates/libs/metadata/src/value.rs
+++ b/crates/libs/metadata/src/value.rs
@@ -16,7 +16,6 @@ pub enum Value {
     Utf8(String),
     Utf16(String),
     TypeName(TypeName),
-    AttributeEnum(String, i32),
 }
 
 impl Value {
@@ -36,7 +35,6 @@ impl Value {
             Self::Utf8(..) => Type::String,
             Self::Utf16(..) => Type::String,
             Self::TypeName(..) => Type::Name(TypeName::named("System", "Type")),
-            Self::AttributeEnum(..) => Type::AttributeEnum,
         }
     }
 }

--- a/crates/libs/metadata/src/writer/file/helpers.rs
+++ b/crates/libs/metadata/src/writer/file/helpers.rs
@@ -101,7 +101,6 @@ impl Write for Vec<u8> {
             Value::I64(value) => self.extend_from_slice(&value.to_le_bytes()),
             Value::F32(value) => self.extend_from_slice(&value.to_le_bytes()),
             Value::F64(value) => self.extend_from_slice(&value.to_le_bytes()),
-            Value::AttributeEnum(_, value) => self.extend_from_slice(&value.to_le_bytes()),
             Value::Utf8(value) => {
                 self.write_compressed(value.len());
                 self.extend_from_slice(value.as_bytes());

--- a/crates/libs/metadata/src/writer/file/mod.rs
+++ b/crates/libs/metadata/src/writer/file/mod.rs
@@ -428,7 +428,6 @@ impl File {
             }
 
             Type::Name(ty) => self.TypeName(&ty.namespace, &ty.name, &ty.generics, buffer),
-            Type::AttributeEnum => buffer.push(0x55),
         }
     }
 
@@ -506,11 +505,6 @@ impl File {
         for (name, value) in &values[count..] {
             buffer.push(0x53); // field=0x53 property=0x54
             buffer.push(value.ty().code());
-
-            if let Value::AttributeEnum(type_name, _) = value {
-                buffer.write_compressed(type_name.len());
-                buffer.extend_from_slice(type_name.as_bytes());
-            }
 
             buffer.write_compressed(name.len());
             buffer.extend_from_slice(name.as_bytes());

--- a/crates/libs/rdl/src/writer/mod.rs
+++ b/crates/libs/rdl/src/writer/mod.rs
@@ -364,7 +364,6 @@ fn write_value(namespace: &str, value: &metadata::Value) -> TokenStream {
         metadata::Value::Utf8(value) => quote! { #value },
         metadata::Value::Utf16(value) => quote! { #value },
         metadata::Value::TypeName(tn) => write_type(namespace, &metadata::Type::Name(tn.clone())),
-        metadata::Value::AttributeEnum(..) => todo!(),
     }
 }
 
@@ -484,7 +483,6 @@ fn write_type(namespace: &str, item: &metadata::Type) -> TokenStream {
             let name = write_ident(name);
             quote! { #name }
         }
-        rest => todo!("{rest:?}"),
     }
 }
 


### PR DESCRIPTION
Trying to track down the practical usage of this variant. It's related to the 0x55 value ECMA-335 section II.23.1.16 but not finding any test coverage locally. Going to see whether the PR workflows can trip up the parser. 

Looks like this is definitely not used at the moment. I suspect we'll need it for named attribute arguments but I'll remove it for now and we can bring it back once we have a scenario. 