### PR TITLE
`windows-rdl` exclude all `System` namespaces

### DIFF
--- a/crates/libs/rdl/src/writer/mod.rs
+++ b/crates/libs/rdl/src/writer/mod.rs
@@ -280,7 +280,9 @@ fn write_custom_attributes_except<'a>(
     exclude: &[&str],
 ) -> Vec<TokenStream> {
     attributes
-        .filter(|attr| attr.namespace() != "System" && !exclude.contains(&attr.name()))
+        .filter(|attr| {
+            !namespace_starts_with(attr.namespace(), "System") && !exclude.contains(&attr.name())
+        })
         .map(|attr| {
             let attr_ns = attr.namespace();
             let attr_short = attr

--- a/crates/tools/rdl_roundtrip/src/main.rs
+++ b/crates/tools/rdl_roundtrip/src/main.rs
@@ -3,6 +3,7 @@ use windows_rdl::*;
 fn roundtrip(winmd: &str, rdl: &str) {
     writer()
         .input(winmd)
+        .reference("crates/libs/bindgen/default/Windows.winmd") // for Windows.Foundation.HRESULT
         .output(rdl)
         .namespace("Windows")
         .split()


### PR DESCRIPTION
#4019 excluded types in the `System` namespace but not nested namespaces. This covers that as well.