### PR TITLE
Fix `windows-rdl` support for multi-arch definitions

### DIFF
--- a/crates/libs/rdl/src/writer/layout.rs
+++ b/crates/libs/rdl/src/writer/layout.rs
@@ -3,8 +3,8 @@ use super::*;
 #[derive(Default)]
 pub struct Layout {
     modules: BTreeMap<String, Layout>,
-    winrt: BTreeMap<String, Vec<String>>, // key is type name
-    win32: BTreeMap<(String, i32), Vec<String>>, // key is type name + arches
+    winrt: BTreeMap<String, Vec<String>>,
+    win32: BTreeMap<String, Vec<String>>,
 }
 
 impl Layout {
@@ -16,19 +16,12 @@ impl Layout {
         }
     }
 
-    pub fn insert(
-        &mut self,
-        namespace: &str,
-        name: &str,
-        arches: i32,
-        winrt: bool,
-        tokens: String,
-    ) {
+    pub fn insert(&mut self, namespace: &str, name: &str, winrt: bool, tokens: String) {
         if let Some((first, rest)) = namespace.split_once('.') {
             self.modules
                 .entry(first.to_string())
                 .or_default()
-                .insert(rest, name, arches, winrt, tokens)
+                .insert(rest, name, winrt, tokens)
         } else if winrt {
             self.modules
                 .entry(namespace.to_string())
@@ -42,7 +35,7 @@ impl Layout {
                 .entry(namespace.to_string())
                 .or_default()
                 .win32
-                .entry((name.to_string(), arches))
+                .entry(name.to_string())
                 .or_default()
                 .push(tokens);
         }

--- a/crates/libs/rdl/src/writer/mod.rs
+++ b/crates/libs/rdl/src/writer/mod.rs
@@ -106,13 +106,7 @@ impl Writer {
 
                 for (_, item) in index.namespace_items(namespace) {
                     for (name, tokens) in write_items(namespace, item) {
-                        layout.insert(
-                            namespace,
-                            &name,
-                            item_arches(item),
-                            item_winrt(item),
-                            tokens.to_string(),
-                        );
+                        layout.insert(namespace, &name, item_winrt(item), tokens.to_string());
                     }
                 }
 
@@ -138,13 +132,7 @@ impl Writer {
 
                 for (_, item) in index.namespace_items(namespace) {
                     for (name, tokens) in write_items(namespace, item) {
-                        layout.insert(
-                            namespace,
-                            &name,
-                            item_arches(item),
-                            item_winrt(item),
-                            tokens.to_string(),
-                        );
+                        layout.insert(namespace, &name, item_winrt(item), tokens.to_string());
                     }
                 }
             }
@@ -200,14 +188,6 @@ fn namespace_included(namespace: &str, filter: &[String]) -> bool {
     }
 
     included
-}
-
-fn item_arches(item: &metadata::reader::Item) -> i32 {
-    match item {
-        metadata::reader::Item::Type(ty) => ty.arches(),
-        metadata::reader::Item::Fn(ty) => ty.arches(),
-        metadata::reader::Item::Const(ty) => ty.arches(),
-    }
 }
 
 fn item_winrt(item: &metadata::reader::Item) -> bool {


### PR DESCRIPTION
Early support was colliding with newer multi-definition support. This strips out the earlier support for arches in favor of the more generalized support. 