### PR TITLE
Simper test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,25 +34,21 @@ jobs:
             host: x86_64-pc-windows-msvc
             target: x86_64-pc-windows-msvc
             runner: windows-2025
-            extra_excludes: ""
           - name: nightly i686
             version: nightly
             host: x86_64-pc-windows-msvc
             target: i686-pc-windows-msvc
             runner: windows-2025
-            extra_excludes: ""
           - name: nightly gnu
             version: nightly
             host: x86_64-pc-windows-gnu
             target: x86_64-pc-windows-gnu
             runner: windows-2025
-            extra_excludes: ""
           - name: stable arm64
             version: stable
             host: aarch64-pc-windows-msvc
             target: aarch64-pc-windows-msvc
             runner: windows-11-arm
-            extra_excludes: ""
 
     runs-on: ${{ matrix.runner }}
 
@@ -79,7 +75,7 @@ jobs:
         run: echo "LIBCLANG_PATH=${{ env.LLVM_PATH }}/bin" >> "$GITHUB_ENV"
         shell: bash
       - name: Test
-        run: cargo test --all --target ${{ matrix.target }} --exclude windows_aarch64_gnullvm --exclude windows_aarch64_msvc --exclude windows_i686_gnu --exclude windows_i686_gnullvm --exclude windows_i686_msvc --exclude windows_x86_64_gnu --exclude windows_x86_64_gnullvm --exclude windows_x86_64_msvc ${{ matrix.extra_excludes }}
+        run: cargo test --all --target ${{ matrix.target }} --exclude windows_aarch64_gnullvm --exclude windows_aarch64_msvc --exclude windows_i686_gnu --exclude windows_i686_gnullvm --exclude windows_i686_msvc --exclude windows_x86_64_gnu --exclude windows_x86_64_gnullvm --exclude windows_x86_64_msvc
       - name: Check diff
         shell: bash
         run: |


### PR DESCRIPTION
Copilot added `extra_excludes` to the test matrix but it is unused and unnecessary. 