### PR TITLE
`windows-rdl`: add support for Clang parsing of typedefs

### DIFF
--- a/crates/libs/rdl/src/clang/cx.rs
+++ b/crates/libs/rdl/src/clang/cx.rs
@@ -177,6 +177,10 @@ impl Cursor {
     pub fn ty(&self) -> Type {
         Type(unsafe { clang_getCursorType(self.0) })
     }
+
+    pub fn typedef_underlying_type(&self) -> Type {
+        Type(unsafe { clang_getTypedefDeclUnderlyingType(self.0) })
+    }
 }
 
 pub struct Type(CXType);
@@ -204,6 +208,7 @@ impl Type {
 
     pub fn to_type(&self, namespace: &str) -> metadata::Type {
         match self.kind() {
+            CXType_Void => metadata::Type::Void,
             CXType_Char_U | CXType_UChar => metadata::Type::U8,
             CXType_UShort => metadata::Type::U16,
             CXType_UInt => metadata::Type::U32,
@@ -227,7 +232,7 @@ impl Type {
                     metadata::Type::PtrMut(Box::new(inner), 1)
                 }
             }
-            _ => todo!(),
+            rest => panic!("{rest:?}"),
         }
     }
 }

--- a/crates/libs/rdl/src/clang/item.rs
+++ b/crates/libs/rdl/src/clang/item.rs
@@ -4,6 +4,7 @@ use super::*;
 pub enum Item {
     Enum(Enum),
     Struct(Struct),
+    Typedef(Typedef),
 }
 
 impl Item {
@@ -11,6 +12,7 @@ impl Item {
         match self {
             Self::Enum(item) => item.write(),
             Self::Struct(item) => item.write(),
+            Self::Typedef(item) => item.write(),
         }
     }
 }
@@ -20,6 +22,7 @@ impl std::fmt::Display for Item {
         match self {
             Self::Enum(item) => item.name.fmt(f),
             Self::Struct(item) => item.name.fmt(f),
+            Self::Typedef(item) => item.name.fmt(f),
         }
     }
 }

--- a/crates/libs/rdl/src/clang/mod.rs
+++ b/crates/libs/rdl/src/clang/mod.rs
@@ -14,6 +14,8 @@ mod collector;
 use collector::*;
 use field::*;
 mod field;
+mod typedef;
+use typedef::*;
 
 #[derive(Default)]
 pub struct Clang {
@@ -96,8 +98,12 @@ impl Clang {
                     CXCursor_StructDecl => {
                         collector.insert(Item::Struct(Struct::parse(child, &self.namespace)?))
                     }
-                    CXCursor_UnionDecl => {}
                     CXCursor_EnumDecl => collector.insert(Item::Enum(Enum::parse(child)?)),
+                    CXCursor_TypedefDecl => {
+                        if let Some(td) = Typedef::parse(child, &self.namespace)? {
+                            collector.insert(Item::Typedef(td));
+                        }
+                    }
                     _ => {}
                 }
             }

--- a/crates/libs/rdl/src/clang/typedef.rs
+++ b/crates/libs/rdl/src/clang/typedef.rs
@@ -1,0 +1,48 @@
+use super::*;
+
+#[derive(Debug)]
+pub struct Typedef {
+    pub name: String,
+    pub namespace: String,
+    pub ty: metadata::Type,
+}
+
+impl Typedef {
+    pub fn parse(cursor: Cursor, namespace: &str) -> Result<Option<Self>, Error> {
+        let name = cursor.name();
+        let underlying = cursor.typedef_underlying_type();
+
+        // TODO: is this needed:
+        // Skip typedefs that alias structs, unions, or enums — those are
+        // collected separately from the corresponding struct/enum cursors.
+        match underlying.kind() {
+            CXType_Record | CXType_Enum => return Ok(None),
+            CXType_Elaborated => {
+                let inner_kind = underlying.underlying_type().kind();
+                if inner_kind == CXType_Record || inner_kind == CXType_Enum {
+                    return Ok(None);
+                }
+            }
+            _ => {}
+        }
+
+        let ty = underlying.to_type(namespace);
+        Ok(Some(Self {
+            name,
+            namespace: namespace.to_string(),
+            ty,
+        }))
+    }
+
+    pub fn write(&self) -> Result<TokenStream, Error> {
+        let name = write_ident(&self.name);
+        let ty = write_type(&self.namespace, &self.ty);
+
+        Ok(quote! {
+            #[typedef]
+            struct #name {
+                value: #ty,
+            }
+        })
+    }
+}

--- a/crates/tests/libs/clang/roundtrip/typedef.h
+++ b/crates/tests/libs/clang/roundtrip/typedef.h
@@ -1,0 +1,3 @@
+typedef long HRESULT;
+typedef unsigned int DWORD;
+typedef void* HANDLE;

--- a/crates/tests/libs/clang/roundtrip/typedef.rdl
+++ b/crates/tests/libs/clang/roundtrip/typedef.rdl
@@ -1,0 +1,15 @@
+#[win32]
+mod Test {
+    #[typedef]
+    struct DWORD {
+        value: u32,
+    }
+    #[typedef]
+    struct HANDLE {
+        value: *mut void,
+    }
+    #[typedef]
+    struct HRESULT {
+        value: isize,
+    }
+}


### PR DESCRIPTION
Building on #4192, this update adds support for typedefs.