### PR TITLE
Enable the `unused_qualifications` lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ opt-level = 2
 [workspace.lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(windows_raw_dylib, windows_slim_errors)'] }
 missing_unsafe_on_extern = "warn"
+unused_qualifications = "warn"
 
 [workspace.dependencies]
 helpers = { path = "crates/tools/helpers" }

--- a/crates/libs/bindgen/src/lib.rs
+++ b/crates/libs/bindgen/src/lib.rs
@@ -757,7 +757,7 @@ where
                 expand = false;
             }
             if expand {
-                for args in io::read_file_lines(&arg) {
+                for args in read_file_lines(&arg) {
                     if !args.starts_with("//") {
                         from_string(result, &args);
                     }

--- a/crates/libs/bindgen/src/winmd/mod.rs
+++ b/crates/libs/bindgen/src/winmd/mod.rs
@@ -54,7 +54,7 @@ pub trait GuidAttributeExt {
     fn guid_attribute(&self) -> Option<GUID>;
 }
 
-impl<T: windows_metadata::HasAttributes<'static>> GuidAttributeExt for T {
+impl<T: HasAttributes<'static>> GuidAttributeExt for T {
     fn guid_attribute(&self) -> Option<GUID> {
         self.find_attribute("GuidAttribute").map(|attribute| {
             fn unwrap_u32(value: &Value) -> u32 {

--- a/crates/libs/core/src/array.rs
+++ b/crates/libs/core/src/array.rs
@@ -25,7 +25,7 @@ impl<T: Type<T>> Array<T> {
     pub fn with_len(len: usize) -> Self {
         assert!(len < u32::MAX as usize);
         let bytes_amount = len
-            .checked_mul(core::mem::size_of::<T>())
+            .checked_mul(size_of::<T>())
             .expect("Attempted to allocate too large an Array");
 
         // WinRT arrays must be allocated with CoTaskMemAlloc.

--- a/crates/libs/core/src/com_object.rs
+++ b/crates/libs/core/src/com_object.rs
@@ -382,7 +382,7 @@ where
     }
 }
 
-impl<T> core::ops::Deref for StaticComObject<T>
+impl<T> Deref for StaticComObject<T>
 where
     T: ComObjectInner,
 {

--- a/crates/libs/core/src/imp/factory_cache.rs
+++ b/crates/libs/core/src/imp/factory_cache.rs
@@ -87,7 +87,7 @@ pub fn load_factory<C: crate::RuntimeName, I: Interface>() -> crate::Result<I> {
         // If RoGetActivationFactory fails because combase hasn't been loaded yet then load combase
         // automatically so that it "just works" for apartment-agnostic code.
         if code == CO_E_NOTINITIALIZED {
-            let mut cookie = core::ptr::null_mut();
+            let mut cookie = null_mut();
             CoIncrementMTAUsage(&mut cookie);
 
             // Now try a second time to get the activation factory via the OS.
@@ -159,7 +159,7 @@ unsafe fn delay_load<T>(library: crate::PCSTR, function: crate::PCSTR) -> Option
     unsafe {
         let library = LoadLibraryExA(
             library.0,
-            core::ptr::null_mut(),
+            null_mut(),
             LOAD_LIBRARY_SEARCH_DEFAULT_DIRS,
         );
 
@@ -170,7 +170,7 @@ unsafe fn delay_load<T>(library: crate::PCSTR, function: crate::PCSTR) -> Option
         let address = GetProcAddress(library, function.0);
 
         if address.is_some() {
-            return Some(core::mem::transmute_copy(&address));
+            return Some(transmute_copy(&address));
         }
 
         FreeLibrary(library);

--- a/crates/libs/future/src/bindings.rs
+++ b/crates/libs/future/src/bindings.rs
@@ -20,7 +20,7 @@ impl AsyncActionCompletedHandler {
             count: windows_core::imp::RefCount::new(1),
             invoke,
         };
-        unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+        unsafe { core::mem::transmute(Box::new(com)) }
     }
     pub fn Invoke<P0>(&self, asyncinfo: P0, asyncstatus: AsyncStatus) -> windows_core::Result<()>
     where
@@ -112,7 +112,7 @@ impl<
             let this = this as *mut *mut core::ffi::c_void as *mut Self;
             let remaining = (*this).count.release();
             if remaining == 0 {
-                let _ = windows_core::imp::Box::from_raw(this);
+                let _ = Box::from_raw(this);
             }
             remaining
         }
@@ -168,7 +168,7 @@ impl<TProgress: windows_core::RuntimeType + 'static> AsyncActionProgressHandler<
             count: windows_core::imp::RefCount::new(1),
             invoke,
         };
-        unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+        unsafe { core::mem::transmute(Box::new(com)) }
     }
     pub fn Invoke<P0, P1>(&self, asyncinfo: P0, progressinfo: P1) -> windows_core::Result<()>
     where
@@ -280,7 +280,7 @@ impl<
             let this = this as *mut *mut core::ffi::c_void as *mut Self;
             let remaining = (*this).count.release();
             if remaining == 0 {
-                let _ = windows_core::imp::Box::from_raw(this);
+                let _ = Box::from_raw(this);
             }
             remaining
         }
@@ -342,7 +342,7 @@ impl<TProgress: windows_core::RuntimeType + 'static>
             count: windows_core::imp::RefCount::new(1),
             invoke,
         };
-        unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+        unsafe { core::mem::transmute(Box::new(com)) }
     }
     pub fn Invoke<P0>(&self, asyncinfo: P0, asyncstatus: AsyncStatus) -> windows_core::Result<()>
     where
@@ -439,7 +439,7 @@ impl<
             let this = this as *mut *mut core::ffi::c_void as *mut Self;
             let remaining = (*this).count.release();
             if remaining == 0 {
-                let _ = windows_core::imp::Box::from_raw(this);
+                let _ = Box::from_raw(this);
             }
             remaining
         }
@@ -492,7 +492,7 @@ impl<TResult: windows_core::RuntimeType + 'static> AsyncOperationCompletedHandle
             count: windows_core::imp::RefCount::new(1),
             invoke,
         };
-        unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+        unsafe { core::mem::transmute(Box::new(com)) }
     }
     pub fn Invoke<P0>(&self, asyncinfo: P0, asyncstatus: AsyncStatus) -> windows_core::Result<()>
     where
@@ -597,7 +597,7 @@ impl<
             let this = this as *mut *mut core::ffi::c_void as *mut Self;
             let remaining = (*this).count.release();
             if remaining == 0 {
-                let _ = windows_core::imp::Box::from_raw(this);
+                let _ = Box::from_raw(this);
             }
             remaining
         }
@@ -665,7 +665,7 @@ impl<
             count: windows_core::imp::RefCount::new(1),
             invoke,
         };
-        unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+        unsafe { core::mem::transmute(Box::new(com)) }
     }
     pub fn Invoke<P0, P1>(&self, asyncinfo: P0, progressinfo: P1) -> windows_core::Result<()>
     where
@@ -769,7 +769,7 @@ impl<
             let this = this as *mut *mut core::ffi::c_void as *mut Self;
             let remaining = (*this).count.release();
             if remaining == 0 {
-                let _ = windows_core::imp::Box::from_raw(this);
+                let _ = Box::from_raw(this);
             }
             remaining
         }
@@ -841,7 +841,7 @@ impl<
             count: windows_core::imp::RefCount::new(1),
             invoke,
         };
-        unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+        unsafe { core::mem::transmute(Box::new(com)) }
     }
     pub fn Invoke<P0>(&self, asyncinfo: P0, asyncstatus: AsyncStatus) -> windows_core::Result<()>
     where
@@ -944,7 +944,7 @@ impl<
             let this = this as *mut *mut core::ffi::c_void as *mut Self;
             let remaining = (*this).count.release();
             if remaining == 0 {
-                let _ = windows_core::imp::Box::from_raw(this);
+                let _ = Box::from_raw(this);
             }
             remaining
         }

--- a/crates/libs/future/src/waiter.rs
+++ b/crates/libs/future/src/waiter.rs
@@ -5,11 +5,11 @@ pub struct WaiterSignaler(HANDLE);
 unsafe impl Send for WaiterSignaler {}
 
 impl Waiter {
-    pub fn new() -> crate::Result<(Self, WaiterSignaler)> {
+    pub fn new() -> Result<(Self, WaiterSignaler)> {
         unsafe {
             let handle = CreateEventW(core::ptr::null(), 1, 0, core::ptr::null());
             if handle.is_null() {
-                Err(crate::Error::from_thread())
+                Err(Error::from_thread())
             } else {
                 Ok((Self(handle), WaiterSignaler(handle)))
             }

--- a/crates/libs/metadata/src/writer/codes.rs
+++ b/crates/libs/metadata/src/writer/codes.rs
@@ -36,7 +36,7 @@ code! { TypeDefOrRef(2)
 impl Default for TypeDefOrRef {
     fn default() -> Self {
         // This results in an encoded value of zero.
-        TypeDefOrRef::TypeDef(id::TypeDef(u32::MAX))
+        TypeDefOrRef::TypeDef(TypeDef(u32::MAX))
     }
 }
 

--- a/crates/libs/metadata/src/writer/file/blobs.rs
+++ b/crates/libs/metadata/src/writer/file/blobs.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 pub struct Blobs {
-    map: HashMap<Vec<u8>, id::BlobId>,
+    map: HashMap<Vec<u8>, BlobId>,
     stream: Vec<u8>,
 }
 
@@ -15,16 +15,16 @@ impl Default for Blobs {
 }
 
 impl Blobs {
-    pub fn insert(&mut self, value: &[u8]) -> id::BlobId {
+    pub fn insert(&mut self, value: &[u8]) -> BlobId {
         if value.is_empty() {
-            return id::BlobId(0);
+            return BlobId(0);
         }
 
         if let Some(pos) = self.map.get(value) {
             return *pos;
         }
 
-        let pos = id::BlobId(self.stream.len().try_into().unwrap());
+        let pos = BlobId(self.stream.len().try_into().unwrap());
         self.map.insert(value.to_vec(), pos);
         let len = value.len();
 

--- a/crates/libs/metadata/src/writer/file/helpers.rs
+++ b/crates/libs/metadata/src/writer/file/helpers.rs
@@ -32,7 +32,7 @@ impl Write for Vec<u8> {
         unsafe {
             self.extend_from_slice(std::slice::from_raw_parts(
                 value as *const _ as _,
-                core::mem::size_of::<T>(),
+                size_of::<T>(),
             ));
         }
     }

--- a/crates/libs/metadata/src/writer/file/into_stream.rs
+++ b/crates/libs/metadata/src/writer/file/into_stream.rs
@@ -104,12 +104,12 @@ impl File {
             let mut dos: IMAGE_DOS_HEADER = core::mem::zeroed();
             dos.e_magic = IMAGE_DOS_SIGNATURE;
             dos.e_lfarlc = 64;
-            dos.e_lfanew = core::mem::size_of::<IMAGE_DOS_HEADER>() as i32;
+            dos.e_lfanew = size_of::<IMAGE_DOS_HEADER>() as i32;
 
             let mut file: IMAGE_FILE_HEADER = core::mem::zeroed();
             file.Machine = IMAGE_FILE_MACHINE_I386;
             file.NumberOfSections = 1;
-            file.SizeOfOptionalHeader = core::mem::size_of::<IMAGE_OPTIONAL_HEADER32>() as u16;
+            file.SizeOfOptionalHeader = size_of::<IMAGE_OPTIONAL_HEADER32>() as u16;
             file.Characteristics =
                 IMAGE_FILE_DLL | IMAGE_FILE_32BIT_MACHINE | IMAGE_FILE_EXECUTABLE_IMAGE;
 
@@ -140,7 +140,7 @@ impl File {
             section.VirtualAddress = SECTION_ALIGNMENT;
 
             let mut clr: IMAGE_COR20_HEADER = core::mem::zeroed();
-            clr.cb = core::mem::size_of::<IMAGE_COR20_HEADER>() as u32;
+            clr.cb = size_of::<IMAGE_COR20_HEADER>() as u32;
             clr.MajorRuntimeVersion = 2;
             clr.MinorRuntimeVersion = 5;
             clr.Flags = 1;
@@ -160,14 +160,14 @@ impl File {
             type GuidsHeader = STREAM_HEADER<8>;
             type BlobsHeader = STREAM_HEADER<8>;
 
-            let size_of_stream_headers = core::mem::size_of::<TablesHeader>()
-                + core::mem::size_of::<StringsHeader>()
-                + core::mem::size_of::<GuidsHeader>()
-                + core::mem::size_of::<BlobsHeader>();
+            let size_of_stream_headers = size_of::<TablesHeader>()
+                + size_of::<StringsHeader>()
+                + size_of::<GuidsHeader>()
+                + size_of::<BlobsHeader>();
 
             let size_of_image = optional.FileAlignment as usize
-                + core::mem::size_of::<IMAGE_COR20_HEADER>()
-                + core::mem::size_of::<METADATA_HEADER>()
+                + size_of::<IMAGE_COR20_HEADER>()
+                + size_of::<METADATA_HEADER>()
                 + size_of_stream_headers
                 + size_of_streams;
 
@@ -185,16 +185,15 @@ impl File {
 
             optional.DataDirectory[14] = IMAGE_DATA_DIRECTORY {
                 VirtualAddress: SECTION_ALIGNMENT,
-                Size: core::mem::size_of::<IMAGE_COR20_HEADER>() as u32,
+                Size: size_of::<IMAGE_COR20_HEADER>() as u32,
             };
 
             section.PointerToRawData = optional.FileAlignment;
 
             clr.MetaData.VirtualAddress =
-                SECTION_ALIGNMENT + core::mem::size_of::<IMAGE_COR20_HEADER>() as u32;
+                SECTION_ALIGNMENT + size_of::<IMAGE_COR20_HEADER>() as u32;
 
-            clr.MetaData.Size =
-                section.Misc.VirtualSize - core::mem::size_of::<IMAGE_COR20_HEADER>() as u32;
+            clr.MetaData.Size = section.Misc.VirtualSize - size_of::<IMAGE_COR20_HEADER>() as u32;
 
             let mut buffer = Vec::<u8>::new();
             buffer.write_header(&dos);

--- a/crates/libs/metadata/src/writer/file/mod.rs
+++ b/crates/libs/metadata/src/writer/file/mod.rs
@@ -18,14 +18,14 @@ pub struct File {
     strings: Strings,
     blobs: Blobs,
     records: rec::Records,
-    reference: Option<crate::reader::TypeIndex>,
+    reference: Option<reader::TypeIndex>,
 
     // Indexes for fast lookup of preexisting rows.
-    TypeRef: HashMap<String, HashMap<String, id::TypeRef>>,
-    TypeSpec: HashMap<id::BlobId, id::TypeSpec>,
-    AssemblyRef: HashMap<String, id::AssemblyRef>,
-    ModuleRef: HashMap<String, id::ModuleRef>,
-    MemberRef: HashMap<rec::MemberRef, id::MemberRef>,
+    TypeRef: HashMap<String, HashMap<String, TypeRef>>,
+    TypeSpec: HashMap<BlobId, TypeSpec>,
+    AssemblyRef: HashMap<String, AssemblyRef>,
+    ModuleRef: HashMap<String, ModuleRef>,
+    MemberRef: HashMap<rec::MemberRef, MemberRef>,
 
     // Staging for sorted rows before these records can be written. BTreeMap is used rather than HashMap to allow reproducible builds.
     Constant: BTreeMap<HasConstant, rec::Constant>,
@@ -68,21 +68,21 @@ impl File {
 
     /// Sets the reference `TypeIndex` used to resolve whether a `TypeRef` refers to a type
     /// defined locally in this file or in an external assembly.
-    pub fn set_reference(&mut self, reference: crate::reader::TypeIndex) {
+    pub fn set_reference(&mut self, reference: reader::TypeIndex) {
         self.reference = Some(reference);
     }
 
     /// Returns the reference `TypeIndex`, if one has been set via [`Self::set_reference`].
-    pub fn reference(&self) -> Option<&crate::reader::TypeIndex> {
+    pub fn reference(&self) -> Option<&reader::TypeIndex> {
         self.reference.as_ref()
     }
 
-    fn ModuleRef(&mut self, name: &str) -> id::ModuleRef {
+    fn ModuleRef(&mut self, name: &str) -> ModuleRef {
         if let Some(pos) = self.ModuleRef.get(name) {
             return *pos;
         }
 
-        let pos = id::ModuleRef(self.records.ModuleRef.push_pos(rec::ModuleRef {
+        let pos = ModuleRef(self.records.ModuleRef.push_pos(rec::ModuleRef {
             Name: self.strings.insert(name),
         }));
 
@@ -92,7 +92,7 @@ impl File {
 
     pub fn ImplMap(
         &mut self,
-        method: id::MethodDef,
+        method: MethodDef,
         flags: PInvokeAttributes,
         import_name: &str,
         import_scope: &str,
@@ -108,12 +108,12 @@ impl File {
     }
 
     /// Adds an `AssemblyRef` row for the given assembly name, returning the row offset.
-    fn AssemblyRef(&mut self, assembly_name: &str) -> id::AssemblyRef {
+    fn AssemblyRef(&mut self, assembly_name: &str) -> AssemblyRef {
         if let Some(pos) = self.AssemblyRef.get(assembly_name) {
             return *pos;
         }
 
-        let pos = id::AssemblyRef(if assembly_name == "System" {
+        let pos = AssemblyRef(if assembly_name == "System" {
             self.records.AssemblyRef.push_pos(rec::AssemblyRef {
                 Name: self.strings.insert("mscorlib"),
                 MajorVersion: 4,
@@ -145,8 +145,8 @@ impl File {
         name: &str,
         extends: TypeDefOrRef,
         flags: TypeAttributes,
-    ) -> id::TypeDef {
-        id::TypeDef(self.records.TypeDef.push_pos(rec::TypeDef {
+    ) -> TypeDef {
+        TypeDef(self.records.TypeDef.push_pos(rec::TypeDef {
             TypeName: self.strings.insert(name),
             TypeNamespace: self.strings.insert(namespace),
             Flags: flags,
@@ -157,7 +157,7 @@ impl File {
     }
 
     /// Adds a `TypeRef` row to the file, returning the row offset.
-    pub fn TypeRef(&mut self, namespace: &str, name: &str) -> id::TypeRef {
+    pub fn TypeRef(&mut self, namespace: &str, name: &str) -> TypeRef {
         if let Some(key) = self.TypeRef.get(namespace) {
             if let Some(pos) = key.get(name) {
                 return *pos;
@@ -166,7 +166,7 @@ impl File {
 
         let pos = if let Some((parent, leaf)) = name.rsplit_once('/') {
             let enclosing = self.TypeRef(namespace, parent);
-            id::TypeRef(self.records.TypeRef.push_pos(rec::TypeRef {
+            TypeRef(self.records.TypeRef.push_pos(rec::TypeRef {
                 TypeName: self.strings.insert(leaf),
                 TypeNamespace: self.strings.insert(""),
                 ResolutionScope: ResolutionScope::TypeRef(enclosing),
@@ -183,10 +183,10 @@ impl File {
             } else if namespace == "System" {
                 ResolutionScope::AssemblyRef(self.AssemblyRef("System"))
             } else {
-                ResolutionScope::Module(id::Module(0))
+                ResolutionScope::Module(Module(0))
             };
 
-            id::TypeRef(self.records.TypeRef.push_pos(rec::TypeRef {
+            TypeRef(self.records.TypeRef.push_pos(rec::TypeRef {
                 TypeName: self.strings.insert(name),
                 TypeNamespace: self.strings.insert(namespace),
                 ResolutionScope: scope,
@@ -201,7 +201,7 @@ impl File {
         pos
     }
 
-    pub fn TypeSpec(&mut self, namespace: &str, name: &str, generics: &[Type]) -> id::TypeSpec {
+    pub fn TypeSpec(&mut self, namespace: &str, name: &str, generics: &[Type]) -> TypeSpec {
         debug_assert!(!generics.is_empty());
         // Generic type references use the backtick-suffix convention per ECMA-335 §II.10.7.2.
         let name = format!("{name}`{}", generics.len());
@@ -223,7 +223,7 @@ impl File {
             return *pos;
         }
 
-        let pos = id::TypeSpec(self.records.TypeSpec.push_pos(rec::TypeSpec {
+        let pos = TypeSpec(self.records.TypeSpec.push_pos(rec::TypeSpec {
             Signature: signature,
         }));
         self.TypeSpec.insert(signature, pos);
@@ -231,10 +231,10 @@ impl File {
     }
 
     /// Adds a `Field` row to the file, returning the row offset.
-    pub fn Field(&mut self, name: &str, ty: &Type, flags: FieldAttributes) -> id::Field {
+    pub fn Field(&mut self, name: &str, ty: &Type, flags: FieldAttributes) -> Field {
         let signature = self.FieldSig(ty);
 
-        id::Field(self.records.Field.push_pos(rec::Field {
+        Field(self.records.Field.push_pos(rec::Field {
             Name: self.strings.insert(name),
             Flags: flags,
             Signature: signature,
@@ -248,10 +248,10 @@ impl File {
         signature: &Signature,
         flags: MethodAttributes,
         impl_flags: MethodImplAttributes,
-    ) -> id::MethodDef {
+    ) -> MethodDef {
         let signature = self.MethodDefSig(signature);
 
-        id::MethodDef(self.records.MethodDef.push_pos(rec::MethodDef {
+        MethodDef(self.records.MethodDef.push_pos(rec::MethodDef {
             RVA: 0,
             ImplFlags: impl_flags,
             Flags: flags,
@@ -266,7 +266,7 @@ impl File {
         name: &str,
         signature: &Signature,
         parent: MemberRefParent,
-    ) -> id::MemberRef {
+    ) -> MemberRef {
         let signature = self.MethodDefSig(signature);
 
         let record = rec::MemberRef {
@@ -279,14 +279,14 @@ impl File {
             return *pos;
         }
 
-        let pos = id::MemberRef(self.records.MemberRef.push_pos(record));
+        let pos = MemberRef(self.records.MemberRef.push_pos(record));
         self.MemberRef.insert(record, pos);
         pos
     }
 
     /// Adds a `Param` row to the file, returning the row offset.
-    pub fn Param(&mut self, name: &str, sequence: u16, flags: ParamAttributes) -> id::Param {
-        id::Param(self.records.Param.push_pos(rec::Param {
+    pub fn Param(&mut self, name: &str, sequence: u16, flags: ParamAttributes) -> Param {
+        Param(self.records.Param.push_pos(rec::Param {
             Flags: flags,
             Sequence: sequence,
             Name: self.strings.insert(name),
@@ -344,7 +344,7 @@ impl File {
             });
     }
 
-    pub fn ClassLayout(&mut self, parent: id::TypeDef, packing_size: u16, class_size: u32) {
+    pub fn ClassLayout(&mut self, parent: TypeDef, packing_size: u16, class_size: u32) {
         self.records.ClassLayout.push(rec::ClassLayout {
             PackingSize: packing_size,
             ClassSize: class_size,
@@ -352,14 +352,14 @@ impl File {
         })
     }
 
-    pub fn FieldLayout(&mut self, field: id::Field, offset: u32) {
+    pub fn FieldLayout(&mut self, field: Field, offset: u32) {
         self.records.FieldLayout.push(rec::FieldLayout {
             Offset: offset,
             Field: field.0,
         })
     }
 
-    pub fn NestedClass(&mut self, inner: id::TypeDef, outer: id::TypeDef) {
+    pub fn NestedClass(&mut self, inner: TypeDef, outer: TypeDef) {
         debug_assert!(inner.0 > outer.0);
 
         self.records.NestedClass.push(rec::NestedClass {
@@ -368,7 +368,7 @@ impl File {
         })
     }
 
-    pub fn InterfaceImpl(&mut self, class: id::TypeDef, interface: &Type) -> id::InterfaceImpl {
+    pub fn InterfaceImpl(&mut self, class: TypeDef, interface: &Type) -> InterfaceImpl {
         let Type::ClassName(interface) = interface else {
             panic!("invalid interface type");
         };
@@ -383,7 +383,7 @@ impl File {
             ))
         };
 
-        id::InterfaceImpl(self.records.InterfaceImpl.push_pos(rec::InterfaceImpl {
+        InterfaceImpl(self.records.InterfaceImpl.push_pos(rec::InterfaceImpl {
             Class: class,
             Interface: interface,
         }))
@@ -505,14 +505,14 @@ impl File {
     }
 
     /// Writes the `Type` into a `FileSig` buffer and stores it in the file, returning the blob offset.
-    fn FieldSig(&mut self, ty: &Type) -> id::BlobId {
+    fn FieldSig(&mut self, ty: &Type) -> BlobId {
         let mut buffer = vec![0x6]; // FIELD
         self.Type(ty, &mut buffer);
         self.blobs.insert(&buffer)
     }
 
     /// Writes the method signature into a `MethodDefSig` buffer and stores it in the file, returning the blob offset.
-    fn MethodDefSig(&mut self, signature: &Signature) -> id::BlobId {
+    fn MethodDefSig(&mut self, signature: &Signature) -> BlobId {
         let mut buffer = vec![signature.flags.0];
         buffer.write_compressed(signature.types.len());
         self.Type(&signature.return_type, &mut buffer);
@@ -524,13 +524,13 @@ impl File {
         self.blobs.insert(&buffer)
     }
 
-    fn ConstantValue(&mut self, value: &Value) -> id::BlobId {
+    fn ConstantValue(&mut self, value: &Value) -> BlobId {
         let mut buffer = vec![];
         buffer.write_value(value);
         self.blobs.insert(&buffer)
     }
 
-    fn AttributeValue(&mut self, values: &[(String, Value)]) -> id::BlobId {
+    fn AttributeValue(&mut self, values: &[(String, Value)]) -> BlobId {
         let mut buffer = vec![];
         buffer.write_u16(1); // prolog
 

--- a/crates/libs/metadata/src/writer/file/rec.rs
+++ b/crates/libs/metadata/src/writer/file/rec.rs
@@ -24,7 +24,7 @@ pub struct Records {
 }
 
 pub struct TypeSpec {
-    pub Signature: id::BlobId,
+    pub Signature: BlobId,
 }
 
 pub struct NestedClass {
@@ -33,7 +33,7 @@ pub struct NestedClass {
 }
 
 pub struct ModuleRef {
-    pub Name: id::StringId,
+    pub Name: StringId,
 }
 
 #[derive(Default)]
@@ -45,7 +45,7 @@ pub struct Assembly {
     pub RevisionNumber: u16,
     pub Flags: AssemblyFlags,
     pub PublicKey: u32,
-    pub Name: id::StringId,
+    pub Name: StringId,
     pub Culture: u32,
 }
 
@@ -58,7 +58,7 @@ pub struct InterfaceImpl {
 pub struct ImplMap {
     pub MappingFlags: PInvokeAttributes,
     pub MemberForwarded: MemberForwarded,
-    pub ImportName: id::StringId,
+    pub ImportName: StringId,
     pub ImportScope: id::ModuleRef,
 }
 
@@ -69,8 +69,8 @@ pub struct AssemblyRef {
     pub BuildNumber: u16,
     pub RevisionNumber: u16,
     pub Flags: AssemblyFlags,
-    pub PublicKeyOrToken: id::BlobId,
-    pub Name: id::StringId,
+    pub PublicKeyOrToken: BlobId,
+    pub Name: StringId,
     pub Culture: u32,
     pub HashValue: u32,
 }
@@ -85,13 +85,13 @@ pub struct ClassLayout {
 pub struct Constant {
     pub Type: u8,
     pub Parent: HasConstant,
-    pub Value: id::BlobId,
+    pub Value: BlobId,
 }
 
 pub struct Field {
     pub Flags: FieldAttributes,
-    pub Name: id::StringId,
-    pub Signature: id::BlobId,
+    pub Name: StringId,
+    pub Signature: BlobId,
 }
 
 pub struct FieldLayout {
@@ -103,15 +103,15 @@ pub struct MethodDef {
     pub RVA: u32,
     pub ImplFlags: MethodImplAttributes,
     pub Flags: MethodAttributes,
-    pub Name: id::StringId,
-    pub Signature: id::BlobId,
+    pub Name: StringId,
+    pub Signature: BlobId,
     pub ParamList: u32,
 }
 
 #[derive(Default)]
 pub struct Module {
     pub Generation: u16,
-    pub Name: id::StringId,
+    pub Name: StringId,
     pub Mvid: u32,
     pub EncId: u32,
     pub EncBaseId: u32,
@@ -122,19 +122,19 @@ pub struct GenericParam {
     pub Number: u16,
     pub Flags: GenericParamAttributes,
     pub Owner: TypeOrMethodDef,
-    pub Name: id::StringId,
+    pub Name: StringId,
 }
 
 pub struct Param {
     pub Flags: ParamAttributes,
     pub Sequence: u16,
-    pub Name: id::StringId,
+    pub Name: StringId,
 }
 
 pub struct TypeDef {
     pub Flags: TypeAttributes,
-    pub TypeName: id::StringId,
-    pub TypeNamespace: id::StringId,
+    pub TypeName: StringId,
+    pub TypeNamespace: StringId,
     pub Extends: TypeDefOrRef,
     pub FieldList: u32,
     pub MethodList: u32,
@@ -142,22 +142,22 @@ pub struct TypeDef {
 
 pub struct TypeRef {
     pub ResolutionScope: ResolutionScope,
-    pub TypeName: id::StringId,
-    pub TypeNamespace: id::StringId,
+    pub TypeName: StringId,
+    pub TypeNamespace: StringId,
 }
 
 #[derive(Copy, Clone)]
 pub struct Attribute {
     pub Parent: HasAttribute,
     pub Type: AttributeType,
-    pub Value: id::BlobId,
+    pub Value: BlobId,
 }
 
 #[derive(Hash, PartialEq, Eq, Copy, Clone)]
 pub struct MemberRef {
     pub Parent: MemberRefParent,
-    pub Name: id::StringId,
-    pub Signature: id::BlobId,
+    pub Name: StringId,
+    pub Signature: BlobId,
 }
 
 impl Records {

--- a/crates/libs/metadata/src/writer/file/strings.rs
+++ b/crates/libs/metadata/src/writer/file/strings.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 pub struct Strings {
-    map: HashMap<String, id::StringId>,
+    map: HashMap<String, StringId>,
     stream: Vec<u8>,
 }
 
@@ -15,16 +15,16 @@ impl Default for Strings {
 }
 
 impl Strings {
-    pub fn insert(&mut self, value: &str) -> id::StringId {
+    pub fn insert(&mut self, value: &str) -> StringId {
         if value.is_empty() {
-            return id::StringId(0);
+            return StringId(0);
         }
 
         if let Some(pos) = self.map.get(value) {
             return *pos;
         }
 
-        let pos = id::StringId(self.stream.len().try_into().unwrap());
+        let pos = StringId(self.stream.len().try_into().unwrap());
         self.map.insert(value.to_string(), pos);
         self.stream.extend_from_slice(value.as_bytes());
         self.stream.push(0);

--- a/crates/libs/rdl/src/reader/mod.rs
+++ b/crates/libs/rdl/src/reader/mod.rs
@@ -274,7 +274,7 @@ fn resolve_winrt(item: &mut Item, source_file: &str, parent: Option<bool>) -> Re
     Ok(())
 }
 
-fn read_winrt_expected<S: syn::spanned::Spanned>(
+fn read_winrt_expected<S: Spanned>(
     source_file: &str,
     span: &S,
     attrs: &[syn::Attribute],
@@ -294,7 +294,7 @@ fn read_winrt_expected<S: syn::spanned::Spanned>(
     }
 }
 
-fn read_winrt<S: syn::spanned::Spanned>(
+fn read_winrt<S: Spanned>(
     source_file: &str,
     span: &S,
     attrs: &[syn::Attribute],
@@ -388,13 +388,13 @@ struct Encoder<'a> {
 }
 
 impl Encoder<'_> {
-    fn error<S: syn::spanned::Spanned>(&self, spanned: S, message: &str) -> Error {
+    fn error<S: Spanned>(&self, spanned: S, message: &str) -> Error {
         let start = spanned.span().start();
 
         Error::new(message, &self.file.source, start.line, start.column)
     }
 
-    fn err<T, S: syn::spanned::Spanned>(&self, spanned: S, message: &str) -> Result<T, Error> {
+    fn err<T, S: Spanned>(&self, spanned: S, message: &str) -> Result<T, Error> {
         Err(self.error(spanned, message))
     }
 
@@ -831,7 +831,7 @@ impl Encoder<'_> {
     /// or anywhere else.  Primitive types and generic type parameters are always valid.
     /// Named types (structs, enums, interfaces, …) are checked against the local index
     /// first, then against any loaded reference metadata.
-    fn validate_type_is_winrt<S: syn::spanned::Spanned + quote::ToTokens>(
+    fn validate_type_is_winrt<S: Spanned + quote::ToTokens>(
         &self,
         span: &S,
         ty: &metadata::Type,

--- a/crates/libs/rdl/src/writer/interface.rs
+++ b/crates/libs/rdl/src/writer/interface.rs
@@ -63,7 +63,7 @@ fn write_members(
     let count = methods.len();
     let mut consumed = vec![false; count];
     let mut tokens = Vec::with_capacity(count);
-    let event_kw = proc_macro2::Ident::new("event", proc_macro2::Span::call_site());
+    let event_kw = Ident::new("event", Span::call_site());
 
     for i in 0..count {
         if consumed[i] {

--- a/crates/libs/rdl/src/writer/mod.rs
+++ b/crates/libs/rdl/src/writer/mod.rs
@@ -927,12 +927,12 @@ fn guid_output(
         return Ok(GuidOutput::None);
     };
     let stored = extract_guid_from_attribute(attr)?;
-    let s = crate::reader::guid::build_interface_string(
+    let s = reader::guid::build_interface_string(
         item.namespace(),
         metadata::trim_tick(item.name()),
         methods,
     );
-    let derived = crate::reader::guid::guid_from_interface_string(&s);
+    let derived = reader::guid::guid_from_interface_string(&s);
     if stored == derived {
         Ok(GuidOutput::Omit)
     } else {

--- a/crates/libs/rdl/src/writer/struct.rs
+++ b/crates/libs/rdl/src/writer/struct.rs
@@ -219,7 +219,7 @@ fn write_packed_attr(item: &metadata::reader::TypeDef) -> TokenStream {
 /// token stream when `packing` is `None`.
 fn write_packed_attr_value(packing: Option<u16>) -> TokenStream {
     if let Some(size) = packing {
-        let size_literal = proc_macro2::Literal::u16_unsuffixed(size);
+        let size_literal = Literal::u16_unsuffixed(size);
         return quote! { #[packed(#size_literal)] };
     }
     quote! {}

--- a/crates/libs/registry/src/key.rs
+++ b/crates/libs/registry/src/key.rs
@@ -80,11 +80,7 @@ impl Key {
     }
 
     /// Sets the name and value in the registry key.
-    pub fn set_hstring<T: AsRef<str>>(
-        &self,
-        name: T,
-        value: &windows_strings::HSTRING,
-    ) -> Result<()> {
+    pub fn set_hstring<T: AsRef<str>>(&self, name: T, value: &HSTRING) -> Result<()> {
         self.set_bytes(name, Type::String, as_bytes(value))
     }
 
@@ -94,11 +90,7 @@ impl Key {
     }
 
     /// Sets the name and value in the registry key.
-    pub fn set_expand_hstring<T: AsRef<str>>(
-        &self,
-        name: T,
-        value: &windows_strings::HSTRING,
-    ) -> Result<()> {
+    pub fn set_expand_hstring<T: AsRef<str>>(&self, name: T, value: &HSTRING) -> Result<()> {
         self.set_bytes(name, Type::ExpandString, as_bytes(value))
     }
 
@@ -226,7 +218,7 @@ impl Key {
                 name.as_ref().as_ptr(),
                 null(),
                 &mut ty,
-                core::ptr::null_mut(),
+                null_mut(),
                 &mut len,
             )
         };

--- a/crates/libs/registry/src/value.rs
+++ b/crates/libs/registry/src/value.rs
@@ -24,7 +24,7 @@ impl Value {
     }
 }
 
-impl core::ops::Deref for Value {
+impl Deref for Value {
     type Target = [u8];
 
     fn deref(&self) -> &[u8] {

--- a/crates/libs/registry/src/value_iterator.rs
+++ b/crates/libs/registry/src/value_iterator.rs
@@ -57,7 +57,7 @@ impl Iterator for ValueIterator<'_> {
                     index as u32,
                     self.name.as_mut_ptr(),
                     &mut name_len,
-                    core::ptr::null(),
+                    null(),
                     &mut ty,
                     self.data.as_mut_ptr(),
                     &mut data_len,

--- a/crates/libs/result/src/error.rs
+++ b/crates/libs/result/src/error.rs
@@ -274,7 +274,7 @@ mod error_info {
         pub(crate) fn from_thread() -> Self {
             unsafe {
                 let mut ptr = core::mem::MaybeUninit::zeroed();
-                crate::bindings::GetErrorInfo(0, ptr.as_mut_ptr() as *mut _);
+                GetErrorInfo(0, ptr.as_mut_ptr() as *mut _);
                 Self {
                     ptr: ptr.assume_init(),
                 }
@@ -284,7 +284,7 @@ mod error_info {
         pub(crate) fn into_thread(self) {
             if let Some(ptr) = self.ptr {
                 unsafe {
-                    crate::bindings::SetErrorInfo(0, ptr.as_raw());
+                    SetErrorInfo(0, ptr.as_raw());
                 }
             }
         }

--- a/crates/libs/services/src/lib.rs
+++ b/crates/libs/services/src/lib.rs
@@ -214,7 +214,7 @@ impl<'a> Service<'a> {
     }
 
     /// The raw handle representing the service.
-    pub fn handle(&self) -> *mut core::ffi::c_void {
+    pub fn handle(&self) -> *mut c_void {
         *self.handle.read().unwrap()
     }
 

--- a/crates/libs/strings/src/bstr.rs
+++ b/crates/libs/strings/src/bstr.rs
@@ -81,7 +81,7 @@ impl Clone for BSTR {
 
 impl From<&str> for BSTR {
     fn from(value: &str) -> Self {
-        let value: alloc::vec::Vec<u16> = value.encode_utf16().collect();
+        let value: Vec<u16> = value.encode_utf16().collect();
         Self::from_wide(&value)
     }
 }
@@ -101,7 +101,7 @@ impl From<&String> for BSTR {
 impl TryFrom<&BSTR> for String {
     type Error = alloc::string::FromUtf16Error;
 
-    fn try_from(value: &BSTR) -> core::result::Result<Self, Self::Error> {
+    fn try_from(value: &BSTR) -> Result<Self, Self::Error> {
         Self::from_utf16(value)
     }
 }
@@ -109,7 +109,7 @@ impl TryFrom<&BSTR> for String {
 impl TryFrom<BSTR> for String {
     type Error = alloc::string::FromUtf16Error;
 
-    fn try_from(value: BSTR) -> core::result::Result<Self, Self::Error> {
+    fn try_from(value: BSTR) -> Result<Self, Self::Error> {
         Self::try_from(&value)
     }
 }

--- a/crates/libs/strings/src/decode.rs
+++ b/crates/libs/strings/src/decode.rs
@@ -4,7 +4,7 @@ pub struct Decode<F>(pub F);
 impl<F, R, E> core::fmt::Display for Decode<F>
 where
     F: Clone + FnOnce() -> R,
-    R: IntoIterator<Item = core::result::Result<char, E>>,
+    R: IntoIterator<Item = Result<char, E>>,
 {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         use core::fmt::Write;
@@ -19,7 +19,7 @@ where
 /// Mirror of `std::char::decode_utf16` for utf-8.
 pub fn decode_utf8(
     mut buffer: &[u8],
-) -> impl Iterator<Item = core::result::Result<char, core::str::Utf8Error>> + '_ {
+) -> impl Iterator<Item = Result<char, core::str::Utf8Error>> + '_ {
     let mut current = "".chars();
     let mut previous_error = None;
     core::iter::from_fn(move || {

--- a/crates/libs/strings/src/hstring.rs
+++ b/crates/libs/strings/src/hstring.rs
@@ -359,7 +359,7 @@ impl PartialEq<&HSTRING> for std::ffi::OsString {
 impl TryFrom<&HSTRING> for String {
     type Error = alloc::string::FromUtf16Error;
 
-    fn try_from(hstring: &HSTRING) -> core::result::Result<Self, Self::Error> {
+    fn try_from(hstring: &HSTRING) -> Result<Self, Self::Error> {
         Self::from_utf16(hstring)
     }
 }
@@ -367,7 +367,7 @@ impl TryFrom<&HSTRING> for String {
 impl TryFrom<HSTRING> for String {
     type Error = alloc::string::FromUtf16Error;
 
-    fn try_from(hstring: HSTRING) -> core::result::Result<Self, Self::Error> {
+    fn try_from(hstring: HSTRING) -> Result<Self, Self::Error> {
         Self::try_from(&hstring)
     }
 }

--- a/crates/libs/strings/src/hstring_header.rs
+++ b/crates/libs/strings/src/hstring_header.rs
@@ -21,7 +21,7 @@ impl HStringHeader {
 
         // Allocate enough space for header and two bytes per character.
         // The space for the terminating null character is already accounted for inside of `HStringHeader`.
-        let bytes = core::mem::size_of::<Self>() + 2 * len as usize;
+        let bytes = size_of::<Self>() + 2 * len as usize;
 
         let header =
             unsafe { bindings::HeapAlloc(bindings::GetProcessHeap(), 0, bytes) } as *mut Self;

--- a/crates/libs/strings/src/pcstr.rs
+++ b/crates/libs/strings/src/pcstr.rs
@@ -43,7 +43,7 @@ impl PCSTR {
     /// # Safety
     ///
     /// See the safety information for `PCSTR::as_bytes`.
-    pub unsafe fn to_string(&self) -> core::result::Result<String, alloc::string::FromUtf8Error> {
+    pub unsafe fn to_string(&self) -> Result<String, alloc::string::FromUtf8Error> {
         unsafe { String::from_utf8(self.as_bytes().into()) }
     }
 

--- a/crates/libs/strings/src/pcwstr.rs
+++ b/crates/libs/strings/src/pcwstr.rs
@@ -61,7 +61,7 @@ impl PCWSTR {
     /// # Safety
     ///
     /// See the safety information for `PCWSTR::as_wide`.
-    pub unsafe fn to_string(&self) -> core::result::Result<String, alloc::string::FromUtf16Error> {
+    pub unsafe fn to_string(&self) -> Result<String, alloc::string::FromUtf16Error> {
         unsafe { String::from_utf16(self.as_wide()) }
     }
 

--- a/crates/libs/strings/src/pstr.rs
+++ b/crates/libs/strings/src/pstr.rs
@@ -43,7 +43,7 @@ impl PSTR {
     /// # Safety
     ///
     /// See the safety information for `PSTR::as_bytes`.
-    pub unsafe fn to_string(&self) -> core::result::Result<String, alloc::string::FromUtf8Error> {
+    pub unsafe fn to_string(&self) -> Result<String, alloc::string::FromUtf8Error> {
         unsafe { String::from_utf8(self.as_bytes().into()) }
     }
 

--- a/crates/libs/strings/src/pwstr.rs
+++ b/crates/libs/strings/src/pwstr.rs
@@ -58,7 +58,7 @@ impl PWSTR {
     /// # Safety
     ///
     /// See the safety information for `PWSTR::as_wide`.
-    pub unsafe fn to_string(&self) -> core::result::Result<String, alloc::string::FromUtf16Error> {
+    pub unsafe fn to_string(&self) -> Result<String, alloc::string::FromUtf16Error> {
         unsafe { String::from_utf16(self.as_wide()) }
     }
 

--- a/crates/libs/threading/src/pool.rs
+++ b/crates/libs/threading/src/pool.rs
@@ -13,7 +13,7 @@ impl Pool {
         let mut e = TP_CALLBACK_ENVIRON_V3 {
             Version: 3,
             CallbackPriority: TP_CALLBACK_PRIORITY_NORMAL,
-            Size: core::mem::size_of::<TP_CALLBACK_ENVIRON_V3>() as u32,
+            Size: size_of::<TP_CALLBACK_ENVIRON_V3>() as u32,
             ..Default::default()
         };
 

--- a/crates/libs/version/src/lib.rs
+++ b/crates/libs/version/src/lib.rs
@@ -95,7 +95,7 @@ pub fn revision() -> u32 {
 impl OSVERSIONINFOEXW {
     fn new() -> Self {
         Self {
-            dwOSVersionInfoSize: core::mem::size_of::<Self>() as u32,
+            dwOSVersionInfoSize: size_of::<Self>() as u32,
             ..Default::default()
         }
     }

--- a/crates/libs/windows/src/Windows/ApplicationModel/Background/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Background/mod.rs
@@ -584,7 +584,7 @@ impl windows_core::RuntimeType for BackgroundTaskCanceledEventHandler {
 impl BackgroundTaskCanceledEventHandler {
     pub fn new<F: Fn(windows_core::Ref<IBackgroundTaskInstance>, BackgroundTaskCancellationReason) -> windows_core::Result<()> + Send + 'static>(invoke: F) -> Self {
         let com = BackgroundTaskCanceledEventHandlerBox { vtable: &BackgroundTaskCanceledEventHandlerBox::<F>::VTABLE, count: windows_core::imp::RefCount::new(1), invoke };
-        unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+        unsafe { core::mem::transmute(Box::new(com)) }
     }
     pub fn Invoke<P0>(&self, sender: P0, reason: BackgroundTaskCancellationReason) -> windows_core::Result<()>
     where
@@ -641,7 +641,7 @@ impl<F: Fn(windows_core::Ref<IBackgroundTaskInstance>, BackgroundTaskCancellatio
             let this = this as *mut *mut core::ffi::c_void as *mut Self;
             let remaining = (*this).count.release();
             if remaining == 0 {
-                let _ = windows_core::imp::Box::from_raw(this);
+                let _ = Box::from_raw(this);
             }
             remaining
         }
@@ -712,7 +712,7 @@ impl windows_core::RuntimeType for BackgroundTaskCompletedEventHandler {
 impl BackgroundTaskCompletedEventHandler {
     pub fn new<F: Fn(windows_core::Ref<BackgroundTaskRegistration>, windows_core::Ref<BackgroundTaskCompletedEventArgs>) -> windows_core::Result<()> + Send + 'static>(invoke: F) -> Self {
         let com = BackgroundTaskCompletedEventHandlerBox { vtable: &BackgroundTaskCompletedEventHandlerBox::<F>::VTABLE, count: windows_core::imp::RefCount::new(1), invoke };
-        unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+        unsafe { core::mem::transmute(Box::new(com)) }
     }
     pub fn Invoke<P0, P1>(&self, sender: P0, args: P1) -> windows_core::Result<()>
     where
@@ -770,7 +770,7 @@ impl<F: Fn(windows_core::Ref<BackgroundTaskRegistration>, windows_core::Ref<Back
             let this = this as *mut *mut core::ffi::c_void as *mut Self;
             let remaining = (*this).count.release();
             if remaining == 0 {
-                let _ = windows_core::imp::Box::from_raw(this);
+                let _ = Box::from_raw(this);
             }
             remaining
         }
@@ -843,7 +843,7 @@ impl windows_core::RuntimeType for BackgroundTaskProgressEventHandler {
 impl BackgroundTaskProgressEventHandler {
     pub fn new<F: Fn(windows_core::Ref<BackgroundTaskRegistration>, windows_core::Ref<BackgroundTaskProgressEventArgs>) -> windows_core::Result<()> + Send + 'static>(invoke: F) -> Self {
         let com = BackgroundTaskProgressEventHandlerBox { vtable: &BackgroundTaskProgressEventHandlerBox::<F>::VTABLE, count: windows_core::imp::RefCount::new(1), invoke };
-        unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+        unsafe { core::mem::transmute(Box::new(com)) }
     }
     pub fn Invoke<P0, P1>(&self, sender: P0, args: P1) -> windows_core::Result<()>
     where
@@ -901,7 +901,7 @@ impl<F: Fn(windows_core::Ref<BackgroundTaskRegistration>, windows_core::Ref<Back
             let this = this as *mut *mut core::ffi::c_void as *mut Self;
             let remaining = (*this).count.release();
             if remaining == 0 {
-                let _ = windows_core::imp::Box::from_raw(this);
+                let _ = Box::from_raw(this);
             }
             remaining
         }

--- a/crates/libs/windows/src/Windows/Devices/Sms/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Sms/mod.rs
@@ -1979,7 +1979,7 @@ impl windows_core::RuntimeType for SmsDeviceStatusChangedEventHandler {
 impl SmsDeviceStatusChangedEventHandler {
     pub fn new<F: Fn(windows_core::Ref<SmsDevice>) -> windows_core::Result<()> + Send + 'static>(invoke: F) -> Self {
         let com = SmsDeviceStatusChangedEventHandlerBox { vtable: &SmsDeviceStatusChangedEventHandlerBox::<F>::VTABLE, count: windows_core::imp::RefCount::new(1), invoke };
-        unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+        unsafe { core::mem::transmute(Box::new(com)) }
     }
     pub fn Invoke<P0>(&self, sender: P0) -> windows_core::Result<()>
     where
@@ -2036,7 +2036,7 @@ impl<F: Fn(windows_core::Ref<SmsDevice>) -> windows_core::Result<()> + Send + 's
             let this = this as *mut *mut core::ffi::c_void as *mut Self;
             let remaining = (*this).count.release();
             if remaining == 0 {
-                let _ = windows_core::imp::Box::from_raw(this);
+                let _ = Box::from_raw(this);
             }
             remaining
         }
@@ -2350,7 +2350,7 @@ impl windows_core::RuntimeType for SmsMessageReceivedEventHandler {
 impl SmsMessageReceivedEventHandler {
     pub fn new<F: Fn(windows_core::Ref<SmsDevice>, windows_core::Ref<SmsMessageReceivedEventArgs>) -> windows_core::Result<()> + Send + 'static>(invoke: F) -> Self {
         let com = SmsMessageReceivedEventHandlerBox { vtable: &SmsMessageReceivedEventHandlerBox::<F>::VTABLE, count: windows_core::imp::RefCount::new(1), invoke };
-        unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+        unsafe { core::mem::transmute(Box::new(com)) }
     }
     pub fn Invoke<P0, P1>(&self, sender: P0, e: P1) -> windows_core::Result<()>
     where
@@ -2408,7 +2408,7 @@ impl<F: Fn(windows_core::Ref<SmsDevice>, windows_core::Ref<SmsMessageReceivedEve
             let this = this as *mut *mut core::ffi::c_void as *mut Self;
             let remaining = (*this).count.release();
             if remaining == 0 {
-                let _ = windows_core::imp::Box::from_raw(this);
+                let _ = Box::from_raw(this);
             }
             remaining
         }

--- a/crates/libs/windows/src/Windows/Foundation/Collections/mod.rs
+++ b/crates/libs/windows/src/Windows/Foundation/Collections/mod.rs
@@ -649,7 +649,7 @@ impl<K: windows_core::RuntimeType + 'static, V: windows_core::RuntimeType + 'sta
 impl<K: windows_core::RuntimeType + 'static, V: windows_core::RuntimeType + 'static> MapChangedEventHandler<K, V> {
     pub fn new<F: Fn(windows_core::Ref<IObservableMap<K, V>>, windows_core::Ref<IMapChangedEventArgs<K>>) -> windows_core::Result<()> + Send + 'static>(invoke: F) -> Self {
         let com = MapChangedEventHandlerBox { vtable: &MapChangedEventHandlerBox::<K, V, F>::VTABLE, count: windows_core::imp::RefCount::new(1), invoke };
-        unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+        unsafe { core::mem::transmute(Box::new(com)) }
     }
     pub fn Invoke<P0, P1>(&self, sender: P0, event: P1) -> windows_core::Result<()>
     where
@@ -722,7 +722,7 @@ impl<K: windows_core::RuntimeType + 'static, V: windows_core::RuntimeType + 'sta
             let this = this as *mut *mut core::ffi::c_void as *mut Self;
             let remaining = (*this).count.release();
             if remaining == 0 {
-                let _ = windows_core::imp::Box::from_raw(this);
+                let _ = Box::from_raw(this);
             }
             remaining
         }
@@ -1067,7 +1067,7 @@ impl<T: windows_core::RuntimeType + 'static> windows_core::RuntimeType for Vecto
 impl<T: windows_core::RuntimeType + 'static> VectorChangedEventHandler<T> {
     pub fn new<F: Fn(windows_core::Ref<IObservableVector<T>>, windows_core::Ref<IVectorChangedEventArgs>) -> windows_core::Result<()> + Send + 'static>(invoke: F) -> Self {
         let com = VectorChangedEventHandlerBox { vtable: &VectorChangedEventHandlerBox::<T, F>::VTABLE, count: windows_core::imp::RefCount::new(1), invoke };
-        unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+        unsafe { core::mem::transmute(Box::new(com)) }
     }
     pub fn Invoke<P0, P1>(&self, sender: P0, event: P1) -> windows_core::Result<()>
     where
@@ -1136,7 +1136,7 @@ impl<T: windows_core::RuntimeType + 'static, F: Fn(windows_core::Ref<IObservable
             let this = this as *mut *mut core::ffi::c_void as *mut Self;
             let remaining = (*this).count.release();
             if remaining == 0 {
-                let _ = windows_core::imp::Box::from_raw(this);
+                let _ = Box::from_raw(this);
             }
             remaining
         }

--- a/crates/libs/windows/src/Windows/Foundation/mod.rs
+++ b/crates/libs/windows/src/Windows/Foundation/mod.rs
@@ -64,7 +64,7 @@ impl windows_core::RuntimeType for DeferralCompletedHandler {
 impl DeferralCompletedHandler {
     pub fn new<F: Fn() -> windows_core::Result<()> + Send + 'static>(invoke: F) -> Self {
         let com = DeferralCompletedHandlerBox { vtable: &DeferralCompletedHandlerBox::<F>::VTABLE, count: windows_core::imp::RefCount::new(1), invoke };
-        unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+        unsafe { core::mem::transmute(Box::new(com)) }
     }
     pub fn Invoke(&self) -> windows_core::Result<()> {
         let this = self;
@@ -118,7 +118,7 @@ impl<F: Fn() -> windows_core::Result<()> + Send + 'static> DeferralCompletedHand
             let this = this as *mut *mut core::ffi::c_void as *mut Self;
             let remaining = (*this).count.release();
             if remaining == 0 {
-                let _ = windows_core::imp::Box::from_raw(this);
+                let _ = Box::from_raw(this);
             }
             remaining
         }
@@ -145,7 +145,7 @@ impl<T: windows_core::RuntimeType + 'static> windows_core::RuntimeType for Event
 impl<T: windows_core::RuntimeType + 'static> EventHandler<T> {
     pub fn new<F: Fn(windows_core::Ref<windows_core::IInspectable>, windows_core::Ref<T>) -> windows_core::Result<()> + Send + 'static>(invoke: F) -> Self {
         let com = EventHandlerBox { vtable: &EventHandlerBox::<T, F>::VTABLE, count: windows_core::imp::RefCount::new(1), invoke };
-        unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+        unsafe { core::mem::transmute(Box::new(com)) }
     }
     pub fn Invoke<P0, P1>(&self, sender: P0, args: P1) -> windows_core::Result<()>
     where
@@ -214,7 +214,7 @@ impl<T: windows_core::RuntimeType + 'static, F: Fn(windows_core::Ref<windows_cor
             let this = this as *mut *mut core::ffi::c_void as *mut Self;
             let remaining = (*this).count.release();
             if remaining == 0 {
-                let _ = windows_core::imp::Box::from_raw(this);
+                let _ = Box::from_raw(this);
             }
             remaining
         }
@@ -2466,7 +2466,7 @@ impl<TSender: windows_core::RuntimeType + 'static, TResult: windows_core::Runtim
 impl<TSender: windows_core::RuntimeType + 'static, TResult: windows_core::RuntimeType + 'static> TypedEventHandler<TSender, TResult> {
     pub fn new<F: Fn(windows_core::Ref<TSender>, windows_core::Ref<TResult>) -> windows_core::Result<()> + Send + 'static>(invoke: F) -> Self {
         let com = TypedEventHandlerBox { vtable: &TypedEventHandlerBox::<TSender, TResult, F>::VTABLE, count: windows_core::imp::RefCount::new(1), invoke };
-        unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+        unsafe { core::mem::transmute(Box::new(com)) }
     }
     pub fn Invoke<P0, P1>(&self, sender: P0, args: P1) -> windows_core::Result<()>
     where
@@ -2539,7 +2539,7 @@ impl<TSender: windows_core::RuntimeType + 'static, TResult: windows_core::Runtim
             let this = this as *mut *mut core::ffi::c_void as *mut Self;
             let remaining = (*this).count.release();
             if remaining == 0 {
-                let _ = windows_core::imp::Box::from_raw(this);
+                let _ = Box::from_raw(this);
             }
             remaining
         }

--- a/crates/libs/windows/src/Windows/Security/Credentials/mod.rs
+++ b/crates/libs/windows/src/Windows/Security/Credentials/mod.rs
@@ -10,7 +10,7 @@ impl windows_core::RuntimeType for AttestationChallengeHandler {
 impl AttestationChallengeHandler {
     pub fn new<F: Fn(windows_core::Ref<super::super::Storage::Streams::IBuffer>) -> windows_core::Result<super::super::Storage::Streams::IBuffer> + Send + 'static>(invoke: F) -> Self {
         let com = AttestationChallengeHandlerBox { vtable: &AttestationChallengeHandlerBox::<F>::VTABLE, count: windows_core::imp::RefCount::new(1), invoke };
-        unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+        unsafe { core::mem::transmute(Box::new(com)) }
     }
     pub fn Invoke<P0>(&self, challenge: P0) -> windows_core::Result<super::super::Storage::Streams::IBuffer>
     where
@@ -73,7 +73,7 @@ impl<F: Fn(windows_core::Ref<super::super::Storage::Streams::IBuffer>) -> window
             let this = this as *mut *mut core::ffi::c_void as *mut Self;
             let remaining = (*this).count.release();
             if remaining == 0 {
-                let _ = windows_core::imp::Box::from_raw(this);
+                let _ = Box::from_raw(this);
             }
             remaining
         }

--- a/crates/libs/windows/src/Windows/Storage/mod.rs
+++ b/crates/libs/windows/src/Windows/Storage/mod.rs
@@ -615,7 +615,7 @@ impl windows_core::RuntimeType for ApplicationDataSetVersionHandler {
 impl ApplicationDataSetVersionHandler {
     pub fn new<F: Fn(windows_core::Ref<SetVersionRequest>) -> windows_core::Result<()> + Send + 'static>(invoke: F) -> Self {
         let com = ApplicationDataSetVersionHandlerBox { vtable: &ApplicationDataSetVersionHandlerBox::<F>::VTABLE, count: windows_core::imp::RefCount::new(1), invoke };
-        unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+        unsafe { core::mem::transmute(Box::new(com)) }
     }
     pub fn Invoke<P0>(&self, setversionrequest: P0) -> windows_core::Result<()>
     where
@@ -672,7 +672,7 @@ impl<F: Fn(windows_core::Ref<SetVersionRequest>) -> windows_core::Result<()> + S
             let this = this as *mut *mut core::ffi::c_void as *mut Self;
             let remaining = (*this).count.release();
             if remaining == 0 {
-                let _ = windows_core::imp::Box::from_raw(this);
+                let _ = Box::from_raw(this);
             }
             remaining
         }
@@ -5696,7 +5696,7 @@ impl windows_core::RuntimeType for StreamedFileDataRequestedHandler {
 impl StreamedFileDataRequestedHandler {
     pub fn new<F: Fn(windows_core::Ref<StreamedFileDataRequest>) -> windows_core::Result<()> + Send + 'static>(invoke: F) -> Self {
         let com = StreamedFileDataRequestedHandlerBox { vtable: &StreamedFileDataRequestedHandlerBox::<F>::VTABLE, count: windows_core::imp::RefCount::new(1), invoke };
-        unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+        unsafe { core::mem::transmute(Box::new(com)) }
     }
     pub fn Invoke<P0>(&self, stream: P0) -> windows_core::Result<()>
     where
@@ -5756,7 +5756,7 @@ impl<F: Fn(windows_core::Ref<StreamedFileDataRequest>) -> windows_core::Result<(
             let this = this as *mut *mut core::ffi::c_void as *mut Self;
             let remaining = (*this).count.release();
             if remaining == 0 {
-                let _ = windows_core::imp::Box::from_raw(this);
+                let _ = Box::from_raw(this);
             }
             remaining
         }

--- a/crates/libs/windows/src/Windows/System/Threading/mod.rs
+++ b/crates/libs/windows/src/Windows/System/Threading/mod.rs
@@ -159,7 +159,7 @@ impl windows_core::RuntimeType for TimerDestroyedHandler {
 impl TimerDestroyedHandler {
     pub fn new<F: Fn(windows_core::Ref<ThreadPoolTimer>) -> windows_core::Result<()> + Send + 'static>(invoke: F) -> Self {
         let com = TimerDestroyedHandlerBox { vtable: &TimerDestroyedHandlerBox::<F>::VTABLE, count: windows_core::imp::RefCount::new(1), invoke };
-        unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+        unsafe { core::mem::transmute(Box::new(com)) }
     }
     pub fn Invoke<P0>(&self, timer: P0) -> windows_core::Result<()>
     where
@@ -216,7 +216,7 @@ impl<F: Fn(windows_core::Ref<ThreadPoolTimer>) -> windows_core::Result<()> + Sen
             let this = this as *mut *mut core::ffi::c_void as *mut Self;
             let remaining = (*this).count.release();
             if remaining == 0 {
-                let _ = windows_core::imp::Box::from_raw(this);
+                let _ = Box::from_raw(this);
             }
             remaining
         }
@@ -235,7 +235,7 @@ impl windows_core::RuntimeType for TimerElapsedHandler {
 impl TimerElapsedHandler {
     pub fn new<F: Fn(windows_core::Ref<ThreadPoolTimer>) -> windows_core::Result<()> + Send + 'static>(invoke: F) -> Self {
         let com = TimerElapsedHandlerBox { vtable: &TimerElapsedHandlerBox::<F>::VTABLE, count: windows_core::imp::RefCount::new(1), invoke };
-        unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+        unsafe { core::mem::transmute(Box::new(com)) }
     }
     pub fn Invoke<P0>(&self, timer: P0) -> windows_core::Result<()>
     where
@@ -292,7 +292,7 @@ impl<F: Fn(windows_core::Ref<ThreadPoolTimer>) -> windows_core::Result<()> + Sen
             let this = this as *mut *mut core::ffi::c_void as *mut Self;
             let remaining = (*this).count.release();
             if remaining == 0 {
-                let _ = windows_core::imp::Box::from_raw(this);
+                let _ = Box::from_raw(this);
             }
             remaining
         }
@@ -311,7 +311,7 @@ impl windows_core::RuntimeType for WorkItemHandler {
 impl WorkItemHandler {
     pub fn new<F: Fn(windows_core::Ref<windows_future::IAsyncAction>) -> windows_core::Result<()> + Send + 'static>(invoke: F) -> Self {
         let com = WorkItemHandlerBox { vtable: &WorkItemHandlerBox::<F>::VTABLE, count: windows_core::imp::RefCount::new(1), invoke };
-        unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+        unsafe { core::mem::transmute(Box::new(com)) }
     }
     pub fn Invoke<P0>(&self, operation: P0) -> windows_core::Result<()>
     where
@@ -368,7 +368,7 @@ impl<F: Fn(windows_core::Ref<windows_future::IAsyncAction>) -> windows_core::Res
             let this = this as *mut *mut core::ffi::c_void as *mut Self;
             let remaining = (*this).count.release();
             if remaining == 0 {
-                let _ = windows_core::imp::Box::from_raw(this);
+                let _ = Box::from_raw(this);
             }
             remaining
         }

--- a/crates/libs/windows/src/Windows/System/mod.rs
+++ b/crates/libs/windows/src/Windows/System/mod.rs
@@ -1204,7 +1204,7 @@ impl windows_core::RuntimeType for DispatcherQueueHandler {
 impl DispatcherQueueHandler {
     pub fn new<F: Fn() -> windows_core::Result<()> + Send + 'static>(invoke: F) -> Self {
         let com = DispatcherQueueHandlerBox { vtable: &DispatcherQueueHandlerBox::<F>::VTABLE, count: windows_core::imp::RefCount::new(1), invoke };
-        unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+        unsafe { core::mem::transmute(Box::new(com)) }
     }
     pub fn Invoke(&self) -> windows_core::Result<()> {
         let this = self;
@@ -1258,7 +1258,7 @@ impl<F: Fn() -> windows_core::Result<()> + Send + 'static> DispatcherQueueHandle
             let this = this as *mut *mut core::ffi::c_void as *mut Self;
             let remaining = (*this).count.release();
             if remaining == 0 {
-                let _ = windows_core::imp::Box::from_raw(this);
+                let _ = Box::from_raw(this);
             }
             remaining
         }

--- a/crates/libs/windows/src/Windows/UI/Core/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Core/mod.rs
@@ -2205,7 +2205,7 @@ impl windows_core::RuntimeType for DispatchedHandler {
 impl DispatchedHandler {
     pub fn new<F: Fn() -> windows_core::Result<()> + Send + 'static>(invoke: F) -> Self {
         let com = DispatchedHandlerBox { vtable: &DispatchedHandlerBox::<F>::VTABLE, count: windows_core::imp::RefCount::new(1), invoke };
-        unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+        unsafe { core::mem::transmute(Box::new(com)) }
     }
     pub fn Invoke(&self) -> windows_core::Result<()> {
         let this = self;
@@ -2259,7 +2259,7 @@ impl<F: Fn() -> windows_core::Result<()> + Send + 'static> DispatchedHandlerBox<
             let this = this as *mut *mut core::ffi::c_void as *mut Self;
             let remaining = (*this).count.release();
             if remaining == 0 {
-                let _ = windows_core::imp::Box::from_raw(this);
+                let _ = Box::from_raw(this);
             }
             remaining
         }
@@ -4904,7 +4904,7 @@ impl windows_core::RuntimeType for IdleDispatchedHandler {
 impl IdleDispatchedHandler {
     pub fn new<F: Fn(windows_core::Ref<IdleDispatchedHandlerArgs>) -> windows_core::Result<()> + Send + 'static>(invoke: F) -> Self {
         let com = IdleDispatchedHandlerBox { vtable: &IdleDispatchedHandlerBox::<F>::VTABLE, count: windows_core::imp::RefCount::new(1), invoke };
-        unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+        unsafe { core::mem::transmute(Box::new(com)) }
     }
     pub fn Invoke<P0>(&self, e: P0) -> windows_core::Result<()>
     where
@@ -4961,7 +4961,7 @@ impl<F: Fn(windows_core::Ref<IdleDispatchedHandlerArgs>) -> windows_core::Result
             let this = this as *mut *mut core::ffi::c_void as *mut Self;
             let remaining = (*this).count.release();
             if remaining == 0 {
-                let _ = windows_core::imp::Box::from_raw(this);
+                let _ = Box::from_raw(this);
             }
             remaining
         }

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D/mod.rs
@@ -984,7 +984,7 @@ impl<T: ID3DInclude_Impl> ID3DInclude_ImplVtbl<T> {
 impl ID3DInclude {
     pub fn new<'a, T: ID3DInclude_Impl>(this: &'a T) -> windows_core::ScopedInterface<'a, Self> {
         let this = windows_core::ScopedHeap { vtable: &ID3DInclude_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
-        let this = core::mem::ManuallyDrop::new(windows_core::imp::Box::new(this));
+        let this = core::mem::ManuallyDrop::new(Box::new(this));
         unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
     }
 }
@@ -1539,7 +1539,7 @@ impl<T: ID3DShaderCacheInstallerClient_Impl> ID3DShaderCacheInstallerClient_Impl
 impl ID3DShaderCacheInstallerClient {
     pub fn new<'a, T: ID3DShaderCacheInstallerClient_Impl>(this: &'a T) -> windows_core::ScopedInterface<'a, Self> {
         let this = windows_core::ScopedHeap { vtable: &ID3DShaderCacheInstallerClient_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
-        let this = core::mem::ManuallyDrop::new(windows_core::imp::Box::new(this));
+        let this = core::mem::ManuallyDrop::new(Box::new(this));
         unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
     }
 }

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D10/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D10/mod.rs
@@ -4686,7 +4686,7 @@ impl<T: ID3D10EffectBlendVariable_Impl> ID3D10EffectBlendVariable_ImplVtbl<T> {
 impl ID3D10EffectBlendVariable {
     pub fn new<'a, T: ID3D10EffectBlendVariable_Impl>(this: &'a T) -> windows_core::ScopedInterface<'a, Self> {
         let this = windows_core::ScopedHeap { vtable: &ID3D10EffectBlendVariable_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
-        let this = core::mem::ManuallyDrop::new(windows_core::imp::Box::new(this));
+        let this = core::mem::ManuallyDrop::new(Box::new(this));
         unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
     }
 }
@@ -4799,7 +4799,7 @@ impl<T: ID3D10EffectConstantBuffer_Impl> ID3D10EffectConstantBuffer_ImplVtbl<T> 
 impl ID3D10EffectConstantBuffer {
     pub fn new<'a, T: ID3D10EffectConstantBuffer_Impl>(this: &'a T) -> windows_core::ScopedInterface<'a, Self> {
         let this = windows_core::ScopedHeap { vtable: &ID3D10EffectConstantBuffer_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
-        let this = core::mem::ManuallyDrop::new(windows_core::imp::Box::new(this));
+        let this = core::mem::ManuallyDrop::new(Box::new(this));
         unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
     }
 }
@@ -4871,7 +4871,7 @@ impl<T: ID3D10EffectDepthStencilVariable_Impl> ID3D10EffectDepthStencilVariable_
 impl ID3D10EffectDepthStencilVariable {
     pub fn new<'a, T: ID3D10EffectDepthStencilVariable_Impl>(this: &'a T) -> windows_core::ScopedInterface<'a, Self> {
         let this = windows_core::ScopedHeap { vtable: &ID3D10EffectDepthStencilVariable_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
-        let this = core::mem::ManuallyDrop::new(windows_core::imp::Box::new(this));
+        let this = core::mem::ManuallyDrop::new(Box::new(this));
         unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
     }
 }
@@ -4972,7 +4972,7 @@ impl<T: ID3D10EffectDepthStencilViewVariable_Impl> ID3D10EffectDepthStencilViewV
 impl ID3D10EffectDepthStencilViewVariable {
     pub fn new<'a, T: ID3D10EffectDepthStencilViewVariable_Impl>(this: &'a T) -> windows_core::ScopedInterface<'a, Self> {
         let this = windows_core::ScopedHeap { vtable: &ID3D10EffectDepthStencilViewVariable_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
-        let this = core::mem::ManuallyDrop::new(windows_core::imp::Box::new(this));
+        let this = core::mem::ManuallyDrop::new(Box::new(this));
         unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
     }
 }
@@ -5113,7 +5113,7 @@ impl<T: ID3D10EffectMatrixVariable_Impl> ID3D10EffectMatrixVariable_ImplVtbl<T> 
 impl ID3D10EffectMatrixVariable {
     pub fn new<'a, T: ID3D10EffectMatrixVariable_Impl>(this: &'a T) -> windows_core::ScopedInterface<'a, Self> {
         let this = windows_core::ScopedHeap { vtable: &ID3D10EffectMatrixVariable_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
-        let this = core::mem::ManuallyDrop::new(windows_core::imp::Box::new(this));
+        let this = core::mem::ManuallyDrop::new(Box::new(this));
         unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
     }
 }
@@ -5261,7 +5261,7 @@ impl<T: ID3D10EffectPass_Impl> ID3D10EffectPass_ImplVtbl<T> {
 impl ID3D10EffectPass {
     pub fn new<'a, T: ID3D10EffectPass_Impl>(this: &'a T) -> windows_core::ScopedInterface<'a, Self> {
         let this = windows_core::ScopedHeap { vtable: &ID3D10EffectPass_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
-        let this = core::mem::ManuallyDrop::new(windows_core::imp::Box::new(this));
+        let this = core::mem::ManuallyDrop::new(Box::new(this));
         unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
     }
 }
@@ -5366,7 +5366,7 @@ impl<T: ID3D10EffectRasterizerVariable_Impl> ID3D10EffectRasterizerVariable_Impl
 impl ID3D10EffectRasterizerVariable {
     pub fn new<'a, T: ID3D10EffectRasterizerVariable_Impl>(this: &'a T) -> windows_core::ScopedInterface<'a, Self> {
         let this = windows_core::ScopedHeap { vtable: &ID3D10EffectRasterizerVariable_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
-        let this = core::mem::ManuallyDrop::new(windows_core::imp::Box::new(this));
+        let this = core::mem::ManuallyDrop::new(Box::new(this));
         unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
     }
 }
@@ -5467,7 +5467,7 @@ impl<T: ID3D10EffectRenderTargetViewVariable_Impl> ID3D10EffectRenderTargetViewV
 impl ID3D10EffectRenderTargetViewVariable {
     pub fn new<'a, T: ID3D10EffectRenderTargetViewVariable_Impl>(this: &'a T) -> windows_core::ScopedInterface<'a, Self> {
         let this = windows_core::ScopedHeap { vtable: &ID3D10EffectRenderTargetViewVariable_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
-        let this = core::mem::ManuallyDrop::new(windows_core::imp::Box::new(this));
+        let this = core::mem::ManuallyDrop::new(Box::new(this));
         unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
     }
 }
@@ -5535,7 +5535,7 @@ impl<T: ID3D10EffectSamplerVariable_Impl> ID3D10EffectSamplerVariable_ImplVtbl<T
 impl ID3D10EffectSamplerVariable {
     pub fn new<'a, T: ID3D10EffectSamplerVariable_Impl>(this: &'a T) -> windows_core::ScopedInterface<'a, Self> {
         let this = windows_core::ScopedHeap { vtable: &ID3D10EffectSamplerVariable_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
-        let this = core::mem::ManuallyDrop::new(windows_core::imp::Box::new(this));
+        let this = core::mem::ManuallyDrop::new(Box::new(this));
         unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
     }
 }
@@ -5755,7 +5755,7 @@ impl<T: ID3D10EffectScalarVariable_Impl> ID3D10EffectScalarVariable_ImplVtbl<T> 
 impl ID3D10EffectScalarVariable {
     pub fn new<'a, T: ID3D10EffectScalarVariable_Impl>(this: &'a T) -> windows_core::ScopedInterface<'a, Self> {
         let this = windows_core::ScopedHeap { vtable: &ID3D10EffectScalarVariable_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
-        let this = core::mem::ManuallyDrop::new(windows_core::imp::Box::new(this));
+        let this = core::mem::ManuallyDrop::new(Box::new(this));
         unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
     }
 }
@@ -5856,7 +5856,7 @@ impl<T: ID3D10EffectShaderResourceVariable_Impl> ID3D10EffectShaderResourceVaria
 impl ID3D10EffectShaderResourceVariable {
     pub fn new<'a, T: ID3D10EffectShaderResourceVariable_Impl>(this: &'a T) -> windows_core::ScopedInterface<'a, Self> {
         let this = windows_core::ScopedHeap { vtable: &ID3D10EffectShaderResourceVariable_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
-        let this = core::mem::ManuallyDrop::new(windows_core::imp::Box::new(this));
+        let this = core::mem::ManuallyDrop::new(Box::new(this));
         unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
     }
 }
@@ -6011,7 +6011,7 @@ impl<T: ID3D10EffectShaderVariable_Impl> ID3D10EffectShaderVariable_ImplVtbl<T> 
 impl ID3D10EffectShaderVariable {
     pub fn new<'a, T: ID3D10EffectShaderVariable_Impl>(this: &'a T) -> windows_core::ScopedInterface<'a, Self> {
         let this = windows_core::ScopedHeap { vtable: &ID3D10EffectShaderVariable_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
-        let this = core::mem::ManuallyDrop::new(windows_core::imp::Box::new(this));
+        let this = core::mem::ManuallyDrop::new(Box::new(this));
         unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
     }
 }
@@ -6079,7 +6079,7 @@ impl<T: ID3D10EffectStringVariable_Impl> ID3D10EffectStringVariable_ImplVtbl<T> 
 impl ID3D10EffectStringVariable {
     pub fn new<'a, T: ID3D10EffectStringVariable_Impl>(this: &'a T) -> windows_core::ScopedInterface<'a, Self> {
         let this = windows_core::ScopedHeap { vtable: &ID3D10EffectStringVariable_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
-        let this = core::mem::ManuallyDrop::new(windows_core::imp::Box::new(this));
+        let this = core::mem::ManuallyDrop::new(Box::new(this));
         unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
     }
 }
@@ -6204,7 +6204,7 @@ impl<T: ID3D10EffectTechnique_Impl> ID3D10EffectTechnique_ImplVtbl<T> {
 impl ID3D10EffectTechnique {
     pub fn new<'a, T: ID3D10EffectTechnique_Impl>(this: &'a T) -> windows_core::ScopedInterface<'a, Self> {
         let this = windows_core::ScopedHeap { vtable: &ID3D10EffectTechnique_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
-        let this = core::mem::ManuallyDrop::new(windows_core::imp::Box::new(this));
+        let this = core::mem::ManuallyDrop::new(Box::new(this));
         unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
     }
 }
@@ -6338,7 +6338,7 @@ impl<T: ID3D10EffectType_Impl> ID3D10EffectType_ImplVtbl<T> {
 impl ID3D10EffectType {
     pub fn new<'a, T: ID3D10EffectType_Impl>(this: &'a T) -> windows_core::ScopedInterface<'a, Self> {
         let this = windows_core::ScopedHeap { vtable: &ID3D10EffectType_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
-        let this = core::mem::ManuallyDrop::new(windows_core::imp::Box::new(this));
+        let this = core::mem::ManuallyDrop::new(Box::new(this));
         unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
     }
 }
@@ -6700,7 +6700,7 @@ impl<T: ID3D10EffectVariable_Impl> ID3D10EffectVariable_ImplVtbl<T> {
 impl ID3D10EffectVariable {
     pub fn new<'a, T: ID3D10EffectVariable_Impl>(this: &'a T) -> windows_core::ScopedInterface<'a, Self> {
         let this = windows_core::ScopedHeap { vtable: &ID3D10EffectVariable_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
-        let this = core::mem::ManuallyDrop::new(windows_core::imp::Box::new(this));
+        let this = core::mem::ManuallyDrop::new(Box::new(this));
         unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
     }
 }
@@ -6893,7 +6893,7 @@ impl<T: ID3D10EffectVectorVariable_Impl> ID3D10EffectVectorVariable_ImplVtbl<T> 
 impl ID3D10EffectVectorVariable {
     pub fn new<'a, T: ID3D10EffectVectorVariable_Impl>(this: &'a T) -> windows_core::ScopedInterface<'a, Self> {
         let this = windows_core::ScopedHeap { vtable: &ID3D10EffectVectorVariable_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
-        let this = core::mem::ManuallyDrop::new(windows_core::imp::Box::new(this));
+        let this = core::mem::ManuallyDrop::new(Box::new(this));
         unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
     }
 }
@@ -8248,7 +8248,7 @@ impl<T: ID3D10ShaderReflectionConstantBuffer_Impl> ID3D10ShaderReflectionConstan
 impl ID3D10ShaderReflectionConstantBuffer {
     pub fn new<'a, T: ID3D10ShaderReflectionConstantBuffer_Impl>(this: &'a T) -> windows_core::ScopedInterface<'a, Self> {
         let this = windows_core::ScopedHeap { vtable: &ID3D10ShaderReflectionConstantBuffer_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
-        let this = core::mem::ManuallyDrop::new(windows_core::imp::Box::new(this));
+        let this = core::mem::ManuallyDrop::new(Box::new(this));
         unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
     }
 }
@@ -8340,7 +8340,7 @@ impl<T: ID3D10ShaderReflectionType_Impl> ID3D10ShaderReflectionType_ImplVtbl<T> 
 impl ID3D10ShaderReflectionType {
     pub fn new<'a, T: ID3D10ShaderReflectionType_Impl>(this: &'a T) -> windows_core::ScopedInterface<'a, Self> {
         let this = windows_core::ScopedHeap { vtable: &ID3D10ShaderReflectionType_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
-        let this = core::mem::ManuallyDrop::new(windows_core::imp::Box::new(this));
+        let this = core::mem::ManuallyDrop::new(Box::new(this));
         unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
     }
 }
@@ -8391,7 +8391,7 @@ impl<T: ID3D10ShaderReflectionVariable_Impl> ID3D10ShaderReflectionVariable_Impl
 impl ID3D10ShaderReflectionVariable {
     pub fn new<'a, T: ID3D10ShaderReflectionVariable_Impl>(this: &'a T) -> windows_core::ScopedInterface<'a, Self> {
         let this = windows_core::ScopedHeap { vtable: &ID3D10ShaderReflectionVariable_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
-        let this = core::mem::ManuallyDrop::new(windows_core::imp::Box::new(this));
+        let this = core::mem::ManuallyDrop::new(Box::new(this));
         unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
     }
 }

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D11/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D11/mod.rs
@@ -9896,7 +9896,7 @@ impl<T: ID3D11FunctionParameterReflection_Impl> ID3D11FunctionParameterReflectio
 impl ID3D11FunctionParameterReflection {
     pub fn new<'a, T: ID3D11FunctionParameterReflection_Impl>(this: &'a T) -> windows_core::ScopedInterface<'a, Self> {
         let this = windows_core::ScopedHeap { vtable: &ID3D11FunctionParameterReflection_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
-        let this = core::mem::ManuallyDrop::new(windows_core::imp::Box::new(this));
+        let this = core::mem::ManuallyDrop::new(Box::new(this));
         unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
     }
 }
@@ -10041,7 +10041,7 @@ impl<T: ID3D11FunctionReflection_Impl> ID3D11FunctionReflection_ImplVtbl<T> {
 impl ID3D11FunctionReflection {
     pub fn new<'a, T: ID3D11FunctionReflection_Impl>(this: &'a T) -> windows_core::ScopedInterface<'a, Self> {
         let this = windows_core::ScopedHeap { vtable: &ID3D11FunctionReflection_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
-        let this = core::mem::ManuallyDrop::new(windows_core::imp::Box::new(this));
+        let this = core::mem::ManuallyDrop::new(Box::new(this));
         unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
     }
 }
@@ -11893,7 +11893,7 @@ impl<T: ID3D11ShaderReflectionConstantBuffer_Impl> ID3D11ShaderReflectionConstan
 impl ID3D11ShaderReflectionConstantBuffer {
     pub fn new<'a, T: ID3D11ShaderReflectionConstantBuffer_Impl>(this: &'a T) -> windows_core::ScopedInterface<'a, Self> {
         let this = windows_core::ScopedHeap { vtable: &ID3D11ShaderReflectionConstantBuffer_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
-        let this = core::mem::ManuallyDrop::new(windows_core::imp::Box::new(this));
+        let this = core::mem::ManuallyDrop::new(Box::new(this));
         unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
     }
 }
@@ -12085,7 +12085,7 @@ impl<T: ID3D11ShaderReflectionType_Impl> ID3D11ShaderReflectionType_ImplVtbl<T> 
 impl ID3D11ShaderReflectionType {
     pub fn new<'a, T: ID3D11ShaderReflectionType_Impl>(this: &'a T) -> windows_core::ScopedInterface<'a, Self> {
         let this = windows_core::ScopedHeap { vtable: &ID3D11ShaderReflectionType_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
-        let this = core::mem::ManuallyDrop::new(windows_core::imp::Box::new(this));
+        let this = core::mem::ManuallyDrop::new(Box::new(this));
         unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
     }
 }
@@ -12160,7 +12160,7 @@ impl<T: ID3D11ShaderReflectionVariable_Impl> ID3D11ShaderReflectionVariable_Impl
 impl ID3D11ShaderReflectionVariable {
     pub fn new<'a, T: ID3D11ShaderReflectionVariable_Impl>(this: &'a T) -> windows_core::ScopedInterface<'a, Self> {
         let this = windows_core::ScopedHeap { vtable: &ID3D11ShaderReflectionVariable_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
-        let this = core::mem::ManuallyDrop::new(windows_core::imp::Box::new(this));
+        let this = core::mem::ManuallyDrop::new(Box::new(this));
         unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
     }
 }

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D12/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D12/mod.rs
@@ -13062,7 +13062,7 @@ impl<T: ID3D12FunctionParameterReflection_Impl> ID3D12FunctionParameterReflectio
 impl ID3D12FunctionParameterReflection {
     pub fn new<'a, T: ID3D12FunctionParameterReflection_Impl>(this: &'a T) -> windows_core::ScopedInterface<'a, Self> {
         let this = windows_core::ScopedHeap { vtable: &ID3D12FunctionParameterReflection_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
-        let this = core::mem::ManuallyDrop::new(windows_core::imp::Box::new(this));
+        let this = core::mem::ManuallyDrop::new(Box::new(this));
         unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
     }
 }
@@ -13207,7 +13207,7 @@ impl<T: ID3D12FunctionReflection_Impl> ID3D12FunctionReflection_ImplVtbl<T> {
 impl ID3D12FunctionReflection {
     pub fn new<'a, T: ID3D12FunctionReflection_Impl>(this: &'a T) -> windows_core::ScopedInterface<'a, Self> {
         let this = windows_core::ScopedHeap { vtable: &ID3D12FunctionReflection_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
-        let this = core::mem::ManuallyDrop::new(windows_core::imp::Box::new(this));
+        let this = core::mem::ManuallyDrop::new(Box::new(this));
         unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
     }
 }
@@ -16965,7 +16965,7 @@ impl<T: ID3D12ShaderReflectionConstantBuffer_Impl> ID3D12ShaderReflectionConstan
 impl ID3D12ShaderReflectionConstantBuffer {
     pub fn new<'a, T: ID3D12ShaderReflectionConstantBuffer_Impl>(this: &'a T) -> windows_core::ScopedInterface<'a, Self> {
         let this = windows_core::ScopedHeap { vtable: &ID3D12ShaderReflectionConstantBuffer_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
-        let this = core::mem::ManuallyDrop::new(windows_core::imp::Box::new(this));
+        let this = core::mem::ManuallyDrop::new(Box::new(this));
         unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
     }
 }
@@ -17157,7 +17157,7 @@ impl<T: ID3D12ShaderReflectionType_Impl> ID3D12ShaderReflectionType_ImplVtbl<T> 
 impl ID3D12ShaderReflectionType {
     pub fn new<'a, T: ID3D12ShaderReflectionType_Impl>(this: &'a T) -> windows_core::ScopedInterface<'a, Self> {
         let this = windows_core::ScopedHeap { vtable: &ID3D12ShaderReflectionType_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
-        let this = core::mem::ManuallyDrop::new(windows_core::imp::Box::new(this));
+        let this = core::mem::ManuallyDrop::new(Box::new(this));
         unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
     }
 }
@@ -17232,7 +17232,7 @@ impl<T: ID3D12ShaderReflectionVariable_Impl> ID3D12ShaderReflectionVariable_Impl
 impl ID3D12ShaderReflectionVariable {
     pub fn new<'a, T: ID3D12ShaderReflectionVariable_Impl>(this: &'a T) -> windows_core::ScopedInterface<'a, Self> {
         let this = windows_core::ScopedHeap { vtable: &ID3D12ShaderReflectionVariable_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
-        let this = core::mem::ManuallyDrop::new(windows_core::imp::Box::new(this));
+        let this = core::mem::ManuallyDrop::new(Box::new(this));
         unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
     }
 }

--- a/crates/libs/windows/src/Windows/Win32/Media/Audio/XAudio2/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/Audio/XAudio2/mod.rs
@@ -674,7 +674,7 @@ impl<T: IXAudio2EngineCallback_Impl> IXAudio2EngineCallback_ImplVtbl<T> {
 impl IXAudio2EngineCallback {
     pub fn new<'a, T: IXAudio2EngineCallback_Impl>(this: &'a T) -> windows_core::ScopedInterface<'a, Self> {
         let this = windows_core::ScopedHeap { vtable: &IXAudio2EngineCallback_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
-        let this = core::mem::ManuallyDrop::new(windows_core::imp::Box::new(this));
+        let this = core::mem::ManuallyDrop::new(Box::new(this));
         unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
     }
 }
@@ -774,7 +774,7 @@ impl<T: IXAudio2MasteringVoice_Impl> IXAudio2MasteringVoice_ImplVtbl<T> {
 impl IXAudio2MasteringVoice {
     pub fn new<'a, T: IXAudio2MasteringVoice_Impl>(this: &'a T) -> windows_core::ScopedInterface<'a, Self> {
         let this = windows_core::ScopedHeap { vtable: &IXAudio2MasteringVoice_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
-        let this = core::mem::ManuallyDrop::new(windows_core::imp::Box::new(this));
+        let this = core::mem::ManuallyDrop::new(Box::new(this));
         unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
     }
 }
@@ -943,7 +943,7 @@ impl<T: IXAudio2SourceVoice_Impl> IXAudio2SourceVoice_ImplVtbl<T> {
 impl IXAudio2SourceVoice {
     pub fn new<'a, T: IXAudio2SourceVoice_Impl>(this: &'a T) -> windows_core::ScopedInterface<'a, Self> {
         let this = windows_core::ScopedHeap { vtable: &IXAudio2SourceVoice_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
-        let this = core::mem::ManuallyDrop::new(windows_core::imp::Box::new(this));
+        let this = core::mem::ManuallyDrop::new(Box::new(this));
         unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
     }
 }
@@ -973,7 +973,7 @@ impl<T: IXAudio2SubmixVoice_Impl> IXAudio2SubmixVoice_ImplVtbl<T> {
 impl IXAudio2SubmixVoice {
     pub fn new<'a, T: IXAudio2SubmixVoice_Impl>(this: &'a T) -> windows_core::ScopedInterface<'a, Self> {
         let this = windows_core::ScopedHeap { vtable: &IXAudio2SubmixVoice_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
-        let this = core::mem::ManuallyDrop::new(windows_core::imp::Box::new(this));
+        let this = core::mem::ManuallyDrop::new(Box::new(this));
         unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
     }
 }
@@ -1282,7 +1282,7 @@ impl<T: IXAudio2Voice_Impl> IXAudio2Voice_ImplVtbl<T> {
 impl IXAudio2Voice {
     pub fn new<'a, T: IXAudio2Voice_Impl>(this: &'a T) -> windows_core::ScopedInterface<'a, Self> {
         let this = windows_core::ScopedHeap { vtable: &IXAudio2Voice_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
-        let this = core::mem::ManuallyDrop::new(windows_core::imp::Box::new(this));
+        let this = core::mem::ManuallyDrop::new(Box::new(this));
         unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
     }
 }
@@ -1399,7 +1399,7 @@ impl<T: IXAudio2VoiceCallback_Impl> IXAudio2VoiceCallback_ImplVtbl<T> {
 impl IXAudio2VoiceCallback {
     pub fn new<'a, T: IXAudio2VoiceCallback_Impl>(this: &'a T) -> windows_core::ScopedInterface<'a, Self> {
         let this = windows_core::ScopedHeap { vtable: &IXAudio2VoiceCallback_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
-        let this = core::mem::ManuallyDrop::new(windows_core::imp::Box::new(this));
+        let this = core::mem::ManuallyDrop::new(Box::new(this));
         unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
     }
 }

--- a/crates/libs/windows/src/Windows/Win32/System/Com/StructuredStorage/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Com/StructuredStorage/mod.rs
@@ -1918,7 +1918,7 @@ impl<T: IMemoryAllocator_Impl> IMemoryAllocator_ImplVtbl<T> {
 impl IMemoryAllocator {
     pub fn new<'a, T: IMemoryAllocator_Impl>(this: &'a T) -> windows_core::ScopedInterface<'a, Self> {
         let this = windows_core::ScopedHeap { vtable: &IMemoryAllocator_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
-        let this = core::mem::ManuallyDrop::new(windows_core::imp::Box::new(this));
+        let this = core::mem::ManuallyDrop::new(Box::new(this));
         unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
     }
 }

--- a/crates/libs/windows/src/extensions/Win32/System/StructuredStorage.rs
+++ b/crates/libs/windows/src/extensions/Win32/System/StructuredStorage.rs
@@ -252,14 +252,14 @@ impl From<IDispatch> for PROPVARIANT {
 }
 
 impl TryFrom<&PROPVARIANT> for IDispatch {
-    type Error = windows_core::Error;
-    fn try_from(from: &PROPVARIANT) -> windows_core::Result<Self> {
+    type Error = Error;
+    fn try_from(from: &PROPVARIANT) -> Result<Self> {
         unsafe {
             if from.Anonymous.Anonymous.vt == VT_DISPATCH && !from.Anonymous.Anonymous.Anonymous.pdispVal.is_none() {
                 let dispatch: &Self = transmute(&from.Anonymous.Anonymous.Anonymous.pdispVal);
                 Ok(dispatch.clone())
             } else {
-                Err(windows_core::Error::from_hresult(TYPE_E_TYPEMISMATCH))
+                Err(Error::from_hresult(TYPE_E_TYPEMISMATCH))
             }
         }
     }

--- a/crates/libs/windows/src/extensions/Win32/System/Variant.rs
+++ b/crates/libs/windows/src/extensions/Win32/System/Variant.rs
@@ -265,14 +265,14 @@ impl From<IDispatch> for VARIANT {
 }
 
 impl TryFrom<&VARIANT> for IDispatch {
-    type Error = windows_core::Error;
-    fn try_from(from: &VARIANT) -> windows_core::Result<Self> {
+    type Error = Error;
+    fn try_from(from: &VARIANT) -> Result<Self> {
         unsafe {
             if from.Anonymous.Anonymous.vt == VT_DISPATCH && !from.Anonymous.Anonymous.Anonymous.pdispVal.is_none() {
                 let dispatch: &Self = transmute(&from.Anonymous.Anonymous.Anonymous.pdispVal);
                 Ok(dispatch.clone())
             } else {
-                Err(windows_core::Error::from_hresult(TYPE_E_TYPEMISMATCH))
+                Err(Error::from_hresult(TYPE_E_TYPEMISMATCH))
             }
         }
     }

--- a/crates/samples/robot/component/src/lib.rs
+++ b/crates/samples/robot/component/src/lib.rs
@@ -18,7 +18,7 @@ extern "system" fn DllGetActivationFactory(
 extern "system" fn CreateRobotFromHandle(
     handle: *mut std::ffi::c_void,
     robot: OutRef<bindings::Robot>,
-) -> windows_core::HRESULT {
+) -> HRESULT {
     robot.write(Some(Robot { handle }.into())).into()
 }
 

--- a/crates/tests/libs/bindgen/src/class_with_handler.rs
+++ b/crates/tests/libs/bindgen/src/class_with_handler.rs
@@ -81,7 +81,7 @@ impl DeferralCompletedHandler {
             count: windows_core::imp::RefCount::new(1),
             invoke,
         };
-        unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+        unsafe { core::mem::transmute(Box::new(com)) }
     }
     pub fn Invoke(&self) -> windows_core::Result<()> {
         let this = self;
@@ -155,7 +155,7 @@ impl<F: Fn() -> windows_core::Result<()> + Send + 'static> DeferralCompletedHand
             let this = this as *mut *mut core::ffi::c_void as *mut Self;
             let remaining = (*this).count.release();
             if remaining == 0 {
-                let _ = windows_core::imp::Box::from_raw(this);
+                let _ = Box::from_raw(this);
             }
             remaining
         }

--- a/crates/tests/libs/bindgen/src/delegate.rs
+++ b/crates/tests/libs/bindgen/src/delegate.rs
@@ -22,7 +22,7 @@ impl DeferralCompletedHandler {
             count: windows_core::imp::RefCount::new(1),
             invoke,
         };
-        unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+        unsafe { core::mem::transmute(Box::new(com)) }
     }
     pub fn Invoke(&self) -> windows_core::Result<()> {
         let this = self;
@@ -96,7 +96,7 @@ impl<F: Fn() -> windows_core::Result<()> + Send + 'static> DeferralCompletedHand
             let this = this as *mut *mut core::ffi::c_void as *mut Self;
             let remaining = (*this).count.release();
             if remaining == 0 {
-                let _ = windows_core::imp::Box::from_raw(this);
+                let _ = Box::from_raw(this);
             }
             remaining
         }

--- a/crates/tests/libs/bindgen/src/delegate_generic.rs
+++ b/crates/tests/libs/bindgen/src/delegate_generic.rs
@@ -39,7 +39,7 @@ impl<T: windows_core::RuntimeType + 'static> EventHandler<T> {
             count: windows_core::imp::RefCount::new(1),
             invoke,
         };
-        unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+        unsafe { core::mem::transmute(Box::new(com)) }
     }
     pub fn Invoke<P0, P1>(&self, sender: P0, args: P1) -> windows_core::Result<()>
     where
@@ -149,7 +149,7 @@ impl<
             let this = this as *mut *mut core::ffi::c_void as *mut Self;
             let remaining = (*this).count.release();
             if remaining == 0 {
-                let _ = windows_core::imp::Box::from_raw(this);
+                let _ = Box::from_raw(this);
             }
             remaining
         }

--- a/crates/tests/libs/rdl/tests/roundtrip/property-order.rdl
+++ b/crates/tests/libs/rdl/tests/roundtrip/property-order.rdl
@@ -1,0 +1,9 @@
+#[winrt]
+mod Test {
+    interface ITest {
+        #[get]
+        foo: u32;
+        #[set]
+        foo: String; // <-- foo is of type String, not u32
+    }
+}

--- a/crates/tests/libs/sys/tests/simple.rs
+++ b/crates/tests/libs/sys/tests/simple.rs
@@ -19,7 +19,7 @@ fn types() {
     let _: u32 = CS_HREDRAW | CS_VREDRAW;
 
     // Constant
-    let _: windows_sys::core::HRESULT = E_FAIL;
+    let _: HRESULT = E_FAIL;
 
     // Constant
     let _: NTSTATUS = DBG_APP_NOT_IDLE;

--- a/crates/tests/misc/component/src/bindings.rs
+++ b/crates/tests/misc/component/src/bindings.rs
@@ -22,7 +22,7 @@ impl Callback {
             count: windows_core::imp::RefCount::new(1),
             invoke,
         };
-        unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+        unsafe { core::mem::transmute(Box::new(com)) }
     }
     pub fn Invoke(&self, a: i32) -> windows_core::Result<i32> {
         let this = self;
@@ -105,7 +105,7 @@ impl<F: Fn(i32) -> windows_core::Result<i32> + Send + 'static> CallbackBox<F> {
             let this = this as *mut *mut core::ffi::c_void as *mut Self;
             let remaining = (*this).count.release();
             if remaining == 0 {
-                let _ = windows_core::imp::Box::from_raw(this);
+                let _ = Box::from_raw(this);
             }
             remaining
         }

--- a/crates/tests/winrt/constructors/src/lib.rs
+++ b/crates/tests/winrt/constructors/src/lib.rs
@@ -62,8 +62,8 @@ impl IActivationFactory_Impl for ComposableFactory_Impl {
 impl bindings::IComposableFactory_Impl for ComposableFactory_Impl {
     fn CreateInstance(
         &self,
-        base: Ref<windows_core::IInspectable>,
-        inner: OutRef<windows_core::IInspectable>,
+        base: Ref<IInspectable>,
+        inner: OutRef<IInspectable>,
     ) -> Result<bindings::Composable> {
         // windows-rs doesn't support binary composition
         _ = inner.write(None);
@@ -77,8 +77,8 @@ impl bindings::IComposableFactory_Impl for ComposableFactory_Impl {
     fn WithValue(
         &self,
         arg: i32,
-        base: Ref<windows_core::IInspectable>,
-        inner: OutRef<windows_core::IInspectable>,
+        base: Ref<IInspectable>,
+        inner: OutRef<IInspectable>,
     ) -> Result<bindings::Composable> {
         // windows-rs doesn't support binary composition
         _ = inner.write(None);

--- a/crates/tests/winrt/events/src/lib.rs
+++ b/crates/tests/winrt/events/src/lib.rs
@@ -64,14 +64,11 @@ impl bindings::IClass_Impl for Class_Impl {
         Ok(counter)
     }
 
-    fn Event(
-        &self,
-        handler: Ref<TypedEventHandler<bindings::Class, i32>>,
-    ) -> windows_core::Result<i64> {
+    fn Event(&self, handler: Ref<TypedEventHandler<bindings::Class, i32>>) -> Result<i64> {
         self.0.add(handler.unwrap())
     }
 
-    fn RemoveEvent(&self, token: i64) -> windows_core::Result<()> {
+    fn RemoveEvent(&self, token: i64) -> Result<()> {
         self.0.remove(token);
         Ok(())
     }

--- a/crates/tools/merge/src/main.rs
+++ b/crates/tools/merge/src/main.rs
@@ -208,7 +208,7 @@ fn write_type(
     }
 }
 
-fn write_attributes<'a, R: reader::HasAttributes<'a>>(
+fn write_attributes<'a, R: HasAttributes<'a>>(
     writer: &mut writer::File,
     parent: writer::HasAttribute,
     row: R,


### PR DESCRIPTION
Manual attempt of #4168 with `cargo fix --lib --allow-dirty --broken-code`