### PR TITLE
Remove GNU test runs

### DIFF
--- a/.github/workflows/slim_errors.yml
+++ b/.github/workflows/slim_errors.yml
@@ -33,8 +33,6 @@ jobs:
         include:
           - target: x86_64-pc-windows-msvc
           - target: i686-pc-windows-msvc
-          - target: x86_64-pc-windows-gnu
-          - target: i686-pc-windows-gnu
         runs-on:
           - windows-2025
     runs-on: ${{ matrix.runs-on }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,11 +39,6 @@ jobs:
             host: x86_64-pc-windows-msvc
             target: i686-pc-windows-msvc
             runner: windows-2025
-          - name: nightly gnu
-            version: nightly
-            host: x86_64-pc-windows-gnu
-            target: x86_64-pc-windows-gnu
-            runner: windows-2025
           - name: stable arm64
             version: stable
             host: aarch64-pc-windows-msvc


### PR DESCRIPTION
The GNU toolchain has been unreliable all day. Removing for now. 