### PR TITLE
Test all

### DIFF
--- a/.github/workflows/test2.yml
+++ b/.github/workflows/test2.yml
@@ -1,0 +1,69 @@
+name: test2
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    paths-ignore:
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.github/workflows/web.yml'
+      - 'crates/libs/rdl/rdl.md'
+      - 'web/**'
+  push:
+    paths-ignore:
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.github/workflows/web.yml'
+      - 'crates/libs/rdl/rdl.md'
+      - 'web/**'
+    branches:
+      - master
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        include:
+          - version: stable
+            host: x86_64-pc-windows-msvc
+            target: x86_64-pc-windows-msvc
+            runner: windows-2025
+          - version: nightly
+            host: x86_64-pc-windows-msvc
+            target: i686-pc-windows-msvc
+            runner: windows-2025
+          - version: nightly
+            host: x86_64-pc-windows-gnu
+            target: x86_64-pc-windows-gnu
+            runner: windows-2025
+          - version: stable
+            host: x86_64-pc-windows-gnu
+            target: i686-pc-windows-gnu
+            runner: windows-2025
+          - version: stable
+            host: aarch64-pc-windows-msvc
+            target: aarch64-pc-windows-msvc
+            runner: windows-11-arm
+
+    runs-on: ${{ matrix.runner }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Update toolchain
+        run: rustup update --no-self-update ${{ matrix.version }} && rustup default ${{ matrix.version }}-${{ matrix.host }}
+      - name: Add toolchain target
+        run: rustup target add ${{ matrix.target }}
+      - name: Install fmt, clippy
+        run: rustup component add clippy rustfmt
+      - name: Fix environment
+        uses: ./.github/actions/fix-environment
+        with:
+          target: ${{ matrix.target }}
+      - name: Test all
+        run:  cargo test --all --target ${{ matrix.target }}
+      - name: Check diff
+        shell: bash
+        run: |
+          git add -N .
+          git diff --exit-code || (echo 'Tests changed code in the repo.'; exit 1)


### PR DESCRIPTION
We never could run `cargo test --all` in a workflow due to various limitations. Some of those limitations have been removed so let's give it another try. That could potentially be a lot faster. 