### PR TITLE
`windows-rdl`: clang parsing of functions

### DIFF
--- a/crates/libs/rdl/src/clang/cx.rs
+++ b/crates/libs/rdl/src/clang/cx.rs
@@ -181,6 +181,10 @@ impl Cursor {
     pub fn typedef_underlying_type(&self) -> Type {
         Type(unsafe { clang_getTypedefDeclUnderlyingType(self.0) })
     }
+
+    pub fn result_type(&self) -> Type {
+        Type(unsafe { clang_getCursorResultType(self.0) })
+    }
 }
 
 pub struct Type(CXType);

--- a/crates/libs/rdl/src/clang/fn.rs
+++ b/crates/libs/rdl/src/clang/fn.rs
@@ -1,0 +1,61 @@
+use super::*;
+
+#[derive(Debug)]
+pub struct Fn {
+    pub name: String,
+    pub namespace: String,
+    pub library: String,
+    pub params: Vec<Param>,
+    pub return_type: metadata::Type,
+}
+
+impl Fn {
+    pub fn parse(cursor: Cursor, namespace: &str, library: &str) -> Result<Self, Error> {
+        let name = cursor.name();
+        let return_type = cursor.result_type().to_type(namespace);
+
+        let mut params = vec![];
+
+        for child in cursor.children() {
+            if child.kind() != CXCursor_ParmDecl {
+                continue;
+            }
+
+            let name = child.name();
+            let ty = child.ty().to_type(namespace);
+            params.push(Param { name, ty });
+        }
+
+        Ok(Self {
+            name,
+            namespace: namespace.to_string(),
+            library: library.to_string(),
+            params,
+            return_type,
+        })
+    }
+
+    pub fn write(&self) -> Result<TokenStream, Error> {
+        let name = write_ident(&self.name);
+        let library = &self.library;
+
+        let params = self.params.iter().map(|param| {
+            let name = write_ident(&param.name);
+            let ty = write_type(&self.namespace, &param.ty);
+            quote! { #name: #ty }
+        });
+
+        let return_type = match &self.return_type {
+            metadata::Type::Void => quote! {},
+            ty => {
+                let ty = write_type(&self.namespace, ty);
+                quote! { -> #ty }
+            }
+        };
+
+        Ok(quote! {
+            #[library(#library)]
+            extern fn #name(#(#params),*) #return_type;
+        })
+    }
+}

--- a/crates/libs/rdl/src/clang/item.rs
+++ b/crates/libs/rdl/src/clang/item.rs
@@ -5,6 +5,7 @@ pub enum Item {
     Enum(Enum),
     Struct(Struct),
     Typedef(Typedef),
+    Fn(Fn),
 }
 
 impl Item {
@@ -13,6 +14,7 @@ impl Item {
             Self::Enum(item) => item.write(),
             Self::Struct(item) => item.write(),
             Self::Typedef(item) => item.write(),
+            Self::Fn(item) => item.write(),
         }
     }
 }
@@ -23,6 +25,7 @@ impl std::fmt::Display for Item {
             Self::Enum(item) => item.name.fmt(f),
             Self::Struct(item) => item.name.fmt(f),
             Self::Typedef(item) => item.name.fmt(f),
+            Self::Fn(item) => item.name.fmt(f),
         }
     }
 }

--- a/crates/libs/rdl/src/clang/mod.rs
+++ b/crates/libs/rdl/src/clang/mod.rs
@@ -16,6 +16,10 @@ use field::*;
 mod field;
 mod typedef;
 use typedef::*;
+mod r#fn;
+use r#fn::*;
+mod param;
+use param::*;
 
 #[derive(Default)]
 pub struct Clang {
@@ -23,6 +27,7 @@ pub struct Clang {
     output: String,
     namespace: String,
     args: Vec<String>,
+    library: String,
 }
 
 impl Clang {
@@ -42,6 +47,11 @@ impl Clang {
 
     pub fn namespace(&mut self, namespace: &str) -> &mut Self {
         self.namespace = namespace.to_string();
+        self
+    }
+
+    pub fn library(&mut self, library: &str) -> &mut Self {
+        self.library = library.to_string();
         self
     }
 
@@ -90,19 +100,24 @@ impl Clang {
             }
 
             for child in tu.cursor().children() {
-                if !child.is_definition() {
-                    continue;
-                }
-
                 match child.kind() {
-                    CXCursor_StructDecl => {
-                        collector.insert(Item::Struct(Struct::parse(child, &self.namespace)?))
+                    CXCursor_StructDecl if child.is_definition() => {
+                        collector.insert(Item::Struct(Struct::parse(child, &self.namespace)?));
                     }
-                    CXCursor_EnumDecl => collector.insert(Item::Enum(Enum::parse(child)?)),
-                    CXCursor_TypedefDecl => {
+                    CXCursor_EnumDecl if child.is_definition() => {
+                        collector.insert(Item::Enum(Enum::parse(child)?));
+                    }
+                    CXCursor_TypedefDecl if child.is_definition() => {
                         if let Some(td) = Typedef::parse(child, &self.namespace)? {
                             collector.insert(Item::Typedef(td));
                         }
+                    }
+                    CXCursor_FunctionDecl if !child.is_definition() => {
+                        collector.insert(Item::Fn(Fn::parse(
+                            child,
+                            &self.namespace,
+                            &self.library,
+                        )?));
                     }
                     _ => {}
                 }

--- a/crates/libs/rdl/src/clang/param.rs
+++ b/crates/libs/rdl/src/clang/param.rs
@@ -1,0 +1,7 @@
+use super::*;
+
+#[derive(Debug)]
+pub struct Param {
+    pub name: String,
+    pub ty: metadata::Type,
+}

--- a/crates/tests/libs/clang/roundtrip/fn.h
+++ b/crates/tests/libs/clang/roundtrip/fn.h
@@ -1,0 +1,2 @@
+unsigned int GetTickCount();
+void SetLastErrorEx(unsigned a, signed b);

--- a/crates/tests/libs/clang/roundtrip/fn.rdl
+++ b/crates/tests/libs/clang/roundtrip/fn.rdl
@@ -1,0 +1,7 @@
+#[win32]
+mod Test {
+    #[library("test.dll")]
+    extern fn GetTickCount() -> u32;
+    #[library("test.dll")]
+    extern fn SetLastErrorEx(a: u32, b: i32);
+}

--- a/crates/tests/libs/clang/tests/roundtrip.rs
+++ b/crates/tests/libs/clang/tests/roundtrip.rs
@@ -21,6 +21,7 @@ fn roundtrip() {
             .input(reference)
             .output(&rdl)
             .namespace("Test")
+            .library("test.dll")
             .write()
             .unwrap();
 


### PR DESCRIPTION
Building on #4193, this update adds support for parsing API functions. 