### PR TITLE
`windows-rdl`: add struct field parsing to Clang parser

### DIFF
--- a/crates/libs/rdl/src/clang/cx.rs
+++ b/crates/libs/rdl/src/clang/cx.rs
@@ -173,6 +173,10 @@ impl Cursor {
     pub fn enum_value(&self) -> i64 {
         unsafe { clang_getEnumConstantDeclValue(self.0) }
     }
+
+    pub fn ty(&self) -> CXType {
+        unsafe { clang_getCursorType(self.0) }
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/crates/libs/rdl/src/clang/field.rs
+++ b/crates/libs/rdl/src/clang/field.rs
@@ -1,0 +1,5 @@
+#[derive(Debug)]
+pub struct Field {
+    pub name: String,
+    pub ty: &'static str,
+}

--- a/crates/libs/rdl/src/clang/mod.rs
+++ b/crates/libs/rdl/src/clang/mod.rs
@@ -12,6 +12,8 @@ mod r#struct;
 use r#struct::*;
 mod collector;
 use collector::*;
+use field::*;
+mod field;
 
 #[derive(Default)]
 pub struct Clang {

--- a/crates/libs/rdl/src/clang/struct.rs
+++ b/crates/libs/rdl/src/clang/struct.rs
@@ -3,20 +3,51 @@ use super::*;
 #[derive(Debug)]
 pub struct Struct {
     pub name: String,
+    pub fields: Vec<Field>,
 }
 
 impl Struct {
     pub fn parse(cursor: Cursor) -> Result<Self, Error> {
         let name = cursor.name();
+        let mut fields = vec![];
 
-        Ok(Self { name })
+        for child in cursor.children() {
+            if child.kind() == CXCursor_FieldDecl {
+                let name = child.name();
+                let ty = match child.ty().kind {
+                    CXType_Char_U | CXType_UChar => "u8",
+                    CXType_UShort => "u16",
+                    CXType_UInt => "u32",
+                    CXType_ULong => "usize",
+                    CXType_ULongLong => "u64",
+                    CXType_Char_S | CXType_SChar => "i8",
+                    CXType_Short => "i16",
+                    CXType_Int => "i32",
+                    CXType_Long => "isize",
+                    CXType_LongLong => "i64",
+                    CXType_Float => "f32",
+                    CXType_Double => "f64",
+                    _ => continue,
+                };
+                fields.push(Field { name, ty });
+            }
+        }
+
+        Ok(Self { name, fields })
     }
 
     pub fn write(&self) -> Result<TokenStream, Error> {
         let name = write_ident(&self.name);
 
+        let fields = self.fields.iter().map(|field| {
+            let name = write_ident(&field.name);
+            let ty = write_ident(field.ty);
+            quote! { #name: #ty, }
+        });
+
         Ok(quote! {
             struct #name {
+                #(#fields)*
             }
         })
     }

--- a/crates/tests/libs/clang/roundtrip/struct.h
+++ b/crates/tests/libs/clang/roundtrip/struct.h
@@ -1,2 +1,17 @@
-struct Name {
+struct Empty {
+};
+
+struct Numbers {
+    unsigned char f1;
+    unsigned short f2;
+    unsigned int f3;
+    unsigned long long f4;
+    signed char f5;
+    short f6;
+    int f7;
+    long long f8;
+    float f9;
+    double f10;
+    unsigned long f11;
+    long f12;
 };

--- a/crates/tests/libs/clang/roundtrip/struct.rdl
+++ b/crates/tests/libs/clang/roundtrip/struct.rdl
@@ -1,4 +1,18 @@
 #[win32]
 mod Test {
-    struct Name {}
+    struct Empty {}
+    struct Numbers {
+        f1: u8,
+        f2: u16,
+        f3: u32,
+        f4: u64,
+        f5: i8,
+        f6: i16,
+        f7: i32,
+        f8: i64,
+        f9: f32,
+        f10: f64,
+        f11: usize,
+        f12: isize,
+    }
 }


### PR DESCRIPTION
Building on #4189, this update adds basic support for parsing struct fields, with roundtripping through rdl and winmd for validation.