### PR TITLE
Speed up `test_clang`

### DIFF
--- a/crates/tests/libs/clang/build.rs
+++ b/crates/tests/libs/clang/build.rs
@@ -1,0 +1,23 @@
+fn main() {
+    let out_dir = std::env::var("OUT_DIR").unwrap();
+
+    let mut paths: Vec<_> = std::fs::read_dir("roundtrip")
+        .unwrap()
+        .map(|e| e.unwrap().path())
+        .filter(|p| p.extension().and_then(|e| e.to_str()) == Some("h"))
+        .collect();
+    paths.sort();
+
+    let mut out = String::new();
+    for path in &paths {
+        let stem = path.file_stem().unwrap().to_str().unwrap();
+        out.push_str(&format!(
+            "#[test]\nfn roundtrip_{stem}() {{\n    run_roundtrip({stem:?});\n}}\n"
+        ));
+    }
+
+    std::fs::write(format!("{out_dir}/roundtrip_tests.rs"), out).unwrap();
+
+    // Re-run the build script whenever a .h file is added or removed.
+    println!("cargo:rerun-if-changed=roundtrip");
+}

--- a/crates/tests/libs/clang/tests/roundtrip.rs
+++ b/crates/tests/libs/clang/tests/roundtrip.rs
@@ -2,47 +2,41 @@
 
 use windows_rdl::*;
 
-#[test]
-fn roundtrip() {
-    let paths = std::fs::read_dir("roundtrip")
-        .unwrap()
-        .map(|e| e.unwrap().path())
-        .filter(|p| p.extension().and_then(|e| e.to_str()) == Some("h"));
+fn run_roundtrip(file: &str) {
+    let h = format!("roundtrip/{file}.h");
+    let rdl = format!("roundtrip/{file}.rdl");
+    let winmd = format!("roundtrip/{file}.winmd");
+    let reference = "../../../libs/bindgen/default";
 
-    for h in paths {
-        let rdl = h.with_extension("rdl").to_str().unwrap().to_string();
-        let winmd = h.with_extension("winmd").to_str().unwrap().to_string();
-        let h = h.to_str().unwrap().to_string();
-        let reference = "../../../libs/bindgen/default";
+    clang()
+        .args([
+            "-x",
+            "c++",
+            "--target=x86_64-pc-windows-msvc",
+            "-fms-extensions",
+        ])
+        .input(&h)
+        .input(reference)
+        .output(&rdl)
+        .namespace("Test")
+        .library("test.dll")
+        .write()
+        .unwrap();
 
-        clang()
-            .args([
-                "-x",
-                "c++",
-                "--target=x86_64-pc-windows-msvc",
-                "-fms-extensions",
-            ])
-            .input(&h)
-            .input(reference)
-            .output(&rdl)
-            .namespace("Test")
-            .library("test.dll")
-            .write()
-            .unwrap();
+    reader()
+        .input(&rdl)
+        .input(reference)
+        .output(&winmd)
+        .write()
+        .unwrap();
 
-        reader()
-            .input(&rdl)
-            .input(reference)
-            .output(&winmd)
-            .write()
-            .unwrap();
-
-        writer()
-            .input(&winmd)
-            .input(reference)
-            .output(&rdl)
-            .filter("Test")
-            .write()
-            .unwrap();
-    }
+    writer()
+        .input(&winmd)
+        .input(reference)
+        .output(&rdl)
+        .filter("Test")
+        .write()
+        .unwrap();
 }
+
+include!(concat!(env!("OUT_DIR"), "/roundtrip_tests.rs"));


### PR DESCRIPTION
Currently the `roundtrip` test runs each test pass in sequence. This adds a build script that creates a test for each test pass thus allowing `cargo test` to run them all in parallel. 