### PR TITLE
`windows-bindgen` fix bindings for empty unions

### DIFF
--- a/crates/libs/bindgen/src/types/cpp_struct.rs
+++ b/crates/libs/bindgen/src/types/cpp_struct.rs
@@ -119,8 +119,14 @@ impl CppStruct {
             let fields = quote! { #(#fields)* };
 
             if fields.is_empty() {
-                quote! {
-                    (pub u8);
+                if is_union {
+                    quote! {
+                        { pub value: u8 }
+                    }
+                } else {
+                    quote! {
+                        (pub u8);
+                    }
                 }
             } else {
                 quote! {

--- a/crates/tests/libs/rdl_bindgen/src/empty_struct_union.rs
+++ b/crates/tests/libs/rdl_bindgen/src/empty_struct_union.rs
@@ -1,0 +1,23 @@
+#![allow(
+    non_snake_case,
+    non_upper_case_globals,
+    non_camel_case_types,
+    dead_code,
+    clippy::all
+)]
+
+pub mod Test {
+    #[repr(C)]
+    #[derive(Clone, Copy, Default)]
+    pub struct S(pub u8);
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    pub union U {
+        pub value: u8,
+    }
+    impl Default for U {
+        fn default() -> Self {
+            unsafe { core::mem::zeroed() }
+        }
+    }
+}

--- a/crates/tests/libs/rdl_bindgen/src/lib.rs
+++ b/crates/tests/libs/rdl_bindgen/src/lib.rs
@@ -1,1 +1,2 @@
+mod empty_struct_union;
 mod fn_abi;

--- a/crates/tests/libs/rdl_bindgen/tests/empty_struct_union.rdl
+++ b/crates/tests/libs/rdl_bindgen/tests/empty_struct_union.rdl
@@ -1,0 +1,5 @@
+#[win32]
+mod Test {
+    struct S {}
+    union U {}
+}

--- a/crates/tests/libs/rdl_bindgen/tests/empty_struct_union.rs
+++ b/crates/tests/libs/rdl_bindgen/tests/empty_struct_union.rs
@@ -1,0 +1,27 @@
+#[test]
+fn test() {
+    windows_rdl::Reader::new()
+        .input("tests/empty_struct_union.rdl")
+        .output("tests/empty_struct_union.winmd")
+        .write()
+        .unwrap();
+
+    windows_rdl::Writer::new()
+        .input("tests/empty_struct_union.winmd")
+        .output("tests/empty_struct_union.rdl")
+        .namespace("Test")
+        .write()
+        .unwrap();
+
+    windows_bindgen::bindgen([
+        "--in",
+        "tests/empty_struct_union.winmd",
+        "--out",
+        "src/empty_struct_union.rs",
+        "--filter",
+        "Test",
+        "--sys",
+        "--no-comment",
+    ])
+    .unwrap();
+}


### PR DESCRIPTION
Adds support for empty unions and uses `windows-rdl` for test isolation. 

Fixes: #3505