### PR TITLE
`windows-rdl`: add support for more complex Clang field parsing 

### DIFF
--- a/crates/libs/rdl/src/clang/cx.rs
+++ b/crates/libs/rdl/src/clang/cx.rs
@@ -162,8 +162,8 @@ impl Cursor {
         unsafe { clang_isCursorDefinition(self.0) != 0 }
     }
 
-    pub fn enum_repr(&self) -> CXType {
-        unsafe { clang_getEnumDeclIntegerType(self.0) }
+    pub fn enum_repr(&self) -> Type {
+        Type(unsafe { clang_getEnumDeclIntegerType(self.0) })
     }
 
     pub fn name(&self) -> String {
@@ -174,8 +174,61 @@ impl Cursor {
         unsafe { clang_getEnumConstantDeclValue(self.0) }
     }
 
-    pub fn ty(&self) -> CXType {
-        unsafe { clang_getCursorType(self.0) }
+    pub fn ty(&self) -> Type {
+        Type(unsafe { clang_getCursorType(self.0) })
+    }
+}
+
+pub struct Type(CXType);
+
+impl Type {
+    pub fn kind(&self) -> CXTypeKind {
+        self.0.kind
+    }
+
+    pub fn ty(&self) -> Cursor {
+        Cursor(unsafe { clang_getTypeDeclaration(self.0) })
+    }
+
+    pub fn pointee_type(&self) -> Self {
+        Self(unsafe { clang_getPointeeType(self.0) })
+    }
+
+    pub fn is_const(&self) -> bool {
+        unsafe { clang_isConstQualifiedType(self.0) != 0 }
+    }
+
+    pub fn underlying_type(&self) -> Self {
+        Self(unsafe { clang_Type_getNamedType(self.0) })
+    }
+
+    pub fn to_type(&self, namespace: &str) -> metadata::Type {
+        match self.kind() {
+            CXType_Char_U | CXType_UChar => metadata::Type::U8,
+            CXType_UShort => metadata::Type::U16,
+            CXType_UInt => metadata::Type::U32,
+            CXType_ULong => metadata::Type::USize,
+            CXType_ULongLong => metadata::Type::U64,
+            CXType_Char_S | CXType_SChar => metadata::Type::I8,
+            CXType_Short => metadata::Type::I16,
+            CXType_Int => metadata::Type::I32,
+            CXType_Long => metadata::Type::ISize,
+            CXType_LongLong => metadata::Type::I64,
+            CXType_Float => metadata::Type::F32,
+            CXType_Double => metadata::Type::F64,
+            CXType_Record => metadata::Type::value_named(namespace, &self.ty().name()),
+            CXType_Elaborated => self.underlying_type().to_type(namespace),
+            CXType_Pointer => {
+                let pointee = self.pointee_type();
+                let inner = pointee.to_type(namespace);
+                if pointee.is_const() {
+                    metadata::Type::PtrConst(Box::new(inner), 1)
+                } else {
+                    metadata::Type::PtrMut(Box::new(inner), 1)
+                }
+            }
+            _ => todo!(),
+        }
     }
 }
 

--- a/crates/libs/rdl/src/clang/enum.rs
+++ b/crates/libs/rdl/src/clang/enum.rs
@@ -9,7 +9,7 @@ pub struct Enum {
 
 impl Enum {
     pub fn parse(cursor: Cursor) -> Result<Self, Error> {
-        let repr = match cursor.enum_repr().kind {
+        let repr = match cursor.enum_repr().kind() {
             CXType_Int | CXType_Long => "i32",
             CXType_UInt | CXType_ULong => "u32",
             CXType_Short => "i16",

--- a/crates/libs/rdl/src/clang/field.rs
+++ b/crates/libs/rdl/src/clang/field.rs
@@ -1,5 +1,7 @@
+use super::*;
+
 #[derive(Debug)]
 pub struct Field {
     pub name: String,
-    pub ty: &'static str,
+    pub ty: metadata::Type,
 }

--- a/crates/libs/rdl/src/clang/mod.rs
+++ b/crates/libs/rdl/src/clang/mod.rs
@@ -80,7 +80,9 @@ impl Clang {
                 }
 
                 match child.kind() {
-                    CXCursor_StructDecl => collector.insert(Item::Struct(Struct::parse(child)?)),
+                    CXCursor_StructDecl => {
+                        collector.insert(Item::Struct(Struct::parse(child, &self.namespace)?))
+                    }
                     CXCursor_UnionDecl => {}
                     CXCursor_EnumDecl => collector.insert(Item::Enum(Enum::parse(child)?)),
                     _ => {}

--- a/crates/libs/rdl/src/clang/struct.rs
+++ b/crates/libs/rdl/src/clang/struct.rs
@@ -3,37 +3,30 @@ use super::*;
 #[derive(Debug)]
 pub struct Struct {
     pub name: String,
+    pub namespace: String,
     pub fields: Vec<Field>,
 }
 
 impl Struct {
-    pub fn parse(cursor: Cursor) -> Result<Self, Error> {
+    pub fn parse(cursor: Cursor, namespace: &str) -> Result<Self, Error> {
         let name = cursor.name();
         let mut fields = vec![];
 
         for child in cursor.children() {
-            if child.kind() == CXCursor_FieldDecl {
-                let name = child.name();
-                let ty = match child.ty().kind {
-                    CXType_Char_U | CXType_UChar => "u8",
-                    CXType_UShort => "u16",
-                    CXType_UInt => "u32",
-                    CXType_ULong => "usize",
-                    CXType_ULongLong => "u64",
-                    CXType_Char_S | CXType_SChar => "i8",
-                    CXType_Short => "i16",
-                    CXType_Int => "i32",
-                    CXType_Long => "isize",
-                    CXType_LongLong => "i64",
-                    CXType_Float => "f32",
-                    CXType_Double => "f64",
-                    _ => continue,
-                };
-                fields.push(Field { name, ty });
+            if child.kind() != CXCursor_FieldDecl {
+                continue;
             }
+
+            let name = child.name();
+            let ty = child.ty().to_type(namespace);
+            fields.push(Field { name, ty });
         }
 
-        Ok(Self { name, fields })
+        Ok(Self {
+            name,
+            namespace: namespace.to_string(),
+            fields,
+        })
     }
 
     pub fn write(&self) -> Result<TokenStream, Error> {
@@ -41,7 +34,7 @@ impl Struct {
 
         let fields = self.fields.iter().map(|field| {
             let name = write_ident(&field.name);
-            let ty = write_ident(field.ty);
+            let ty = write_type(&self.namespace, &field.ty);
             quote! { #name: #ty, }
         });
 

--- a/crates/libs/rdl/src/lib.rs
+++ b/crates/libs/rdl/src/lib.rs
@@ -8,6 +8,7 @@ mod writer;
 
 use std::collections::{BTreeMap, HashSet};
 use syn::spanned::Spanned;
+use windows_metadata as metadata;
 
 pub use clang::Clang;
 pub use error::Error;
@@ -127,3 +128,115 @@ macro_rules! writer_err {
 }
 
 use writer_err;
+
+fn write_type(namespace: &str, item: &metadata::Type) -> TokenStream {
+    use metadata::Type::*;
+    match item {
+        Bool => quote! { bool },
+        Char => quote! { u16 },
+        I8 => quote! { i8 },
+        U8 => quote! { u8 },
+        I16 => quote! { i16 },
+        U16 => quote! { u16 },
+        I32 => quote! { i32 },
+        U32 => quote! { u32 },
+        I64 => quote! { i64 },
+        U64 => quote! { u64 },
+        F32 => quote! { f32 },
+        F64 => quote! { f64 },
+        ISize => quote! { isize },
+        USize => quote! { usize },
+
+        Void => quote! { void },
+        String => quote! { String },
+        Object => quote! { Object },
+        ClassName(tn) if tn == ("System", "Type") => quote! { Type },
+        ValueName(tn) if tn == ("System", "Guid") => quote! { GUID },
+        ValueName(tn) if tn == ("Windows.Foundation", "HResult") => quote! { HRESULT },
+
+        Array(ty) => {
+            let ty = write_type(namespace, ty);
+            quote! { [#ty] }
+        }
+        ArrayFixed(ty, len) => {
+            let ty = write_type(namespace, ty);
+            let len = Literal::usize_unsuffixed(*len);
+            quote! { [#ty; #len] }
+        }
+        RefMut(ty) => {
+            let ty = write_type(namespace, ty);
+            quote! { &mut #ty }
+        }
+        RefConst(ty) => {
+            let ty = write_type(namespace, ty);
+            quote! { & #ty }
+        }
+        PtrMut(ty, pointers) => {
+            let mut ty = write_type(namespace, ty);
+
+            for _ in 0..*pointers {
+                ty = quote! { *mut #ty };
+            }
+
+            ty
+        }
+        PtrConst(ty, pointers) => {
+            let mut ty = write_type(namespace, ty);
+
+            for _ in 0..*pointers {
+                ty = quote! { *const #ty };
+            }
+
+            ty
+        }
+        ClassName(type_name) | ValueName(type_name) => {
+            let name = write_ident(&type_name.name);
+
+            let name = if type_name.generics.is_empty() {
+                name
+            } else {
+                let generics = type_name
+                    .generics
+                    .iter()
+                    .map(|ty| write_type(namespace, ty));
+                quote! { #name <#(#generics),*> }
+            };
+
+            // The empty namespace test is for nested types.
+            if namespace == type_name.namespace || type_name.namespace.is_empty() {
+                name
+            } else {
+                let mut relative = namespace.split('.').peekable();
+                let mut namespace = type_name.namespace.split('.').peekable();
+                let shares_root = relative.peek() == namespace.peek();
+
+                while relative.peek() == namespace.peek() {
+                    if relative.next().is_none() {
+                        break;
+                    }
+
+                    namespace.next();
+                }
+
+                let mut tokens = TokenStream::new();
+
+                if shares_root {
+                    for _ in 0..relative.count() {
+                        tokens = quote! { #tokens super:: };
+                    }
+                }
+
+                for namespace in namespace {
+                    let namespace = write_ident(namespace);
+                    tokens = quote! { #tokens #namespace ::};
+                }
+
+                quote! { #tokens #name }
+            }
+        }
+        Generic(name, _) => {
+            let name = write_ident(name);
+            quote! { #name }
+        }
+    }
+}

--- a/crates/libs/rdl/src/writer/mod.rs
+++ b/crates/libs/rdl/src/writer/mod.rs
@@ -20,7 +20,6 @@ use metadata::HasAttributes;
 use r#enum::*;
 use r#fn::*;
 use r#struct::*;
-use windows_metadata as metadata;
 
 // The writer is primarily an internal tool as most developers will write their own
 // definitions or just accept whatever a component author provides. This is thus mostly for
@@ -737,118 +736,6 @@ fn write_type_ref(namespace: &str, item: &metadata::reader::TypeDefOrRef) -> Tok
         namespace,
         &metadata::Type::class_named(item.namespace(), item.name()),
     )
-}
-
-fn write_type(namespace: &str, item: &metadata::Type) -> TokenStream {
-    use metadata::Type::*;
-    match item {
-        Bool => quote! { bool },
-        Char => quote! { u16 },
-        I8 => quote! { i8 },
-        U8 => quote! { u8 },
-        I16 => quote! { i16 },
-        U16 => quote! { u16 },
-        I32 => quote! { i32 },
-        U32 => quote! { u32 },
-        I64 => quote! { i64 },
-        U64 => quote! { u64 },
-        F32 => quote! { f32 },
-        F64 => quote! { f64 },
-        ISize => quote! { isize },
-        USize => quote! { usize },
-
-        Void => quote! { void },
-        String => quote! { String },
-        Object => quote! { Object },
-        ClassName(tn) if tn == ("System", "Type") => quote! { Type },
-        ValueName(tn) if tn == ("System", "Guid") => quote! { GUID },
-        ValueName(tn) if tn == ("Windows.Foundation", "HResult") => quote! { HRESULT },
-
-        Array(ty) => {
-            let ty = write_type(namespace, ty);
-            quote! { [#ty] }
-        }
-        ArrayFixed(ty, len) => {
-            let ty = write_type(namespace, ty);
-            let len = Literal::usize_unsuffixed(*len);
-            quote! { [#ty; #len] }
-        }
-        RefMut(ty) => {
-            let ty = write_type(namespace, ty);
-            quote! { &mut #ty }
-        }
-        RefConst(ty) => {
-            let ty = write_type(namespace, ty);
-            quote! { & #ty }
-        }
-        PtrMut(ty, pointers) => {
-            let mut ty = write_type(namespace, ty);
-
-            for _ in 0..*pointers {
-                ty = quote! { *mut #ty };
-            }
-
-            ty
-        }
-        PtrConst(ty, pointers) => {
-            let mut ty = write_type(namespace, ty);
-
-            for _ in 0..*pointers {
-                ty = quote! { *const #ty };
-            }
-
-            ty
-        }
-        ClassName(type_name) | ValueName(type_name) => {
-            let name = write_ident(&type_name.name);
-
-            let name = if type_name.generics.is_empty() {
-                name
-            } else {
-                let generics = type_name
-                    .generics
-                    .iter()
-                    .map(|ty| write_type(namespace, ty));
-                quote! { #name <#(#generics),*> }
-            };
-
-            // The empty namespace test is for nested types.
-            if namespace == type_name.namespace || type_name.namespace.is_empty() {
-                name
-            } else {
-                let mut relative = namespace.split('.').peekable();
-                let mut namespace = type_name.namespace.split('.').peekable();
-                let shares_root = relative.peek() == namespace.peek();
-
-                while relative.peek() == namespace.peek() {
-                    if relative.next().is_none() {
-                        break;
-                    }
-
-                    namespace.next();
-                }
-
-                let mut tokens = TokenStream::new();
-
-                if shares_root {
-                    for _ in 0..relative.count() {
-                        tokens = quote! { #tokens super:: };
-                    }
-                }
-
-                for namespace in namespace {
-                    let namespace = write_ident(namespace);
-                    tokens = quote! { #tokens #namespace ::};
-                }
-
-                quote! { #tokens #name }
-            }
-        }
-        Generic(name, _) => {
-            let name = write_ident(name);
-            quote! { #name }
-        }
-    }
 }
 
 /// Extracts the raw GUID tuple `(data1, data2, data3, data4)` from a `GuidAttribute`.

--- a/crates/tests/libs/clang/roundtrip/struct.h
+++ b/crates/tests/libs/clang/roundtrip/struct.h
@@ -15,3 +15,13 @@ struct Numbers {
     unsigned long f11;
     long f12;
 };
+
+struct Named {
+    struct Empty f1;
+    struct Numbers f2
+};
+
+struct Pointers {
+    struct Named* f1;
+    int* f2;
+};

--- a/crates/tests/libs/clang/roundtrip/struct.rdl
+++ b/crates/tests/libs/clang/roundtrip/struct.rdl
@@ -1,6 +1,10 @@
 #[win32]
 mod Test {
     struct Empty {}
+    struct Named {
+        f1: Empty,
+        f2: Numbers,
+    }
     struct Numbers {
         f1: u8,
         f2: u16,
@@ -14,5 +18,9 @@ mod Test {
         f10: f64,
         f11: usize,
         f12: isize,
+    }
+    struct Pointers {
+        f1: *mut Named,
+        f2: *mut i32,
     }
 }


### PR DESCRIPTION
Building on #4190, this update adds support for named and pointer field types. This generalizes type parsing further and leads the way to more generally support type conversion from Clang to Windows metadata types. 