### PR TITLE
Use `String` to refer to `System.String` in `windows-rdl`

### DIFF
--- a/crates/libs/rdl/src/reader/mod.rs
+++ b/crates/libs/rdl/src/reader/mod.rs
@@ -596,7 +596,7 @@ fn encode_path(encoder: &Encoder, ty: &syn::Path) -> Result<metadata::Type, Erro
             "usize" => return Ok(metadata::Type::USize),
 
             "void" => return Ok(metadata::Type::Void),
-            "HSTRING" => return Ok(metadata::Type::String),
+            "String" => return Ok(metadata::Type::String),
             "IInspectable" => return Ok(metadata::Type::Object),
             "Type" => return Ok(metadata::Type::named("System", "Type")),
             "GUID" => return Ok(("System", "Guid").into()),

--- a/crates/libs/rdl/src/writer/mod.rs
+++ b/crates/libs/rdl/src/writer/mod.rs
@@ -452,7 +452,7 @@ fn write_type(namespace: &str, item: &metadata::Type) -> TokenStream {
         USize => quote! { usize },
 
         Void => quote! { void },
-        String => quote! { HSTRING },
+        String => quote! { String },
         Object => quote! { IInspectable },
         Name(tn) if tn == ("System", "Type") => quote! { Type },
         Name(tn) if tn == ("System", "Guid") => quote! { GUID },

--- a/crates/libs/rdl/tests/attribute-on-class-multi.rdl
+++ b/crates/libs/rdl/tests/attribute-on-class-multi.rdl
@@ -2,7 +2,7 @@
 mod Test {
     attribute FooAttribute {
         fn(value: u32);
-        fn(name: HSTRING);
+        fn(name: String);
     }
     #[Foo("hello")]
     class MyClass {}

--- a/crates/libs/rdl/tests/attribute.rdl
+++ b/crates/libs/rdl/tests/attribute.rdl
@@ -2,10 +2,10 @@
 mod Test {
     attribute ActivatableAttribute {
         fn(version: u32);
-        fn(version: u32, r#type: HSTRING);
+        fn(version: u32, r#type: String);
         fn(version: u32, platform: Platform);
         fn(r#type: Type, version: u32);
-        fn(r#type: Type, version: u32, contractName: HSTRING);
+        fn(r#type: Type, version: u32, contractName: String);
         fn(r#type: Type, version: u32, platform: Platform);
     }
     #[repr(i32)]

--- a/crates/libs/rdl/tests/signature.rdl
+++ b/crates/libs/rdl/tests/signature.rdl
@@ -1,7 +1,7 @@
 #[winrt]
 mod Test {
     interface ITest {
-        fn ToString(&self) -> HSTRING;
+        fn ToString(&self) -> String;
         fn Close(&self);
         fn Add(&self, a: u8, b: u16) -> u32;
         fn RefMut(&self, p: &mut u32);

--- a/crates/libs/rdl/tests/special.rdl
+++ b/crates/libs/rdl/tests/special.rdl
@@ -1,4 +1,4 @@
 #[win32]
 mod Test {
-    delegate fn Special(a: *mut void, b: *const void, c: HSTRING, d: IInspectable, e: Type, f: GUID, g: HRESULT);
+    delegate fn Special(a: *mut void, b: *const void, c: String, d: IInspectable, e: Type, f: GUID, g: HRESULT);
 }


### PR DESCRIPTION
#3930 introduced the "special names" but while `HSTRING` is what `System.String` lands up as for WinRT types, this isn't universal and can be confusing in .rdl files when we are clearly not referring to an `HSTRING`. The most obvious examples are attributes and Win32-style constants. 