### PR TITLE
`windows-rdl` targeted clang testing

### DIFF
--- a/crates/libs/rdl/src/clang/cx.rs
+++ b/crates/libs/rdl/src/clang/cx.rs
@@ -403,6 +403,7 @@ impl Type {
     pub fn to_type(&self, namespace: &str) -> metadata::Type {
         match self.kind() {
             CXType_Void => metadata::Type::Void,
+            CXType_Bool => metadata::Type::Bool,
             CXType_Char_U | CXType_UChar => metadata::Type::U8,
             CXType_UShort => metadata::Type::U16,
             CXType_UInt => metadata::Type::U32,

--- a/crates/libs/rdl/src/clang/mod.rs
+++ b/crates/libs/rdl/src/clang/mod.rs
@@ -185,15 +185,14 @@ impl Clang {
                         collector.insert(Item::Struct(Struct::parse(child, &self.namespace)?));
                     }
                 }
-                CXCursor_ClassDecl if child.is_definition() => {
-                    if Interface::is_com_interface(child) {
-                        collector.insert(Item::Interface(Interface::parse(
-                            child,
-                            &self.namespace,
-                            tu,
-                        )?));
-                    }
-                    // Non-abstract C++ classes are not emitted.
+                CXCursor_ClassDecl
+                    if child.is_definition() && Interface::is_com_interface(child) =>
+                {
+                    collector.insert(Item::Interface(Interface::parse(
+                        child,
+                        &self.namespace,
+                        tu,
+                    )?));
                 }
                 CXCursor_EnumDecl if child.is_definition() => {
                     let e = Enum::parse(child)?;

--- a/crates/tests/libs/clang/roundtrip/callback.h
+++ b/crates/tests/libs/clang/roundtrip/callback.h
@@ -1,7 +1,2 @@
-typedef int BOOL;
-typedef void* HWND;
-typedef long long LPARAM;
-
-typedef BOOL (*WNDENUMPROC)(HWND hwnd, LPARAM lParam);
-
-BOOL EnumWindows(WNDENUMPROC lpEnumFunc, LPARAM lParam);
+typedef void (*A)();
+typedef int (*B)(bool a, float b);

--- a/crates/tests/libs/clang/roundtrip/callback.rdl
+++ b/crates/tests/libs/clang/roundtrip/callback.rdl
@@ -1,9 +1,5 @@
 #[win32]
 mod Test {
-    type BOOL = i32;
-    #[library("test.dll")]
-    extern fn EnumWindows(lpEnumFunc: WNDENUMPROC, lParam: LPARAM) -> BOOL;
-    type HWND = *mut void;
-    type LPARAM = i64;
-    extern fn WNDENUMPROC(hwnd: HWND, lParam: LPARAM) -> BOOL;
+    extern fn A();
+    extern fn B(a: bool, b: f32) -> i32;
 }

--- a/crates/tests/libs/clang/roundtrip/fn.h
+++ b/crates/tests/libs/clang/roundtrip/fn.h
@@ -1,2 +1,8 @@
-unsigned int GetTickCount();
-void SetLastErrorEx(unsigned a, signed b);
+unsigned int A();
+void B(unsigned a, signed b);
+
+extern "C"
+{
+    unsigned int C();
+    void D(unsigned a, signed b);
+}

--- a/crates/tests/libs/clang/roundtrip/fn.rdl
+++ b/crates/tests/libs/clang/roundtrip/fn.rdl
@@ -1,7 +1,11 @@
 #[win32]
 mod Test {
     #[library("test.dll")]
-    extern fn GetTickCount() -> u32;
+    extern fn A() -> u32;
     #[library("test.dll")]
-    extern fn SetLastErrorEx(a: u32, b: i32);
+    extern fn B(a: u32, b: i32);
+    #[library("test.dll")]
+    extern "C" fn C() -> u32;
+    #[library("test.dll")]
+    extern "C" fn D(a: u32, b: i32);
 }

--- a/crates/tests/libs/clang/roundtrip/fn_extern_c.h
+++ b/crates/tests/libs/clang/roundtrip/fn_extern_c.h
@@ -1,5 +1,0 @@
-extern "C"
-{
-    unsigned int GetTickCount();
-    void SetLastErrorEx(unsigned a, signed b);
-}

--- a/crates/tests/libs/clang/roundtrip/fn_extern_c.rdl
+++ b/crates/tests/libs/clang/roundtrip/fn_extern_c.rdl
@@ -1,7 +1,0 @@
-#[win32]
-mod Test {
-    #[library("test.dll")]
-    extern "C" fn GetTickCount() -> u32;
-    #[library("test.dll")]
-    extern "C" fn SetLastErrorEx(a: u32, b: i32);
-}

--- a/crates/tests/libs/clang/roundtrip/interface.h
+++ b/crates/tests/libs/clang/roundtrip/interface.h
@@ -1,17 +1,14 @@
-typedef int HRESULT;
-typedef unsigned int ULONG;
-
 struct __declspec(uuid("00000000-0000-0000-C000-000000000046"))
-IUnknown {
-    virtual HRESULT __stdcall QueryInterface(void* riid, void** ppvObject) = 0;
-    virtual ULONG __stdcall AddRef() = 0;
-    virtual ULONG __stdcall Release() = 0;
+IBase {
+    virtual int __stdcall QueryInterface(void* riid, void** ppvObject) = 0;
+    virtual unsigned int __stdcall AddRef() = 0;
+    virtual unsigned int __stdcall Release() = 0;
 };
 
 class __declspec(uuid("AF86E2E0-B12D-4c6a-9C5A-D7AA65101E90"))
-IInspectable : public IUnknown {
+IDerived : public IBase {
 public:
-    virtual HRESULT __stdcall GetIids(ULONG* iidCount, void** iids) = 0;
-    virtual HRESULT __stdcall GetRuntimeClassName(void** className) = 0;
-    virtual HRESULT __stdcall GetTrustLevel(int* trustLevel) = 0;
+    virtual int __stdcall GetIids(unsigned int* iidCount, void** iids) = 0;
+    virtual int __stdcall GetRuntimeClassName(void** className) = 0;
+    virtual int __stdcall GetTrustLevel(int* trustLevel) = 0;
 };

--- a/crates/tests/libs/clang/roundtrip/interface.rdl
+++ b/crates/tests/libs/clang/roundtrip/interface.rdl
@@ -1,17 +1,15 @@
 #[win32]
 mod Test {
-    type HRESULT = i32;
-    #[guid(0xaf86e2e0_b12d_4c6a_9c5a_d7aa65101e90)]
-    interface IInspectable: IUnknown {
-        fn GetIids(&self, iidCount: *mut ULONG, iids: *mut *mut void) -> HRESULT;
-        fn GetRuntimeClassName(&self, className: *mut *mut void) -> HRESULT;
-        fn GetTrustLevel(&self, trustLevel: *mut i32) -> HRESULT;
-    }
     #[guid(0x00000000_0000_0000_c000_000000000046)]
-    interface IUnknown {
-        fn QueryInterface(&self, riid: *mut void, ppvObject: *mut *mut void) -> HRESULT;
-        fn AddRef(&self) -> ULONG;
-        fn Release(&self) -> ULONG;
+    interface IBase {
+        fn QueryInterface(&self, riid: *mut void, ppvObject: *mut *mut void) -> i32;
+        fn AddRef(&self) -> u32;
+        fn Release(&self) -> u32;
     }
-    type ULONG = u32;
+    #[guid(0xaf86e2e0_b12d_4c6a_9c5a_d7aa65101e90)]
+    interface IDerived: IBase {
+        fn GetIids(&self, iidCount: *mut u32, iids: *mut *mut void) -> i32;
+        fn GetRuntimeClassName(&self, className: *mut *mut void) -> i32;
+        fn GetTrustLevel(&self, trustLevel: *mut i32) -> i32;
+    }
 }

--- a/crates/tests/libs/clang/roundtrip/typedef.h
+++ b/crates/tests/libs/clang/roundtrip/typedef.h
@@ -1,3 +1,3 @@
-typedef long HRESULT;
-typedef unsigned int DWORD;
-typedef void* HANDLE;
+typedef long A;
+typedef unsigned int B;
+typedef void* C;

--- a/crates/tests/libs/clang/roundtrip/typedef.rdl
+++ b/crates/tests/libs/clang/roundtrip/typedef.rdl
@@ -1,6 +1,6 @@
 #[win32]
 mod Test {
-    type DWORD = u32;
-    type HANDLE = *mut void;
-    type HRESULT = isize;
+    type A = isize;
+    type B = u32;
+    type C = *mut void;
 }


### PR DESCRIPTION
Minor update tweaking tests to be more targeted and avoid common names in anticipation of new reference metadata support for the clang parser. This update also adds support for parsing `bool` types.