### PR TITLE
`windows-rdl` allow reference dupes in Clang resolution

### DIFF
--- a/crates/libs/rdl/src/clang/mod.rs
+++ b/crates/libs/rdl/src/clang/mod.rs
@@ -90,22 +90,9 @@ impl Clang {
 
         let reference = metadata::reader::TypeIndex::new(winmd_files);
 
-        // Build a map from type name to namespace for all types in the reference.
-        // This is used to suppress locally-defined types that already exist in
-        // the reference metadata and to emit qualified names when referencing them.
-        // Only types whose short name is unique across all reference namespaces are
-        // included; ambiguous names (same short name in multiple namespaces) are
-        // excluded so that unqualified C/C++ references are not silently mapped to
-        // a potentially wrong namespace.
-        let mut name_count: HashMap<String, usize> = HashMap::new();
-        for (_, name, _) in reference.iter() {
-            *name_count.entry(name.to_string()).or_insert(0) += 1;
-        }
         let mut ref_map: HashMap<String, String> = HashMap::new();
         for (namespace, name, _) in reference.iter() {
-            if name_count.get(name).copied().unwrap_or(0) == 1 {
-                ref_map.insert(name.to_string(), namespace.to_string());
-            }
+            ref_map.insert(name.to_string(), namespace.to_string());
         }
 
         let _library = Library::new()?;


### PR DESCRIPTION
This is going to happen and simply dropping them isn't any better. We need better diagnostics but for now I'd rather a build failure early.