### PR TITLE
`windows-rdl`: add support for Clang arguments

### DIFF
--- a/crates/libs/rdl/src/clang/mod.rs
+++ b/crates/libs/rdl/src/clang/mod.rs
@@ -20,6 +20,7 @@ pub struct Clang {
     input: Vec<String>,
     output: String,
     namespace: String,
+    args: Vec<String>,
 }
 
 impl Clang {
@@ -42,6 +43,17 @@ impl Clang {
         self
     }
 
+    pub fn args<I>(&mut self, args: I) -> &mut Self
+    where
+        I: IntoIterator,
+        I::Item: AsRef<str>,
+    {
+        for arg in args {
+            self.args.push(arg.as_ref().to_string());
+        }
+        self
+    }
+
     pub fn write(&self) -> Result<(), Error> {
         let (h_paths, winmd_paths) = expand_input_paths(&self.input, "h", "winmd")?;
 
@@ -59,9 +71,10 @@ impl Clang {
         let _library = Library::new()?;
         let index = Index::new()?;
         let mut collector = Collector::new();
+        let args: Vec<_> = self.args.iter().map(String::as_str).collect();
 
         for input in &h_paths {
-            let tu = index.parse(input, &[])?;
+            let tu = index.parse(input, &args)?;
 
             for diag in tu.diagnostics() {
                 if diag.is_err() {

--- a/crates/tests/libs/clang/roundtrip/struct.h
+++ b/crates/tests/libs/clang/roundtrip/struct.h
@@ -17,11 +17,11 @@ struct Numbers {
 };
 
 struct Named {
-    struct Empty f1;
-    struct Numbers f2
+    Empty f1;
+    Numbers f2;
 };
 
 struct Pointers {
-    struct Named* f1;
+    Named* f1;
     int* f2;
 };

--- a/crates/tests/libs/clang/tests/roundtrip.rs
+++ b/crates/tests/libs/clang/tests/roundtrip.rs
@@ -16,6 +16,7 @@ fn roundtrip() {
         let reference = "../../../libs/bindgen/default";
 
         clang()
+            .args(["-x", "c++"])
             .input(&h)
             .input(reference)
             .output(&rdl)


### PR DESCRIPTION
Building on #4191, this update adds the ability to pass arguments to libclang so that the caller can control parsing modes like C or C++ and so on. 