### PR TITLE
Update riddle to support both reading and writing

### DIFF
--- a/crates/libs/rdl/src/reader/mod.rs
+++ b/crates/libs/rdl/src/reader/mod.rs
@@ -59,6 +59,18 @@ impl Reader {
         self
     }
 
+    pub fn inputs<I, S>(&mut self, inputs: I) -> &mut Self
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        for input in inputs {
+            self.input.push(input.as_ref().to_string());
+        }
+
+        self
+    }
+
     pub fn output(&mut self, output: &str) -> &mut Self {
         self.output = output.to_string();
         self

--- a/crates/libs/rdl/src/writer/mod.rs
+++ b/crates/libs/rdl/src/writer/mod.rs
@@ -53,6 +53,30 @@ impl Writer {
         self
     }
 
+    pub fn inputs<I, S>(&mut self, inputs: I) -> &mut Self
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        for input in inputs {
+            self.input.push(input.as_ref().to_string());
+        }
+
+        self
+    }
+
+    pub fn filters<I, S>(&mut self, filters: I) -> &mut Self
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        for filter in filters {
+            self.filter.push(filter.as_ref().to_string());
+        }
+
+        self
+    }
+
     /// Filter what to include in the output.  Each call appends one rule.
     ///
     /// Rules are resolved against the input metadata and may be:
@@ -67,8 +91,8 @@ impl Writer {
         self
     }
 
-    pub fn split(&mut self) -> &mut Self {
-        self.split = true;
+    pub fn split(&mut self, split: bool) -> &mut Self {
+        self.split = split;
         self
     }
 

--- a/crates/libs/riddle/src/main.rs
+++ b/crates/libs/riddle/src/main.rs
@@ -15,8 +15,10 @@ Options:
     } else {
         let mut kind = ArgKind::None;
 
-        // TODO: use writer if output is .winmd or reader if output is .rdl
-        let mut reader = windows_rdl::reader();
+        let mut input = vec![];
+        let mut output = String::new();
+        let mut filter = vec![];
+        let mut split = false;
 
         for arg in &args {
             if arg.starts_with('-') {
@@ -27,14 +29,33 @@ Options:
                 ArgKind::None => match arg.as_str() {
                     "--in" => kind = ArgKind::Input,
                     "--out" => kind = ArgKind::Output,
+                    "--filter" => kind = ArgKind::Filter,
+                    "--split" => split = true,
                     _ => panic!("invalid option `{arg}`"),
                 },
-                ArgKind::Output => _ = reader.output(arg.as_str()),
-                ArgKind::Input => _ = reader.input(arg.as_str()),
+                ArgKind::Output => output = arg.to_string(),
+                ArgKind::Input => input.push(arg.to_string()),
+                ArgKind::Filter => filter.push(arg.to_string()),
             }
         }
 
-        if let Err(error) = reader.write() {
+        let path = std::path::Path::new(&output);
+
+        let result = if path
+            .extension()
+            .is_some_and(|extension| extension.eq_ignore_ascii_case("winmd"))
+        {
+            windows_rdl::reader().inputs(&input).output(&output).write()
+        } else {
+            windows_rdl::writer()
+                .inputs(&input)
+                .output(&output)
+                .filters(&filter)
+                .split(split)
+                .write()
+        };
+
+        if let Err(error) = result {
             eprintln!("{error}");
             std::process::exit(1);
         }
@@ -45,4 +66,5 @@ enum ArgKind {
     None,
     Input,
     Output,
+    Filter,
 }

--- a/crates/tests/libs/rdl/tests/split.rs
+++ b/crates/tests/libs/rdl/tests/split.rs
@@ -12,7 +12,7 @@ pub fn parse() {
         .input("tests/split.winmd")
         .output("tests/split")
         .filter("Test")
-        .split()
+        .split(true)
         .write()
         .unwrap();
 }

--- a/crates/tools/rdl_roundtrip/src/main.rs
+++ b/crates/tools/rdl_roundtrip/src/main.rs
@@ -1,12 +1,13 @@
 use windows_rdl::*;
 
-fn roundtrip(winmd: &str, rdl: &str, filter: &[&str]) {
-    let mut w = writer();
-    w.input("crates/libs/bindgen/default").output(rdl).split();
-    for f in filter {
-        w.filter(f);
-    }
-    w.write().unwrap();
+fn roundtrip(winmd: &str, rdl: &str, filters: &[&str]) {
+    writer()
+        .input("crates/libs/bindgen/default")
+        .output(rdl)
+        .filters(filters)
+        .split(true)
+        .write()
+        .unwrap();
 
     reader()
         .input(rdl)


### PR DESCRIPTION
The riddle tool is just a thin command line wrapper around the `windows-rdl` library but at the moment only supports reading RDL files. This update adds the ability to also write RDL files. This is switched based on the extension of the output. I demoed both versions of the tool in this preview: https://youtu.be/VnE8Bm3M650

