### PR TITLE
Use `Object` to refer to `System.Object` in `windows-rdl`

### DIFF
--- a/crates/libs/rdl/src/reader/guid.rs
+++ b/crates/libs/rdl/src/reader/guid.rs
@@ -409,7 +409,7 @@ mod tests {
         //       ...
         //       object Object([In] object a, [In] object[] b);
         //   }
-        // Array params expand to (UInt32, T*) for value types; the `object` / IInspectable type
+        // Array params expand to (UInt32, T*) for value types; the `object` / Object type
         // is already a pointer so its [in] param is Object* and its array elements are Object**.
         check(
             "Sample.ICompareWithMidl:\

--- a/crates/libs/rdl/src/reader/mod.rs
+++ b/crates/libs/rdl/src/reader/mod.rs
@@ -629,7 +629,7 @@ fn encode_path(encoder: &Encoder, ty: &syn::Path) -> Result<metadata::Type, Erro
 
             "void" => return Ok(metadata::Type::Void),
             "String" => return Ok(metadata::Type::String),
-            "IInspectable" => return Ok(metadata::Type::Object),
+            "Object" => return Ok(metadata::Type::Object),
             "Type" => return Ok(metadata::Type::named("System", "Type")),
             "GUID" => return Ok(("System", "Guid").into()),
             "HRESULT" => return Ok(("Windows.Foundation", "HResult").into()),

--- a/crates/libs/rdl/src/writer/mod.rs
+++ b/crates/libs/rdl/src/writer/mod.rs
@@ -573,7 +573,7 @@ fn write_type(namespace: &str, item: &metadata::Type) -> TokenStream {
 
         Void => quote! { void },
         String => quote! { String },
-        Object => quote! { IInspectable },
+        Object => quote! { Object },
         Name(tn) if tn == ("System", "Type") => quote! { Type },
         Name(tn) if tn == ("System", "Guid") => quote! { GUID },
         Name(tn) if tn == ("Windows.Foundation", "HResult") => quote! { HRESULT },

--- a/crates/libs/rdl/tests/guid-derive.rdl
+++ b/crates/libs/rdl/tests/guid-derive.rdl
@@ -26,7 +26,7 @@ mod Test {
         fn get_F64(&self) -> f64;
         fn get_ISize(&self) -> isize;
         fn get_USize(&self) -> usize;
-        fn get_Obj(&self) -> IInspectable;
+        fn get_Obj(&self) -> Object;
         fn read_const(&self, p: *const i32);
         fn read_ref(&self, p: &i32);
         fn write_ptr(&self, p: *mut *mut i32);
@@ -56,9 +56,9 @@ mod Test {
 // No explicit [Guid] here — the test asserts that our derivation produces the same
 // GUID that midlrt.exe would assign: 382ceef6-493d-5722-9320-2d701e7a5021.
 // The `b: [T]` array syntax expands to two ABI params for GUID purposes: UInt32 (length) + T*.
-// The `object` (IInspectable) type is an interface pointer, so its [in] param is *mut IInspectable
-// (Object*), its array elements are *mut *mut IInspectable (Object**), and its return type is
-// *mut IInspectable which gains one extra star as the [out,retval] → Object**.
+// The `object` (Object) type is an interface pointer, so its [in] param is *mut Object
+// (Object*), its array elements are *mut *mut Object (Object**), and its return type is
+// *mut Object which gains one extra star as the [out,retval] → Object**.
 #[winrt]
 mod Sample {
     interface ICompareWithMidl {
@@ -73,6 +73,6 @@ mod Sample {
         fn F32(&self, a: f32, b: [f32]) -> f32;
         fn F64(&self, a: f64, b: [f64]) -> f64;
         fn String(&self, a: String, b: [String]) -> String;
-        fn Object(&self, a: *mut IInspectable, b: [*mut IInspectable]) -> *mut IInspectable;
+        fn Object(&self, a: *mut Object, b: [*mut Object]) -> *mut Object;
     }
 }

--- a/crates/libs/rdl/tests/guid-derive.rs
+++ b/crates/libs/rdl/tests/guid-derive.rs
@@ -133,7 +133,7 @@ fn guid_derive() {
 
     // ICompareWithMidl: validates against the GUID midlrt.exe assigns to the equivalent C# MIDL3
     // interface. Array params ([In] T[] b) expand to (b_len: u32, b: *mut T) → (UInt32, T*).
-    // The `object` type (IInspectable) is already a pointer, so [in] object a → Object*, its
+    // The `object` type (Object) is already a pointer, so [in] object a → Object*, its
     // array elements → Object**, and the [out,retval] return → Object**.
     assert_guid(
         "tests/guid-derive.winmd",

--- a/crates/libs/rdl/tests/special.rdl
+++ b/crates/libs/rdl/tests/special.rdl
@@ -1,4 +1,4 @@
 #[win32]
 mod Test {
-    delegate fn Special(a: *mut void, b: *const void, c: String, d: IInspectable, e: Type, f: GUID, g: HRESULT);
+    delegate fn Special(a: *mut void, b: *const void, c: String, d: Object, e: Type, f: GUID, g: HRESULT);
 }


### PR DESCRIPTION
Much like #3956, this update uses `Object` to refer to `System.Object` in metadata rather than the language-specific `IInspectable`. 