### PR TITLE
Test `windows-rdl` on Linux

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -31,5 +31,9 @@ jobs:
         uses: actions/checkout@v6
       - name: Update toolchain
         run: rustup update --no-self-update stable && rustup default stable
-      - name: Run cargo test
+      - name: Run test_linux
         run: cargo test -p test_linux --target x86_64-unknown-linux-gnu
+      - name: Run test_clang
+        run: cargo test -p test_clang --target x86_64-unknown-linux-gnu
+      - name: Run test_rdl
+        run: cargo test -p test_rdl --target x86_64-unknown-linux-gnu

--- a/crates/tests/libs/clang/tests/roundtrip.rs
+++ b/crates/tests/libs/clang/tests/roundtrip.rs
@@ -16,7 +16,7 @@ fn roundtrip() {
         let reference = "../../../libs/bindgen/default";
 
         clang()
-            .args(["-x", "c++"])
+            .args(["-x", "c++", "-fdeclspec"])
             .input(&h)
             .input(reference)
             .output(&rdl)


### PR DESCRIPTION
Clang has some different defaults on Linux. This just gives us a simple smoke test to determine whether it is working as is. 