### PR TITLE
windows-bindgen: Intrinsify WIN32_ERROR, NTSTATUS and RPC_STATUS

### DIFF
--- a/crates/libs/bindgen/src/lib.rs
+++ b/crates/libs/bindgen/src/lib.rs
@@ -766,48 +766,6 @@ impl Bindgen {
                     ReferenceStage::parse("windows_future,flat,Windows.Foundation.IAsync*"),
                 );
             }
-
-            if reader.contains_key("Windows.Win32.Foundation") {
-                if self.specific_deps {
-                    references.insert(
-                        0,
-                        ReferenceStage::parse(
-                            "windows_result,flat,Windows.Win32.Foundation.WIN32_ERROR",
-                        ),
-                    );
-                    references.insert(
-                        0,
-                        ReferenceStage::parse(
-                            "windows_result,flat,Windows.Win32.Foundation.NTSTATUS",
-                        ),
-                    );
-                    references.insert(
-                        0,
-                        ReferenceStage::parse(
-                            "windows_result,flat,Windows.Win32.System.Rpc.RPC_STATUS",
-                        ),
-                    );
-                } else {
-                    references.insert(
-                        0,
-                        ReferenceStage::parse(
-                            "windows_core,flat,Windows.Win32.Foundation.WIN32_ERROR",
-                        ),
-                    );
-                    references.insert(
-                        0,
-                        ReferenceStage::parse(
-                            "windows_core,flat,Windows.Win32.Foundation.NTSTATUS",
-                        ),
-                    );
-                    references.insert(
-                        0,
-                        ReferenceStage::parse(
-                            "windows_core,flat,Windows.Win32.System.Rpc.RPC_STATUS",
-                        ),
-                    );
-                }
-            }
         }
 
         let derive_str: Vec<&str> = self.derive.iter().map(|s| s.as_str()).collect();

--- a/crates/libs/bindgen/src/types/mod.rs
+++ b/crates/libs/bindgen/src/types/mod.rs
@@ -28,6 +28,7 @@ pub use method::*;
 pub use r#enum::*;
 pub use r#struct::*;
 
+#[allow(non_camel_case_types)]
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum Type {
     CppFn(CppFn),
@@ -76,6 +77,9 @@ pub enum Type {
     PCWSTR,
     GUID,
     HRESULT,
+    WIN32_ERROR,
+    NTSTATUS,
+    RPC_STATUS,
     IUnknown,
     BSTR,
     BOOL,
@@ -173,6 +177,10 @@ impl Type {
             ("Windows.Foundation", "HResult") | ("Windows.Win32.Foundation", "HRESULT") => {
                 Remap::Type(Self::HRESULT)
             }
+
+            ("Windows.Win32.Foundation", "WIN32_ERROR") => Remap::Type(Self::WIN32_ERROR),
+            ("Windows.Win32.Foundation", "NTSTATUS") => Remap::Type(Self::NTSTATUS),
+            ("Windows.Win32.System.Rpc", "RPC_STATUS") => Remap::Type(Self::RPC_STATUS),
 
             ("Windows.Foundation", "EventRegistrationToken")
             | ("Windows.Win32.System.WinRT", "EventRegistrationToken") => Remap::Type(Self::I64),
@@ -412,6 +420,18 @@ impl Type {
             Self::HRESULT => {
                 let result = config.write_result();
                 quote! { #result HRESULT }
+            }
+            Self::WIN32_ERROR => {
+                let result = config.write_result();
+                quote! { #result WIN32_ERROR }
+            }
+            Self::NTSTATUS => {
+                let result = config.write_result();
+                quote! { #result NTSTATUS }
+            }
+            Self::RPC_STATUS => {
+                let result = config.write_result();
+                quote! { #result RPC_STATUS }
             }
             Self::BOOL => {
                 let result = config.write_result();
@@ -708,6 +728,9 @@ impl Type {
             | Self::ISize
             | Self::USize
             | Self::HRESULT
+            | Self::WIN32_ERROR
+            | Self::NTSTATUS
+            | Self::RPC_STATUS
             | Self::BOOL
             | Self::PtrConst(_, _)
             | Self::PtrMut(_, _) => true,
@@ -777,6 +800,9 @@ impl Type {
             Self::Enum(ty) => ty.def.underlying_type_ext(reader),
             Self::CppStruct(ty) => ty.def.underlying_type_ext(reader),
             Self::HRESULT => Self::I32,
+            Self::WIN32_ERROR => Self::U32,
+            Self::NTSTATUS => Self::I32,
+            Self::RPC_STATUS => Self::I32,
             Self::BOOL => Self::I32,
             _ => self.clone(),
         }
@@ -789,6 +815,9 @@ impl Type {
 
         match self {
             Self::HRESULT => quote! { pub type HRESULT = i32; },
+            Self::WIN32_ERROR => quote! { pub type WIN32_ERROR = u32; },
+            Self::NTSTATUS => quote! { pub type NTSTATUS = i32; },
+            Self::RPC_STATUS => quote! { pub type RPC_STATUS = i32; },
             Self::BOOL => quote! { pub type BOOL = i32; },
 
             Self::PWSTR => quote! { pub type PWSTR = *mut u16; },
@@ -884,6 +913,9 @@ impl Type {
             Self::PCWSTR => TypeName("", "PCWSTR"),
             Self::GUID => TypeName("", "GUID"),
             Self::HRESULT => TypeName("", "HRESULT"),
+            Self::WIN32_ERROR => TypeName("", "WIN32_ERROR"),
+            Self::NTSTATUS => TypeName("", "NTSTATUS"),
+            Self::RPC_STATUS => TypeName("", "RPC_STATUS"),
             Self::BOOL => TypeName("", "BOOL"),
             Self::IUnknown => TypeName("", "IUnknown"),
             Self::BSTR => TypeName("", "BSTR"),
@@ -903,6 +935,9 @@ impl Type {
                 | Self::PCWSTR
                 | Self::GUID
                 | Self::HRESULT
+                | Self::WIN32_ERROR
+                | Self::NTSTATUS
+                | Self::RPC_STATUS
                 | Self::BOOL
                 | Self::IUnknown
                 | Self::Object

--- a/crates/tests/libs/bindgen/data/bindgen/derive_cpp_enum/expected.rs
+++ b/crates/tests/libs/bindgen/data/bindgen/derive_cpp_enum/expected.rs
@@ -11,4 +11,4 @@
 pub struct WAIT_EVENT(pub u32);
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
-pub struct WIN32_ERROR(pub u32);
+pub struct NTSTATUS_FACILITY_CODE(pub u32);

--- a/crates/tests/libs/bindgen/data/bindgen/derive_cpp_enum/fixture.toml
+++ b/crates/tests/libs/bindgen/data/bindgen/derive_cpp_enum/fixture.toml
@@ -1,1 +1,1 @@
-args = "--no-comment --in default --flat --filter WAIT_EVENT WIN32_ERROR --derive WAIT_EVENT=PartialOrd"
+args = "--no-comment --in default --flat --filter WAIT_EVENT NTSTATUS_FACILITY_CODE --derive WAIT_EVENT=PartialOrd"

--- a/crates/tests/misc/just_core/src/bindings.rs
+++ b/crates/tests/misc/just_core/src/bindings.rs
@@ -16,7 +16,7 @@ pub unsafe fn CoGetCallerTID() -> windows_core::Result<u32> {
 }
 #[inline]
 pub unsafe fn GetLastError() -> windows_core::WIN32_ERROR {
-    windows_core::link!("kernel32.dll" "system" fn GetLastError() -> windows_core:: WIN32_ERROR);
+    windows_core::link!("kernel32.dll" "system" fn GetLastError() -> windows_core::WIN32_ERROR);
     unsafe { GetLastError() }
 }
 #[inline]
@@ -26,7 +26,7 @@ pub unsafe fn IsCharLowerA(ch: i8) -> windows_core::Result<()> {
 }
 #[inline]
 pub unsafe fn RpcMgmtEnableIdleCleanup() -> windows_core::RPC_STATUS {
-    windows_core::link!("rpcrt4.dll" "system" fn RpcMgmtEnableIdleCleanup() -> windows_core:: RPC_STATUS);
+    windows_core::link!("rpcrt4.dll" "system" fn RpcMgmtEnableIdleCleanup() -> windows_core::RPC_STATUS);
     unsafe { RpcMgmtEnableIdleCleanup() }
 }
 #[inline]
@@ -36,7 +36,7 @@ pub unsafe fn SysFreeString(bstrstring: &windows_core::BSTR) {
 }
 #[inline]
 pub unsafe fn VhfStart(vhfhandle: *const core::ffi::c_void) -> windows_core::NTSTATUS {
-    windows_core::link!("vhfum.dll" "system" fn VhfStart(vhfhandle : *const core::ffi::c_void) -> windows_core:: NTSTATUS);
+    windows_core::link!("vhfum.dll" "system" fn VhfStart(vhfhandle : *const core::ffi::c_void) -> windows_core::NTSTATUS);
     unsafe { VhfStart(vhfhandle) }
 }
 windows_core::imp::define_interface!(

--- a/crates/tests/misc/no_core/src/bindings.rs
+++ b/crates/tests/misc/no_core/src/bindings.rs
@@ -16,7 +16,7 @@ pub unsafe fn CoGetCallerTID() -> windows_result::Result<u32> {
 }
 #[inline]
 pub unsafe fn GetLastError() -> windows_result::WIN32_ERROR {
-    windows_link::link!("kernel32.dll" "system" fn GetLastError() -> windows_result:: WIN32_ERROR);
+    windows_link::link!("kernel32.dll" "system" fn GetLastError() -> windows_result::WIN32_ERROR);
     unsafe { GetLastError() }
 }
 #[inline]
@@ -26,7 +26,7 @@ pub unsafe fn IsCharLowerA(ch: i8) -> windows_result::Result<()> {
 }
 #[inline]
 pub unsafe fn RpcMgmtEnableIdleCleanup() -> windows_result::RPC_STATUS {
-    windows_link::link!("rpcrt4.dll" "system" fn RpcMgmtEnableIdleCleanup() -> windows_result:: RPC_STATUS);
+    windows_link::link!("rpcrt4.dll" "system" fn RpcMgmtEnableIdleCleanup() -> windows_result::RPC_STATUS);
     unsafe { RpcMgmtEnableIdleCleanup() }
 }
 #[inline]
@@ -36,7 +36,7 @@ pub unsafe fn SysFreeString(bstrstring: &windows_strings::BSTR) {
 }
 #[inline]
 pub unsafe fn VhfStart(vhfhandle: *const core::ffi::c_void) -> windows_result::NTSTATUS {
-    windows_link::link!("vhfum.dll" "system" fn VhfStart(vhfhandle : *const core::ffi::c_void) -> windows_result:: NTSTATUS);
+    windows_link::link!("vhfum.dll" "system" fn VhfStart(vhfhandle : *const core::ffi::c_void) -> windows_result::NTSTATUS);
     unsafe { VhfStart(vhfhandle) }
 }
 #[inline]

--- a/crates/tools/bindings/src/windows.txt
+++ b/crates/tools/bindings/src/windows.txt
@@ -46,8 +46,3 @@
     !Windows.Win32.System.WinRT.Xaml
     !Windows.Win32.UI.Xaml
     !Windows.Win32.Web.MsHtml
-
-// windows-result
-    !Windows.Win32.Foundation.WIN32_ERROR
-    !Windows.Win32.Foundation.NTSTATUS
-    !Windows.Win32.System.Rpc.RPC_STATUS


### PR DESCRIPTION
Fixes #4392 by making windows-bindgen explicitly aware of these types, and handling them exactly like `HRESULT` currently is handled.