### PR TITLE
Enable `semicolon_if_nothing_returned` Clippy lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,9 @@ opt-level = 2
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(windows_raw_dylib, windows_slim_errors)'] }
 missing_unsafe_on_extern = "warn"
 
+[workspace.lints.clippy]
+semicolon_if_nothing_returned = "warn"
+
 [workspace.dependencies]
 helpers = { path = "crates/tools/helpers" }
 proc-macro2 = { version = "1.0", default-features = false }

--- a/crates/libs/bindgen/src/derive_writer.rs
+++ b/crates/libs/bindgen/src/derive_writer.rs
@@ -24,7 +24,7 @@ impl ToTokens for DeriveWriter {
             let derive = self.0.iter().map(|derive| to_ident(derive));
             tokens.combine(quote! {
                 #[derive(#(#derive),*)]
-            })
+            });
         }
     }
 }

--- a/crates/libs/bindgen/src/lib.rs
+++ b/crates/libs/bindgen/src/lib.rs
@@ -1101,7 +1101,7 @@ where
     // This function is needed to avoid a recursion limit in the Rust compiler.
     #[track_caller]
     fn from_string(result: &mut Vec<String>, value: &str) {
-        expand_args(result, value.split_whitespace().map(|arg| arg.to_string()))
+        expand_args(result, value.split_whitespace().map(|arg| arg.to_string()));
     }
 
     #[track_caller]

--- a/crates/libs/bindgen/src/references.rs
+++ b/crates/libs/bindgen/src/references.rs
@@ -25,7 +25,7 @@ impl ReferenceStage {
     #[track_caller]
     pub fn parse(mut arg: &str) -> Self {
         if arg == "windows" {
-            arg = "windows,skip-root,Windows"
+            arg = "windows,skip-root,Windows";
         }
 
         let arg: Vec<_> = arg.split(',').collect();

--- a/crates/libs/bindgen/src/tokens/token_stream.rs
+++ b/crates/libs/bindgen/src/tokens/token_stream.rs
@@ -30,7 +30,7 @@ impl TokenStream {
     /// note: a space will be inserted before the other stream
     pub fn combine<T: AsRef<Self>>(&mut self, other: T) {
         self.push_space();
-        self.0.push_str(&other.as_ref().0)
+        self.0.push_str(&other.as_ref().0);
     }
 
     #[must_use]
@@ -67,11 +67,11 @@ impl TokenStream {
     }
 
     pub fn push(&mut self, c: char) {
-        self.0.push(c)
+        self.0.push(c);
     }
 
     pub fn push_str(&mut self, str: &str) {
-        self.0.push_str(str)
+        self.0.push_str(str);
     }
 
     fn last_char(&self) -> Option<char> {

--- a/crates/libs/bindgen/src/types/cpp_enum.rs
+++ b/crates/libs/bindgen/src/types/cpp_enum.rs
@@ -93,12 +93,12 @@ impl CppEnum {
                 }
                 impl core::ops::BitOrAssign for #name {
                     fn bitor_assign(&mut self, other: Self) {
-                        self.0.bitor_assign(other.0)
+                        self.0.bitor_assign(other.0);
                     }
                 }
                 impl core::ops::BitAndAssign for #name {
                     fn bitand_assign(&mut self, other: Self) {
-                        self.0.bitand_assign(other.0)
+                        self.0.bitand_assign(other.0);
                     }
                 }
                 impl core::ops::Not for #name {

--- a/crates/libs/bindgen/src/types/cpp_interface.rs
+++ b/crates/libs/bindgen/src/types/cpp_interface.rs
@@ -200,7 +200,7 @@ impl CppInterface {
                 result.combine(quote! {
                     #cfg
                     windows_core::imp::interface_hierarchy!(#name, #(#bases),*);
-                })
+                });
             }
 
             let method_names = &mut MethodNames::new();

--- a/crates/libs/bindgen/src/types/cpp_method.rs
+++ b/crates/libs/bindgen/src/types/cpp_method.rs
@@ -169,9 +169,9 @@ impl CppMethod {
                 Type::Void if is_retval => return_hint = ReturnHint::ReturnValue,
                 Type::HRESULT => {
                     if is_retval {
-                        return_hint = ReturnHint::ResultValue
+                        return_hint = ReturnHint::ResultValue;
                     } else {
-                        return_hint = ReturnHint::ResultVoid
+                        return_hint = ReturnHint::ResultVoid;
                     };
 
                     if signature.params.len() >= 2 {
@@ -187,7 +187,7 @@ impl CppMethod {
                 Type::BOOL if last_error => return_hint = ReturnHint::ResultVoid,
                 Type::GUID => return_hint = ReturnHint::ReturnStruct,
                 Type::CppStruct(ty) if !ty.is_handle(reader) => {
-                    return_hint = ReturnHint::ReturnStruct
+                    return_hint = ReturnHint::ReturnStruct;
                 }
                 _ => {}
             };
@@ -232,12 +232,12 @@ impl CppMethod {
             if self.param_hints[position] == ParamHint::IntoParam {
                 let name: TokenStream = format!("P{position}").into();
                 let into = param.write_name(config);
-                tokens.combine(quote! { #name: windows_core::Param<#into>, })
+                tokens.combine(quote! { #name: windows_core::Param<#into>, });
             }
         }
 
         if query {
-            tokens.combine(quote! { T: windows_core::Interface })
+            tokens.combine(quote! { T: windows_core::Interface });
         }
 
         if tokens.is_empty() {
@@ -687,7 +687,7 @@ impl CppMethod {
                     }
                 }
             };
-            tokens.combine(&new)
+            tokens.combine(&new);
         }
 
         tokens

--- a/crates/libs/bindgen/src/types/enum.rs
+++ b/crates/libs/bindgen/src/types/enum.rs
@@ -61,12 +61,12 @@ impl Enum {
                 }
                 impl core::ops::BitOrAssign for #name {
                     fn bitor_assign(&mut self, other: Self) {
-                        self.0.bitor_assign(other.0)
+                        self.0.bitor_assign(other.0);
                     }
                 }
                 impl core::ops::BitAndAssign for #name {
                     fn bitand_assign(&mut self, other: Self) {
-                        self.0.bitand_assign(other.0)
+                        self.0.bitand_assign(other.0);
                     }
                 }
                 impl core::ops::Not for #name {

--- a/crates/libs/bindgen/src/types/mod.rs
+++ b/crates/libs/bindgen/src/types/mod.rs
@@ -992,7 +992,7 @@ impl Dependencies for Type {
         } {
             multi.for_each(|multi| {
                 if ty != multi {
-                    multi.combine(dependencies, reader)
+                    multi.combine(dependencies, reader);
                 }
             });
         }
@@ -1034,7 +1034,7 @@ pub fn interface_signature(def: TypeDef, generics: &[Type], reader: &Reader) -> 
 
         for generic in generics {
             signature.push(';');
-            signature.push_str(&generic.runtime_signature(reader))
+            signature.push_str(&generic.runtime_signature(reader));
         }
 
         signature.push(')');

--- a/crates/libs/metadata/src/reader/blob.rs
+++ b/crates/libs/metadata/src/reader/blob.rs
@@ -73,7 +73,7 @@ impl<'a> Blob<'a> {
                     self.index,
                     self.file,
                     self.read_compressed(),
-                ))
+                ));
             }
         }
         mods

--- a/crates/libs/metadata/src/reader/file.rs
+++ b/crates/libs/metadata/src/reader/file.rs
@@ -616,7 +616,7 @@ impl File {
             let count2 = count / 2;
             let middle = first + count2;
             if value < self.usize(middle, table, column) {
-                count = count2
+                count = count2;
             } else {
                 first = middle + 1;
                 count -= count2 + 1;

--- a/crates/libs/metadata/src/writer/file/helpers.rs
+++ b/crates/libs/metadata/src/writer/file/helpers.rs
@@ -86,9 +86,9 @@ impl Write for Vec<u8> {
         match value {
             Value::Bool(value) => {
                 if *value {
-                    self.push(1)
+                    self.push(1);
                 } else {
-                    self.push(0)
+                    self.push(0);
                 }
             }
             Value::U8(value) => self.extend_from_slice(&value.to_le_bytes()),

--- a/crates/libs/metadata/src/writer/file/mod.rs
+++ b/crates/libs/metadata/src/writer/file/mod.rs
@@ -104,7 +104,7 @@ impl File {
             MemberForwarded: MemberForwarded::MethodDef(method),
             ImportName: self.strings.insert(import_name),
             ImportScope: scope,
-        })
+        });
     }
 
     /// Adds an `AssemblyRef` row for the given assembly name, returning the row offset.
@@ -349,14 +349,14 @@ impl File {
             PackingSize: packing_size,
             ClassSize: class_size,
             Parent: parent.0,
-        })
+        });
     }
 
     pub fn FieldLayout(&mut self, field: id::Field, offset: u32) {
         self.records.FieldLayout.push(rec::FieldLayout {
             Offset: offset,
             Field: field.0,
-        })
+        });
     }
 
     pub fn NestedClass(&mut self, inner: id::TypeDef, outer: id::TypeDef) {
@@ -365,7 +365,7 @@ impl File {
         self.records.NestedClass.push(rec::NestedClass {
             NestedClass: inner.0,
             EnclosingClass: outer.0,
-        })
+        });
     }
 
     pub fn InterfaceImpl(&mut self, class: id::TypeDef, interface: &Type) -> id::InterfaceImpl {
@@ -464,10 +464,10 @@ impl File {
             }
 
             Type::ClassName(ty) => {
-                self.TypeName(false, &ty.namespace, &ty.name, &ty.generics, buffer)
+                self.TypeName(false, &ty.namespace, &ty.name, &ty.generics, buffer);
             }
             Type::ValueName(ty) => {
-                self.TypeName(true, &ty.namespace, &ty.name, &ty.generics, buffer)
+                self.TypeName(true, &ty.namespace, &ty.name, &ty.generics, buffer);
             }
         }
     }

--- a/crates/libs/rdl/src/writer/layout.rs
+++ b/crates/libs/rdl/src/writer/layout.rs
@@ -21,7 +21,7 @@ impl Layout {
             self.modules
                 .entry(first.to_string())
                 .or_default()
-                .insert(rest, name, winrt, tokens)
+                .insert(rest, name, winrt, tokens);
         } else if winrt {
             self.modules
                 .entry(namespace.to_string())
@@ -144,7 +144,7 @@ impl Layout {
                 output.push_str(&module.to_module(name));
             }
 
-            output.push('}')
+            output.push('}');
         }
 
         if has_winrt {
@@ -160,7 +160,7 @@ impl Layout {
                 }
             }
 
-            output.push('}')
+            output.push('}');
         }
 
         if has_win32 {
@@ -176,7 +176,7 @@ impl Layout {
                 }
             }
 
-            output.push('}')
+            output.push('}');
         }
 
         output

--- a/crates/libs/result/src/error.rs
+++ b/crates/libs/result/src/error.rs
@@ -311,7 +311,7 @@ mod error_info {
                 }
 
                 if message.is_empty() {
-                    message = fallback
+                    message = fallback;
                 };
             }
 

--- a/crates/libs/strings/src/decode.rs
+++ b/crates/libs/strings/src/decode.rs
@@ -10,7 +10,7 @@ where
         use core::fmt::Write;
         let iter = self.0.clone();
         for c in iter().into_iter() {
-            f.write_char(c.unwrap_or(core::char::REPLACEMENT_CHARACTER))?
+            f.write_char(c.unwrap_or(core::char::REPLACEMENT_CHARACTER))?;
         }
         Ok(())
     }

--- a/crates/libs/strings/src/hstring.rs
+++ b/crates/libs/strings/src/hstring.rs
@@ -182,7 +182,7 @@ impl Ord for HSTRING {
 
 impl core::hash::Hash for HSTRING {
     fn hash<H: core::hash::Hasher>(&self, hasher: &mut H) {
-        self.deref().hash(hasher)
+        self.deref().hash(hasher);
     }
 }
 

--- a/crates/libs/windows/src/Windows/ApplicationModel/Appointments/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Appointments/mod.rs
@@ -852,12 +852,12 @@ impl core::ops::BitAnd for AppointmentDaysOfWeek {
 }
 impl core::ops::BitOrAssign for AppointmentDaysOfWeek {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for AppointmentDaysOfWeek {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for AppointmentDaysOfWeek {
@@ -2094,12 +2094,12 @@ impl core::ops::BitAnd for FindAppointmentCalendarsOptions {
 }
 impl core::ops::BitOrAssign for FindAppointmentCalendarsOptions {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for FindAppointmentCalendarsOptions {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for FindAppointmentCalendarsOptions {

--- a/crates/libs/windows/src/Windows/ApplicationModel/Calls/Background/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Calls/Background/mod.rs
@@ -340,12 +340,12 @@ impl core::ops::BitAnd for PhoneLineProperties {
 }
 impl core::ops::BitOrAssign for PhoneLineProperties {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for PhoneLineProperties {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for PhoneLineProperties {

--- a/crates/libs/windows/src/Windows/ApplicationModel/Calls/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Calls/mod.rs
@@ -2166,12 +2166,12 @@ impl core::ops::BitAnd for PhoneCallHistoryEntryQueryDesiredMedia {
 }
 impl core::ops::BitOrAssign for PhoneCallHistoryEntryQueryDesiredMedia {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for PhoneCallHistoryEntryQueryDesiredMedia {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for PhoneCallHistoryEntryQueryDesiredMedia {
@@ -3889,12 +3889,12 @@ impl core::ops::BitAnd for VoipPhoneCallMedia {
 }
 impl core::ops::BitOrAssign for VoipPhoneCallMedia {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for VoipPhoneCallMedia {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for VoipPhoneCallMedia {

--- a/crates/libs/windows/src/Windows/ApplicationModel/Contacts/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Contacts/mod.rs
@@ -756,12 +756,12 @@ impl core::ops::BitAnd for ContactAnnotationOperations {
 }
 impl core::ops::BitOrAssign for ContactAnnotationOperations {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for ContactAnnotationOperations {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for ContactAnnotationOperations {
@@ -3286,12 +3286,12 @@ impl core::ops::BitAnd for ContactQueryDesiredFields {
 }
 impl core::ops::BitOrAssign for ContactQueryDesiredFields {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for ContactQueryDesiredFields {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for ContactQueryDesiredFields {
@@ -3421,12 +3421,12 @@ impl core::ops::BitAnd for ContactQuerySearchFields {
 }
 impl core::ops::BitOrAssign for ContactQuerySearchFields {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for ContactQuerySearchFields {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for ContactQuerySearchFields {

--- a/crates/libs/windows/src/Windows/ApplicationModel/DataTransfer/DragDrop/Core/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/DataTransfer/DragDrop/Core/mod.rs
@@ -196,12 +196,12 @@ impl core::ops::BitAnd for CoreDragUIContentMode {
 }
 impl core::ops::BitOrAssign for CoreDragUIContentMode {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CoreDragUIContentMode {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CoreDragUIContentMode {

--- a/crates/libs/windows/src/Windows/ApplicationModel/DataTransfer/DragDrop/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/DataTransfer/DragDrop/mod.rs
@@ -37,12 +37,12 @@ impl core::ops::BitAnd for DragDropModifiers {
 }
 impl core::ops::BitOrAssign for DragDropModifiers {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for DragDropModifiers {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for DragDropModifiers {

--- a/crates/libs/windows/src/Windows/ApplicationModel/DataTransfer/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/DataTransfer/mod.rs
@@ -487,12 +487,12 @@ impl core::ops::BitAnd for DataPackageOperation {
 }
 impl core::ops::BitOrAssign for DataPackageOperation {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for DataPackageOperation {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for DataPackageOperation {

--- a/crates/libs/windows/src/Windows/ApplicationModel/Email/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Email/mod.rs
@@ -2967,12 +2967,12 @@ impl core::ops::BitAnd for EmailQuerySearchFields {
 }
 impl core::ops::BitOrAssign for EmailQuerySearchFields {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for EmailQuerySearchFields {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for EmailQuerySearchFields {

--- a/crates/libs/windows/src/Windows/ApplicationModel/UserDataAccounts/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/UserDataAccounts/mod.rs
@@ -396,12 +396,12 @@ impl core::ops::BitAnd for UserDataAccountContentKinds {
 }
 impl core::ops::BitOrAssign for UserDataAccountContentKinds {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for UserDataAccountContentKinds {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for UserDataAccountContentKinds {

--- a/crates/libs/windows/src/Windows/ApplicationModel/UserDataTasks/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/UserDataTasks/mod.rs
@@ -434,12 +434,12 @@ impl core::ops::BitAnd for UserDataTaskDaysOfWeek {
 }
 impl core::ops::BitOrAssign for UserDataTaskDaysOfWeek {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for UserDataTaskDaysOfWeek {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for UserDataTaskDaysOfWeek {

--- a/crates/libs/windows/src/Windows/ApplicationModel/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/mod.rs
@@ -83,12 +83,12 @@ impl core::ops::BitAnd for AddResourcePackageOptions {
 }
 impl core::ops::BitOrAssign for AddResourcePackageOptions {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for AddResourcePackageOptions {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for AddResourcePackageOptions {

--- a/crates/libs/windows/src/Windows/Data/Text/mod.rs
+++ b/crates/libs/windows/src/Windows/Data/Text/mod.rs
@@ -655,12 +655,12 @@ impl core::ops::BitAnd for TextPredictionOptions {
 }
 impl core::ops::BitOrAssign for TextPredictionOptions {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for TextPredictionOptions {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for TextPredictionOptions {

--- a/crates/libs/windows/src/Windows/Devices/Bluetooth/Advertisement/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Bluetooth/Advertisement/mod.rs
@@ -426,12 +426,12 @@ impl core::ops::BitAnd for BluetoothLEAdvertisementFlags {
 }
 impl core::ops::BitOrAssign for BluetoothLEAdvertisementFlags {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for BluetoothLEAdvertisementFlags {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for BluetoothLEAdvertisementFlags {

--- a/crates/libs/windows/src/Windows/Devices/Bluetooth/GenericAttributeProfile/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Bluetooth/GenericAttributeProfile/mod.rs
@@ -239,12 +239,12 @@ impl core::ops::BitAnd for GattCharacteristicProperties {
 }
 impl core::ops::BitOrAssign for GattCharacteristicProperties {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for GattCharacteristicProperties {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for GattCharacteristicProperties {

--- a/crates/libs/windows/src/Windows/Devices/Bluetooth/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Bluetooth/mod.rs
@@ -1586,12 +1586,12 @@ impl core::ops::BitAnd for BluetoothServiceCapabilities {
 }
 impl core::ops::BitOrAssign for BluetoothServiceCapabilities {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for BluetoothServiceCapabilities {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for BluetoothServiceCapabilities {

--- a/crates/libs/windows/src/Windows/Devices/Display/Core/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Display/Core/mod.rs
@@ -127,12 +127,12 @@ impl core::ops::BitAnd for DisplayBitsPerChannel {
 }
 impl core::ops::BitOrAssign for DisplayBitsPerChannel {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for DisplayBitsPerChannel {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for DisplayBitsPerChannel {
@@ -572,12 +572,12 @@ impl core::ops::BitAnd for DisplayManagerOptions {
 }
 impl core::ops::BitOrAssign for DisplayManagerOptions {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for DisplayManagerOptions {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for DisplayManagerOptions {
@@ -790,12 +790,12 @@ impl core::ops::BitAnd for DisplayModeQueryOptions {
 }
 impl core::ops::BitOrAssign for DisplayModeQueryOptions {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for DisplayModeQueryOptions {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for DisplayModeQueryOptions {
@@ -1285,12 +1285,12 @@ impl core::ops::BitAnd for DisplayScanoutOptions {
 }
 impl core::ops::BitOrAssign for DisplayScanoutOptions {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for DisplayScanoutOptions {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for DisplayScanoutOptions {
@@ -1527,12 +1527,12 @@ impl core::ops::BitAnd for DisplayStateApplyOptions {
 }
 impl core::ops::BitOrAssign for DisplayStateApplyOptions {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for DisplayStateApplyOptions {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for DisplayStateApplyOptions {
@@ -1574,12 +1574,12 @@ impl core::ops::BitAnd for DisplayStateFunctionalizeOptions {
 }
 impl core::ops::BitOrAssign for DisplayStateFunctionalizeOptions {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for DisplayStateFunctionalizeOptions {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for DisplayStateFunctionalizeOptions {

--- a/crates/libs/windows/src/Windows/Devices/Enumeration/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Enumeration/mod.rs
@@ -760,12 +760,12 @@ impl core::ops::BitAnd for DevicePairingKinds {
 }
 impl core::ops::BitOrAssign for DevicePairingKinds {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for DevicePairingKinds {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for DevicePairingKinds {
@@ -1181,12 +1181,12 @@ impl core::ops::BitAnd for DevicePickerDisplayStatusOptions {
 }
 impl core::ops::BitOrAssign for DevicePickerDisplayStatusOptions {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for DevicePickerDisplayStatusOptions {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for DevicePickerDisplayStatusOptions {

--- a/crates/libs/windows/src/Windows/Devices/Geolocation/Geofencing/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Geolocation/Geofencing/mod.rs
@@ -238,12 +238,12 @@ impl core::ops::BitAnd for GeofenceState {
 }
 impl core::ops::BitOrAssign for GeofenceState {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for GeofenceState {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for GeofenceState {
@@ -397,12 +397,12 @@ impl core::ops::BitAnd for MonitoredGeofenceStates {
 }
 impl core::ops::BitOrAssign for MonitoredGeofenceStates {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for MonitoredGeofenceStates {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for MonitoredGeofenceStates {

--- a/crates/libs/windows/src/Windows/Devices/Lights/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Lights/mod.rs
@@ -621,12 +621,12 @@ impl core::ops::BitAnd for LampPurposes {
 }
 impl core::ops::BitOrAssign for LampPurposes {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for LampPurposes {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for LampPurposes {

--- a/crates/libs/windows/src/Windows/Devices/PointOfService/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/PointOfService/mod.rs
@@ -7963,12 +7963,12 @@ impl core::ops::BitAnd for PosConnectionTypes {
 }
 impl core::ops::BitOrAssign for PosConnectionTypes {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for PosConnectionTypes {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for PosConnectionTypes {
@@ -8250,12 +8250,12 @@ impl core::ops::BitAnd for PosPrinterCartridgeSensors {
 }
 impl core::ops::BitOrAssign for PosPrinterCartridgeSensors {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for PosPrinterCartridgeSensors {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for PosPrinterCartridgeSensors {
@@ -8334,12 +8334,12 @@ impl core::ops::BitAnd for PosPrinterColorCapabilities {
 }
 impl core::ops::BitOrAssign for PosPrinterColorCapabilities {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for PosPrinterColorCapabilities {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for PosPrinterColorCapabilities {
@@ -8484,12 +8484,12 @@ impl core::ops::BitAnd for PosPrinterMarkFeedCapabilities {
 }
 impl core::ops::BitOrAssign for PosPrinterMarkFeedCapabilities {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for PosPrinterMarkFeedCapabilities {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for PosPrinterMarkFeedCapabilities {
@@ -8734,12 +8734,12 @@ impl core::ops::BitAnd for PosPrinterRuledLineCapabilities {
 }
 impl core::ops::BitOrAssign for PosPrinterRuledLineCapabilities {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for PosPrinterRuledLineCapabilities {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for PosPrinterRuledLineCapabilities {

--- a/crates/libs/windows/src/Windows/Devices/SmartCards/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/SmartCards/mod.rs
@@ -1975,12 +1975,12 @@ impl core::ops::BitAnd for SmartCardCryptogramPlacementOptions {
 }
 impl core::ops::BitOrAssign for SmartCardCryptogramPlacementOptions {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for SmartCardCryptogramPlacementOptions {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for SmartCardCryptogramPlacementOptions {
@@ -2149,12 +2149,12 @@ impl core::ops::BitAnd for SmartCardCryptogramStorageKeyCapabilities {
 }
 impl core::ops::BitOrAssign for SmartCardCryptogramStorageKeyCapabilities {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for SmartCardCryptogramStorageKeyCapabilities {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for SmartCardCryptogramStorageKeyCapabilities {

--- a/crates/libs/windows/src/Windows/Devices/Usb/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Usb/mod.rs
@@ -1637,12 +1637,12 @@ impl core::ops::BitAnd for UsbReadOptions {
 }
 impl core::ops::BitOrAssign for UsbReadOptions {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for UsbReadOptions {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for UsbReadOptions {
@@ -1784,12 +1784,12 @@ impl core::ops::BitAnd for UsbWriteOptions {
 }
 impl core::ops::BitOrAssign for UsbWriteOptions {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for UsbWriteOptions {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for UsbWriteOptions {

--- a/crates/libs/windows/src/Windows/Foundation/Diagnostics/mod.rs
+++ b/crates/libs/windows/src/Windows/Foundation/Diagnostics/mod.rs
@@ -174,12 +174,12 @@ impl core::ops::BitAnd for ErrorOptions {
 }
 impl core::ops::BitOrAssign for ErrorOptions {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for ErrorOptions {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for ErrorOptions {

--- a/crates/libs/windows/src/Windows/Foundation/Metadata/mod.rs
+++ b/crates/libs/windows/src/Windows/Foundation/Metadata/mod.rs
@@ -111,12 +111,12 @@ impl core::ops::BitAnd for AttributeTargets {
 }
 impl core::ops::BitOrAssign for AttributeTargets {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for AttributeTargets {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for AttributeTargets {

--- a/crates/libs/windows/src/Windows/Gaming/Input/ForceFeedback/mod.rs
+++ b/crates/libs/windows/src/Windows/Gaming/Input/ForceFeedback/mod.rs
@@ -161,12 +161,12 @@ impl core::ops::BitAnd for ForceFeedbackEffectAxes {
 }
 impl core::ops::BitOrAssign for ForceFeedbackEffectAxes {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for ForceFeedbackEffectAxes {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for ForceFeedbackEffectAxes {

--- a/crates/libs/windows/src/Windows/Gaming/Input/mod.rs
+++ b/crates/libs/windows/src/Windows/Gaming/Input/mod.rs
@@ -198,12 +198,12 @@ impl core::ops::BitAnd for ArcadeStickButtons {
 }
 impl core::ops::BitOrAssign for ArcadeStickButtons {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for ArcadeStickButtons {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for ArcadeStickButtons {
@@ -410,12 +410,12 @@ impl core::ops::BitAnd for FlightStickButtons {
 }
 impl core::ops::BitOrAssign for FlightStickButtons {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for FlightStickButtons {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for FlightStickButtons {
@@ -765,12 +765,12 @@ impl core::ops::BitAnd for GamepadButtons {
 }
 impl core::ops::BitOrAssign for GamepadButtons {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for GamepadButtons {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for GamepadButtons {
@@ -1410,12 +1410,12 @@ impl core::ops::BitAnd for OptionalUINavigationButtons {
 }
 impl core::ops::BitOrAssign for OptionalUINavigationButtons {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for OptionalUINavigationButtons {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for OptionalUINavigationButtons {
@@ -1665,12 +1665,12 @@ impl core::ops::BitAnd for RacingWheelButtons {
 }
 impl core::ops::BitOrAssign for RacingWheelButtons {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for RacingWheelButtons {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for RacingWheelButtons {
@@ -1948,12 +1948,12 @@ impl core::ops::BitAnd for RequiredUINavigationButtons {
 }
 impl core::ops::BitOrAssign for RequiredUINavigationButtons {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for RequiredUINavigationButtons {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for RequiredUINavigationButtons {

--- a/crates/libs/windows/src/Windows/Graphics/DirectX/Direct3D11/mod.rs
+++ b/crates/libs/windows/src/Windows/Graphics/DirectX/Direct3D11/mod.rs
@@ -38,12 +38,12 @@ impl core::ops::BitAnd for Direct3DBindings {
 }
 impl core::ops::BitOrAssign for Direct3DBindings {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for Direct3DBindings {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for Direct3DBindings {

--- a/crates/libs/windows/src/Windows/Graphics/Display/mod.rs
+++ b/crates/libs/windows/src/Windows/Graphics/Display/mod.rs
@@ -331,12 +331,12 @@ impl core::ops::BitAnd for DisplayBrightnessOverrideOptions {
 }
 impl core::ops::BitOrAssign for DisplayBrightnessOverrideOptions {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for DisplayBrightnessOverrideOptions {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for DisplayBrightnessOverrideOptions {
@@ -788,12 +788,12 @@ impl core::ops::BitAnd for DisplayOrientations {
 }
 impl core::ops::BitOrAssign for DisplayOrientations {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for DisplayOrientations {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for DisplayOrientations {

--- a/crates/libs/windows/src/Windows/Graphics/Printing/OptionDetails/mod.rs
+++ b/crates/libs/windows/src/Windows/Graphics/Printing/OptionDetails/mod.rs
@@ -2149,12 +2149,12 @@ impl core::ops::BitAnd for PrintOptionStates {
 }
 impl core::ops::BitOrAssign for PrintOptionStates {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for PrintOptionStates {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for PrintOptionStates {

--- a/crates/libs/windows/src/Windows/Graphics/Printing/PrintSupport/mod.rs
+++ b/crates/libs/windows/src/Windows/Graphics/Printing/PrintSupport/mod.rs
@@ -427,12 +427,12 @@ impl core::ops::BitAnd for PrintSupportAppContracts {
 }
 impl core::ops::BitOrAssign for PrintSupportAppContracts {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for PrintSupportAppContracts {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for PrintSupportAppContracts {

--- a/crates/libs/windows/src/Windows/Graphics/Printing/Workflow/mod.rs
+++ b/crates/libs/windows/src/Windows/Graphics/Printing/Workflow/mod.rs
@@ -708,12 +708,12 @@ impl core::ops::BitAnd for PdlConversionHostBasedProcessingOperations {
 }
 impl core::ops::BitOrAssign for PdlConversionHostBasedProcessingOperations {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for PdlConversionHostBasedProcessingOperations {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for PdlConversionHostBasedProcessingOperations {

--- a/crates/libs/windows/src/Windows/Management/Deployment/mod.rs
+++ b/crates/libs/windows/src/Windows/Management/Deployment/mod.rs
@@ -35,12 +35,12 @@ impl core::ops::BitAnd for AddPackageByAppInstallerOptions {
 }
 impl core::ops::BitOrAssign for AddPackageByAppInstallerOptions {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for AddPackageByAppInstallerOptions {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for AddPackageByAppInstallerOptions {
@@ -642,12 +642,12 @@ impl core::ops::BitAnd for DeploymentOptions {
 }
 impl core::ops::BitOrAssign for DeploymentOptions {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for DeploymentOptions {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for DeploymentOptions {
@@ -2326,12 +2326,12 @@ impl core::ops::BitAnd for PackageStatus {
 }
 impl core::ops::BitOrAssign for PackageStatus {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for PackageStatus {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for PackageStatus {
@@ -2391,12 +2391,12 @@ impl core::ops::BitAnd for PackageTypes {
 }
 impl core::ops::BitOrAssign for PackageTypes {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for PackageTypes {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for PackageTypes {
@@ -2783,12 +2783,12 @@ impl core::ops::BitAnd for RemovalOptions {
 }
 impl core::ops::BitOrAssign for RemovalOptions {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for RemovalOptions {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for RemovalOptions {

--- a/crates/libs/windows/src/Windows/Management/Update/mod.rs
+++ b/crates/libs/windows/src/Windows/Management/Update/mod.rs
@@ -2474,12 +2474,12 @@ impl core::ops::BitAnd for WindowsUpdateAdministratorOptions {
 }
 impl core::ops::BitOrAssign for WindowsUpdateAdministratorOptions {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for WindowsUpdateAdministratorOptions {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for WindowsUpdateAdministratorOptions {

--- a/crates/libs/windows/src/Windows/Media/Audio/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/Audio/mod.rs
@@ -1763,12 +1763,12 @@ impl core::ops::BitAnd for AudioNodeEmitterSettings {
 }
 impl core::ops::BitOrAssign for AudioNodeEmitterSettings {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for AudioNodeEmitterSettings {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for AudioNodeEmitterSettings {

--- a/crates/libs/windows/src/Windows/Media/Casting/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/Casting/mod.rs
@@ -413,12 +413,12 @@ impl core::ops::BitAnd for CastingPlaybackTypes {
 }
 impl core::ops::BitOrAssign for CastingPlaybackTypes {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CastingPlaybackTypes {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CastingPlaybackTypes {

--- a/crates/libs/windows/src/Windows/Media/MediaProperties/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/MediaProperties/mod.rs
@@ -1960,12 +1960,12 @@ impl core::ops::BitAnd for MediaMirroringOptions {
 }
 impl core::ops::BitOrAssign for MediaMirroringOptions {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for MediaMirroringOptions {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for MediaMirroringOptions {

--- a/crates/libs/windows/src/Windows/Media/Protection/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/Protection/mod.rs
@@ -757,12 +757,12 @@ impl core::ops::BitAnd for RevocationAndRenewalReasons {
 }
 impl core::ops::BitOrAssign for RevocationAndRenewalReasons {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for RevocationAndRenewalReasons {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for RevocationAndRenewalReasons {

--- a/crates/libs/windows/src/Windows/Networking/Connectivity/mod.rs
+++ b/crates/libs/windows/src/Windows/Networking/Connectivity/mod.rs
@@ -1749,12 +1749,12 @@ impl core::ops::BitAnd for NetworkTypes {
 }
 impl core::ops::BitOrAssign for NetworkTypes {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for NetworkTypes {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for NetworkTypes {
@@ -1910,12 +1910,12 @@ impl core::ops::BitAnd for RoamingStates {
 }
 impl core::ops::BitOrAssign for RoamingStates {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for RoamingStates {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for RoamingStates {
@@ -2115,12 +2115,12 @@ impl core::ops::BitAnd for WwanDataClass {
 }
 impl core::ops::BitOrAssign for WwanDataClass {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for WwanDataClass {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for WwanDataClass {

--- a/crates/libs/windows/src/Windows/Networking/NetworkOperators/mod.rs
+++ b/crates/libs/windows/src/Windows/Networking/NetworkOperators/mod.rs
@@ -45,12 +45,12 @@ impl core::ops::BitAnd for DataClasses {
 }
 impl core::ops::BitOrAssign for DataClasses {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for DataClasses {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for DataClasses {

--- a/crates/libs/windows/src/Windows/Networking/Proximity/mod.rs
+++ b/crates/libs/windows/src/Windows/Networking/Proximity/mod.rs
@@ -404,12 +404,12 @@ impl core::ops::BitAnd for PeerDiscoveryTypes {
 }
 impl core::ops::BitOrAssign for PeerDiscoveryTypes {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for PeerDiscoveryTypes {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for PeerDiscoveryTypes {

--- a/crates/libs/windows/src/Windows/Networking/Vpn/mod.rs
+++ b/crates/libs/windows/src/Windows/Networking/Vpn/mod.rs
@@ -2196,12 +2196,12 @@ impl core::ops::BitAnd for VpnChannelRequestCredentialsOptions {
 }
 impl core::ops::BitOrAssign for VpnChannelRequestCredentialsOptions {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for VpnChannelRequestCredentialsOptions {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for VpnChannelRequestCredentialsOptions {

--- a/crates/libs/windows/src/Windows/Networking/XboxLive/mod.rs
+++ b/crates/libs/windows/src/Windows/Networking/XboxLive/mod.rs
@@ -461,12 +461,12 @@ impl core::ops::BitAnd for XboxLiveEndpointPairCreationBehaviors {
 }
 impl core::ops::BitOrAssign for XboxLiveEndpointPairCreationBehaviors {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for XboxLiveEndpointPairCreationBehaviors {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for XboxLiveEndpointPairCreationBehaviors {

--- a/crates/libs/windows/src/Windows/Networking/mod.rs
+++ b/crates/libs/windows/src/Windows/Networking/mod.rs
@@ -221,12 +221,12 @@ impl core::ops::BitAnd for HostNameSortOptions {
 }
 impl core::ops::BitOrAssign for HostNameSortOptions {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for HostNameSortOptions {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for HostNameSortOptions {

--- a/crates/libs/windows/src/Windows/Security/Authentication/Web/Provider/mod.rs
+++ b/crates/libs/windows/src/Windows/Security/Authentication/Web/Provider/mod.rs
@@ -1566,12 +1566,12 @@ impl core::ops::BitAnd for WebAccountSelectionOptions {
 }
 impl core::ops::BitOrAssign for WebAccountSelectionOptions {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for WebAccountSelectionOptions {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for WebAccountSelectionOptions {

--- a/crates/libs/windows/src/Windows/Security/Authentication/Web/mod.rs
+++ b/crates/libs/windows/src/Windows/Security/Authentication/Web/mod.rs
@@ -171,12 +171,12 @@ impl core::ops::BitAnd for WebAuthenticationOptions {
 }
 impl core::ops::BitOrAssign for WebAuthenticationOptions {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for WebAuthenticationOptions {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for WebAuthenticationOptions {

--- a/crates/libs/windows/src/Windows/Security/Cryptography/Certificates/mod.rs
+++ b/crates/libs/windows/src/Windows/Security/Cryptography/Certificates/mod.rs
@@ -1285,12 +1285,12 @@ impl core::ops::BitAnd for EnrollKeyUsages {
 }
 impl core::ops::BitOrAssign for EnrollKeyUsages {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for EnrollKeyUsages {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for EnrollKeyUsages {
@@ -1966,12 +1966,12 @@ impl core::ops::BitAnd for InstallOptions {
 }
 impl core::ops::BitOrAssign for InstallOptions {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for InstallOptions {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for InstallOptions {

--- a/crates/libs/windows/src/Windows/Security/Isolation/mod.rs
+++ b/crates/libs/windows/src/Windows/Security/Isolation/mod.rs
@@ -627,12 +627,12 @@ impl core::ops::BitAnd for IsolatedWindowsEnvironmentAllowedClipboardFormats {
 }
 impl core::ops::BitOrAssign for IsolatedWindowsEnvironmentAllowedClipboardFormats {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for IsolatedWindowsEnvironmentAllowedClipboardFormats {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for IsolatedWindowsEnvironmentAllowedClipboardFormats {
@@ -676,12 +676,12 @@ impl core::ops::BitAnd for IsolatedWindowsEnvironmentAvailablePrinters {
 }
 impl core::ops::BitOrAssign for IsolatedWindowsEnvironmentAvailablePrinters {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for IsolatedWindowsEnvironmentAvailablePrinters {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for IsolatedWindowsEnvironmentAvailablePrinters {
@@ -723,12 +723,12 @@ impl core::ops::BitAnd for IsolatedWindowsEnvironmentClipboardCopyPasteDirection
 }
 impl core::ops::BitOrAssign for IsolatedWindowsEnvironmentClipboardCopyPasteDirections {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for IsolatedWindowsEnvironmentClipboardCopyPasteDirections {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for IsolatedWindowsEnvironmentClipboardCopyPasteDirections {

--- a/crates/libs/windows/src/Windows/Services/Maps/Guidance/mod.rs
+++ b/crates/libs/windows/src/Windows/Services/Maps/Guidance/mod.rs
@@ -102,12 +102,12 @@ impl core::ops::BitAnd for GuidanceAudioNotifications {
 }
 impl core::ops::BitOrAssign for GuidanceAudioNotifications {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for GuidanceAudioNotifications {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for GuidanceAudioNotifications {
@@ -187,12 +187,12 @@ impl core::ops::BitAnd for GuidanceLaneMarkers {
 }
 impl core::ops::BitOrAssign for GuidanceLaneMarkers {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for GuidanceLaneMarkers {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for GuidanceLaneMarkers {

--- a/crates/libs/windows/src/Windows/Services/Maps/mod.rs
+++ b/crates/libs/windows/src/Windows/Services/Maps/mod.rs
@@ -965,12 +965,12 @@ impl core::ops::BitAnd for MapManeuverNotices {
 }
 impl core::ops::BitOrAssign for MapManeuverNotices {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for MapManeuverNotices {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for MapManeuverNotices {
@@ -1591,12 +1591,12 @@ impl core::ops::BitAnd for MapRouteRestrictions {
 }
 impl core::ops::BitOrAssign for MapRouteRestrictions {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for MapRouteRestrictions {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for MapRouteRestrictions {

--- a/crates/libs/windows/src/Windows/Storage/AccessCache/mod.rs
+++ b/crates/libs/windows/src/Windows/Storage/AccessCache/mod.rs
@@ -33,12 +33,12 @@ impl core::ops::BitAnd for AccessCacheOptions {
 }
 impl core::ops::BitOrAssign for AccessCacheOptions {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for AccessCacheOptions {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for AccessCacheOptions {

--- a/crates/libs/windows/src/Windows/Storage/FileProperties/mod.rs
+++ b/crates/libs/windows/src/Windows/Storage/FileProperties/mod.rs
@@ -793,12 +793,12 @@ impl core::ops::BitAnd for PropertyPrefetchOptions {
 }
 impl core::ops::BitOrAssign for PropertyPrefetchOptions {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for PropertyPrefetchOptions {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for PropertyPrefetchOptions {
@@ -1073,12 +1073,12 @@ impl core::ops::BitAnd for ThumbnailOptions {
 }
 impl core::ops::BitOrAssign for ThumbnailOptions {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for ThumbnailOptions {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for ThumbnailOptions {

--- a/crates/libs/windows/src/Windows/Storage/Provider/mod.rs
+++ b/crates/libs/windows/src/Windows/Storage/Provider/mod.rs
@@ -32,12 +32,12 @@ impl core::ops::BitAnd for CachedFileOptions {
 }
 impl core::ops::BitOrAssign for CachedFileOptions {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CachedFileOptions {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CachedFileOptions {
@@ -2010,12 +2010,12 @@ impl core::ops::BitAnd for StorageProviderHardlinkPolicy {
 }
 impl core::ops::BitOrAssign for StorageProviderHardlinkPolicy {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for StorageProviderHardlinkPolicy {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for StorageProviderHardlinkPolicy {
@@ -2074,12 +2074,12 @@ impl core::ops::BitAnd for StorageProviderHydrationPolicyModifier {
 }
 impl core::ops::BitOrAssign for StorageProviderHydrationPolicyModifier {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for StorageProviderHydrationPolicyModifier {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for StorageProviderHydrationPolicyModifier {
@@ -2130,12 +2130,12 @@ impl core::ops::BitAnd for StorageProviderInSyncPolicy {
 }
 impl core::ops::BitOrAssign for StorageProviderInSyncPolicy {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for StorageProviderInSyncPolicy {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for StorageProviderInSyncPolicy {

--- a/crates/libs/windows/src/Windows/Storage/Streams/mod.rs
+++ b/crates/libs/windows/src/Windows/Storage/Streams/mod.rs
@@ -2696,12 +2696,12 @@ impl core::ops::BitAnd for InputStreamOptions {
 }
 impl core::ops::BitOrAssign for InputStreamOptions {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for InputStreamOptions {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for InputStreamOptions {

--- a/crates/libs/windows/src/Windows/Storage/mod.rs
+++ b/crates/libs/windows/src/Windows/Storage/mod.rs
@@ -792,12 +792,12 @@ impl core::ops::BitAnd for FileAttributes {
 }
 impl core::ops::BitOrAssign for FileAttributes {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for FileAttributes {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for FileAttributes {
@@ -5038,12 +5038,12 @@ impl core::ops::BitAnd for StorageItemTypes {
 }
 impl core::ops::BitOrAssign for StorageItemTypes {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for StorageItemTypes {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for StorageItemTypes {
@@ -5391,12 +5391,12 @@ impl core::ops::BitAnd for StorageOpenOptions {
 }
 impl core::ops::BitOrAssign for StorageOpenOptions {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for StorageOpenOptions {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for StorageOpenOptions {

--- a/crates/libs/windows/src/Windows/System/Diagnostics/TraceReporting/mod.rs
+++ b/crates/libs/windows/src/Windows/System/Diagnostics/TraceReporting/mod.rs
@@ -162,12 +162,12 @@ impl core::ops::BitAnd for PlatformDiagnosticEventBufferLatencies {
 }
 impl core::ops::BitOrAssign for PlatformDiagnosticEventBufferLatencies {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for PlatformDiagnosticEventBufferLatencies {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for PlatformDiagnosticEventBufferLatencies {

--- a/crates/libs/windows/src/Windows/System/Profile/mod.rs
+++ b/crates/libs/windows/src/Windows/System/Profile/mod.rs
@@ -894,12 +894,12 @@ impl core::ops::BitAnd for UnsupportedAppRequirementReasons {
 }
 impl core::ops::BitOrAssign for UnsupportedAppRequirementReasons {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for UnsupportedAppRequirementReasons {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for UnsupportedAppRequirementReasons {

--- a/crates/libs/windows/src/Windows/System/RemoteDesktop/Input/mod.rs
+++ b/crates/libs/windows/src/Windows/System/RemoteDesktop/Input/mod.rs
@@ -77,12 +77,12 @@ impl core::ops::BitAnd for RemoteKeyEventAttributes {
 }
 impl core::ops::BitOrAssign for RemoteKeyEventAttributes {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for RemoteKeyEventAttributes {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for RemoteKeyEventAttributes {
@@ -239,12 +239,12 @@ impl core::ops::BitAnd for RemoteTextConnectionOptions {
 }
 impl core::ops::BitOrAssign for RemoteTextConnectionOptions {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for RemoteTextConnectionOptions {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for RemoteTextConnectionOptions {

--- a/crates/libs/windows/src/Windows/System/Threading/mod.rs
+++ b/crates/libs/windows/src/Windows/System/Threading/mod.rs
@@ -298,12 +298,12 @@ impl core::ops::BitAnd for WorkItemOptions {
 }
 impl core::ops::BitOrAssign for WorkItemOptions {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for WorkItemOptions {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for WorkItemOptions {

--- a/crates/libs/windows/src/Windows/System/mod.rs
+++ b/crates/libs/windows/src/Windows/System/mod.rs
@@ -4396,12 +4396,12 @@ impl core::ops::BitAnd for VirtualKeyModifiers {
 }
 impl core::ops::BitOrAssign for VirtualKeyModifiers {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for VirtualKeyModifiers {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for VirtualKeyModifiers {

--- a/crates/libs/windows/src/Windows/UI/ApplicationSettings/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/ApplicationSettings/mod.rs
@@ -735,12 +735,12 @@ impl core::ops::BitAnd for SupportedWebAccountActions {
 }
 impl core::ops::BitOrAssign for SupportedWebAccountActions {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for SupportedWebAccountActions {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for SupportedWebAccountActions {

--- a/crates/libs/windows/src/Windows/UI/Composition/Diagnostics/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Composition/Diagnostics/mod.rs
@@ -79,12 +79,12 @@ impl core::ops::BitAnd for CompositionDebugOverdrawContentKinds {
 }
 impl core::ops::BitOrAssign for CompositionDebugOverdrawContentKinds {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CompositionDebugOverdrawContentKinds {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CompositionDebugOverdrawContentKinds {

--- a/crates/libs/windows/src/Windows/UI/Composition/Interactions/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Composition/Interactions/mod.rs
@@ -1001,12 +1001,12 @@ impl core::ops::BitAnd for InteractionBindingAxisModes {
 }
 impl core::ops::BitOrAssign for InteractionBindingAxisModes {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for InteractionBindingAxisModes {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for InteractionBindingAxisModes {

--- a/crates/libs/windows/src/Windows/UI/Composition/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Composition/mod.rs
@@ -3132,12 +3132,12 @@ impl core::ops::BitAnd for CompositionBatchTypes {
 }
 impl core::ops::BitOrAssign for CompositionBatchTypes {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CompositionBatchTypes {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CompositionBatchTypes {

--- a/crates/libs/windows/src/Windows/UI/Core/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Core/mod.rs
@@ -801,12 +801,12 @@ impl core::ops::BitAnd for CoreIndependentInputFilters {
 }
 impl core::ops::BitOrAssign for CoreIndependentInputFilters {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CoreIndependentInputFilters {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CoreIndependentInputFilters {
@@ -1156,12 +1156,12 @@ impl core::ops::BitAnd for CoreInputDeviceTypes {
 }
 impl core::ops::BitOrAssign for CoreInputDeviceTypes {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CoreInputDeviceTypes {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CoreInputDeviceTypes {
@@ -1259,12 +1259,12 @@ impl core::ops::BitAnd for CoreVirtualKeyStates {
 }
 impl core::ops::BitOrAssign for CoreVirtualKeyStates {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CoreVirtualKeyStates {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CoreVirtualKeyStates {

--- a/crates/libs/windows/src/Windows/UI/Input/Preview/Injection/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Input/Preview/Injection/mod.rs
@@ -322,12 +322,12 @@ impl core::ops::BitAnd for InjectedInputKeyOptions {
 }
 impl core::ops::BitOrAssign for InjectedInputKeyOptions {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for InjectedInputKeyOptions {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for InjectedInputKeyOptions {
@@ -499,12 +499,12 @@ impl core::ops::BitAnd for InjectedInputMouseOptions {
 }
 impl core::ops::BitOrAssign for InjectedInputMouseOptions {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for InjectedInputMouseOptions {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for InjectedInputMouseOptions {
@@ -547,12 +547,12 @@ impl core::ops::BitAnd for InjectedInputPenButtons {
 }
 impl core::ops::BitOrAssign for InjectedInputPenButtons {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for InjectedInputPenButtons {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for InjectedInputPenButtons {
@@ -682,12 +682,12 @@ impl core::ops::BitAnd for InjectedInputPenParameters {
 }
 impl core::ops::BitOrAssign for InjectedInputPenParameters {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for InjectedInputPenParameters {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for InjectedInputPenParameters {
@@ -766,12 +766,12 @@ impl core::ops::BitAnd for InjectedInputPointerOptions {
 }
 impl core::ops::BitOrAssign for InjectedInputPointerOptions {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for InjectedInputPointerOptions {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for InjectedInputPointerOptions {
@@ -910,12 +910,12 @@ impl core::ops::BitAnd for InjectedInputTouchParameters {
 }
 impl core::ops::BitOrAssign for InjectedInputTouchParameters {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for InjectedInputTouchParameters {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for InjectedInputTouchParameters {

--- a/crates/libs/windows/src/Windows/UI/Input/Preview/Text/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Input/Preview/Text/mod.rs
@@ -794,12 +794,12 @@ impl core::ops::BitAnd for TextBoxFeatures {
 }
 impl core::ops::BitOrAssign for TextBoxFeatures {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for TextBoxFeatures {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for TextBoxFeatures {
@@ -932,12 +932,12 @@ impl core::ops::BitAnd for TextBoxSettings {
 }
 impl core::ops::BitOrAssign for TextBoxSettings {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for TextBoxSettings {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for TextBoxSettings {
@@ -1492,12 +1492,12 @@ impl core::ops::BitAnd for TextStyleAttributes {
 }
 impl core::ops::BitOrAssign for TextStyleAttributes {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for TextStyleAttributes {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for TextStyleAttributes {

--- a/crates/libs/windows/src/Windows/UI/Input/Spatial/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Input/Spatial/mod.rs
@@ -888,12 +888,12 @@ impl core::ops::BitAnd for SpatialGestureSettings {
 }
 impl core::ops::BitOrAssign for SpatialGestureSettings {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for SpatialGestureSettings {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for SpatialGestureSettings {

--- a/crates/libs/windows/src/Windows/UI/Input/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Input/mod.rs
@@ -731,12 +731,12 @@ impl core::ops::BitAnd for GestureSettings {
 }
 impl core::ops::BitOrAssign for GestureSettings {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for GestureSettings {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for GestureSettings {
@@ -4201,12 +4201,12 @@ impl core::ops::BitAnd for TouchpadGlobalGestureKinds {
 }
 impl core::ops::BitOrAssign for TouchpadGlobalGestureKinds {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for TouchpadGlobalGestureKinds {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for TouchpadGlobalGestureKinds {

--- a/crates/libs/windows/src/Windows/UI/Notifications/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Notifications/mod.rs
@@ -1616,12 +1616,12 @@ impl core::ops::BitAnd for NotificationKinds {
 }
 impl core::ops::BitOrAssign for NotificationKinds {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for NotificationKinds {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for NotificationKinds {

--- a/crates/libs/windows/src/Windows/UI/Popups/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Popups/mod.rs
@@ -311,12 +311,12 @@ impl core::ops::BitAnd for MessageDialogOptions {
 }
 impl core::ops::BitOrAssign for MessageDialogOptions {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for MessageDialogOptions {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for MessageDialogOptions {

--- a/crates/libs/windows/src/Windows/UI/StartScreen/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/StartScreen/mod.rs
@@ -1173,12 +1173,12 @@ impl core::ops::BitAnd for TileOptions {
 }
 impl core::ops::BitOrAssign for TileOptions {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for TileOptions {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for TileOptions {

--- a/crates/libs/windows/src/Windows/UI/Text/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Text/mod.rs
@@ -119,12 +119,12 @@ impl core::ops::BitAnd for FindOptions {
 }
 impl core::ops::BitOrAssign for FindOptions {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for FindOptions {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for FindOptions {
@@ -4266,12 +4266,12 @@ impl core::ops::BitAnd for PointOptions {
 }
 impl core::ops::BitOrAssign for PointOptions {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for PointOptions {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for PointOptions {
@@ -4830,12 +4830,12 @@ impl core::ops::BitAnd for SelectionOptions {
 }
 impl core::ops::BitOrAssign for SelectionOptions {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for SelectionOptions {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for SelectionOptions {
@@ -4984,12 +4984,12 @@ impl core::ops::BitAnd for TextDecorations {
 }
 impl core::ops::BitOrAssign for TextDecorations {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for TextDecorations {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for TextDecorations {
@@ -5037,12 +5037,12 @@ impl core::ops::BitAnd for TextGetOptions {
 }
 impl core::ops::BitOrAssign for TextGetOptions {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for TextGetOptions {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for TextGetOptions {
@@ -5207,12 +5207,12 @@ impl core::ops::BitAnd for TextSetOptions {
 }
 impl core::ops::BitOrAssign for TextSetOptions {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for TextSetOptions {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for TextSetOptions {

--- a/crates/libs/windows/src/Windows/UI/ViewManagement/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/ViewManagement/mod.rs
@@ -660,12 +660,12 @@ impl core::ops::BitAnd for ApplicationViewSwitchingOptions {
 }
 impl core::ops::BitOrAssign for ApplicationViewSwitchingOptions {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for ApplicationViewSwitchingOptions {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for ApplicationViewSwitchingOptions {

--- a/crates/libs/windows/src/Windows/Wdk/Storage/FileSystem/mod.rs
+++ b/crates/libs/windows/src/Windows/Wdk/Storage/FileSystem/mod.rs
@@ -6843,12 +6843,12 @@ impl core::ops::BitAnd for NTCREATEFILE_CREATE_OPTIONS {
 }
 impl core::ops::BitOrAssign for NTCREATEFILE_CREATE_OPTIONS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for NTCREATEFILE_CREATE_OPTIONS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for NTCREATEFILE_CREATE_OPTIONS {

--- a/crates/libs/windows/src/Windows/Win32/AI/MachineLearning/DirectML/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/AI/MachineLearning/DirectML/mod.rs
@@ -584,12 +584,12 @@ impl core::ops::BitAnd for DML_CREATE_DEVICE_FLAGS {
 }
 impl core::ops::BitOrAssign for DML_CREATE_DEVICE_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for DML_CREATE_DEVICE_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for DML_CREATE_DEVICE_FLAGS {
@@ -1502,12 +1502,12 @@ impl core::ops::BitAnd for DML_EXECUTION_FLAGS {
 }
 impl core::ops::BitOrAssign for DML_EXECUTION_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for DML_EXECUTION_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for DML_EXECUTION_FLAGS {
@@ -2718,12 +2718,12 @@ impl core::ops::BitAnd for DML_TENSOR_FLAGS {
 }
 impl core::ops::BitOrAssign for DML_TENSOR_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for DML_TENSOR_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for DML_TENSOR_FLAGS {

--- a/crates/libs/windows/src/Windows/Win32/AI/MachineLearning/WinML/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/AI/MachineLearning/WinML/mod.rs
@@ -1514,12 +1514,12 @@ impl core::ops::BitAnd for MLOperatorKernelOptions {
 }
 impl core::ops::BitOrAssign for MLOperatorKernelOptions {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for MLOperatorKernelOptions {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for MLOperatorKernelOptions {
@@ -1555,12 +1555,12 @@ impl core::ops::BitAnd for MLOperatorParameterOptions {
 }
 impl core::ops::BitOrAssign for MLOperatorParameterOptions {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for MLOperatorParameterOptions {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for MLOperatorParameterOptions {

--- a/crates/libs/windows/src/Windows/Win32/Devices/Communication/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/Communication/mod.rs
@@ -206,12 +206,12 @@ impl core::ops::BitAnd for CLEAR_COMM_ERROR_FLAGS {
 }
 impl core::ops::BitOrAssign for CLEAR_COMM_ERROR_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CLEAR_COMM_ERROR_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CLEAR_COMM_ERROR_FLAGS {
@@ -289,12 +289,12 @@ impl core::ops::BitAnd for COMMPROP_STOP_PARITY {
 }
 impl core::ops::BitOrAssign for COMMPROP_STOP_PARITY {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for COMMPROP_STOP_PARITY {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for COMMPROP_STOP_PARITY {
@@ -334,12 +334,12 @@ impl core::ops::BitAnd for COMM_EVENT_MASK {
 }
 impl core::ops::BitOrAssign for COMM_EVENT_MASK {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for COMM_EVENT_MASK {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for COMM_EVENT_MASK {
@@ -561,12 +561,12 @@ impl core::ops::BitAnd for MODEMDEVCAPS_DIAL_OPTIONS {
 }
 impl core::ops::BitOrAssign for MODEMDEVCAPS_DIAL_OPTIONS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for MODEMDEVCAPS_DIAL_OPTIONS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for MODEMDEVCAPS_DIAL_OPTIONS {
@@ -597,12 +597,12 @@ impl core::ops::BitAnd for MODEMDEVCAPS_SPEAKER_MODE {
 }
 impl core::ops::BitOrAssign for MODEMDEVCAPS_SPEAKER_MODE {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for MODEMDEVCAPS_SPEAKER_MODE {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for MODEMDEVCAPS_SPEAKER_MODE {
@@ -633,12 +633,12 @@ impl core::ops::BitAnd for MODEMDEVCAPS_SPEAKER_VOLUME {
 }
 impl core::ops::BitOrAssign for MODEMDEVCAPS_SPEAKER_VOLUME {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for MODEMDEVCAPS_SPEAKER_VOLUME {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for MODEMDEVCAPS_SPEAKER_VOLUME {
@@ -696,12 +696,12 @@ impl core::ops::BitAnd for MODEM_STATUS_FLAGS {
 }
 impl core::ops::BitOrAssign for MODEM_STATUS_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for MODEM_STATUS_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for MODEM_STATUS_FLAGS {
@@ -745,12 +745,12 @@ impl core::ops::BitAnd for PURGE_COMM_FLAGS {
 }
 impl core::ops::BitOrAssign for PURGE_COMM_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for PURGE_COMM_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for PURGE_COMM_FLAGS {

--- a/crates/libs/windows/src/Windows/Win32/Devices/DeviceAndDriverInstallation/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/DeviceAndDriverInstallation/mod.rs
@@ -3928,12 +3928,12 @@ impl core::ops::BitAnd for CM_CDFLAGS {
 }
 impl core::ops::BitOrAssign for CM_CDFLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CM_CDFLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CM_CDFLAGS {
@@ -3967,12 +3967,12 @@ impl core::ops::BitAnd for CM_CDMASK {
 }
 impl core::ops::BitOrAssign for CM_CDMASK {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CM_CDMASK {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CM_CDMASK {
@@ -4043,12 +4043,12 @@ impl core::ops::BitAnd for CM_DEVCAP {
 }
 impl core::ops::BitOrAssign for CM_DEVCAP {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CM_DEVCAP {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CM_DEVCAP {
@@ -4112,12 +4112,12 @@ impl core::ops::BitAnd for CM_DEVNODE_STATUS_FLAGS {
 }
 impl core::ops::BitOrAssign for CM_DEVNODE_STATUS_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CM_DEVNODE_STATUS_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CM_DEVNODE_STATUS_FLAGS {
@@ -4196,12 +4196,12 @@ impl core::ops::BitAnd for CM_ENUMERATE_FLAGS {
 }
 impl core::ops::BitOrAssign for CM_ENUMERATE_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CM_ENUMERATE_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CM_ENUMERATE_FLAGS {
@@ -4476,12 +4476,12 @@ impl core::ops::BitAnd for CM_REENUMERATE_FLAGS {
 }
 impl core::ops::BitOrAssign for CM_REENUMERATE_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CM_REENUMERATE_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CM_REENUMERATE_FLAGS {
@@ -4761,12 +4761,12 @@ impl core::ops::BitAnd for DD_FLAGS {
 }
 impl core::ops::BitOrAssign for DD_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for DD_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for DD_FLAGS {
@@ -4900,12 +4900,12 @@ impl core::ops::BitAnd for DIINSTALLDEVICE_FLAGS {
 }
 impl core::ops::BitOrAssign for DIINSTALLDEVICE_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for DIINSTALLDEVICE_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for DIINSTALLDEVICE_FLAGS {
@@ -4936,12 +4936,12 @@ impl core::ops::BitAnd for DIINSTALLDRIVER_FLAGS {
 }
 impl core::ops::BitOrAssign for DIINSTALLDRIVER_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for DIINSTALLDRIVER_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for DIINSTALLDRIVER_FLAGS {
@@ -5027,12 +5027,12 @@ impl core::ops::BitAnd for DIROLLBACKDRIVER_FLAGS {
 }
 impl core::ops::BitOrAssign for DIROLLBACKDRIVER_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for DIROLLBACKDRIVER_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for DIROLLBACKDRIVER_FLAGS {
@@ -5063,12 +5063,12 @@ impl core::ops::BitAnd for DIUNINSTALLDRIVER_FLAGS {
 }
 impl core::ops::BitOrAssign for DIUNINSTALLDRIVER_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for DIUNINSTALLDRIVER_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for DIUNINSTALLDRIVER_FLAGS {
@@ -5391,12 +5391,12 @@ impl core::ops::BitAnd for FILE_COMPRESSION_TYPE {
 }
 impl core::ops::BitOrAssign for FILE_COMPRESSION_TYPE {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for FILE_COMPRESSION_TYPE {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for FILE_COMPRESSION_TYPE {
@@ -6064,12 +6064,12 @@ impl core::ops::BitAnd for INF_STYLE {
 }
 impl core::ops::BitOrAssign for INF_STYLE {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for INF_STYLE {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for INF_STYLE {
@@ -6111,12 +6111,12 @@ impl core::ops::BitAnd for IOD_DESFLAGS {
 }
 impl core::ops::BitOrAssign for IOD_DESFLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for IOD_DESFLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for IOD_DESFLAGS {
@@ -6181,12 +6181,12 @@ impl core::ops::BitAnd for IRQD_FLAGS {
 }
 impl core::ops::BitOrAssign for IRQD_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for IRQD_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for IRQD_FLAGS {
@@ -6310,12 +6310,12 @@ impl core::ops::BitAnd for MD_FLAGS {
 }
 impl core::ops::BitOrAssign for MD_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for MD_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for MD_FLAGS {
@@ -6483,12 +6483,12 @@ impl core::ops::BitAnd for PCD_FLAGS {
 }
 impl core::ops::BitOrAssign for PCD_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for PCD_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for PCD_FLAGS {
@@ -6523,12 +6523,12 @@ impl core::ops::BitAnd for PMF_FLAGS {
 }
 impl core::ops::BitOrAssign for PMF_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for PMF_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for PMF_FLAGS {
@@ -6606,12 +6606,12 @@ impl core::ops::BitAnd for SETUPSCANFILEQUEUE_FLAGS {
 }
 impl core::ops::BitOrAssign for SETUPSCANFILEQUEUE_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for SETUPSCANFILEQUEUE_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for SETUPSCANFILEQUEUE_FLAGS {
@@ -6642,12 +6642,12 @@ impl core::ops::BitAnd for SETUP_DI_DEVICE_CONFIGURATION_FLAGS {
 }
 impl core::ops::BitOrAssign for SETUP_DI_DEVICE_CONFIGURATION_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for SETUP_DI_DEVICE_CONFIGURATION_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for SETUP_DI_DEVICE_CONFIGURATION_FLAGS {
@@ -6678,12 +6678,12 @@ impl core::ops::BitAnd for SETUP_DI_DEVICE_CREATION_FLAGS {
 }
 impl core::ops::BitOrAssign for SETUP_DI_DEVICE_CREATION_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for SETUP_DI_DEVICE_CREATION_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for SETUP_DI_DEVICE_CREATION_FLAGS {
@@ -6714,12 +6714,12 @@ impl core::ops::BitAnd for SETUP_DI_DEVICE_INSTALL_FLAGS {
 }
 impl core::ops::BitOrAssign for SETUP_DI_DEVICE_INSTALL_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for SETUP_DI_DEVICE_INSTALL_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for SETUP_DI_DEVICE_INSTALL_FLAGS {
@@ -6750,12 +6750,12 @@ impl core::ops::BitAnd for SETUP_DI_DEVICE_INSTALL_FLAGS_EX {
 }
 impl core::ops::BitOrAssign for SETUP_DI_DEVICE_INSTALL_FLAGS_EX {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for SETUP_DI_DEVICE_INSTALL_FLAGS_EX {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for SETUP_DI_DEVICE_INSTALL_FLAGS_EX {
@@ -6786,12 +6786,12 @@ impl core::ops::BitAnd for SETUP_DI_DRIVER_INSTALL_FLAGS {
 }
 impl core::ops::BitOrAssign for SETUP_DI_DRIVER_INSTALL_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for SETUP_DI_DRIVER_INSTALL_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for SETUP_DI_DRIVER_INSTALL_FLAGS {
@@ -6825,12 +6825,12 @@ impl core::ops::BitAnd for SETUP_DI_GET_CLASS_DEVS_FLAGS {
 }
 impl core::ops::BitOrAssign for SETUP_DI_GET_CLASS_DEVS_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for SETUP_DI_GET_CLASS_DEVS_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for SETUP_DI_GET_CLASS_DEVS_FLAGS {
@@ -7078,12 +7078,12 @@ impl core::ops::BitAnd for SPSVCINST_FLAGS {
 }
 impl core::ops::BitOrAssign for SPSVCINST_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for SPSVCINST_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for SPSVCINST_FLAGS {
@@ -7478,12 +7478,12 @@ impl core::ops::BitAnd for SP_COPY_STYLE {
 }
 impl core::ops::BitOrAssign for SP_COPY_STYLE {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for SP_COPY_STYLE {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for SP_COPY_STYLE {
@@ -8737,12 +8737,12 @@ impl core::ops::BitAnd for UPDATEDRIVERFORPLUGANDPLAYDEVICES_FLAGS {
 }
 impl core::ops::BitOrAssign for UPDATEDRIVERFORPLUGANDPLAYDEVICES_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for UPDATEDRIVERFORPLUGANDPLAYDEVICES_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for UPDATEDRIVERFORPLUGANDPLAYDEVICES_FLAGS {

--- a/crates/libs/windows/src/Windows/Win32/Devices/DeviceQuery/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/DeviceQuery/mod.rs
@@ -204,12 +204,12 @@ impl core::ops::BitAnd for DEVPROP_OPERATOR {
 }
 impl core::ops::BitOrAssign for DEVPROP_OPERATOR {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for DEVPROP_OPERATOR {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for DEVPROP_OPERATOR {

--- a/crates/libs/windows/src/Windows/Win32/Devices/Display/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/Display/mod.rs
@@ -662,12 +662,12 @@ impl core::ops::BitAnd for AR_STATE {
 }
 impl core::ops::BitOrAssign for AR_STATE {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for AR_STATE {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for AR_STATE {
@@ -3589,12 +3589,12 @@ impl core::ops::BitAnd for ORIENTATION_PREFERENCE {
 }
 impl core::ops::BitOrAssign for ORIENTATION_PREFERENCE {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for ORIENTATION_PREFERENCE {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for ORIENTATION_PREFERENCE {
@@ -4071,12 +4071,12 @@ impl core::ops::BitAnd for QUERY_DISPLAY_CONFIG_FLAGS {
 }
 impl core::ops::BitOrAssign for QUERY_DISPLAY_CONFIG_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for QUERY_DISPLAY_CONFIG_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for QUERY_DISPLAY_CONFIG_FLAGS {
@@ -4152,12 +4152,12 @@ impl core::ops::BitAnd for SET_DISPLAY_CONFIG_FLAGS {
 }
 impl core::ops::BitOrAssign for SET_DISPLAY_CONFIG_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for SET_DISPLAY_CONFIG_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for SET_DISPLAY_CONFIG_FLAGS {

--- a/crates/libs/windows/src/Windows/Win32/Foundation/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Foundation/mod.rs
@@ -1055,12 +1055,12 @@ impl core::ops::BitAnd for DUPLICATE_HANDLE_OPTIONS {
 }
 impl core::ops::BitOrAssign for DUPLICATE_HANDLE_OPTIONS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for DUPLICATE_HANDLE_OPTIONS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for DUPLICATE_HANDLE_OPTIONS {
@@ -5401,12 +5401,12 @@ impl core::ops::BitAnd for GENERIC_ACCESS_RIGHTS {
 }
 impl core::ops::BitOrAssign for GENERIC_ACCESS_RIGHTS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for GENERIC_ACCESS_RIGHTS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for GENERIC_ACCESS_RIGHTS {
@@ -5465,12 +5465,12 @@ impl core::ops::BitAnd for HANDLE_FLAGS {
 }
 impl core::ops::BitOrAssign for HANDLE_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for HANDLE_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for HANDLE_FLAGS {
@@ -6280,12 +6280,12 @@ impl core::ops::BitAnd for OBJECT_ATTRIBUTE_FLAGS {
 }
 impl core::ops::BitOrAssign for OBJECT_ATTRIBUTE_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for OBJECT_ATTRIBUTE_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for OBJECT_ATTRIBUTE_FLAGS {

--- a/crates/libs/windows/src/Windows/Win32/Globalization/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Globalization/mod.rs
@@ -7321,12 +7321,12 @@ impl core::ops::BitAnd for COMPARE_STRING_FLAGS {
 }
 impl core::ops::BitOrAssign for COMPARE_STRING_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for COMPARE_STRING_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for COMPARE_STRING_FLAGS {
@@ -7641,12 +7641,12 @@ impl core::ops::BitAnd for FOLD_STRING_MAP_FLAGS {
 }
 impl core::ops::BitOrAssign for FOLD_STRING_MAP_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for FOLD_STRING_MAP_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for FOLD_STRING_MAP_FLAGS {
@@ -9954,12 +9954,12 @@ impl core::ops::BitAnd for IS_TEXT_UNICODE_RESULT {
 }
 impl core::ops::BitOrAssign for IS_TEXT_UNICODE_RESULT {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for IS_TEXT_UNICODE_RESULT {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for IS_TEXT_UNICODE_RESULT {
@@ -11489,12 +11489,12 @@ impl core::ops::BitAnd for MULTI_BYTE_TO_WIDE_CHAR_FLAGS {
 }
 impl core::ops::BitOrAssign for MULTI_BYTE_TO_WIDE_CHAR_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for MULTI_BYTE_TO_WIDE_CHAR_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for MULTI_BYTE_TO_WIDE_CHAR_FLAGS {
@@ -11820,12 +11820,12 @@ impl core::ops::BitAnd for TIME_FORMAT_FLAGS {
 }
 impl core::ops::BitOrAssign for TIME_FORMAT_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for TIME_FORMAT_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for TIME_FORMAT_FLAGS {

--- a/crates/libs/windows/src/Windows/Win32/Graphics/DXCore/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/DXCore/mod.rs
@@ -174,12 +174,12 @@ impl core::ops::BitAnd for DXCoreHardwareTypeFilterFlags {
 }
 impl core::ops::BitOrAssign for DXCoreHardwareTypeFilterFlags {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for DXCoreHardwareTypeFilterFlags {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for DXCoreHardwareTypeFilterFlags {
@@ -256,12 +256,12 @@ impl core::ops::BitAnd for DXCoreRuntimeFilterFlags {
 }
 impl core::ops::BitOrAssign for DXCoreRuntimeFilterFlags {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for DXCoreRuntimeFilterFlags {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for DXCoreRuntimeFilterFlags {

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct2D/Common/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct2D/Common/mod.rs
@@ -127,12 +127,12 @@ impl core::ops::BitAnd for D2D1_PATH_SEGMENT {
 }
 impl core::ops::BitOrAssign for D2D1_PATH_SEGMENT {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D2D1_PATH_SEGMENT {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D2D1_PATH_SEGMENT {

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct2D/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct2D/mod.rs
@@ -294,12 +294,12 @@ impl core::ops::BitAnd for D2D1_BITMAP_OPTIONS {
 }
 impl core::ops::BitOrAssign for D2D1_BITMAP_OPTIONS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D2D1_BITMAP_OPTIONS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D2D1_BITMAP_OPTIONS {
@@ -435,12 +435,12 @@ impl core::ops::BitAnd for D2D1_CHANGE_TYPE {
 }
 impl core::ops::BitOrAssign for D2D1_CHANGE_TYPE {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D2D1_CHANGE_TYPE {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D2D1_CHANGE_TYPE {
@@ -557,12 +557,12 @@ impl core::ops::BitAnd for D2D1_COMPATIBLE_RENDER_TARGET_OPTIONS {
 }
 impl core::ops::BitOrAssign for D2D1_COMPATIBLE_RENDER_TARGET_OPTIONS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D2D1_COMPATIBLE_RENDER_TARGET_OPTIONS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D2D1_COMPATIBLE_RENDER_TARGET_OPTIONS {
@@ -681,12 +681,12 @@ impl core::ops::BitAnd for D2D1_DEVICE_CONTEXT_OPTIONS {
 }
 impl core::ops::BitOrAssign for D2D1_DEVICE_CONTEXT_OPTIONS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D2D1_DEVICE_CONTEXT_OPTIONS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D2D1_DEVICE_CONTEXT_OPTIONS {
@@ -824,12 +824,12 @@ impl core::ops::BitAnd for D2D1_DRAW_TEXT_OPTIONS {
 }
 impl core::ops::BitOrAssign for D2D1_DRAW_TEXT_OPTIONS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D2D1_DRAW_TEXT_OPTIONS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D2D1_DRAW_TEXT_OPTIONS {
@@ -1100,12 +1100,12 @@ impl core::ops::BitAnd for D2D1_IMAGE_SOURCE_FROM_DXGI_OPTIONS {
 }
 impl core::ops::BitOrAssign for D2D1_IMAGE_SOURCE_FROM_DXGI_OPTIONS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D2D1_IMAGE_SOURCE_FROM_DXGI_OPTIONS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D2D1_IMAGE_SOURCE_FROM_DXGI_OPTIONS {
@@ -1138,12 +1138,12 @@ impl core::ops::BitAnd for D2D1_IMAGE_SOURCE_LOADING_OPTIONS {
 }
 impl core::ops::BitOrAssign for D2D1_IMAGE_SOURCE_LOADING_OPTIONS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D2D1_IMAGE_SOURCE_LOADING_OPTIONS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D2D1_IMAGE_SOURCE_LOADING_OPTIONS {
@@ -1238,12 +1238,12 @@ impl core::ops::BitAnd for D2D1_LAYER_OPTIONS {
 }
 impl core::ops::BitOrAssign for D2D1_LAYER_OPTIONS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D2D1_LAYER_OPTIONS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D2D1_LAYER_OPTIONS {
@@ -1274,12 +1274,12 @@ impl core::ops::BitAnd for D2D1_LAYER_OPTIONS1 {
 }
 impl core::ops::BitOrAssign for D2D1_LAYER_OPTIONS1 {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D2D1_LAYER_OPTIONS1 {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D2D1_LAYER_OPTIONS1 {
@@ -1384,12 +1384,12 @@ impl core::ops::BitAnd for D2D1_MAP_OPTIONS {
 }
 impl core::ops::BitOrAssign for D2D1_MAP_OPTIONS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D2D1_MAP_OPTIONS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D2D1_MAP_OPTIONS {
@@ -1466,12 +1466,12 @@ impl core::ops::BitAnd for D2D1_PIXEL_OPTIONS {
 }
 impl core::ops::BitOrAssign for D2D1_PIXEL_OPTIONS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D2D1_PIXEL_OPTIONS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D2D1_PIXEL_OPTIONS {
@@ -1556,12 +1556,12 @@ impl core::ops::BitAnd for D2D1_PRESENT_OPTIONS {
 }
 impl core::ops::BitOrAssign for D2D1_PRESENT_OPTIONS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D2D1_PRESENT_OPTIONS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D2D1_PRESENT_OPTIONS {
@@ -1701,12 +1701,12 @@ impl core::ops::BitAnd for D2D1_RENDER_TARGET_USAGE {
 }
 impl core::ops::BitOrAssign for D2D1_RENDER_TARGET_USAGE {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D2D1_RENDER_TARGET_USAGE {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D2D1_RENDER_TARGET_USAGE {
@@ -1868,12 +1868,12 @@ impl core::ops::BitAnd for D2D1_SPRITE_OPTIONS {
 }
 impl core::ops::BitOrAssign for D2D1_SPRITE_OPTIONS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D2D1_SPRITE_OPTIONS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D2D1_SPRITE_OPTIONS {
@@ -2132,12 +2132,12 @@ impl core::ops::BitAnd for D2D1_TRANSFORMED_IMAGE_SOURCE_OPTIONS {
 }
 impl core::ops::BitOrAssign for D2D1_TRANSFORMED_IMAGE_SOURCE_OPTIONS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D2D1_TRANSFORMED_IMAGE_SOURCE_OPTIONS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D2D1_TRANSFORMED_IMAGE_SOURCE_OPTIONS {
@@ -2214,12 +2214,12 @@ impl core::ops::BitAnd for D2D1_VERTEX_OPTIONS {
 }
 impl core::ops::BitOrAssign for D2D1_VERTEX_OPTIONS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D2D1_VERTEX_OPTIONS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D2D1_VERTEX_OPTIONS {
@@ -2276,12 +2276,12 @@ impl core::ops::BitAnd for D2D1_WINDOW_STATE {
 }
 impl core::ops::BitOrAssign for D2D1_WINDOW_STATE {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D2D1_WINDOW_STATE {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D2D1_WINDOW_STATE {

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D/mod.rs
@@ -612,12 +612,12 @@ impl core::ops::BitAnd for D3D_SHADER_CACHE_TARGET_FLAGS {
 }
 impl core::ops::BitOrAssign for D3D_SHADER_CACHE_TARGET_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D3D_SHADER_CACHE_TARGET_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D3D_SHADER_CACHE_TARGET_FLAGS {

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D11/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D11/mod.rs
@@ -417,12 +417,12 @@ impl core::ops::BitAnd for D3D11_BIND_FLAG {
 }
 impl core::ops::BitOrAssign for D3D11_BIND_FLAG {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D3D11_BIND_FLAG {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D3D11_BIND_FLAG {
@@ -658,12 +658,12 @@ impl core::ops::BitAnd for D3D11_CLEAR_FLAG {
 }
 impl core::ops::BitOrAssign for D3D11_CLEAR_FLAG {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D3D11_CLEAR_FLAG {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D3D11_CLEAR_FLAG {
@@ -833,12 +833,12 @@ impl core::ops::BitAnd for D3D11_CPU_ACCESS_FLAG {
 }
 impl core::ops::BitOrAssign for D3D11_CPU_ACCESS_FLAG {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D3D11_CPU_ACCESS_FLAG {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D3D11_CPU_ACCESS_FLAG {
@@ -875,12 +875,12 @@ impl core::ops::BitAnd for D3D11_CREATE_DEVICE_FLAG {
 }
 impl core::ops::BitOrAssign for D3D11_CREATE_DEVICE_FLAG {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D3D11_CREATE_DEVICE_FLAG {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D3D11_CREATE_DEVICE_FLAG {
@@ -916,12 +916,12 @@ impl core::ops::BitAnd for D3D11_CRYPTO_SESSION_KEY_EXCHANGE_FLAGS {
 }
 impl core::ops::BitOrAssign for D3D11_CRYPTO_SESSION_KEY_EXCHANGE_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D3D11_CRYPTO_SESSION_KEY_EXCHANGE_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D3D11_CRYPTO_SESSION_KEY_EXCHANGE_FLAGS {
@@ -1430,12 +1430,12 @@ impl core::ops::BitAnd for D3D11_FENCE_FLAG {
 }
 impl core::ops::BitOrAssign for D3D11_FENCE_FLAG {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D3D11_FENCE_FLAG {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D3D11_FENCE_FLAG {
@@ -3570,12 +3570,12 @@ impl core::ops::BitAnd for D3D11_RESOURCE_MISC_FLAG {
 }
 impl core::ops::BitOrAssign for D3D11_RESOURCE_MISC_FLAG {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D3D11_RESOURCE_MISC_FLAG {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D3D11_RESOURCE_MISC_FLAG {
@@ -3624,12 +3624,12 @@ impl core::ops::BitAnd for D3D11_RLDO_FLAGS {
 }
 impl core::ops::BitOrAssign for D3D11_RLDO_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D3D11_RLDO_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D3D11_RLDO_FLAGS {
@@ -4858,12 +4858,12 @@ impl core::ops::BitAnd for D3D11_VIDEO_DECODER_HISTOGRAM_COMPONENT_FLAGS {
 }
 impl core::ops::BitOrAssign for D3D11_VIDEO_DECODER_HISTOGRAM_COMPONENT_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D3D11_VIDEO_DECODER_HISTOGRAM_COMPONENT_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D3D11_VIDEO_DECODER_HISTOGRAM_COMPONENT_FLAGS {

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D12/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D12/mod.rs
@@ -237,12 +237,12 @@ impl core::ops::BitAnd for D3D12_BARRIER_ACCESS {
 }
 impl core::ops::BitOrAssign for D3D12_BARRIER_ACCESS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D3D12_BARRIER_ACCESS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D3D12_BARRIER_ACCESS {
@@ -369,12 +369,12 @@ impl core::ops::BitAnd for D3D12_BARRIER_SYNC {
 }
 impl core::ops::BitOrAssign for D3D12_BARRIER_SYNC {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D3D12_BARRIER_SYNC {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D3D12_BARRIER_SYNC {
@@ -529,12 +529,12 @@ impl core::ops::BitAnd for D3D12_BUFFER_SRV_FLAGS {
 }
 impl core::ops::BitOrAssign for D3D12_BUFFER_SRV_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D3D12_BUFFER_SRV_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D3D12_BUFFER_SRV_FLAGS {
@@ -576,12 +576,12 @@ impl core::ops::BitAnd for D3D12_BUFFER_UAV_FLAGS {
 }
 impl core::ops::BitOrAssign for D3D12_BUFFER_UAV_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D3D12_BUFFER_UAV_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D3D12_BUFFER_UAV_FLAGS {
@@ -678,12 +678,12 @@ impl core::ops::BitAnd for D3D12_CLEAR_FLAGS {
 }
 impl core::ops::BitOrAssign for D3D12_CLEAR_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D3D12_CLEAR_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D3D12_CLEAR_FLAGS {
@@ -767,12 +767,12 @@ impl core::ops::BitAnd for D3D12_COMMAND_LIST_FLAGS {
 }
 impl core::ops::BitOrAssign for D3D12_COMMAND_LIST_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D3D12_COMMAND_LIST_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D3D12_COMMAND_LIST_FLAGS {
@@ -804,12 +804,12 @@ impl core::ops::BitAnd for D3D12_COMMAND_LIST_SUPPORT_FLAGS {
 }
 impl core::ops::BitOrAssign for D3D12_COMMAND_LIST_SUPPORT_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D3D12_COMMAND_LIST_SUPPORT_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D3D12_COMMAND_LIST_SUPPORT_FLAGS {
@@ -859,12 +859,12 @@ impl core::ops::BitAnd for D3D12_COMMAND_POOL_FLAGS {
 }
 impl core::ops::BitOrAssign for D3D12_COMMAND_POOL_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D3D12_COMMAND_POOL_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D3D12_COMMAND_POOL_FLAGS {
@@ -904,12 +904,12 @@ impl core::ops::BitAnd for D3D12_COMMAND_QUEUE_FLAGS {
 }
 impl core::ops::BitOrAssign for D3D12_COMMAND_QUEUE_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D3D12_COMMAND_QUEUE_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D3D12_COMMAND_QUEUE_FLAGS {
@@ -975,12 +975,12 @@ impl core::ops::BitAnd for D3D12_COMMAND_RECORDER_FLAGS {
 }
 impl core::ops::BitOrAssign for D3D12_COMMAND_RECORDER_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D3D12_COMMAND_RECORDER_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D3D12_COMMAND_RECORDER_FLAGS {
@@ -1171,12 +1171,12 @@ impl core::ops::BitAnd for D3D12_COMPILER_VALUE_TYPE_FLAGS {
 }
 impl core::ops::BitOrAssign for D3D12_COMPILER_VALUE_TYPE_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D3D12_COMPILER_VALUE_TYPE_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D3D12_COMPILER_VALUE_TYPE_FLAGS {
@@ -1363,12 +1363,12 @@ impl core::ops::BitAnd for D3D12_DEBUG_FEATURE {
 }
 impl core::ops::BitOrAssign for D3D12_DEBUG_FEATURE {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D3D12_DEBUG_FEATURE {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D3D12_DEBUG_FEATURE {
@@ -1544,12 +1544,12 @@ impl core::ops::BitAnd for D3D12_DESCRIPTOR_HEAP_FLAGS {
 }
 impl core::ops::BitOrAssign for D3D12_DESCRIPTOR_HEAP_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D3D12_DESCRIPTOR_HEAP_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D3D12_DESCRIPTOR_HEAP_FLAGS {
@@ -1609,12 +1609,12 @@ impl core::ops::BitAnd for D3D12_DESCRIPTOR_RANGE_FLAGS {
 }
 impl core::ops::BitOrAssign for D3D12_DESCRIPTOR_RANGE_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D3D12_DESCRIPTOR_RANGE_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D3D12_DESCRIPTOR_RANGE_FLAGS {
@@ -1667,12 +1667,12 @@ impl core::ops::BitAnd for D3D12_DEVICE_FACTORY_FLAGS {
 }
 impl core::ops::BitOrAssign for D3D12_DEVICE_FACTORY_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D3D12_DEVICE_FACTORY_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D3D12_DEVICE_FACTORY_FLAGS {
@@ -1707,12 +1707,12 @@ impl core::ops::BitAnd for D3D12_DEVICE_FLAGS {
 }
 impl core::ops::BitOrAssign for D3D12_DEVICE_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D3D12_DEVICE_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D3D12_DEVICE_FLAGS {
@@ -1972,12 +1972,12 @@ impl core::ops::BitAnd for D3D12_DRED_FLAGS {
 }
 impl core::ops::BitOrAssign for D3D12_DRED_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D3D12_DRED_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D3D12_DRED_FLAGS {
@@ -2011,12 +2011,12 @@ impl core::ops::BitAnd for D3D12_DRED_PAGE_FAULT_FLAGS {
 }
 impl core::ops::BitOrAssign for D3D12_DRED_PAGE_FAULT_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D3D12_DRED_PAGE_FAULT_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D3D12_DRED_PAGE_FAULT_FLAGS {
@@ -2112,12 +2112,12 @@ impl core::ops::BitAnd for D3D12_DSV_FLAGS {
 }
 impl core::ops::BitOrAssign for D3D12_DSV_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D3D12_DSV_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D3D12_DSV_FLAGS {
@@ -2241,12 +2241,12 @@ impl core::ops::BitAnd for D3D12_EXPORT_FLAGS {
 }
 impl core::ops::BitOrAssign for D3D12_EXPORT_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D3D12_EXPORT_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D3D12_EXPORT_FLAGS {
@@ -2701,12 +2701,12 @@ impl core::ops::BitAnd for D3D12_FENCE_FLAGS {
 }
 impl core::ops::BitOrAssign for D3D12_FENCE_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D3D12_FENCE_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D3D12_FENCE_FLAGS {
@@ -2813,12 +2813,12 @@ impl core::ops::BitAnd for D3D12_FORMAT_SUPPORT1 {
 }
 impl core::ops::BitOrAssign for D3D12_FORMAT_SUPPORT1 {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D3D12_FORMAT_SUPPORT1 {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D3D12_FORMAT_SUPPORT1 {
@@ -2879,12 +2879,12 @@ impl core::ops::BitAnd for D3D12_FORMAT_SUPPORT2 {
 }
 impl core::ops::BitOrAssign for D3D12_FORMAT_SUPPORT2 {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D3D12_FORMAT_SUPPORT2 {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D3D12_FORMAT_SUPPORT2 {
@@ -3003,12 +3003,12 @@ impl core::ops::BitAnd for D3D12_GPU_BASED_VALIDATION_FLAGS {
 }
 impl core::ops::BitOrAssign for D3D12_GPU_BASED_VALIDATION_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D3D12_GPU_BASED_VALIDATION_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D3D12_GPU_BASED_VALIDATION_FLAGS {
@@ -3041,12 +3041,12 @@ impl core::ops::BitAnd for D3D12_GPU_BASED_VALIDATION_PIPELINE_STATE_CREATE_FLAG
 }
 impl core::ops::BitOrAssign for D3D12_GPU_BASED_VALIDATION_PIPELINE_STATE_CREATE_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D3D12_GPU_BASED_VALIDATION_PIPELINE_STATE_CREATE_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D3D12_GPU_BASED_VALIDATION_PIPELINE_STATE_CREATE_FLAGS {
@@ -3145,12 +3145,12 @@ impl core::ops::BitAnd for D3D12_GRAPHICS_STATES {
 }
 impl core::ops::BitOrAssign for D3D12_GRAPHICS_STATES {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D3D12_GRAPHICS_STATES {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D3D12_GRAPHICS_STATES {
@@ -3229,12 +3229,12 @@ impl core::ops::BitAnd for D3D12_HEAP_FLAGS {
 }
 impl core::ops::BitOrAssign for D3D12_HEAP_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D3D12_HEAP_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D3D12_HEAP_FLAGS {
@@ -3685,12 +3685,12 @@ impl core::ops::BitAnd for D3D12_MESSAGE_CALLBACK_FLAGS {
 }
 impl core::ops::BitOrAssign for D3D12_MESSAGE_CALLBACK_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D3D12_MESSAGE_CALLBACK_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D3D12_MESSAGE_CALLBACK_FLAGS {
@@ -4758,12 +4758,12 @@ impl core::ops::BitAnd for D3D12_META_COMMAND_PARAMETER_FLAGS {
 }
 impl core::ops::BitOrAssign for D3D12_META_COMMAND_PARAMETER_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D3D12_META_COMMAND_PARAMETER_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D3D12_META_COMMAND_PARAMETER_FLAGS {
@@ -4827,12 +4827,12 @@ impl core::ops::BitAnd for D3D12_MULTIPLE_FENCE_WAIT_FLAGS {
 }
 impl core::ops::BitOrAssign for D3D12_MULTIPLE_FENCE_WAIT_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D3D12_MULTIPLE_FENCE_WAIT_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D3D12_MULTIPLE_FENCE_WAIT_FLAGS {
@@ -4869,12 +4869,12 @@ impl core::ops::BitAnd for D3D12_MULTISAMPLE_QUALITY_LEVEL_FLAGS {
 }
 impl core::ops::BitOrAssign for D3D12_MULTISAMPLE_QUALITY_LEVEL_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D3D12_MULTISAMPLE_QUALITY_LEVEL_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D3D12_MULTISAMPLE_QUALITY_LEVEL_FLAGS {
@@ -5030,12 +5030,12 @@ impl core::ops::BitAnd for D3D12_PIPELINE_STATE_FLAGS {
 }
 impl core::ops::BitOrAssign for D3D12_PIPELINE_STATE_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D3D12_PIPELINE_STATE_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D3D12_PIPELINE_STATE_FLAGS {
@@ -5178,12 +5178,12 @@ impl core::ops::BitAnd for D3D12_PROTECTED_RESOURCE_SESSION_FLAGS {
 }
 impl core::ops::BitOrAssign for D3D12_PROTECTED_RESOURCE_SESSION_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D3D12_PROTECTED_RESOURCE_SESSION_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D3D12_PROTECTED_RESOURCE_SESSION_FLAGS {
@@ -5215,12 +5215,12 @@ impl core::ops::BitAnd for D3D12_PROTECTED_RESOURCE_SESSION_SUPPORT_FLAGS {
 }
 impl core::ops::BitOrAssign for D3D12_PROTECTED_RESOURCE_SESSION_SUPPORT_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D3D12_PROTECTED_RESOURCE_SESSION_SUPPORT_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D3D12_PROTECTED_RESOURCE_SESSION_SUPPORT_FLAGS {
@@ -5418,12 +5418,12 @@ impl core::ops::BitAnd for D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAGS {
 }
 impl core::ops::BitOrAssign for D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAGS {
@@ -5574,12 +5574,12 @@ impl core::ops::BitAnd for D3D12_RAYTRACING_GEOMETRY_FLAGS {
 }
 impl core::ops::BitOrAssign for D3D12_RAYTRACING_GEOMETRY_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D3D12_RAYTRACING_GEOMETRY_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D3D12_RAYTRACING_GEOMETRY_FLAGS {
@@ -5667,12 +5667,12 @@ impl core::ops::BitAnd for D3D12_RAYTRACING_INSTANCE_FLAGS {
 }
 impl core::ops::BitOrAssign for D3D12_RAYTRACING_INSTANCE_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D3D12_RAYTRACING_INSTANCE_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D3D12_RAYTRACING_INSTANCE_FLAGS {
@@ -5796,12 +5796,12 @@ impl core::ops::BitAnd for D3D12_RAYTRACING_PIPELINE_FLAGS {
 }
 impl core::ops::BitOrAssign for D3D12_RAYTRACING_PIPELINE_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D3D12_RAYTRACING_PIPELINE_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D3D12_RAYTRACING_PIPELINE_FLAGS {
@@ -5859,12 +5859,12 @@ impl core::ops::BitAnd for D3D12_RAY_FLAGS {
 }
 impl core::ops::BitOrAssign for D3D12_RAY_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D3D12_RAY_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D3D12_RAY_FLAGS {
@@ -6066,12 +6066,12 @@ impl core::ops::BitAnd for D3D12_RENDER_PASS_FLAGS {
 }
 impl core::ops::BitOrAssign for D3D12_RENDER_PASS_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D3D12_RENDER_PASS_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D3D12_RENDER_PASS_FLAGS {
@@ -6206,12 +6206,12 @@ impl core::ops::BitAnd for D3D12_RESIDENCY_FLAGS {
 }
 impl core::ops::BitOrAssign for D3D12_RESIDENCY_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D3D12_RESIDENCY_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D3D12_RESIDENCY_FLAGS {
@@ -6314,12 +6314,12 @@ impl core::ops::BitAnd for D3D12_RESOURCE_BARRIER_FLAGS {
 }
 impl core::ops::BitOrAssign for D3D12_RESOURCE_BARRIER_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D3D12_RESOURCE_BARRIER_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D3D12_RESOURCE_BARRIER_FLAGS {
@@ -6404,12 +6404,12 @@ impl core::ops::BitAnd for D3D12_RESOURCE_FLAGS {
 }
 impl core::ops::BitOrAssign for D3D12_RESOURCE_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D3D12_RESOURCE_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D3D12_RESOURCE_FLAGS {
@@ -6456,12 +6456,12 @@ impl core::ops::BitAnd for D3D12_RESOURCE_STATES {
 }
 impl core::ops::BitOrAssign for D3D12_RESOURCE_STATES {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D3D12_RESOURCE_STATES {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D3D12_RESOURCE_STATES {
@@ -6538,12 +6538,12 @@ impl core::ops::BitAnd for D3D12_RLDO_FLAGS {
 }
 impl core::ops::BitOrAssign for D3D12_RLDO_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D3D12_RLDO_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D3D12_RLDO_FLAGS {
@@ -6597,12 +6597,12 @@ impl core::ops::BitAnd for D3D12_ROOT_DESCRIPTOR_FLAGS {
 }
 impl core::ops::BitOrAssign for D3D12_ROOT_DESCRIPTOR_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D3D12_ROOT_DESCRIPTOR_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D3D12_ROOT_DESCRIPTOR_FLAGS {
@@ -6757,12 +6757,12 @@ impl core::ops::BitAnd for D3D12_ROOT_SIGNATURE_FLAGS {
 }
 impl core::ops::BitOrAssign for D3D12_ROOT_SIGNATURE_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D3D12_ROOT_SIGNATURE_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D3D12_ROOT_SIGNATURE_FLAGS {
@@ -6888,12 +6888,12 @@ impl core::ops::BitAnd for D3D12_SAMPLER_FLAGS {
 }
 impl core::ops::BitOrAssign for D3D12_SAMPLER_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D3D12_SAMPLER_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D3D12_SAMPLER_FLAGS {
@@ -7049,12 +7049,12 @@ impl core::ops::BitAnd for D3D12_SET_WORK_GRAPH_FLAGS {
 }
 impl core::ops::BitOrAssign for D3D12_SET_WORK_GRAPH_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D3D12_SET_WORK_GRAPH_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D3D12_SET_WORK_GRAPH_FLAGS {
@@ -7108,12 +7108,12 @@ impl core::ops::BitAnd for D3D12_SHADER_CACHE_CONTROL_FLAGS {
 }
 impl core::ops::BitOrAssign for D3D12_SHADER_CACHE_CONTROL_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D3D12_SHADER_CACHE_CONTROL_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D3D12_SHADER_CACHE_CONTROL_FLAGS {
@@ -7147,12 +7147,12 @@ impl core::ops::BitAnd for D3D12_SHADER_CACHE_FLAGS {
 }
 impl core::ops::BitOrAssign for D3D12_SHADER_CACHE_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D3D12_SHADER_CACHE_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D3D12_SHADER_CACHE_FLAGS {
@@ -7186,12 +7186,12 @@ impl core::ops::BitAnd for D3D12_SHADER_CACHE_KIND_FLAGS {
 }
 impl core::ops::BitOrAssign for D3D12_SHADER_CACHE_KIND_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D3D12_SHADER_CACHE_KIND_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D3D12_SHADER_CACHE_KIND_FLAGS {
@@ -7245,12 +7245,12 @@ impl core::ops::BitAnd for D3D12_SHADER_CACHE_SUPPORT_FLAGS {
 }
 impl core::ops::BitOrAssign for D3D12_SHADER_CACHE_SUPPORT_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D3D12_SHADER_CACHE_SUPPORT_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D3D12_SHADER_CACHE_SUPPORT_FLAGS {
@@ -7363,12 +7363,12 @@ impl core::ops::BitAnd for D3D12_SHADER_MIN_PRECISION_SUPPORT {
 }
 impl core::ops::BitOrAssign for D3D12_SHADER_MIN_PRECISION_SUPPORT {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D3D12_SHADER_MIN_PRECISION_SUPPORT {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D3D12_SHADER_MIN_PRECISION_SUPPORT {
@@ -7631,12 +7631,12 @@ impl core::ops::BitAnd for D3D12_STATE_OBJECT_DATABASE_FLAGS {
 }
 impl core::ops::BitOrAssign for D3D12_STATE_OBJECT_DATABASE_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D3D12_STATE_OBJECT_DATABASE_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D3D12_STATE_OBJECT_DATABASE_FLAGS {
@@ -7681,12 +7681,12 @@ impl core::ops::BitAnd for D3D12_STATE_OBJECT_FLAGS {
 }
 impl core::ops::BitOrAssign for D3D12_STATE_OBJECT_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D3D12_STATE_OBJECT_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D3D12_STATE_OBJECT_FLAGS {
@@ -8129,12 +8129,12 @@ impl core::ops::BitAnd for D3D12_TEXTURE_BARRIER_FLAGS {
 }
 impl core::ops::BitOrAssign for D3D12_TEXTURE_BARRIER_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D3D12_TEXTURE_BARRIER_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D3D12_TEXTURE_BARRIER_FLAGS {
@@ -8252,12 +8252,12 @@ impl core::ops::BitAnd for D3D12_TILE_COPY_FLAGS {
 }
 impl core::ops::BitOrAssign for D3D12_TILE_COPY_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D3D12_TILE_COPY_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D3D12_TILE_COPY_FLAGS {
@@ -8292,12 +8292,12 @@ impl core::ops::BitAnd for D3D12_TILE_MAPPING_FLAGS {
 }
 impl core::ops::BitOrAssign for D3D12_TILE_MAPPING_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D3D12_TILE_MAPPING_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D3D12_TILE_MAPPING_FLAGS {
@@ -8523,12 +8523,12 @@ impl core::ops::BitAnd for D3D12_VIEW_INSTANCING_FLAGS {
 }
 impl core::ops::BitOrAssign for D3D12_VIEW_INSTANCING_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D3D12_VIEW_INSTANCING_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D3D12_VIEW_INSTANCING_FLAGS {
@@ -8606,12 +8606,12 @@ impl core::ops::BitAnd for D3D12_WORK_GRAPH_FLAGS {
 }
 impl core::ops::BitOrAssign for D3D12_WORK_GRAPH_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D3D12_WORK_GRAPH_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D3D12_WORK_GRAPH_FLAGS {

--- a/crates/libs/windows/src/Windows/Win32/Graphics/DirectManipulation/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/DirectManipulation/mod.rs
@@ -34,12 +34,12 @@ impl core::ops::BitAnd for DIRECTMANIPULATION_CONFIGURATION {
 }
 impl core::ops::BitOrAssign for DIRECTMANIPULATION_CONFIGURATION {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for DIRECTMANIPULATION_CONFIGURATION {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for DIRECTMANIPULATION_CONFIGURATION {
@@ -85,12 +85,12 @@ impl core::ops::BitAnd for DIRECTMANIPULATION_DRAG_DROP_CONFIGURATION {
 }
 impl core::ops::BitOrAssign for DIRECTMANIPULATION_DRAG_DROP_CONFIGURATION {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for DIRECTMANIPULATION_DRAG_DROP_CONFIGURATION {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for DIRECTMANIPULATION_DRAG_DROP_CONFIGURATION {
@@ -134,12 +134,12 @@ impl core::ops::BitAnd for DIRECTMANIPULATION_GESTURE_CONFIGURATION {
 }
 impl core::ops::BitOrAssign for DIRECTMANIPULATION_GESTURE_CONFIGURATION {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for DIRECTMANIPULATION_GESTURE_CONFIGURATION {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for DIRECTMANIPULATION_GESTURE_CONFIGURATION {
@@ -175,12 +175,12 @@ impl core::ops::BitAnd for DIRECTMANIPULATION_HITTEST_TYPE {
 }
 impl core::ops::BitOrAssign for DIRECTMANIPULATION_HITTEST_TYPE {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for DIRECTMANIPULATION_HITTEST_TYPE {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for DIRECTMANIPULATION_HITTEST_TYPE {
@@ -214,12 +214,12 @@ impl core::ops::BitAnd for DIRECTMANIPULATION_HORIZONTALALIGNMENT {
 }
 impl core::ops::BitOrAssign for DIRECTMANIPULATION_HORIZONTALALIGNMENT {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for DIRECTMANIPULATION_HORIZONTALALIGNMENT {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for DIRECTMANIPULATION_HORIZONTALALIGNMENT {
@@ -278,12 +278,12 @@ impl core::ops::BitAnd for DIRECTMANIPULATION_MOTION_TYPES {
 }
 impl core::ops::BitOrAssign for DIRECTMANIPULATION_MOTION_TYPES {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for DIRECTMANIPULATION_MOTION_TYPES {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for DIRECTMANIPULATION_MOTION_TYPES {
@@ -318,12 +318,12 @@ impl core::ops::BitAnd for DIRECTMANIPULATION_SNAPPOINT_COORDINATE {
 }
 impl core::ops::BitOrAssign for DIRECTMANIPULATION_SNAPPOINT_COORDINATE {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for DIRECTMANIPULATION_SNAPPOINT_COORDINATE {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for DIRECTMANIPULATION_SNAPPOINT_COORDINATE {
@@ -365,12 +365,12 @@ impl core::ops::BitAnd for DIRECTMANIPULATION_VERTICALALIGNMENT {
 }
 impl core::ops::BitOrAssign for DIRECTMANIPULATION_VERTICALALIGNMENT {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for DIRECTMANIPULATION_VERTICALALIGNMENT {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for DIRECTMANIPULATION_VERTICALALIGNMENT {
@@ -406,12 +406,12 @@ impl core::ops::BitAnd for DIRECTMANIPULATION_VIEWPORT_OPTIONS {
 }
 impl core::ops::BitOrAssign for DIRECTMANIPULATION_VIEWPORT_OPTIONS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for DIRECTMANIPULATION_VIEWPORT_OPTIONS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for DIRECTMANIPULATION_VIEWPORT_OPTIONS {

--- a/crates/libs/windows/src/Windows/Win32/Graphics/DirectWrite/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/DirectWrite/mod.rs
@@ -30,12 +30,12 @@ impl core::ops::BitAnd for DWRITE_AUTOMATIC_FONT_AXES {
 }
 impl core::ops::BitOrAssign for DWRITE_AUTOMATIC_FONT_AXES {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for DWRITE_AUTOMATIC_FONT_AXES {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for DWRITE_AUTOMATIC_FONT_AXES {
@@ -203,12 +203,12 @@ impl core::ops::BitAnd for DWRITE_FONT_AXIS_ATTRIBUTES {
 }
 impl core::ops::BitOrAssign for DWRITE_FONT_AXIS_ATTRIBUTES {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for DWRITE_FONT_AXIS_ATTRIBUTES {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for DWRITE_FONT_AXIS_ATTRIBUTES {
@@ -449,12 +449,12 @@ impl core::ops::BitAnd for DWRITE_FONT_SIMULATIONS {
 }
 impl core::ops::BitOrAssign for DWRITE_FONT_SIMULATIONS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for DWRITE_FONT_SIMULATIONS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for DWRITE_FONT_SIMULATIONS {
@@ -556,12 +556,12 @@ impl core::ops::BitAnd for DWRITE_GLYPH_IMAGE_FORMATS {
 }
 impl core::ops::BitOrAssign for DWRITE_GLYPH_IMAGE_FORMATS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for DWRITE_GLYPH_IMAGE_FORMATS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for DWRITE_GLYPH_IMAGE_FORMATS {
@@ -806,12 +806,12 @@ impl core::ops::BitAnd for DWRITE_PAINT_ATTRIBUTES {
 }
 impl core::ops::BitOrAssign for DWRITE_PAINT_ATTRIBUTES {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for DWRITE_PAINT_ATTRIBUTES {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for DWRITE_PAINT_ATTRIBUTES {
@@ -1466,12 +1466,12 @@ impl core::ops::BitAnd for DWRITE_SCRIPT_SHAPES {
 }
 impl core::ops::BitOrAssign for DWRITE_SCRIPT_SHAPES {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for DWRITE_SCRIPT_SHAPES {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for DWRITE_SCRIPT_SHAPES {

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Dwm/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Dwm/mod.rs
@@ -302,12 +302,12 @@ impl core::ops::BitAnd for DWM_SHOWCONTACT {
 }
 impl core::ops::BitOrAssign for DWM_SHOWCONTACT {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for DWM_SHOWCONTACT {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for DWM_SHOWCONTACT {
@@ -348,12 +348,12 @@ impl core::ops::BitAnd for DWM_TAB_WINDOW_REQUIREMENTS {
 }
 impl core::ops::BitOrAssign for DWM_TAB_WINDOW_REQUIREMENTS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for DWM_TAB_WINDOW_REQUIREMENTS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for DWM_TAB_WINDOW_REQUIREMENTS {

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Dxgi/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Dxgi/mod.rs
@@ -147,12 +147,12 @@ impl core::ops::BitAnd for DXGI_ADAPTER_FLAG {
 }
 impl core::ops::BitOrAssign for DXGI_ADAPTER_FLAG {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for DXGI_ADAPTER_FLAG {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for DXGI_ADAPTER_FLAG {
@@ -183,12 +183,12 @@ impl core::ops::BitAnd for DXGI_ADAPTER_FLAG3 {
 }
 impl core::ops::BitOrAssign for DXGI_ADAPTER_FLAG3 {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for DXGI_ADAPTER_FLAG3 {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for DXGI_ADAPTER_FLAG3 {
@@ -238,12 +238,12 @@ impl core::ops::BitAnd for DXGI_CREATE_FACTORY_FLAGS {
 }
 impl core::ops::BitOrAssign for DXGI_CREATE_FACTORY_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for DXGI_CREATE_FACTORY_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for DXGI_CREATE_FACTORY_FLAGS {
@@ -281,12 +281,12 @@ impl core::ops::BitAnd for DXGI_DEBUG_RLO_FLAGS {
 }
 impl core::ops::BitOrAssign for DXGI_DEBUG_RLO_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for DXGI_DEBUG_RLO_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for DXGI_DEBUG_RLO_FLAGS {
@@ -335,12 +335,12 @@ impl core::ops::BitAnd for DXGI_ENUM_MODES {
 }
 impl core::ops::BitOrAssign for DXGI_ENUM_MODES {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for DXGI_ENUM_MODES {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for DXGI_ENUM_MODES {
@@ -454,12 +454,12 @@ impl core::ops::BitAnd for DXGI_HARDWARE_COMPOSITION_SUPPORT_FLAGS {
 }
 impl core::ops::BitOrAssign for DXGI_HARDWARE_COMPOSITION_SUPPORT_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for DXGI_HARDWARE_COMPOSITION_SUPPORT_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for DXGI_HARDWARE_COMPOSITION_SUPPORT_FLAGS {
@@ -598,12 +598,12 @@ impl core::ops::BitAnd for DXGI_MAP_FLAGS {
 }
 impl core::ops::BitOrAssign for DXGI_MAP_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for DXGI_MAP_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for DXGI_MAP_FLAGS {
@@ -995,12 +995,12 @@ impl core::ops::BitAnd for DXGI_MULTIPLANE_OVERLAY_YCbCr_FLAGS {
 }
 impl core::ops::BitOrAssign for DXGI_MULTIPLANE_OVERLAY_YCbCr_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for DXGI_MULTIPLANE_OVERLAY_YCbCr_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for DXGI_MULTIPLANE_OVERLAY_YCbCr_FLAGS {
@@ -1034,12 +1034,12 @@ impl core::ops::BitAnd for DXGI_MWA_FLAGS {
 }
 impl core::ops::BitOrAssign for DXGI_MWA_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for DXGI_MWA_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for DXGI_MWA_FLAGS {
@@ -1077,12 +1077,12 @@ impl core::ops::BitAnd for DXGI_OFFER_RESOURCE_FLAGS {
 }
 impl core::ops::BitOrAssign for DXGI_OFFER_RESOURCE_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for DXGI_OFFER_RESOURCE_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for DXGI_OFFER_RESOURCE_FLAGS {
@@ -1129,12 +1129,12 @@ impl core::ops::BitAnd for DXGI_OUTDUPL_FLAG {
 }
 impl core::ops::BitOrAssign for DXGI_OUTDUPL_FLAG {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for DXGI_OUTDUPL_FLAG {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for DXGI_OUTDUPL_FLAG {
@@ -1245,12 +1245,12 @@ impl core::ops::BitAnd for DXGI_OVERLAY_COLOR_SPACE_SUPPORT_FLAG {
 }
 impl core::ops::BitOrAssign for DXGI_OVERLAY_COLOR_SPACE_SUPPORT_FLAG {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for DXGI_OVERLAY_COLOR_SPACE_SUPPORT_FLAG {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for DXGI_OVERLAY_COLOR_SPACE_SUPPORT_FLAG {
@@ -1282,12 +1282,12 @@ impl core::ops::BitAnd for DXGI_OVERLAY_SUPPORT_FLAG {
 }
 impl core::ops::BitOrAssign for DXGI_OVERLAY_SUPPORT_FLAG {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for DXGI_OVERLAY_SUPPORT_FLAG {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for DXGI_OVERLAY_SUPPORT_FLAG {
@@ -1320,12 +1320,12 @@ impl core::ops::BitAnd for DXGI_PRESENT {
 }
 impl core::ops::BitOrAssign for DXGI_PRESENT {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for DXGI_PRESENT {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for DXGI_PRESENT {
@@ -1426,12 +1426,12 @@ impl core::ops::BitAnd for DXGI_SHARED_RESOURCE_RW {
 }
 impl core::ops::BitOrAssign for DXGI_SHARED_RESOURCE_RW {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for DXGI_SHARED_RESOURCE_RW {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for DXGI_SHARED_RESOURCE_RW {
@@ -1472,12 +1472,12 @@ impl core::ops::BitAnd for DXGI_SWAP_CHAIN_COLOR_SPACE_SUPPORT_FLAG {
 }
 impl core::ops::BitOrAssign for DXGI_SWAP_CHAIN_COLOR_SPACE_SUPPORT_FLAG {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for DXGI_SWAP_CHAIN_COLOR_SPACE_SUPPORT_FLAG {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for DXGI_SWAP_CHAIN_COLOR_SPACE_SUPPORT_FLAG {
@@ -1539,12 +1539,12 @@ impl core::ops::BitAnd for DXGI_SWAP_CHAIN_FLAG {
 }
 impl core::ops::BitOrAssign for DXGI_SWAP_CHAIN_FLAG {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for DXGI_SWAP_CHAIN_FLAG {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for DXGI_SWAP_CHAIN_FLAG {
@@ -1604,12 +1604,12 @@ impl core::ops::BitAnd for DXGI_USAGE {
 }
 impl core::ops::BitOrAssign for DXGI_USAGE {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for DXGI_USAGE {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for DXGI_USAGE {

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Gdi/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Gdi/mod.rs
@@ -2476,12 +2476,12 @@ impl core::ops::BitAnd for CDS_TYPE {
 }
 impl core::ops::BitOrAssign for CDS_TYPE {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CDS_TYPE {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CDS_TYPE {
@@ -2666,12 +2666,12 @@ impl core::ops::BitAnd for DC_LAYOUT {
 }
 impl core::ops::BitOrAssign for DC_LAYOUT {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for DC_LAYOUT {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for DC_LAYOUT {
@@ -2898,12 +2898,12 @@ impl core::ops::BitAnd for DEVMODE_FIELD_FLAGS {
 }
 impl core::ops::BitOrAssign for DEVMODE_FIELD_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for DEVMODE_FIELD_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for DEVMODE_FIELD_FLAGS {
@@ -2966,12 +2966,12 @@ impl core::ops::BitAnd for DFCS_STATE {
 }
 impl core::ops::BitOrAssign for DFCS_STATE {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for DFCS_STATE {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for DFCS_STATE {
@@ -3104,12 +3104,12 @@ impl core::ops::BitAnd for DISPLAY_DEVICE_STATE_FLAGS {
 }
 impl core::ops::BitOrAssign for DISPLAY_DEVICE_STATE_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for DISPLAY_DEVICE_STATE_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for DISPLAY_DEVICE_STATE_FLAGS {
@@ -3389,12 +3389,12 @@ impl core::ops::BitAnd for DRAWEDGE_FLAGS {
 }
 impl core::ops::BitOrAssign for DRAWEDGE_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for DRAWEDGE_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for DRAWEDGE_FLAGS {
@@ -3427,12 +3427,12 @@ impl core::ops::BitAnd for DRAWSTATE_FLAGS {
 }
 impl core::ops::BitOrAssign for DRAWSTATE_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for DRAWSTATE_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for DRAWSTATE_FLAGS {
@@ -3472,12 +3472,12 @@ impl core::ops::BitAnd for DRAW_CAPTION_FLAGS {
 }
 impl core::ops::BitOrAssign for DRAW_CAPTION_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for DRAW_CAPTION_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for DRAW_CAPTION_FLAGS {
@@ -3508,12 +3508,12 @@ impl core::ops::BitAnd for DRAW_EDGE_FLAGS {
 }
 impl core::ops::BitOrAssign for DRAW_EDGE_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for DRAW_EDGE_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for DRAW_EDGE_FLAGS {
@@ -3544,12 +3544,12 @@ impl core::ops::BitAnd for DRAW_TEXT_FORMAT {
 }
 impl core::ops::BitOrAssign for DRAW_TEXT_FORMAT {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for DRAW_TEXT_FORMAT {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for DRAW_TEXT_FORMAT {
@@ -4621,12 +4621,12 @@ impl core::ops::BitAnd for ENUM_DISPLAY_SETTINGS_FLAGS {
 }
 impl core::ops::BitOrAssign for ENUM_DISPLAY_SETTINGS_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for ENUM_DISPLAY_SETTINGS_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for ENUM_DISPLAY_SETTINGS_FLAGS {
@@ -4742,12 +4742,12 @@ impl core::ops::BitAnd for ETO_OPTIONS {
 }
 impl core::ops::BitOrAssign for ETO_OPTIONS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for ETO_OPTIONS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for ETO_OPTIONS {
@@ -4946,12 +4946,12 @@ impl core::ops::BitAnd for FONT_CLIP_PRECISION {
 }
 impl core::ops::BitOrAssign for FONT_CLIP_PRECISION {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for FONT_CLIP_PRECISION {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for FONT_CLIP_PRECISION {
@@ -5139,12 +5139,12 @@ impl core::ops::BitAnd for GET_CHARACTER_PLACEMENT_FLAGS {
 }
 impl core::ops::BitOrAssign for GET_CHARACTER_PLACEMENT_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for GET_CHARACTER_PLACEMENT_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for GET_CHARACTER_PLACEMENT_FLAGS {
@@ -5175,12 +5175,12 @@ impl core::ops::BitAnd for GET_DCX_FLAGS {
 }
 impl core::ops::BitOrAssign for GET_DCX_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for GET_DCX_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for GET_DCX_FLAGS {
@@ -6308,12 +6308,12 @@ impl core::ops::BitAnd for PEN_STYLE {
 }
 impl core::ops::BitOrAssign for PEN_STYLE {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for PEN_STYLE {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for PEN_STYLE {
@@ -6498,12 +6498,12 @@ impl core::ops::BitAnd for REDRAW_WINDOW_FLAGS {
 }
 impl core::ops::BitOrAssign for REDRAW_WINDOW_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for REDRAW_WINDOW_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for REDRAW_WINDOW_FLAGS {
@@ -6582,12 +6582,12 @@ impl core::ops::BitAnd for ROP_CODE {
 }
 impl core::ops::BitOrAssign for ROP_CODE {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for ROP_CODE {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for ROP_CODE {
@@ -6770,12 +6770,12 @@ impl core::ops::BitAnd for TEXT_ALIGN_OPTIONS {
 }
 impl core::ops::BitOrAssign for TEXT_ALIGN_OPTIONS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for TEXT_ALIGN_OPTIONS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for TEXT_ALIGN_OPTIONS {
@@ -6809,12 +6809,12 @@ impl core::ops::BitAnd for TMPF_FLAGS {
 }
 impl core::ops::BitOrAssign for TMPF_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for TMPF_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for TMPF_FLAGS {
@@ -6876,12 +6876,12 @@ impl core::ops::BitAnd for TTEMBED_FLAGS {
 }
 impl core::ops::BitOrAssign for TTEMBED_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for TTEMBED_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for TTEMBED_FLAGS {
@@ -6950,12 +6950,12 @@ impl core::ops::BitAnd for TTLOAD_EMBEDDED_FONT_STATUS {
 }
 impl core::ops::BitOrAssign for TTLOAD_EMBEDDED_FONT_STATUS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for TTLOAD_EMBEDDED_FONT_STATUS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for TTLOAD_EMBEDDED_FONT_STATUS {

--- a/crates/libs/windows/src/Windows/Win32/Graphics/OpenGL/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/OpenGL/mod.rs
@@ -2904,12 +2904,12 @@ impl core::ops::BitAnd for PFD_FLAGS {
 }
 impl core::ops::BitOrAssign for PFD_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for PFD_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for PFD_FLAGS {

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Printing/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Printing/mod.rs
@@ -12478,12 +12478,12 @@ impl core::ops::BitAnd for PRINTER_ACCESS_RIGHTS {
 }
 impl core::ops::BitOrAssign for PRINTER_ACCESS_RIGHTS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for PRINTER_ACCESS_RIGHTS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for PRINTER_ACCESS_RIGHTS {

--- a/crates/libs/windows/src/Windows/Win32/Media/Audio/Apo/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/Audio/Apo/mod.rs
@@ -224,12 +224,12 @@ impl core::ops::BitAnd for APO_REFERENCE_STREAM_PROPERTIES {
 }
 impl core::ops::BitOrAssign for APO_REFERENCE_STREAM_PROPERTIES {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for APO_REFERENCE_STREAM_PROPERTIES {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for APO_REFERENCE_STREAM_PROPERTIES {

--- a/crates/libs/windows/src/Windows/Win32/Media/Audio/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/Audio/mod.rs
@@ -1521,12 +1521,12 @@ impl core::ops::BitAnd for AUDCLNT_STREAMOPTIONS {
 }
 impl core::ops::BitOrAssign for AUDCLNT_STREAMOPTIONS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for AUDCLNT_STREAMOPTIONS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for AUDCLNT_STREAMOPTIONS {
@@ -1598,12 +1598,12 @@ impl core::ops::BitAnd for AUDIO_DUCKING_OPTIONS {
 }
 impl core::ops::BitOrAssign for AUDIO_DUCKING_OPTIONS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for AUDIO_DUCKING_OPTIONS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for AUDIO_DUCKING_OPTIONS {
@@ -1781,12 +1781,12 @@ impl core::ops::BitAnd for AudioObjectType {
 }
 impl core::ops::BitOrAssign for AudioObjectType {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for AudioObjectType {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for AudioObjectType {
@@ -8103,12 +8103,12 @@ impl core::ops::BitAnd for MIDI_WAVE_OPEN_TYPE {
 }
 impl core::ops::BitOrAssign for MIDI_WAVE_OPEN_TYPE {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for MIDI_WAVE_OPEN_TYPE {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for MIDI_WAVE_OPEN_TYPE {
@@ -8680,12 +8680,12 @@ impl core::ops::BitAnd for SND_FLAGS {
 }
 impl core::ops::BitOrAssign for SND_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for SND_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for SND_FLAGS {
@@ -8729,12 +8729,12 @@ impl core::ops::BitAnd for SPATIAL_AUDIO_STREAM_OPTIONS {
 }
 impl core::ops::BitOrAssign for SPATIAL_AUDIO_STREAM_OPTIONS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for SPATIAL_AUDIO_STREAM_OPTIONS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for SPATIAL_AUDIO_STREAM_OPTIONS {

--- a/crates/libs/windows/src/Windows/Win32/Media/DirectShow/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/DirectShow/mod.rs
@@ -40,12 +40,12 @@ impl core::ops::BitAnd for ADVISE_TYPE {
 }
 impl core::ops::BitOrAssign for ADVISE_TYPE {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for ADVISE_TYPE {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for ADVISE_TYPE {
@@ -177,12 +177,12 @@ impl core::ops::BitAnd for AMMSF_MMS_INIT_FLAGS {
 }
 impl core::ops::BitOrAssign for AMMSF_MMS_INIT_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for AMMSF_MMS_INIT_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for AMMSF_MMS_INIT_FLAGS {
@@ -213,12 +213,12 @@ impl core::ops::BitAnd for AMMSF_MS_FLAGS {
 }
 impl core::ops::BitOrAssign for AMMSF_MS_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for AMMSF_MS_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for AMMSF_MS_FLAGS {
@@ -256,12 +256,12 @@ impl core::ops::BitAnd for AMMSF_RENDER_FLAGS {
 }
 impl core::ops::BitOrAssign for AMMSF_RENDER_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for AMMSF_RENDER_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for AMMSF_RENDER_FLAGS {
@@ -2483,12 +2483,12 @@ impl core::ops::BitAnd for DDSFF_FLAGS {
 }
 impl core::ops::BitOrAssign for DDSFF_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for DDSFF_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for DDSFF_FLAGS {
@@ -35349,12 +35349,12 @@ impl core::ops::BitAnd for KSPROPERTY_IPSINK {
 }
 impl core::ops::BitOrAssign for KSPROPERTY_IPSINK {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for KSPROPERTY_IPSINK {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for KSPROPERTY_IPSINK {
@@ -35462,12 +35462,12 @@ impl core::ops::BitAnd for MMSSF_GET_INFORMATION_FLAGS {
 }
 impl core::ops::BitOrAssign for MMSSF_GET_INFORMATION_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for MMSSF_GET_INFORMATION_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for MMSSF_GET_INFORMATION_FLAGS {
@@ -35723,12 +35723,12 @@ impl core::ops::BitAnd for OUTPUT_STATE {
 }
 impl core::ops::BitOrAssign for OUTPUT_STATE {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for OUTPUT_STATE {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for OUTPUT_STATE {
@@ -35974,12 +35974,12 @@ impl core::ops::BitAnd for REG_PINFLAG {
 }
 impl core::ops::BitOrAssign for REG_PINFLAG {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for REG_PINFLAG {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for REG_PINFLAG {

--- a/crates/libs/windows/src/Windows/Win32/Media/MediaFoundation/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/MediaFoundation/mod.rs
@@ -3833,12 +3833,12 @@ impl core::ops::BitAnd for D3D12_VIDEO_DECODE_CONFIGURATION_FLAGS {
 }
 impl core::ops::BitOrAssign for D3D12_VIDEO_DECODE_CONFIGURATION_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D3D12_VIDEO_DECODE_CONFIGURATION_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D3D12_VIDEO_DECODE_CONFIGURATION_FLAGS {
@@ -3896,12 +3896,12 @@ impl core::ops::BitAnd for D3D12_VIDEO_DECODE_CONVERSION_SUPPORT_FLAGS {
 }
 impl core::ops::BitOrAssign for D3D12_VIDEO_DECODE_CONVERSION_SUPPORT_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D3D12_VIDEO_DECODE_CONVERSION_SUPPORT_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D3D12_VIDEO_DECODE_CONVERSION_SUPPORT_FLAGS {
@@ -3951,12 +3951,12 @@ impl core::ops::BitAnd for D3D12_VIDEO_DECODE_HISTOGRAM_COMPONENT_FLAGS {
 }
 impl core::ops::BitOrAssign for D3D12_VIDEO_DECODE_HISTOGRAM_COMPONENT_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D3D12_VIDEO_DECODE_HISTOGRAM_COMPONENT_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D3D12_VIDEO_DECODE_HISTOGRAM_COMPONENT_FLAGS {
@@ -4106,12 +4106,12 @@ impl core::ops::BitAnd for D3D12_VIDEO_DECODE_SUPPORT_FLAGS {
 }
 impl core::ops::BitOrAssign for D3D12_VIDEO_DECODE_SUPPORT_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D3D12_VIDEO_DECODE_SUPPORT_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D3D12_VIDEO_DECODE_SUPPORT_FLAGS {
@@ -4196,12 +4196,12 @@ impl core::ops::BitAnd for D3D12_VIDEO_ENCODER_AV1_FEATURE_FLAGS {
 }
 impl core::ops::BitOrAssign for D3D12_VIDEO_ENCODER_AV1_FEATURE_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D3D12_VIDEO_ENCODER_AV1_FEATURE_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D3D12_VIDEO_ENCODER_AV1_FEATURE_FLAGS {
@@ -4275,12 +4275,12 @@ impl core::ops::BitAnd for D3D12_VIDEO_ENCODER_AV1_FRAME_SUBREGION_LAYOUT_CONFIG
 }
 impl core::ops::BitOrAssign for D3D12_VIDEO_ENCODER_AV1_FRAME_SUBREGION_LAYOUT_CONFIG_VALIDATION_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D3D12_VIDEO_ENCODER_AV1_FRAME_SUBREGION_LAYOUT_CONFIG_VALIDATION_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D3D12_VIDEO_ENCODER_AV1_FRAME_SUBREGION_LAYOUT_CONFIG_VALIDATION_FLAGS {
@@ -4323,12 +4323,12 @@ impl core::ops::BitAnd for D3D12_VIDEO_ENCODER_AV1_FRAME_TYPE_FLAGS {
 }
 impl core::ops::BitOrAssign for D3D12_VIDEO_ENCODER_AV1_FRAME_TYPE_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D3D12_VIDEO_ENCODER_AV1_FRAME_TYPE_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D3D12_VIDEO_ENCODER_AV1_FRAME_TYPE_FLAGS {
@@ -4375,12 +4375,12 @@ impl core::ops::BitAnd for D3D12_VIDEO_ENCODER_AV1_INTERPOLATION_FILTERS_FLAGS {
 }
 impl core::ops::BitOrAssign for D3D12_VIDEO_ENCODER_AV1_INTERPOLATION_FILTERS_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D3D12_VIDEO_ENCODER_AV1_INTERPOLATION_FILTERS_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D3D12_VIDEO_ENCODER_AV1_INTERPOLATION_FILTERS_FLAGS {
@@ -4484,12 +4484,12 @@ impl core::ops::BitAnd for D3D12_VIDEO_ENCODER_AV1_PICTURE_CONTROL_FLAGS {
 }
 impl core::ops::BitOrAssign for D3D12_VIDEO_ENCODER_AV1_PICTURE_CONTROL_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D3D12_VIDEO_ENCODER_AV1_PICTURE_CONTROL_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D3D12_VIDEO_ENCODER_AV1_PICTURE_CONTROL_FLAGS {
@@ -4568,12 +4568,12 @@ impl core::ops::BitAnd for D3D12_VIDEO_ENCODER_AV1_POST_ENCODE_VALUES_FLAGS {
 }
 impl core::ops::BitOrAssign for D3D12_VIDEO_ENCODER_AV1_POST_ENCODE_VALUES_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D3D12_VIDEO_ENCODER_AV1_POST_ENCODE_VALUES_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D3D12_VIDEO_ENCODER_AV1_POST_ENCODE_VALUES_FLAGS {
@@ -4647,12 +4647,12 @@ impl core::ops::BitAnd for D3D12_VIDEO_ENCODER_AV1_REFERENCE_WARPED_MOTION_TRANS
 }
 impl core::ops::BitOrAssign for D3D12_VIDEO_ENCODER_AV1_REFERENCE_WARPED_MOTION_TRANSFORMATION_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D3D12_VIDEO_ENCODER_AV1_REFERENCE_WARPED_MOTION_TRANSFORMATION_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D3D12_VIDEO_ENCODER_AV1_REFERENCE_WARPED_MOTION_TRANSFORMATION_FLAGS {
@@ -4702,12 +4702,12 @@ impl core::ops::BitAnd for D3D12_VIDEO_ENCODER_AV1_RESTORATION_SUPPORT_FLAGS {
 }
 impl core::ops::BitOrAssign for D3D12_VIDEO_ENCODER_AV1_RESTORATION_SUPPORT_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D3D12_VIDEO_ENCODER_AV1_RESTORATION_SUPPORT_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D3D12_VIDEO_ENCODER_AV1_RESTORATION_SUPPORT_FLAGS {
@@ -4803,12 +4803,12 @@ impl core::ops::BitAnd for D3D12_VIDEO_ENCODER_AV1_SEGMENTATION_MODE_FLAGS {
 }
 impl core::ops::BitOrAssign for D3D12_VIDEO_ENCODER_AV1_SEGMENTATION_MODE_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D3D12_VIDEO_ENCODER_AV1_SEGMENTATION_MODE_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D3D12_VIDEO_ENCODER_AV1_SEGMENTATION_MODE_FLAGS {
@@ -4874,12 +4874,12 @@ impl core::ops::BitAnd for D3D12_VIDEO_ENCODER_AV1_TX_MODE_FLAGS {
 }
 impl core::ops::BitOrAssign for D3D12_VIDEO_ENCODER_AV1_TX_MODE_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D3D12_VIDEO_ENCODER_AV1_TX_MODE_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D3D12_VIDEO_ENCODER_AV1_TX_MODE_FLAGS {
@@ -5010,12 +5010,12 @@ impl core::ops::BitAnd for D3D12_VIDEO_ENCODER_CODEC_CONFIGURATION_H264_FLAGS {
 }
 impl core::ops::BitOrAssign for D3D12_VIDEO_ENCODER_CODEC_CONFIGURATION_H264_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D3D12_VIDEO_ENCODER_CODEC_CONFIGURATION_H264_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D3D12_VIDEO_ENCODER_CODEC_CONFIGURATION_H264_FLAGS {
@@ -5061,12 +5061,12 @@ impl core::ops::BitAnd for D3D12_VIDEO_ENCODER_CODEC_CONFIGURATION_H264_SLICES_D
 }
 impl core::ops::BitOrAssign for D3D12_VIDEO_ENCODER_CODEC_CONFIGURATION_H264_SLICES_DEBLOCKING_MODE_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D3D12_VIDEO_ENCODER_CODEC_CONFIGURATION_H264_SLICES_DEBLOCKING_MODE_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D3D12_VIDEO_ENCODER_CODEC_CONFIGURATION_H264_SLICES_DEBLOCKING_MODE_FLAGS {
@@ -5123,12 +5123,12 @@ impl core::ops::BitAnd for D3D12_VIDEO_ENCODER_CODEC_CONFIGURATION_HEVC_FLAGS {
 }
 impl core::ops::BitOrAssign for D3D12_VIDEO_ENCODER_CODEC_CONFIGURATION_HEVC_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D3D12_VIDEO_ENCODER_CODEC_CONFIGURATION_HEVC_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D3D12_VIDEO_ENCODER_CODEC_CONFIGURATION_HEVC_FLAGS {
@@ -5214,12 +5214,12 @@ impl core::ops::BitAnd for D3D12_VIDEO_ENCODER_CODEC_CONFIGURATION_SUPPORT_H264_
 }
 impl core::ops::BitOrAssign for D3D12_VIDEO_ENCODER_CODEC_CONFIGURATION_SUPPORT_H264_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D3D12_VIDEO_ENCODER_CODEC_CONFIGURATION_SUPPORT_H264_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D3D12_VIDEO_ENCODER_CODEC_CONFIGURATION_SUPPORT_H264_FLAGS {
@@ -5297,12 +5297,12 @@ impl core::ops::BitAnd for D3D12_VIDEO_ENCODER_CODEC_CONFIGURATION_SUPPORT_HEVC_
 }
 impl core::ops::BitOrAssign for D3D12_VIDEO_ENCODER_CODEC_CONFIGURATION_SUPPORT_HEVC_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D3D12_VIDEO_ENCODER_CODEC_CONFIGURATION_SUPPORT_HEVC_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D3D12_VIDEO_ENCODER_CODEC_CONFIGURATION_SUPPORT_HEVC_FLAGS {
@@ -5333,12 +5333,12 @@ impl core::ops::BitAnd for D3D12_VIDEO_ENCODER_CODEC_CONFIGURATION_SUPPORT_HEVC_
 }
 impl core::ops::BitOrAssign for D3D12_VIDEO_ENCODER_CODEC_CONFIGURATION_SUPPORT_HEVC_FLAGS1 {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D3D12_VIDEO_ENCODER_CODEC_CONFIGURATION_SUPPORT_HEVC_FLAGS1 {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D3D12_VIDEO_ENCODER_CODEC_CONFIGURATION_SUPPORT_HEVC_FLAGS1 {
@@ -5573,12 +5573,12 @@ impl core::ops::BitAnd for D3D12_VIDEO_ENCODER_DIRTY_REGIONS_SUPPORT_FLAGS {
 }
 impl core::ops::BitOrAssign for D3D12_VIDEO_ENCODER_DIRTY_REGIONS_SUPPORT_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D3D12_VIDEO_ENCODER_DIRTY_REGIONS_SUPPORT_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D3D12_VIDEO_ENCODER_DIRTY_REGIONS_SUPPORT_FLAGS {
@@ -5684,12 +5684,12 @@ impl core::ops::BitAnd for D3D12_VIDEO_ENCODER_ENCODE_ERROR_FLAGS {
 }
 impl core::ops::BitOrAssign for D3D12_VIDEO_ENCODER_ENCODE_ERROR_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D3D12_VIDEO_ENCODER_ENCODE_ERROR_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D3D12_VIDEO_ENCODER_ENCODE_ERROR_FLAGS {
@@ -5733,12 +5733,12 @@ impl core::ops::BitAnd for D3D12_VIDEO_ENCODER_FLAGS {
 }
 impl core::ops::BitOrAssign for D3D12_VIDEO_ENCODER_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D3D12_VIDEO_ENCODER_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D3D12_VIDEO_ENCODER_FLAGS {
@@ -5790,12 +5790,12 @@ impl core::ops::BitAnd for D3D12_VIDEO_ENCODER_FRAME_INPUT_MOTION_UNIT_PRECISION
 }
 impl core::ops::BitOrAssign for D3D12_VIDEO_ENCODER_FRAME_INPUT_MOTION_UNIT_PRECISION_SUPPORT_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D3D12_VIDEO_ENCODER_FRAME_INPUT_MOTION_UNIT_PRECISION_SUPPORT_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D3D12_VIDEO_ENCODER_FRAME_INPUT_MOTION_UNIT_PRECISION_SUPPORT_FLAGS {
@@ -5964,12 +5964,12 @@ impl core::ops::BitAnd for D3D12_VIDEO_ENCODER_HEAP_FLAGS {
 }
 impl core::ops::BitOrAssign for D3D12_VIDEO_ENCODER_HEAP_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D3D12_VIDEO_ENCODER_HEAP_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D3D12_VIDEO_ENCODER_HEAP_FLAGS {
@@ -6201,12 +6201,12 @@ impl core::ops::BitAnd for D3D12_VIDEO_ENCODER_MOTION_SEARCH_SUPPORT_FLAGS {
 }
 impl core::ops::BitOrAssign for D3D12_VIDEO_ENCODER_MOTION_SEARCH_SUPPORT_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D3D12_VIDEO_ENCODER_MOTION_SEARCH_SUPPORT_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D3D12_VIDEO_ENCODER_MOTION_SEARCH_SUPPORT_FLAGS {
@@ -6267,12 +6267,12 @@ impl core::ops::BitAnd for D3D12_VIDEO_ENCODER_OPTIONAL_METADATA_ENABLE_FLAGS {
 }
 impl core::ops::BitOrAssign for D3D12_VIDEO_ENCODER_OPTIONAL_METADATA_ENABLE_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D3D12_VIDEO_ENCODER_OPTIONAL_METADATA_ENABLE_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D3D12_VIDEO_ENCODER_OPTIONAL_METADATA_ENABLE_FLAGS {
@@ -6405,12 +6405,12 @@ impl core::ops::BitAnd for D3D12_VIDEO_ENCODER_PICTURE_CONTROL_CODEC_DATA_H264_F
 }
 impl core::ops::BitOrAssign for D3D12_VIDEO_ENCODER_PICTURE_CONTROL_CODEC_DATA_H264_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D3D12_VIDEO_ENCODER_PICTURE_CONTROL_CODEC_DATA_H264_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D3D12_VIDEO_ENCODER_PICTURE_CONTROL_CODEC_DATA_H264_FLAGS {
@@ -6554,12 +6554,12 @@ impl core::ops::BitAnd for D3D12_VIDEO_ENCODER_PICTURE_CONTROL_CODEC_DATA_HEVC_F
 }
 impl core::ops::BitOrAssign for D3D12_VIDEO_ENCODER_PICTURE_CONTROL_CODEC_DATA_HEVC_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D3D12_VIDEO_ENCODER_PICTURE_CONTROL_CODEC_DATA_HEVC_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D3D12_VIDEO_ENCODER_PICTURE_CONTROL_CODEC_DATA_HEVC_FLAGS {
@@ -6634,12 +6634,12 @@ impl core::ops::BitAnd for D3D12_VIDEO_ENCODER_PICTURE_CONTROL_FLAGS {
 }
 impl core::ops::BitOrAssign for D3D12_VIDEO_ENCODER_PICTURE_CONTROL_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D3D12_VIDEO_ENCODER_PICTURE_CONTROL_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D3D12_VIDEO_ENCODER_PICTURE_CONTROL_FLAGS {
@@ -6873,12 +6873,12 @@ impl core::ops::BitAnd for D3D12_VIDEO_ENCODER_RATE_CONTROL_FLAGS {
 }
 impl core::ops::BitOrAssign for D3D12_VIDEO_ENCODER_RATE_CONTROL_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D3D12_VIDEO_ENCODER_RATE_CONTROL_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D3D12_VIDEO_ENCODER_RATE_CONTROL_FLAGS {
@@ -6919,12 +6919,12 @@ impl core::ops::BitAnd for D3D12_VIDEO_ENCODER_RATE_CONTROL_FRAME_ANALYSIS_SUPPO
 }
 impl core::ops::BitOrAssign for D3D12_VIDEO_ENCODER_RATE_CONTROL_FRAME_ANALYSIS_SUPPORT_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D3D12_VIDEO_ENCODER_RATE_CONTROL_FRAME_ANALYSIS_SUPPORT_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D3D12_VIDEO_ENCODER_RATE_CONTROL_FRAME_ANALYSIS_SUPPORT_FLAGS {
@@ -7157,12 +7157,12 @@ impl core::ops::BitAnd for D3D12_VIDEO_ENCODER_SEQUENCE_CONTROL_FLAGS {
 }
 impl core::ops::BitOrAssign for D3D12_VIDEO_ENCODER_SEQUENCE_CONTROL_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D3D12_VIDEO_ENCODER_SEQUENCE_CONTROL_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D3D12_VIDEO_ENCODER_SEQUENCE_CONTROL_FLAGS {
@@ -7262,12 +7262,12 @@ impl core::ops::BitAnd for D3D12_VIDEO_ENCODER_SUPPORT_FLAGS {
 }
 impl core::ops::BitOrAssign for D3D12_VIDEO_ENCODER_SUPPORT_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D3D12_VIDEO_ENCODER_SUPPORT_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D3D12_VIDEO_ENCODER_SUPPORT_FLAGS {
@@ -7328,12 +7328,12 @@ impl core::ops::BitAnd for D3D12_VIDEO_ENCODER_VALIDATION_FLAGS {
 }
 impl core::ops::BitOrAssign for D3D12_VIDEO_ENCODER_VALIDATION_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D3D12_VIDEO_ENCODER_VALIDATION_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D3D12_VIDEO_ENCODER_VALIDATION_FLAGS {
@@ -7407,12 +7407,12 @@ impl core::ops::BitAnd for D3D12_VIDEO_EXTENSION_COMMAND_PARAMETER_FLAGS {
 }
 impl core::ops::BitOrAssign for D3D12_VIDEO_EXTENSION_COMMAND_PARAMETER_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D3D12_VIDEO_EXTENSION_COMMAND_PARAMETER_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D3D12_VIDEO_EXTENSION_COMMAND_PARAMETER_FLAGS {
@@ -7534,12 +7534,12 @@ impl core::ops::BitAnd for D3D12_VIDEO_MOTION_ESTIMATOR_SEARCH_BLOCK_SIZE_FLAGS 
 }
 impl core::ops::BitOrAssign for D3D12_VIDEO_MOTION_ESTIMATOR_SEARCH_BLOCK_SIZE_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D3D12_VIDEO_MOTION_ESTIMATOR_SEARCH_BLOCK_SIZE_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D3D12_VIDEO_MOTION_ESTIMATOR_SEARCH_BLOCK_SIZE_FLAGS {
@@ -7576,12 +7576,12 @@ impl core::ops::BitAnd for D3D12_VIDEO_MOTION_ESTIMATOR_VECTOR_PRECISION_FLAGS {
 }
 impl core::ops::BitOrAssign for D3D12_VIDEO_MOTION_ESTIMATOR_VECTOR_PRECISION_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D3D12_VIDEO_MOTION_ESTIMATOR_VECTOR_PRECISION_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D3D12_VIDEO_MOTION_ESTIMATOR_VECTOR_PRECISION_FLAGS {
@@ -7638,12 +7638,12 @@ impl core::ops::BitAnd for D3D12_VIDEO_PROCESS_AUTO_PROCESSING_FLAGS {
 }
 impl core::ops::BitOrAssign for D3D12_VIDEO_PROCESS_AUTO_PROCESSING_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D3D12_VIDEO_PROCESS_AUTO_PROCESSING_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D3D12_VIDEO_PROCESS_AUTO_PROCESSING_FLAGS {
@@ -7684,12 +7684,12 @@ impl core::ops::BitAnd for D3D12_VIDEO_PROCESS_DEINTERLACE_FLAGS {
 }
 impl core::ops::BitOrAssign for D3D12_VIDEO_PROCESS_DEINTERLACE_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D3D12_VIDEO_PROCESS_DEINTERLACE_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D3D12_VIDEO_PROCESS_DEINTERLACE_FLAGS {
@@ -7723,12 +7723,12 @@ impl core::ops::BitAnd for D3D12_VIDEO_PROCESS_FEATURE_FLAGS {
 }
 impl core::ops::BitOrAssign for D3D12_VIDEO_PROCESS_FEATURE_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D3D12_VIDEO_PROCESS_FEATURE_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D3D12_VIDEO_PROCESS_FEATURE_FLAGS {
@@ -7774,12 +7774,12 @@ impl core::ops::BitAnd for D3D12_VIDEO_PROCESS_FILTER_FLAGS {
 }
 impl core::ops::BitOrAssign for D3D12_VIDEO_PROCESS_FILTER_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D3D12_VIDEO_PROCESS_FILTER_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D3D12_VIDEO_PROCESS_FILTER_FLAGS {
@@ -7896,12 +7896,12 @@ impl core::ops::BitAnd for D3D12_VIDEO_PROCESS_INPUT_STREAM_FLAGS {
 }
 impl core::ops::BitOrAssign for D3D12_VIDEO_PROCESS_INPUT_STREAM_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D3D12_VIDEO_PROCESS_INPUT_STREAM_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D3D12_VIDEO_PROCESS_INPUT_STREAM_FLAGS {
@@ -8014,12 +8014,12 @@ impl core::ops::BitAnd for D3D12_VIDEO_PROCESS_SUPPORT_FLAGS {
 }
 impl core::ops::BitOrAssign for D3D12_VIDEO_PROCESS_SUPPORT_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D3D12_VIDEO_PROCESS_SUPPORT_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D3D12_VIDEO_PROCESS_SUPPORT_FLAGS {
@@ -8059,12 +8059,12 @@ impl core::ops::BitAnd for D3D12_VIDEO_PROTECTED_RESOURCE_SUPPORT_FLAGS {
 }
 impl core::ops::BitOrAssign for D3D12_VIDEO_PROTECTED_RESOURCE_SUPPORT_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D3D12_VIDEO_PROTECTED_RESOURCE_SUPPORT_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D3D12_VIDEO_PROTECTED_RESOURCE_SUPPORT_FLAGS {
@@ -8111,12 +8111,12 @@ impl core::ops::BitAnd for D3D12_VIDEO_SCALE_SUPPORT_FLAGS {
 }
 impl core::ops::BitOrAssign for D3D12_VIDEO_SCALE_SUPPORT_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for D3D12_VIDEO_SCALE_SUPPORT_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for D3D12_VIDEO_SCALE_SUPPORT_FLAGS {
@@ -45342,12 +45342,12 @@ impl core::ops::BitAnd for MFCameraOcclusionState {
 }
 impl core::ops::BitOrAssign for MFCameraOcclusionState {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for MFCameraOcclusionState {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for MFCameraOcclusionState {
@@ -46196,12 +46196,12 @@ impl core::ops::BitAnd for MFT_ENUM_FLAG {
 }
 impl core::ops::BitOrAssign for MFT_ENUM_FLAG {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for MFT_ENUM_FLAG {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for MFT_ENUM_FLAG {
@@ -48109,12 +48109,12 @@ impl core::ops::BitAnd for MF_RESOLUTION_FLAGS {
 }
 impl core::ops::BitOrAssign for MF_RESOLUTION_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for MF_RESOLUTION_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for MF_RESOLUTION_FLAGS {
@@ -48275,12 +48275,12 @@ impl core::ops::BitAnd for MF_SOURCE_READER_CONTROL_FLAG {
 }
 impl core::ops::BitOrAssign for MF_SOURCE_READER_CONTROL_FLAG {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for MF_SOURCE_READER_CONTROL_FLAG {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for MF_SOURCE_READER_CONTROL_FLAG {
@@ -48325,12 +48325,12 @@ impl core::ops::BitAnd for MF_SOURCE_READER_FLAG {
 }
 impl core::ops::BitOrAssign for MF_SOURCE_READER_FLAG {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for MF_SOURCE_READER_FLAG {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for MF_SOURCE_READER_FLAG {
@@ -48728,12 +48728,12 @@ impl core::ops::BitAnd for MPEG2VIDEOINFO_FLAGS {
 }
 impl core::ops::BitOrAssign for MPEG2VIDEOINFO_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for MPEG2VIDEOINFO_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for MPEG2VIDEOINFO_FLAGS {
@@ -49013,12 +49013,12 @@ impl core::ops::BitAnd for OPM_HDCP_FLAGS {
 }
 impl core::ops::BitOrAssign for OPM_HDCP_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for OPM_HDCP_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for OPM_HDCP_FLAGS {
@@ -49275,12 +49275,12 @@ impl core::ops::BitAnd for PLAYTO_SOURCE_CREATEFLAGS {
 }
 impl core::ops::BitOrAssign for PLAYTO_SOURCE_CREATEFLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for PLAYTO_SOURCE_CREATEFLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for PLAYTO_SOURCE_CREATEFLAGS {

--- a/crates/libs/windows/src/Windows/Win32/Media/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/mod.rs
@@ -430,12 +430,12 @@ impl core::ops::BitAnd for TIMECODE_SAMPLE_FLAGS {
 }
 impl core::ops::BitOrAssign for TIMECODE_SAMPLE_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for TIMECODE_SAMPLE_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for TIMECODE_SAMPLE_FLAGS {

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/Dns/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/Dns/mod.rs
@@ -1089,12 +1089,12 @@ impl core::ops::BitAnd for DNS_QUERY_OPTIONS {
 }
 impl core::ops::BitOrAssign for DNS_QUERY_OPTIONS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for DNS_QUERY_OPTIONS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for DNS_QUERY_OPTIONS {

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/IpHelper/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/IpHelper/mod.rs
@@ -1445,12 +1445,12 @@ impl core::ops::BitAnd for GET_ADAPTERS_ADDRESSES_FLAGS {
 }
 impl core::ops::BitOrAssign for GET_ADAPTERS_ADDRESSES_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for GET_ADAPTERS_ADDRESSES_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for GET_ADAPTERS_ADDRESSES_FLAGS {

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/NetManagement/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/NetManagement/mod.rs
@@ -1727,12 +1727,12 @@ impl core::ops::BitAnd for AF_OP {
 }
 impl core::ops::BitOrAssign for AF_OP {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for AF_OP {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for AF_OP {
@@ -5378,12 +5378,12 @@ impl core::ops::BitAnd for NETSETUP_PROVISION {
 }
 impl core::ops::BitOrAssign for NETSETUP_PROVISION {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for NETSETUP_PROVISION {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for NETSETUP_PROVISION {
@@ -5495,12 +5495,12 @@ impl core::ops::BitAnd for NET_JOIN_DOMAIN_JOIN_OPTIONS {
 }
 impl core::ops::BitOrAssign for NET_JOIN_DOMAIN_JOIN_OPTIONS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for NET_JOIN_DOMAIN_JOIN_OPTIONS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for NET_JOIN_DOMAIN_JOIN_OPTIONS {
@@ -5534,12 +5534,12 @@ impl core::ops::BitAnd for NET_REQUEST_PROVISION_OPTIONS {
 }
 impl core::ops::BitOrAssign for NET_REQUEST_PROVISION_OPTIONS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for NET_REQUEST_PROVISION_OPTIONS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for NET_REQUEST_PROVISION_OPTIONS {
@@ -5570,12 +5570,12 @@ impl core::ops::BitAnd for NET_SERVER_TYPE {
 }
 impl core::ops::BitOrAssign for NET_SERVER_TYPE {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for NET_SERVER_TYPE {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for NET_SERVER_TYPE {
@@ -5606,12 +5606,12 @@ impl core::ops::BitAnd for NET_USER_ENUM_FILTER_FLAGS {
 }
 impl core::ops::BitOrAssign for NET_USER_ENUM_FILTER_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for NET_USER_ENUM_FILTER_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for NET_USER_ENUM_FILTER_FLAGS {
@@ -7402,12 +7402,12 @@ impl core::ops::BitAnd for USER_ACCOUNT_FLAGS {
 }
 impl core::ops::BitOrAssign for USER_ACCOUNT_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for USER_ACCOUNT_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for USER_ACCOUNT_FLAGS {

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/Rras/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/Rras/mod.rs
@@ -4043,12 +4043,12 @@ impl core::ops::BitAnd for RASIKEV_PROJECTION_INFO_FLAGS {
 }
 impl core::ops::BitOrAssign for RASIKEV_PROJECTION_INFO_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for RASIKEV_PROJECTION_INFO_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for RASIKEV_PROJECTION_INFO_FLAGS {

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/WNet/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/WNet/mod.rs
@@ -492,12 +492,12 @@ impl core::ops::BitAnd for CONNECTDLGSTRUCT_FLAGS {
 }
 impl core::ops::BitOrAssign for CONNECTDLGSTRUCT_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CONNECTDLGSTRUCT_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CONNECTDLGSTRUCT_FLAGS {
@@ -565,12 +565,12 @@ impl core::ops::BitAnd for DISCDLGSTRUCT_FLAGS {
 }
 impl core::ops::BitOrAssign for DISCDLGSTRUCT_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for DISCDLGSTRUCT_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for DISCDLGSTRUCT_FLAGS {
@@ -624,12 +624,12 @@ impl core::ops::BitAnd for NETINFOSTRUCT_CHARACTERISTICS {
 }
 impl core::ops::BitOrAssign for NETINFOSTRUCT_CHARACTERISTICS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for NETINFOSTRUCT_CHARACTERISTICS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for NETINFOSTRUCT_CHARACTERISTICS {
@@ -691,12 +691,12 @@ impl core::ops::BitAnd for NET_CONNECT_FLAGS {
 }
 impl core::ops::BitOrAssign for NET_CONNECT_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for NET_CONNECT_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for NET_CONNECT_FLAGS {
@@ -730,12 +730,12 @@ impl core::ops::BitAnd for NET_RESOURCE_TYPE {
 }
 impl core::ops::BitOrAssign for NET_RESOURCE_TYPE {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for NET_RESOURCE_TYPE {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for NET_RESOURCE_TYPE {
@@ -893,12 +893,12 @@ impl core::ops::BitAnd for WNET_OPEN_ENUM_USAGE {
 }
 impl core::ops::BitOrAssign for WNET_OPEN_ENUM_USAGE {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for WNET_OPEN_ENUM_USAGE {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for WNET_OPEN_ENUM_USAGE {

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/WiFi/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/WiFi/mod.rs
@@ -6001,12 +6001,12 @@ impl core::ops::BitAnd for WLAN_NOTIFICATION_SOURCES {
 }
 impl core::ops::BitOrAssign for WLAN_NOTIFICATION_SOURCES {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for WLAN_NOTIFICATION_SOURCES {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for WLAN_NOTIFICATION_SOURCES {

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/WindowsFilteringPlatform/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/WindowsFilteringPlatform/mod.rs
@@ -1627,12 +1627,12 @@ impl core::ops::BitAnd for FWPM_FILTER_FLAGS {
 }
 impl core::ops::BitOrAssign for FWPM_FILTER_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for FWPM_FILTER_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for FWPM_FILTER_FLAGS {
@@ -4129,12 +4129,12 @@ impl core::ops::BitAnd for IKEEXT_CERT_AUTH {
 }
 impl core::ops::BitOrAssign for IKEEXT_CERT_AUTH {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for IKEEXT_CERT_AUTH {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for IKEEXT_CERT_AUTH {
@@ -4203,12 +4203,12 @@ impl core::ops::BitAnd for IKEEXT_CERT_FLAGS {
 }
 impl core::ops::BitOrAssign for IKEEXT_CERT_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for IKEEXT_CERT_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for IKEEXT_CERT_FLAGS {
@@ -4459,12 +4459,12 @@ impl core::ops::BitAnd for IKEEXT_EAP_AUTHENTICATION_FLAGS {
 }
 impl core::ops::BitOrAssign for IKEEXT_EAP_AUTHENTICATION_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for IKEEXT_EAP_AUTHENTICATION_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for IKEEXT_EAP_AUTHENTICATION_FLAGS {
@@ -4637,12 +4637,12 @@ impl core::ops::BitAnd for IKEEXT_KERBEROS_AUTHENTICATION_FLAGS {
 }
 impl core::ops::BitOrAssign for IKEEXT_KERBEROS_AUTHENTICATION_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for IKEEXT_KERBEROS_AUTHENTICATION_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for IKEEXT_KERBEROS_AUTHENTICATION_FLAGS {
@@ -4789,12 +4789,12 @@ impl core::ops::BitAnd for IKEEXT_POLICY_FLAG {
 }
 impl core::ops::BitOrAssign for IKEEXT_POLICY_FLAG {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for IKEEXT_POLICY_FLAG {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for IKEEXT_POLICY_FLAG {
@@ -4846,12 +4846,12 @@ impl core::ops::BitAnd for IKEEXT_PRESHARED_KEY_AUTHENTICATION_FLAGS {
 }
 impl core::ops::BitOrAssign for IKEEXT_PRESHARED_KEY_AUTHENTICATION_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for IKEEXT_PRESHARED_KEY_AUTHENTICATION_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for IKEEXT_PRESHARED_KEY_AUTHENTICATION_FLAGS {
@@ -4907,12 +4907,12 @@ impl core::ops::BitAnd for IKEEXT_RESERVED_AUTHENTICATION_FLAGS {
 }
 impl core::ops::BitOrAssign for IKEEXT_RESERVED_AUTHENTICATION_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for IKEEXT_RESERVED_AUTHENTICATION_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for IKEEXT_RESERVED_AUTHENTICATION_FLAGS {
@@ -5254,12 +5254,12 @@ impl core::ops::BitAnd for IPSEC_DOSP_FLAGS {
 }
 impl core::ops::BitOrAssign for IPSEC_DOSP_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for IPSEC_DOSP_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for IPSEC_DOSP_FLAGS {
@@ -5527,12 +5527,12 @@ impl core::ops::BitAnd for IPSEC_POLICY_FLAG {
 }
 impl core::ops::BitOrAssign for IPSEC_POLICY_FLAG {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for IPSEC_POLICY_FLAG {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for IPSEC_POLICY_FLAG {
@@ -5703,12 +5703,12 @@ impl core::ops::BitAnd for IPSEC_SA_BUNDLE_FLAGS {
 }
 impl core::ops::BitOrAssign for IPSEC_SA_BUNDLE_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for IPSEC_SA_BUNDLE_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for IPSEC_SA_BUNDLE_FLAGS {

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/WindowsFirewall/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/WindowsFirewall/mod.rs
@@ -130,12 +130,12 @@ impl core::ops::BitAnd for FW_DYNAMIC_KEYWORD_ADDRESS_ENUM_FLAGS {
 }
 impl core::ops::BitOrAssign for FW_DYNAMIC_KEYWORD_ADDRESS_ENUM_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for FW_DYNAMIC_KEYWORD_ADDRESS_ENUM_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for FW_DYNAMIC_KEYWORD_ADDRESS_ENUM_FLAGS {
@@ -169,12 +169,12 @@ impl core::ops::BitAnd for FW_DYNAMIC_KEYWORD_ADDRESS_FLAGS {
 }
 impl core::ops::BitOrAssign for FW_DYNAMIC_KEYWORD_ADDRESS_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for FW_DYNAMIC_KEYWORD_ADDRESS_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for FW_DYNAMIC_KEYWORD_ADDRESS_FLAGS {

--- a/crates/libs/windows/src/Windows/Win32/Networking/HttpServer/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Networking/HttpServer/mod.rs
@@ -575,12 +575,12 @@ impl core::ops::BitAnd for HTTP_INITIALIZE {
 }
 impl core::ops::BitOrAssign for HTTP_INITIALIZE {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for HTTP_INITIALIZE {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for HTTP_INITIALIZE {

--- a/crates/libs/windows/src/Windows/Win32/Networking/WinHttp/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Networking/WinHttp/mod.rs
@@ -1396,12 +1396,12 @@ impl core::ops::BitAnd for WINHTTP_OPEN_REQUEST_FLAGS {
 }
 impl core::ops::BitOrAssign for WINHTTP_OPEN_REQUEST_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for WINHTTP_OPEN_REQUEST_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for WINHTTP_OPEN_REQUEST_FLAGS {

--- a/crates/libs/windows/src/Windows/Win32/Networking/WinInet/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Networking/WinInet/mod.rs
@@ -2749,12 +2749,12 @@ impl core::ops::BitAnd for HTTP_ADDREQ_FLAG {
 }
 impl core::ops::BitOrAssign for HTTP_ADDREQ_FLAG {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for HTTP_ADDREQ_FLAG {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for HTTP_ADDREQ_FLAG {
@@ -3600,12 +3600,12 @@ impl core::ops::BitAnd for INTERNET_CONNECTION {
 }
 impl core::ops::BitOrAssign for INTERNET_CONNECTION {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for INTERNET_CONNECTION {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for INTERNET_CONNECTION {
@@ -4544,12 +4544,12 @@ impl core::ops::BitAnd for PROXY_AUTO_DETECT_TYPE {
 }
 impl core::ops::BitOrAssign for PROXY_AUTO_DETECT_TYPE {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for PROXY_AUTO_DETECT_TYPE {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for PROXY_AUTO_DETECT_TYPE {

--- a/crates/libs/windows/src/Windows/Win32/Networking/WinSock/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Networking/WinSock/mod.rs
@@ -4950,12 +4950,12 @@ impl core::ops::BitAnd for SEND_RECV_FLAGS {
 }
 impl core::ops::BitOrAssign for SEND_RECV_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for SEND_RECV_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for SEND_RECV_FLAGS {
@@ -6646,12 +6646,12 @@ impl core::ops::BitAnd for WSAPOLL_EVENT_FLAGS {
 }
 impl core::ops::BitOrAssign for WSAPOLL_EVENT_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for WSAPOLL_EVENT_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for WSAPOLL_EVENT_FLAGS {

--- a/crates/libs/windows/src/Windows/Win32/Security/AppLocker/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/AppLocker/mod.rs
@@ -128,12 +128,12 @@ impl core::ops::BitAnd for SAFER_COMPUTE_TOKEN_FROM_LEVEL_FLAGS {
 }
 impl core::ops::BitOrAssign for SAFER_COMPUTE_TOKEN_FROM_LEVEL_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for SAFER_COMPUTE_TOKEN_FROM_LEVEL_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for SAFER_COMPUTE_TOKEN_FROM_LEVEL_FLAGS {

--- a/crates/libs/windows/src/Windows/Win32/Security/Authentication/Identity/Provider/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/Authentication/Identity/Provider/mod.rs
@@ -1712,12 +1712,12 @@ impl core::ops::BitAnd for IdentityUpdateEvent {
 }
 impl core::ops::BitOrAssign for IdentityUpdateEvent {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for IdentityUpdateEvent {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for IdentityUpdateEvent {

--- a/crates/libs/windows/src/Windows/Win32/Security/Authentication/Identity/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/Authentication/Identity/mod.rs
@@ -1470,12 +1470,12 @@ impl core::ops::BitAnd for ASC_REQ_FLAGS {
 }
 impl core::ops::BitOrAssign for ASC_REQ_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for ASC_REQ_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for ASC_REQ_FLAGS {
@@ -1508,12 +1508,12 @@ impl core::ops::BitAnd for ASC_REQ_HIGH_FLAGS {
 }
 impl core::ops::BitOrAssign for ASC_REQ_HIGH_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for ASC_REQ_HIGH_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for ASC_REQ_HIGH_FLAGS {
@@ -1809,12 +1809,12 @@ impl core::ops::BitAnd for DOMAIN_PASSWORD_PROPERTIES {
 }
 impl core::ops::BitOrAssign for DOMAIN_PASSWORD_PROPERTIES {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for DOMAIN_PASSWORD_PROPERTIES {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for DOMAIN_PASSWORD_PROPERTIES {
@@ -1865,12 +1865,12 @@ impl core::ops::BitAnd for EXPORT_SECURITY_CONTEXT_FLAGS {
 }
 impl core::ops::BitOrAssign for EXPORT_SECURITY_CONTEXT_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for EXPORT_SECURITY_CONTEXT_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for EXPORT_SECURITY_CONTEXT_FLAGS {
@@ -1977,12 +1977,12 @@ impl core::ops::BitAnd for ISC_REQ_FLAGS {
 }
 impl core::ops::BitOrAssign for ISC_REQ_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for ISC_REQ_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for ISC_REQ_FLAGS {
@@ -2016,12 +2016,12 @@ impl core::ops::BitAnd for ISC_REQ_HIGH_FLAGS {
 }
 impl core::ops::BitOrAssign for ISC_REQ_HIGH_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for ISC_REQ_HIGH_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for ISC_REQ_HIGH_FLAGS {
@@ -2922,12 +2922,12 @@ impl core::ops::BitAnd for KERB_TICKET_FLAGS {
 }
 impl core::ops::BitOrAssign for KERB_TICKET_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for KERB_TICKET_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for KERB_TICKET_FLAGS {
@@ -3966,12 +3966,12 @@ impl core::ops::BitAnd for MSV_SUBAUTH_LOGON_PARAMETER_CONTROL {
 }
 impl core::ops::BitOrAssign for MSV_SUBAUTH_LOGON_PARAMETER_CONTROL {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for MSV_SUBAUTH_LOGON_PARAMETER_CONTROL {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for MSV_SUBAUTH_LOGON_PARAMETER_CONTROL {
@@ -4005,12 +4005,12 @@ impl core::ops::BitAnd for MSV_SUPPLEMENTAL_CREDENTIAL_FLAGS {
 }
 impl core::ops::BitOrAssign for MSV_SUPPLEMENTAL_CREDENTIAL_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for MSV_SUPPLEMENTAL_CREDENTIAL_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for MSV_SUPPLEMENTAL_CREDENTIAL_FLAGS {
@@ -4812,12 +4812,12 @@ impl core::ops::BitAnd for SCHANNEL_CRED_FLAGS {
 }
 impl core::ops::BitOrAssign for SCHANNEL_CRED_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for SCHANNEL_CRED_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for SCHANNEL_CRED_FLAGS {
@@ -6970,12 +6970,12 @@ impl core::ops::BitAnd for SchGetExtensionsOptions {
 }
 impl core::ops::BitOrAssign for SchGetExtensionsOptions {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for SchGetExtensionsOptions {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for SchGetExtensionsOptions {

--- a/crates/libs/windows/src/Windows/Win32/Security/Authorization/UI/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/Authorization/UI/mod.rs
@@ -512,12 +512,12 @@ impl core::ops::BitAnd for SECURITY_INFO_PAGE_FLAGS {
 }
 impl core::ops::BitOrAssign for SECURITY_INFO_PAGE_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for SECURITY_INFO_PAGE_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for SECURITY_INFO_PAGE_FLAGS {
@@ -642,12 +642,12 @@ impl core::ops::BitAnd for SI_OBJECT_INFO_FLAGS {
 }
 impl core::ops::BitOrAssign for SI_OBJECT_INFO_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for SI_OBJECT_INFO_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for SI_OBJECT_INFO_FLAGS {

--- a/crates/libs/windows/src/Windows/Win32/Security/Authorization/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/Authorization/mod.rs
@@ -1149,12 +1149,12 @@ impl core::ops::BitAnd for AUTHZ_RESOURCE_MANAGER_FLAGS {
 }
 impl core::ops::BitOrAssign for AUTHZ_RESOURCE_MANAGER_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for AUTHZ_RESOURCE_MANAGER_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for AUTHZ_RESOURCE_MANAGER_FLAGS {
@@ -1249,12 +1249,12 @@ impl core::ops::BitAnd for AUTHZ_SECURITY_ATTRIBUTE_FLAGS {
 }
 impl core::ops::BitOrAssign for AUTHZ_SECURITY_ATTRIBUTE_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for AUTHZ_SECURITY_ATTRIBUTE_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for AUTHZ_SECURITY_ATTRIBUTE_FLAGS {

--- a/crates/libs/windows/src/Windows/Win32/Security/Credentials/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/Credentials/mod.rs
@@ -1062,12 +1062,12 @@ impl core::ops::BitAnd for CREDUIWIN_FLAGS {
 }
 impl core::ops::BitOrAssign for CREDUIWIN_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CREDUIWIN_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CREDUIWIN_FLAGS {
@@ -1105,12 +1105,12 @@ impl core::ops::BitAnd for CREDUI_FLAGS {
 }
 impl core::ops::BitOrAssign for CREDUI_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CREDUI_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CREDUI_FLAGS {
@@ -1188,12 +1188,12 @@ impl core::ops::BitAnd for CRED_ENUMERATE_FLAGS {
 }
 impl core::ops::BitOrAssign for CRED_ENUMERATE_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CRED_ENUMERATE_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CRED_ENUMERATE_FLAGS {
@@ -1224,12 +1224,12 @@ impl core::ops::BitAnd for CRED_FLAGS {
 }
 impl core::ops::BitOrAssign for CRED_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CRED_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CRED_FLAGS {
@@ -1283,12 +1283,12 @@ impl core::ops::BitAnd for CRED_PACK_FLAGS {
 }
 impl core::ops::BitOrAssign for CRED_PACK_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CRED_PACK_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CRED_PACK_FLAGS {
@@ -1418,12 +1418,12 @@ impl core::ops::BitAnd for KeyCredentialManagerOperationErrorStates {
 }
 impl core::ops::BitOrAssign for KeyCredentialManagerOperationErrorStates {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for KeyCredentialManagerOperationErrorStates {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for KeyCredentialManagerOperationErrorStates {

--- a/crates/libs/windows/src/Windows/Win32/Security/Cryptography/Catalog/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/Cryptography/Catalog/mod.rs
@@ -285,12 +285,12 @@ impl core::ops::BitAnd for CRYPTCATATTRIBUTE_FLAGS {
 }
 impl core::ops::BitOrAssign for CRYPTCATATTRIBUTE_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CRYPTCATATTRIBUTE_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CRYPTCATATTRIBUTE_FLAGS {
@@ -402,12 +402,12 @@ impl core::ops::BitAnd for CRYPTCAT_OPEN_FLAGS {
 }
 impl core::ops::BitOrAssign for CRYPTCAT_OPEN_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CRYPTCAT_OPEN_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CRYPTCAT_OPEN_FLAGS {

--- a/crates/libs/windows/src/Windows/Win32/Security/Cryptography/Certificates/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/Cryptography/Certificates/mod.rs
@@ -297,12 +297,12 @@ impl core::ops::BitAnd for CERTADMIN_GET_ROLES_FLAGS {
 }
 impl core::ops::BitOrAssign for CERTADMIN_GET_ROLES_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CERTADMIN_GET_ROLES_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CERTADMIN_GET_ROLES_FLAGS {
@@ -381,12 +381,12 @@ impl core::ops::BitAnd for CERT_EXIT_EVENT_MASK {
 }
 impl core::ops::BitOrAssign for CERT_EXIT_EVENT_MASK {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CERT_EXIT_EVENT_MASK {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CERT_EXIT_EVENT_MASK {

--- a/crates/libs/windows/src/Windows/Win32/Security/Cryptography/UI/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/Cryptography/UI/mod.rs
@@ -175,12 +175,12 @@ impl core::ops::BitAnd for CERT_SELECT_STRUCT_FLAGS {
 }
 impl core::ops::BitOrAssign for CERT_SELECT_STRUCT_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CERT_SELECT_STRUCT_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CERT_SELECT_STRUCT_FLAGS {
@@ -322,12 +322,12 @@ impl core::ops::BitAnd for CERT_VIEWPROPERTIES_STRUCT_FLAGS {
 }
 impl core::ops::BitOrAssign for CERT_VIEWPROPERTIES_STRUCT_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CERT_VIEWPROPERTIES_STRUCT_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CERT_VIEWPROPERTIES_STRUCT_FLAGS {
@@ -457,12 +457,12 @@ impl core::ops::BitAnd for CRYPTUI_VIEWCERTIFICATE_FLAGS {
 }
 impl core::ops::BitOrAssign for CRYPTUI_VIEWCERTIFICATE_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CRYPTUI_VIEWCERTIFICATE_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CRYPTUI_VIEWCERTIFICATE_FLAGS {
@@ -798,12 +798,12 @@ impl core::ops::BitAnd for CRYPTUI_WIZ_FLAGS {
 }
 impl core::ops::BitOrAssign for CRYPTUI_WIZ_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CRYPTUI_WIZ_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CRYPTUI_WIZ_FLAGS {

--- a/crates/libs/windows/src/Windows/Win32/Security/Cryptography/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/Cryptography/mod.rs
@@ -3476,12 +3476,12 @@ impl core::ops::BitAnd for BCRYPT_FLAGS {
 }
 impl core::ops::BitOrAssign for BCRYPT_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for BCRYPT_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for BCRYPT_FLAGS {
@@ -3806,12 +3806,12 @@ impl core::ops::BitAnd for BCRYPT_OPEN_ALGORITHM_PROVIDER_FLAGS {
 }
 impl core::ops::BitOrAssign for BCRYPT_OPEN_ALGORITHM_PROVIDER_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for BCRYPT_OPEN_ALGORITHM_PROVIDER_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for BCRYPT_OPEN_ALGORITHM_PROVIDER_FLAGS {
@@ -3842,12 +3842,12 @@ impl core::ops::BitAnd for BCRYPT_OPERATION {
 }
 impl core::ops::BitOrAssign for BCRYPT_OPERATION {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for BCRYPT_OPERATION {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for BCRYPT_OPERATION {
@@ -3957,12 +3957,12 @@ impl core::ops::BitAnd for BCRYPT_RESOLVE_PROVIDERS_FLAGS {
 }
 impl core::ops::BitOrAssign for BCRYPT_RESOLVE_PROVIDERS_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for BCRYPT_RESOLVE_PROVIDERS_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for BCRYPT_RESOLVE_PROVIDERS_FLAGS {
@@ -5037,12 +5037,12 @@ impl core::ops::BitAnd for CERT_CHAIN_POLICY_FLAGS {
 }
 impl core::ops::BitOrAssign for CERT_CHAIN_POLICY_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CERT_CHAIN_POLICY_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CERT_CHAIN_POLICY_FLAGS {
@@ -5228,12 +5228,12 @@ impl core::ops::BitAnd for CERT_CREATE_SELFSIGN_FLAGS {
 }
 impl core::ops::BitOrAssign for CERT_CREATE_SELFSIGN_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CERT_CREATE_SELFSIGN_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CERT_CREATE_SELFSIGN_FLAGS {
@@ -5352,12 +5352,12 @@ impl core::ops::BitAnd for CERT_FIND_CHAIN_IN_STORE_FLAGS {
 }
 impl core::ops::BitOrAssign for CERT_FIND_CHAIN_IN_STORE_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CERT_FIND_CHAIN_IN_STORE_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CERT_FIND_CHAIN_IN_STORE_FLAGS {
@@ -5394,12 +5394,12 @@ impl core::ops::BitAnd for CERT_FIND_FLAGS {
 }
 impl core::ops::BitOrAssign for CERT_FIND_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CERT_FIND_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CERT_FIND_FLAGS {
@@ -5890,12 +5890,12 @@ impl core::ops::BitAnd for CERT_OPEN_STORE_FLAGS {
 }
 impl core::ops::BitOrAssign for CERT_OPEN_STORE_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CERT_OPEN_STORE_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CERT_OPEN_STORE_FLAGS {
@@ -6186,12 +6186,12 @@ impl core::ops::BitAnd for CERT_QUERY_ENCODING_TYPE {
 }
 impl core::ops::BitOrAssign for CERT_QUERY_ENCODING_TYPE {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CERT_QUERY_ENCODING_TYPE {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CERT_QUERY_ENCODING_TYPE {
@@ -6410,12 +6410,12 @@ impl core::ops::BitAnd for CERT_ROOT_PROGRAM_FLAGS {
 }
 impl core::ops::BitOrAssign for CERT_ROOT_PROGRAM_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CERT_ROOT_PROGRAM_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CERT_ROOT_PROGRAM_FLAGS {
@@ -6658,12 +6658,12 @@ impl core::ops::BitAnd for CERT_STORE_PROV_FLAGS {
 }
 impl core::ops::BitOrAssign for CERT_STORE_PROV_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CERT_STORE_PROV_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CERT_STORE_PROV_FLAGS {
@@ -6777,12 +6777,12 @@ impl core::ops::BitAnd for CERT_STRONG_SIGN_FLAGS {
 }
 impl core::ops::BitOrAssign for CERT_STRONG_SIGN_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CERT_STRONG_SIGN_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CERT_STRONG_SIGN_FLAGS {
@@ -8472,12 +8472,12 @@ impl core::ops::BitAnd for CRYPT_ACQUIRE_FLAGS {
 }
 impl core::ops::BitOrAssign for CRYPT_ACQUIRE_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CRYPT_ACQUIRE_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CRYPT_ACQUIRE_FLAGS {
@@ -8658,12 +8658,12 @@ impl core::ops::BitAnd for CRYPT_CONTEXT_CONFIG_FLAGS {
 }
 impl core::ops::BitOrAssign for CRYPT_CONTEXT_CONFIG_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CRYPT_CONTEXT_CONFIG_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CRYPT_CONTEXT_CONFIG_FLAGS {
@@ -8778,12 +8778,12 @@ impl core::ops::BitAnd for CRYPT_DEFAULT_CONTEXT_FLAGS {
 }
 impl core::ops::BitOrAssign for CRYPT_DEFAULT_CONTEXT_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CRYPT_DEFAULT_CONTEXT_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CRYPT_DEFAULT_CONTEXT_FLAGS {
@@ -8880,12 +8880,12 @@ impl core::ops::BitAnd for CRYPT_ENCODE_OBJECT_FLAGS {
 }
 impl core::ops::BitOrAssign for CRYPT_ENCODE_OBJECT_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CRYPT_ENCODE_OBJECT_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CRYPT_ENCODE_OBJECT_FLAGS {
@@ -9006,12 +9006,12 @@ impl core::ops::BitAnd for CRYPT_GET_URL_FLAGS {
 }
 impl core::ops::BitOrAssign for CRYPT_GET_URL_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CRYPT_GET_URL_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CRYPT_GET_URL_FLAGS {
@@ -9074,12 +9074,12 @@ impl core::ops::BitAnd for CRYPT_IMAGE_REF_FLAGS {
 }
 impl core::ops::BitOrAssign for CRYPT_IMAGE_REF_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CRYPT_IMAGE_REF_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CRYPT_IMAGE_REF_FLAGS {
@@ -9128,12 +9128,12 @@ impl core::ops::BitAnd for CRYPT_IMPORT_PUBLIC_KEY_FLAGS {
 }
 impl core::ops::BitOrAssign for CRYPT_IMPORT_PUBLIC_KEY_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CRYPT_IMPORT_PUBLIC_KEY_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CRYPT_IMPORT_PUBLIC_KEY_FLAGS {
@@ -9199,12 +9199,12 @@ impl core::ops::BitAnd for CRYPT_KEY_FLAGS {
 }
 impl core::ops::BitOrAssign for CRYPT_KEY_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CRYPT_KEY_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CRYPT_KEY_FLAGS {
@@ -10455,12 +10455,12 @@ impl core::ops::BitAnd for CRYPT_XML_TRANSFORM_FLAGS {
 }
 impl core::ops::BitOrAssign for CRYPT_XML_TRANSFORM_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CRYPT_XML_TRANSFORM_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CRYPT_XML_TRANSFORM_FLAGS {
@@ -12704,12 +12704,12 @@ impl core::ops::BitAnd for NCRYPT_FLAGS {
 }
 impl core::ops::BitOrAssign for NCRYPT_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for NCRYPT_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for NCRYPT_FLAGS {
@@ -12932,12 +12932,12 @@ impl core::ops::BitAnd for NCRYPT_OPERATION {
 }
 impl core::ops::BitOrAssign for NCRYPT_OPERATION {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for NCRYPT_OPERATION {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for NCRYPT_OPERATION {
@@ -14246,12 +14246,12 @@ impl core::ops::BitAnd for SIGNER_CERT_POLICY {
 }
 impl core::ops::BitOrAssign for SIGNER_CERT_POLICY {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for SIGNER_CERT_POLICY {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for SIGNER_CERT_POLICY {
@@ -14433,12 +14433,12 @@ impl core::ops::BitAnd for SIGNER_SIGN_FLAGS {
 }
 impl core::ops::BitOrAssign for SIGNER_SIGN_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for SIGNER_SIGN_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for SIGNER_SIGN_FLAGS {

--- a/crates/libs/windows/src/Windows/Win32/Security/EnterpriseData/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/EnterpriseData/mod.rs
@@ -116,12 +116,12 @@ impl core::ops::BitAnd for ENTERPRISE_DATA_POLICIES {
 }
 impl core::ops::BitOrAssign for ENTERPRISE_DATA_POLICIES {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for ENTERPRISE_DATA_POLICIES {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for ENTERPRISE_DATA_POLICIES {

--- a/crates/libs/windows/src/Windows/Win32/Security/WinTrust/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/WinTrust/mod.rs
@@ -889,12 +889,12 @@ impl core::ops::BitAnd for WINTRUST_DATA_PROVIDER_FLAGS {
 }
 impl core::ops::BitOrAssign for WINTRUST_DATA_PROVIDER_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for WINTRUST_DATA_PROVIDER_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for WINTRUST_DATA_PROVIDER_FLAGS {
@@ -1004,12 +1004,12 @@ impl core::ops::BitAnd for WINTRUST_POLICY_FLAGS {
 }
 impl core::ops::BitOrAssign for WINTRUST_POLICY_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for WINTRUST_POLICY_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for WINTRUST_POLICY_FLAGS {
@@ -1073,12 +1073,12 @@ impl core::ops::BitAnd for WINTRUST_SIGNATURE_SETTINGS_FLAGS {
 }
 impl core::ops::BitOrAssign for WINTRUST_SIGNATURE_SETTINGS_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for WINTRUST_SIGNATURE_SETTINGS_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for WINTRUST_SIGNATURE_SETTINGS_FLAGS {

--- a/crates/libs/windows/src/Windows/Win32/Security/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/mod.rs
@@ -966,12 +966,12 @@ impl core::ops::BitAnd for ACE_FLAGS {
 }
 impl core::ops::BitOrAssign for ACE_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for ACE_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for ACE_FLAGS {
@@ -1074,12 +1074,12 @@ impl core::ops::BitAnd for CLAIM_SECURITY_ATTRIBUTE_FLAGS {
 }
 impl core::ops::BitOrAssign for CLAIM_SECURITY_ATTRIBUTE_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CLAIM_SECURITY_ATTRIBUTE_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CLAIM_SECURITY_ATTRIBUTE_FLAGS {
@@ -1200,12 +1200,12 @@ impl core::ops::BitAnd for CREATE_RESTRICTED_TOKEN_FLAGS {
 }
 impl core::ops::BitOrAssign for CREATE_RESTRICTED_TOKEN_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CREATE_RESTRICTED_TOKEN_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CREATE_RESTRICTED_TOKEN_FLAGS {
@@ -1349,12 +1349,12 @@ impl core::ops::BitAnd for OBJECT_SECURITY_INFORMATION {
 }
 impl core::ops::BitOrAssign for OBJECT_SECURITY_INFORMATION {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for OBJECT_SECURITY_INFORMATION {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for OBJECT_SECURITY_INFORMATION {
@@ -1479,12 +1479,12 @@ impl core::ops::BitAnd for SECURITY_AUTO_INHERIT_FLAGS {
 }
 impl core::ops::BitOrAssign for SECURITY_AUTO_INHERIT_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for SECURITY_AUTO_INHERIT_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for SECURITY_AUTO_INHERIT_FLAGS {
@@ -1545,12 +1545,12 @@ impl core::ops::BitAnd for SECURITY_DESCRIPTOR_CONTROL {
 }
 impl core::ops::BitOrAssign for SECURITY_DESCRIPTOR_CONTROL {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for SECURITY_DESCRIPTOR_CONTROL {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for SECURITY_DESCRIPTOR_CONTROL {
@@ -1870,12 +1870,12 @@ impl core::ops::BitAnd for SYSTEM_AUDIT_OBJECT_ACE_FLAGS {
 }
 impl core::ops::BitOrAssign for SYSTEM_AUDIT_OBJECT_ACE_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for SYSTEM_AUDIT_OBJECT_ACE_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for SYSTEM_AUDIT_OBJECT_ACE_FLAGS {
@@ -1971,12 +1971,12 @@ impl core::ops::BitAnd for TOKEN_ACCESS_MASK {
 }
 impl core::ops::BitOrAssign for TOKEN_ACCESS_MASK {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for TOKEN_ACCESS_MASK {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for TOKEN_ACCESS_MASK {
@@ -2152,12 +2152,12 @@ impl core::ops::BitAnd for TOKEN_PRIVILEGES_ATTRIBUTES {
 }
 impl core::ops::BitOrAssign for TOKEN_PRIVILEGES_ATTRIBUTES {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for TOKEN_PRIVILEGES_ATTRIBUTES {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for TOKEN_PRIVILEGES_ATTRIBUTES {

--- a/crates/libs/windows/src/Windows/Win32/Storage/CloudFilters/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/CloudFilters/mod.rs
@@ -251,12 +251,12 @@ impl core::ops::BitAnd for CF_CALLBACK_CANCEL_FLAGS {
 }
 impl core::ops::BitOrAssign for CF_CALLBACK_CANCEL_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CF_CALLBACK_CANCEL_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CF_CALLBACK_CANCEL_FLAGS {
@@ -290,12 +290,12 @@ impl core::ops::BitAnd for CF_CALLBACK_CLOSE_COMPLETION_FLAGS {
 }
 impl core::ops::BitOrAssign for CF_CALLBACK_CLOSE_COMPLETION_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CF_CALLBACK_CLOSE_COMPLETION_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CF_CALLBACK_CLOSE_COMPLETION_FLAGS {
@@ -328,12 +328,12 @@ impl core::ops::BitAnd for CF_CALLBACK_DEHYDRATE_COMPLETION_FLAGS {
 }
 impl core::ops::BitOrAssign for CF_CALLBACK_DEHYDRATE_COMPLETION_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CF_CALLBACK_DEHYDRATE_COMPLETION_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CF_CALLBACK_DEHYDRATE_COMPLETION_FLAGS {
@@ -367,12 +367,12 @@ impl core::ops::BitAnd for CF_CALLBACK_DEHYDRATE_FLAGS {
 }
 impl core::ops::BitOrAssign for CF_CALLBACK_DEHYDRATE_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CF_CALLBACK_DEHYDRATE_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CF_CALLBACK_DEHYDRATE_FLAGS {
@@ -413,12 +413,12 @@ impl core::ops::BitAnd for CF_CALLBACK_DELETE_COMPLETION_FLAGS {
 }
 impl core::ops::BitOrAssign for CF_CALLBACK_DELETE_COMPLETION_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CF_CALLBACK_DELETE_COMPLETION_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CF_CALLBACK_DELETE_COMPLETION_FLAGS {
@@ -450,12 +450,12 @@ impl core::ops::BitAnd for CF_CALLBACK_DELETE_FLAGS {
 }
 impl core::ops::BitOrAssign for CF_CALLBACK_DELETE_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CF_CALLBACK_DELETE_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CF_CALLBACK_DELETE_FLAGS {
@@ -489,12 +489,12 @@ impl core::ops::BitAnd for CF_CALLBACK_FETCH_DATA_FLAGS {
 }
 impl core::ops::BitOrAssign for CF_CALLBACK_FETCH_DATA_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CF_CALLBACK_FETCH_DATA_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CF_CALLBACK_FETCH_DATA_FLAGS {
@@ -528,12 +528,12 @@ impl core::ops::BitAnd for CF_CALLBACK_FETCH_PLACEHOLDERS_FLAGS {
 }
 impl core::ops::BitOrAssign for CF_CALLBACK_FETCH_PLACEHOLDERS_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CF_CALLBACK_FETCH_PLACEHOLDERS_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CF_CALLBACK_FETCH_PLACEHOLDERS_FLAGS {
@@ -595,12 +595,12 @@ impl core::ops::BitAnd for CF_CALLBACK_OPEN_COMPLETION_FLAGS {
 }
 impl core::ops::BitOrAssign for CF_CALLBACK_OPEN_COMPLETION_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CF_CALLBACK_OPEN_COMPLETION_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CF_CALLBACK_OPEN_COMPLETION_FLAGS {
@@ -768,12 +768,12 @@ impl core::ops::BitAnd for CF_CALLBACK_RENAME_COMPLETION_FLAGS {
 }
 impl core::ops::BitOrAssign for CF_CALLBACK_RENAME_COMPLETION_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CF_CALLBACK_RENAME_COMPLETION_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CF_CALLBACK_RENAME_COMPLETION_FLAGS {
@@ -805,12 +805,12 @@ impl core::ops::BitAnd for CF_CALLBACK_RENAME_FLAGS {
 }
 impl core::ops::BitOrAssign for CF_CALLBACK_RENAME_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CF_CALLBACK_RENAME_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CF_CALLBACK_RENAME_FLAGS {
@@ -862,12 +862,12 @@ impl core::ops::BitAnd for CF_CALLBACK_VALIDATE_DATA_FLAGS {
 }
 impl core::ops::BitOrAssign for CF_CALLBACK_VALIDATE_DATA_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CF_CALLBACK_VALIDATE_DATA_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CF_CALLBACK_VALIDATE_DATA_FLAGS {
@@ -919,12 +919,12 @@ impl core::ops::BitAnd for CF_CONNECT_FLAGS {
 }
 impl core::ops::BitOrAssign for CF_CONNECT_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CF_CONNECT_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CF_CONNECT_FLAGS {
@@ -959,12 +959,12 @@ impl core::ops::BitAnd for CF_CONVERT_FLAGS {
 }
 impl core::ops::BitOrAssign for CF_CONVERT_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CF_CONVERT_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CF_CONVERT_FLAGS {
@@ -1001,12 +1001,12 @@ impl core::ops::BitAnd for CF_CREATE_FLAGS {
 }
 impl core::ops::BitOrAssign for CF_CREATE_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CF_CREATE_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CF_CREATE_FLAGS {
@@ -1039,12 +1039,12 @@ impl core::ops::BitAnd for CF_DEHYDRATE_FLAGS {
 }
 impl core::ops::BitOrAssign for CF_DEHYDRATE_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CF_DEHYDRATE_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CF_DEHYDRATE_FLAGS {
@@ -1090,12 +1090,12 @@ impl core::ops::BitAnd for CF_HARDLINK_POLICY {
 }
 impl core::ops::BitOrAssign for CF_HARDLINK_POLICY {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CF_HARDLINK_POLICY {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CF_HARDLINK_POLICY {
@@ -1128,12 +1128,12 @@ impl core::ops::BitAnd for CF_HYDRATE_FLAGS {
 }
 impl core::ops::BitOrAssign for CF_HYDRATE_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CF_HYDRATE_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CF_HYDRATE_FLAGS {
@@ -1173,12 +1173,12 @@ impl core::ops::BitAnd for CF_HYDRATION_POLICY_MODIFIER {
 }
 impl core::ops::BitOrAssign for CF_HYDRATION_POLICY_MODIFIER {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CF_HYDRATION_POLICY_MODIFIER {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CF_HYDRATION_POLICY_MODIFIER {
@@ -1219,12 +1219,12 @@ impl core::ops::BitAnd for CF_INSYNC_POLICY {
 }
 impl core::ops::BitOrAssign for CF_INSYNC_POLICY {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CF_INSYNC_POLICY {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CF_INSYNC_POLICY {
@@ -1278,12 +1278,12 @@ impl core::ops::BitAnd for CF_OPEN_FILE_FLAGS {
 }
 impl core::ops::BitOrAssign for CF_OPEN_FILE_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CF_OPEN_FILE_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CF_OPEN_FILE_FLAGS {
@@ -1319,12 +1319,12 @@ impl core::ops::BitAnd for CF_OPERATION_ACK_DATA_FLAGS {
 }
 impl core::ops::BitOrAssign for CF_OPERATION_ACK_DATA_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CF_OPERATION_ACK_DATA_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CF_OPERATION_ACK_DATA_FLAGS {
@@ -1356,12 +1356,12 @@ impl core::ops::BitAnd for CF_OPERATION_ACK_DEHYDRATE_FLAGS {
 }
 impl core::ops::BitOrAssign for CF_OPERATION_ACK_DEHYDRATE_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CF_OPERATION_ACK_DEHYDRATE_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CF_OPERATION_ACK_DEHYDRATE_FLAGS {
@@ -1393,12 +1393,12 @@ impl core::ops::BitAnd for CF_OPERATION_ACK_DELETE_FLAGS {
 }
 impl core::ops::BitOrAssign for CF_OPERATION_ACK_DELETE_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CF_OPERATION_ACK_DELETE_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CF_OPERATION_ACK_DELETE_FLAGS {
@@ -1430,12 +1430,12 @@ impl core::ops::BitAnd for CF_OPERATION_ACK_RENAME_FLAGS {
 }
 impl core::ops::BitOrAssign for CF_OPERATION_ACK_RENAME_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CF_OPERATION_ACK_RENAME_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CF_OPERATION_ACK_RENAME_FLAGS {
@@ -1619,12 +1619,12 @@ impl core::ops::BitAnd for CF_OPERATION_RESTART_HYDRATION_FLAGS {
 }
 impl core::ops::BitOrAssign for CF_OPERATION_RESTART_HYDRATION_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CF_OPERATION_RESTART_HYDRATION_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CF_OPERATION_RESTART_HYDRATION_FLAGS {
@@ -1657,12 +1657,12 @@ impl core::ops::BitAnd for CF_OPERATION_RETRIEVE_DATA_FLAGS {
 }
 impl core::ops::BitOrAssign for CF_OPERATION_RETRIEVE_DATA_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CF_OPERATION_RETRIEVE_DATA_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CF_OPERATION_RETRIEVE_DATA_FLAGS {
@@ -1694,12 +1694,12 @@ impl core::ops::BitAnd for CF_OPERATION_TRANSFER_DATA_FLAGS {
 }
 impl core::ops::BitOrAssign for CF_OPERATION_TRANSFER_DATA_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CF_OPERATION_TRANSFER_DATA_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CF_OPERATION_TRANSFER_DATA_FLAGS {
@@ -1731,12 +1731,12 @@ impl core::ops::BitAnd for CF_OPERATION_TRANSFER_PLACEHOLDERS_FLAGS {
 }
 impl core::ops::BitOrAssign for CF_OPERATION_TRANSFER_PLACEHOLDERS_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CF_OPERATION_TRANSFER_PLACEHOLDERS_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CF_OPERATION_TRANSFER_PLACEHOLDERS_FLAGS {
@@ -1804,12 +1804,12 @@ impl core::ops::BitAnd for CF_PLACEHOLDER_CREATE_FLAGS {
 }
 impl core::ops::BitOrAssign for CF_PLACEHOLDER_CREATE_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CF_PLACEHOLDER_CREATE_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CF_PLACEHOLDER_CREATE_FLAGS {
@@ -1901,12 +1901,12 @@ impl core::ops::BitAnd for CF_PLACEHOLDER_STATE {
 }
 impl core::ops::BitOrAssign for CF_PLACEHOLDER_STATE {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CF_PLACEHOLDER_STATE {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CF_PLACEHOLDER_STATE {
@@ -1960,12 +1960,12 @@ impl core::ops::BitAnd for CF_POPULATION_POLICY_MODIFIER {
 }
 impl core::ops::BitOrAssign for CF_POPULATION_POLICY_MODIFIER {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CF_POPULATION_POLICY_MODIFIER {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CF_POPULATION_POLICY_MODIFIER {
@@ -2023,12 +2023,12 @@ impl core::ops::BitAnd for CF_REGISTER_FLAGS {
 }
 impl core::ops::BitOrAssign for CF_REGISTER_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CF_REGISTER_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CF_REGISTER_FLAGS {
@@ -2064,12 +2064,12 @@ impl core::ops::BitAnd for CF_REVERT_FLAGS {
 }
 impl core::ops::BitOrAssign for CF_REVERT_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CF_REVERT_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CF_REVERT_FLAGS {
@@ -2101,12 +2101,12 @@ impl core::ops::BitAnd for CF_SET_IN_SYNC_FLAGS {
 }
 impl core::ops::BitOrAssign for CF_SET_IN_SYNC_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CF_SET_IN_SYNC_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CF_SET_IN_SYNC_FLAGS {
@@ -2138,12 +2138,12 @@ impl core::ops::BitAnd for CF_SET_PIN_FLAGS {
 }
 impl core::ops::BitOrAssign for CF_SET_PIN_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CF_SET_PIN_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CF_SET_PIN_FLAGS {
@@ -2188,12 +2188,12 @@ impl core::ops::BitAnd for CF_SYNC_PROVIDER_STATUS {
 }
 impl core::ops::BitOrAssign for CF_SYNC_PROVIDER_STATUS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CF_SYNC_PROVIDER_STATUS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CF_SYNC_PROVIDER_STATUS {
@@ -2293,12 +2293,12 @@ impl core::ops::BitAnd for CF_UPDATE_FLAGS {
 }
 impl core::ops::BitOrAssign for CF_UPDATE_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CF_UPDATE_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CF_UPDATE_FLAGS {

--- a/crates/libs/windows/src/Windows/Win32/Storage/FileSystem/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/FileSystem/mod.rs
@@ -3085,12 +3085,12 @@ impl core::ops::BitAnd for CLFS_FLAG {
 }
 impl core::ops::BitOrAssign for CLFS_FLAG {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CLFS_FLAG {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CLFS_FLAG {
@@ -3593,12 +3593,12 @@ impl core::ops::BitAnd for COPYFILE2_V2_FLAGS {
 }
 impl core::ops::BitOrAssign for COPYFILE2_V2_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for COPYFILE2_V2_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for COPYFILE2_V2_FLAGS {
@@ -3629,12 +3629,12 @@ impl core::ops::BitAnd for COPYFILE_FLAGS {
 }
 impl core::ops::BitOrAssign for COPYFILE_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for COPYFILE_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for COPYFILE_FLAGS {
@@ -3665,12 +3665,12 @@ impl core::ops::BitAnd for COPYPROGRESSROUTINE_PROGRESS {
 }
 impl core::ops::BitOrAssign for COPYPROGRESSROUTINE_PROGRESS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for COPYPROGRESSROUTINE_PROGRESS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for COPYPROGRESSROUTINE_PROGRESS {
@@ -3759,12 +3759,12 @@ impl core::ops::BitAnd for CREATE_BIND_LINK_FLAGS {
 }
 impl core::ops::BitOrAssign for CREATE_BIND_LINK_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CREATE_BIND_LINK_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CREATE_BIND_LINK_FLAGS {
@@ -3869,12 +3869,12 @@ impl core::ops::BitAnd for DEFINE_DOS_DEVICE_FLAGS {
 }
 impl core::ops::BitOrAssign for DEFINE_DOS_DEVICE_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for DEFINE_DOS_DEVICE_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for DEFINE_DOS_DEVICE_FLAGS {
@@ -3906,12 +3906,12 @@ impl core::ops::BitAnd for DIRECTORY_FLAGS {
 }
 impl core::ops::BitOrAssign for DIRECTORY_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for DIRECTORY_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for DIRECTORY_FLAGS {
@@ -4200,12 +4200,12 @@ impl core::ops::BitAnd for FILE_ACCESS_RIGHTS {
 }
 impl core::ops::BitOrAssign for FILE_ACCESS_RIGHTS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for FILE_ACCESS_RIGHTS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for FILE_ACCESS_RIGHTS {
@@ -4361,12 +4361,12 @@ impl core::ops::BitAnd for FILE_FLAGS_AND_ATTRIBUTES {
 }
 impl core::ops::BitOrAssign for FILE_FLAGS_AND_ATTRIBUTES {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for FILE_FLAGS_AND_ATTRIBUTES {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for FILE_FLAGS_AND_ATTRIBUTES {
@@ -4550,12 +4550,12 @@ impl core::ops::BitAnd for FILE_INFO_FLAGS_PERMISSIONS {
 }
 impl core::ops::BitOrAssign for FILE_INFO_FLAGS_PERMISSIONS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for FILE_INFO_FLAGS_PERMISSIONS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for FILE_INFO_FLAGS_PERMISSIONS {
@@ -4605,12 +4605,12 @@ impl core::ops::BitAnd for FILE_NOTIFY_CHANGE {
 }
 impl core::ops::BitOrAssign for FILE_NOTIFY_CHANGE {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for FILE_NOTIFY_CHANGE {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for FILE_NOTIFY_CHANGE {
@@ -4796,12 +4796,12 @@ impl core::ops::BitAnd for FILE_SHARE_MODE {
 }
 impl core::ops::BitOrAssign for FILE_SHARE_MODE {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for FILE_SHARE_MODE {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for FILE_SHARE_MODE {
@@ -4903,12 +4903,12 @@ impl core::ops::BitAnd for FILE_WRITE_FLAGS {
 }
 impl core::ops::BitOrAssign for FILE_WRITE_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for FILE_WRITE_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for FILE_WRITE_FLAGS {
@@ -4948,12 +4948,12 @@ impl core::ops::BitAnd for FIND_FIRST_EX_FLAGS {
 }
 impl core::ops::BitOrAssign for FIND_FIRST_EX_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for FIND_FIRST_EX_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for FIND_FIRST_EX_FLAGS {
@@ -5040,12 +5040,12 @@ impl core::ops::BitAnd for GET_FILE_VERSION_INFO_FLAGS {
 }
 impl core::ops::BitOrAssign for GET_FILE_VERSION_INFO_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for GET_FILE_VERSION_INFO_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for GET_FILE_VERSION_INFO_FLAGS {
@@ -5958,12 +5958,12 @@ impl core::ops::BitAnd for IORING_CREATE_ADVISORY_FLAGS {
 }
 impl core::ops::BitOrAssign for IORING_CREATE_ADVISORY_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for IORING_CREATE_ADVISORY_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for IORING_CREATE_ADVISORY_FLAGS {
@@ -6001,12 +6001,12 @@ impl core::ops::BitAnd for IORING_CREATE_REQUIRED_FLAGS {
 }
 impl core::ops::BitOrAssign for IORING_CREATE_REQUIRED_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for IORING_CREATE_REQUIRED_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for IORING_CREATE_REQUIRED_FLAGS {
@@ -6039,12 +6039,12 @@ impl core::ops::BitAnd for IORING_FEATURE_FLAGS {
 }
 impl core::ops::BitOrAssign for IORING_FEATURE_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for IORING_FEATURE_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for IORING_FEATURE_FLAGS {
@@ -6131,12 +6131,12 @@ impl core::ops::BitAnd for IORING_SQE_FLAGS {
 }
 impl core::ops::BitOrAssign for IORING_SQE_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for IORING_SQE_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for IORING_SQE_FLAGS {
@@ -6216,12 +6216,12 @@ impl core::ops::BitAnd for LOCK_FILE_FLAGS {
 }
 impl core::ops::BitOrAssign for LOCK_FILE_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for LOCK_FILE_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for LOCK_FILE_FLAGS {
@@ -6279,12 +6279,12 @@ impl core::ops::BitAnd for LZOPENFILE_STYLE {
 }
 impl core::ops::BitOrAssign for LZOPENFILE_STYLE {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for LZOPENFILE_STYLE {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for LZOPENFILE_STYLE {
@@ -6326,12 +6326,12 @@ impl core::ops::BitAnd for MOVE_FILE_FLAGS {
 }
 impl core::ops::BitOrAssign for MOVE_FILE_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for MOVE_FILE_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for MOVE_FILE_FLAGS {
@@ -7663,12 +7663,12 @@ impl core::ops::BitAnd for REPLACE_FILE_FLAGS {
 }
 impl core::ops::BitOrAssign for REPLACE_FILE_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for REPLACE_FILE_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for REPLACE_FILE_FLAGS {
@@ -7884,12 +7884,12 @@ impl core::ops::BitAnd for SHARE_TYPE {
 }
 impl core::ops::BitOrAssign for SHARE_TYPE {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for SHARE_TYPE {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for SHARE_TYPE {
@@ -8032,12 +8032,12 @@ impl core::ops::BitAnd for SYMBOLIC_LINK_FLAGS {
 }
 impl core::ops::BitOrAssign for SYMBOLIC_LINK_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for SYMBOLIC_LINK_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for SYMBOLIC_LINK_FLAGS {
@@ -8310,12 +8310,12 @@ impl core::ops::BitAnd for VER_FIND_FILE_STATUS {
 }
 impl core::ops::BitOrAssign for VER_FIND_FILE_STATUS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for VER_FIND_FILE_STATUS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for VER_FIND_FILE_STATUS {
@@ -8349,12 +8349,12 @@ impl core::ops::BitAnd for VER_INSTALL_FILE_STATUS {
 }
 impl core::ops::BitOrAssign for VER_INSTALL_FILE_STATUS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for VER_INSTALL_FILE_STATUS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for VER_INSTALL_FILE_STATUS {
@@ -8620,12 +8620,12 @@ impl core::ops::BitAnd for VS_FIXEDFILEINFO_FILE_FLAGS {
 }
 impl core::ops::BitOrAssign for VS_FIXEDFILEINFO_FILE_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for VS_FIXEDFILEINFO_FILE_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for VS_FIXEDFILEINFO_FILE_FLAGS {

--- a/crates/libs/windows/src/Windows/Win32/Storage/OperationRecorder/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/OperationRecorder/mod.rs
@@ -38,12 +38,12 @@ impl core::ops::BitAnd for OPERATION_END_PARAMETERS_FLAGS {
 }
 impl core::ops::BitOrAssign for OPERATION_END_PARAMETERS_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for OPERATION_END_PARAMETERS_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for OPERATION_END_PARAMETERS_FLAGS {
@@ -74,12 +74,12 @@ impl core::ops::BitAnd for OPERATION_START_FLAGS {
 }
 impl core::ops::BitOrAssign for OPERATION_START_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for OPERATION_START_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for OPERATION_START_FLAGS {

--- a/crates/libs/windows/src/Windows/Win32/Storage/Packaging/Appx/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/Packaging/Appx/mod.rs
@@ -516,12 +516,12 @@ impl core::ops::BitAnd for APPX_CAPABILITIES {
 }
 impl core::ops::BitOrAssign for APPX_CAPABILITIES {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for APPX_CAPABILITIES {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for APPX_CAPABILITIES {
@@ -592,12 +592,12 @@ impl core::ops::BitAnd for APPX_ENCRYPTED_PACKAGE_OPTIONS {
 }
 impl core::ops::BitOrAssign for APPX_ENCRYPTED_PACKAGE_OPTIONS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for APPX_ENCRYPTED_PACKAGE_OPTIONS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for APPX_ENCRYPTED_PACKAGE_OPTIONS {
@@ -688,12 +688,12 @@ impl core::ops::BitAnd for APPX_PACKAGE_EDITOR_UPDATE_PACKAGE_MANIFEST_OPTIONS {
 }
 impl core::ops::BitOrAssign for APPX_PACKAGE_EDITOR_UPDATE_PACKAGE_MANIFEST_OPTIONS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for APPX_PACKAGE_EDITOR_UPDATE_PACKAGE_MANIFEST_OPTIONS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for APPX_PACKAGE_EDITOR_UPDATE_PACKAGE_MANIFEST_OPTIONS {
@@ -754,12 +754,12 @@ impl core::ops::BitAnd for AddPackageDependencyOptions {
 }
 impl core::ops::BitOrAssign for AddPackageDependencyOptions {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for AddPackageDependencyOptions {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for AddPackageDependencyOptions {
@@ -790,12 +790,12 @@ impl core::ops::BitAnd for AddPackageDependencyOptions2 {
 }
 impl core::ops::BitOrAssign for AddPackageDependencyOptions2 {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for AddPackageDependencyOptions2 {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for AddPackageDependencyOptions2 {
@@ -881,12 +881,12 @@ impl core::ops::BitAnd for CreatePackageDependencyOptions {
 }
 impl core::ops::BitOrAssign for CreatePackageDependencyOptions {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CreatePackageDependencyOptions {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CreatePackageDependencyOptions {
@@ -8228,12 +8228,12 @@ impl core::ops::BitAnd for PackageDependencyProcessorArchitectures {
 }
 impl core::ops::BitOrAssign for PackageDependencyProcessorArchitectures {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for PackageDependencyProcessorArchitectures {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for PackageDependencyProcessorArchitectures {

--- a/crates/libs/windows/src/Windows/Win32/Storage/Packaging/Opc/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/Packaging/Opc/mod.rs
@@ -4113,12 +4113,12 @@ impl core::ops::BitAnd for OPC_READ_FLAGS {
 }
 impl core::ops::BitOrAssign for OPC_READ_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for OPC_READ_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for OPC_READ_FLAGS {
@@ -4185,12 +4185,12 @@ impl core::ops::BitAnd for OPC_WRITE_FLAGS {
 }
 impl core::ops::BitOrAssign for OPC_WRITE_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for OPC_WRITE_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for OPC_WRITE_FLAGS {

--- a/crates/libs/windows/src/Windows/Win32/Storage/ProjectedFileSystem/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/ProjectedFileSystem/mod.rs
@@ -291,12 +291,12 @@ impl core::ops::BitAnd for PRJ_FILE_STATE {
 }
 impl core::ops::BitOrAssign for PRJ_FILE_STATE {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for PRJ_FILE_STATE {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for PRJ_FILE_STATE {
@@ -413,12 +413,12 @@ impl core::ops::BitAnd for PRJ_NOTIFY_TYPES {
 }
 impl core::ops::BitOrAssign for PRJ_NOTIFY_TYPES {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for PRJ_NOTIFY_TYPES {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for PRJ_NOTIFY_TYPES {
@@ -499,12 +499,12 @@ impl core::ops::BitAnd for PRJ_STARTVIRTUALIZING_FLAGS {
 }
 impl core::ops::BitOrAssign for PRJ_STARTVIRTUALIZING_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for PRJ_STARTVIRTUALIZING_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for PRJ_STARTVIRTUALIZING_FLAGS {
@@ -554,12 +554,12 @@ impl core::ops::BitAnd for PRJ_UPDATE_FAILURE_CAUSES {
 }
 impl core::ops::BitOrAssign for PRJ_UPDATE_FAILURE_CAUSES {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for PRJ_UPDATE_FAILURE_CAUSES {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for PRJ_UPDATE_FAILURE_CAUSES {
@@ -599,12 +599,12 @@ impl core::ops::BitAnd for PRJ_UPDATE_TYPES {
 }
 impl core::ops::BitOrAssign for PRJ_UPDATE_TYPES {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for PRJ_UPDATE_TYPES {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for PRJ_UPDATE_TYPES {

--- a/crates/libs/windows/src/Windows/Win32/Storage/Vhd/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/Vhd/mod.rs
@@ -186,12 +186,12 @@ impl core::ops::BitAnd for APPLY_SNAPSHOT_VHDSET_FLAG {
 }
 impl core::ops::BitOrAssign for APPLY_SNAPSHOT_VHDSET_FLAG {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for APPLY_SNAPSHOT_VHDSET_FLAG {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for APPLY_SNAPSHOT_VHDSET_FLAG {
@@ -256,12 +256,12 @@ impl core::ops::BitAnd for ATTACH_VIRTUAL_DISK_FLAG {
 }
 impl core::ops::BitOrAssign for ATTACH_VIRTUAL_DISK_FLAG {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for ATTACH_VIRTUAL_DISK_FLAG {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for ATTACH_VIRTUAL_DISK_FLAG {
@@ -343,12 +343,12 @@ impl core::ops::BitAnd for COMPACT_VIRTUAL_DISK_FLAG {
 }
 impl core::ops::BitOrAssign for COMPACT_VIRTUAL_DISK_FLAG {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for COMPACT_VIRTUAL_DISK_FLAG {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for COMPACT_VIRTUAL_DISK_FLAG {
@@ -413,12 +413,12 @@ impl core::ops::BitAnd for CREATE_VIRTUAL_DISK_FLAG {
 }
 impl core::ops::BitOrAssign for CREATE_VIRTUAL_DISK_FLAG {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CREATE_VIRTUAL_DISK_FLAG {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CREATE_VIRTUAL_DISK_FLAG {
@@ -556,12 +556,12 @@ impl core::ops::BitAnd for DELETE_SNAPSHOT_VHDSET_FLAG {
 }
 impl core::ops::BitOrAssign for DELETE_SNAPSHOT_VHDSET_FLAG {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for DELETE_SNAPSHOT_VHDSET_FLAG {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for DELETE_SNAPSHOT_VHDSET_FLAG {
@@ -625,12 +625,12 @@ impl core::ops::BitAnd for DEPENDENT_DISK_FLAG {
 }
 impl core::ops::BitOrAssign for DEPENDENT_DISK_FLAG {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for DEPENDENT_DISK_FLAG {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for DEPENDENT_DISK_FLAG {
@@ -676,12 +676,12 @@ impl core::ops::BitAnd for DETACH_VIRTUAL_DISK_FLAG {
 }
 impl core::ops::BitOrAssign for DETACH_VIRTUAL_DISK_FLAG {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for DETACH_VIRTUAL_DISK_FLAG {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for DETACH_VIRTUAL_DISK_FLAG {
@@ -713,12 +713,12 @@ impl core::ops::BitAnd for EXPAND_VIRTUAL_DISK_FLAG {
 }
 impl core::ops::BitOrAssign for EXPAND_VIRTUAL_DISK_FLAG {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for EXPAND_VIRTUAL_DISK_FLAG {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for EXPAND_VIRTUAL_DISK_FLAG {
@@ -782,12 +782,12 @@ impl core::ops::BitAnd for FORK_VIRTUAL_DISK_FLAG {
 }
 impl core::ops::BitOrAssign for FORK_VIRTUAL_DISK_FLAG {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for FORK_VIRTUAL_DISK_FLAG {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for FORK_VIRTUAL_DISK_FLAG {
@@ -851,12 +851,12 @@ impl core::ops::BitAnd for GET_STORAGE_DEPENDENCY_FLAG {
 }
 impl core::ops::BitOrAssign for GET_STORAGE_DEPENDENCY_FLAG {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for GET_STORAGE_DEPENDENCY_FLAG {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for GET_STORAGE_DEPENDENCY_FLAG {
@@ -983,12 +983,12 @@ impl core::ops::BitAnd for MERGE_VIRTUAL_DISK_FLAG {
 }
 impl core::ops::BitOrAssign for MERGE_VIRTUAL_DISK_FLAG {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for MERGE_VIRTUAL_DISK_FLAG {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for MERGE_VIRTUAL_DISK_FLAG {
@@ -1059,12 +1059,12 @@ impl core::ops::BitAnd for MIRROR_VIRTUAL_DISK_FLAG {
 }
 impl core::ops::BitOrAssign for MIRROR_VIRTUAL_DISK_FLAG {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for MIRROR_VIRTUAL_DISK_FLAG {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for MIRROR_VIRTUAL_DISK_FLAG {
@@ -1132,12 +1132,12 @@ impl core::ops::BitAnd for MODIFY_VHDSET_FLAG {
 }
 impl core::ops::BitOrAssign for MODIFY_VHDSET_FLAG {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for MODIFY_VHDSET_FLAG {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for MODIFY_VHDSET_FLAG {
@@ -1205,12 +1205,12 @@ impl core::ops::BitAnd for OPEN_VIRTUAL_DISK_FLAG {
 }
 impl core::ops::BitOrAssign for OPEN_VIRTUAL_DISK_FLAG {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for OPEN_VIRTUAL_DISK_FLAG {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for OPEN_VIRTUAL_DISK_FLAG {
@@ -1305,12 +1305,12 @@ impl core::ops::BitAnd for QUERY_CHANGES_VIRTUAL_DISK_FLAG {
 }
 impl core::ops::BitOrAssign for QUERY_CHANGES_VIRTUAL_DISK_FLAG {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for QUERY_CHANGES_VIRTUAL_DISK_FLAG {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for QUERY_CHANGES_VIRTUAL_DISK_FLAG {
@@ -1349,12 +1349,12 @@ impl core::ops::BitAnd for RAW_SCSI_VIRTUAL_DISK_FLAG {
 }
 impl core::ops::BitOrAssign for RAW_SCSI_VIRTUAL_DISK_FLAG {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for RAW_SCSI_VIRTUAL_DISK_FLAG {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for RAW_SCSI_VIRTUAL_DISK_FLAG {
@@ -1458,12 +1458,12 @@ impl core::ops::BitAnd for RESIZE_VIRTUAL_DISK_FLAG {
 }
 impl core::ops::BitOrAssign for RESIZE_VIRTUAL_DISK_FLAG {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for RESIZE_VIRTUAL_DISK_FLAG {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for RESIZE_VIRTUAL_DISK_FLAG {
@@ -1626,12 +1626,12 @@ impl core::ops::BitAnd for TAKE_SNAPSHOT_VHDSET_FLAG {
 }
 impl core::ops::BitOrAssign for TAKE_SNAPSHOT_VHDSET_FLAG {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for TAKE_SNAPSHOT_VHDSET_FLAG {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for TAKE_SNAPSHOT_VHDSET_FLAG {
@@ -1701,12 +1701,12 @@ impl core::ops::BitAnd for VIRTUAL_DISK_ACCESS_MASK {
 }
 impl core::ops::BitOrAssign for VIRTUAL_DISK_ACCESS_MASK {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for VIRTUAL_DISK_ACCESS_MASK {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for VIRTUAL_DISK_ACCESS_MASK {

--- a/crates/libs/windows/src/Windows/Win32/Storage/Xps/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/Xps/mod.rs
@@ -12564,12 +12564,12 @@ impl core::ops::BitAnd for PSINJECT_POINT {
 }
 impl core::ops::BitOrAssign for PSINJECT_POINT {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for PSINJECT_POINT {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for PSINJECT_POINT {
@@ -12886,12 +12886,12 @@ impl core::ops::BitAnd for XPS_SIGN_FLAGS {
 }
 impl core::ops::BitOrAssign for XPS_SIGN_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for XPS_SIGN_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for XPS_SIGN_FLAGS {
@@ -12924,12 +12924,12 @@ impl core::ops::BitAnd for XPS_SIGN_POLICY {
 }
 impl core::ops::BitOrAssign for XPS_SIGN_POLICY {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for XPS_SIGN_POLICY {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for XPS_SIGN_POLICY {

--- a/crates/libs/windows/src/Windows/Win32/System/ApplicationInstallationAndServicing/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/ApplicationInstallationAndServicing/mod.rs
@@ -2788,12 +2788,12 @@ impl core::ops::BitAnd for ASM_BIND_FLAGS {
 }
 impl core::ops::BitOrAssign for ASM_BIND_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for ASM_BIND_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for ASM_BIND_FLAGS {
@@ -10074,12 +10074,12 @@ impl core::ops::BitAnd for QUERYASMINFO_FLAGS {
 }
 impl core::ops::BitOrAssign for QUERYASMINFO_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for QUERYASMINFO_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for QUERYASMINFO_FLAGS {

--- a/crates/libs/windows/src/Windows/Win32/System/ApplicationVerifier/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/ApplicationVerifier/mod.rs
@@ -86,12 +86,12 @@ impl core::ops::BitAnd for VERIFIER_ENUM_RESOURCE_FLAGS {
 }
 impl core::ops::BitOrAssign for VERIFIER_ENUM_RESOURCE_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for VERIFIER_ENUM_RESOURCE_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for VERIFIER_ENUM_RESOURCE_FLAGS {

--- a/crates/libs/windows/src/Windows/Win32/System/Com/StructuredStorage/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Com/StructuredStorage/mod.rs
@@ -3091,12 +3091,12 @@ impl core::ops::BitAnd for PROPVAR_CHANGE_FLAGS {
 }
 impl core::ops::BitOrAssign for PROPVAR_CHANGE_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for PROPVAR_CHANGE_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for PROPVAR_CHANGE_FLAGS {
@@ -3127,12 +3127,12 @@ impl core::ops::BitAnd for PROPVAR_COMPARE_FLAGS {
 }
 impl core::ops::BitOrAssign for PROPVAR_COMPARE_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for PROPVAR_COMPARE_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for PROPVAR_COMPARE_FLAGS {

--- a/crates/libs/windows/src/Windows/Win32/System/Com/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Com/mod.rs
@@ -877,12 +877,12 @@ impl core::ops::BitAnd for ADVANCED_FEATURE_FLAGS {
 }
 impl core::ops::BitOrAssign for ADVANCED_FEATURE_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for ADVANCED_FEATURE_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for ADVANCED_FEATURE_FLAGS {
@@ -1683,12 +1683,12 @@ impl core::ops::BitAnd for CLSCTX {
 }
 impl core::ops::BitOrAssign for CLSCTX {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CLSCTX {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CLSCTX {
@@ -1784,12 +1784,12 @@ impl core::ops::BitAnd for COINIT {
 }
 impl core::ops::BitOrAssign for COINIT {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for COINIT {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for COINIT {
@@ -1897,12 +1897,12 @@ impl core::ops::BitAnd for COWAIT_FLAGS {
 }
 impl core::ops::BitOrAssign for COWAIT_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for COWAIT_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for COWAIT_FLAGS {
@@ -2047,12 +2047,12 @@ impl core::ops::BitAnd for CWMO_FLAGS {
 }
 impl core::ops::BitOrAssign for CWMO_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CWMO_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CWMO_FLAGS {
@@ -2146,12 +2146,12 @@ impl core::ops::BitAnd for DISPATCH_FLAGS {
 }
 impl core::ops::BitOrAssign for DISPATCH_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for DISPATCH_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for DISPATCH_FLAGS {
@@ -4559,12 +4559,12 @@ impl core::ops::BitAnd for IDLFLAGS {
 }
 impl core::ops::BitOrAssign for IDLFLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for IDLFLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for IDLFLAGS {
@@ -6262,12 +6262,12 @@ impl core::ops::BitAnd for IMPLTYPEFLAGS {
 }
 impl core::ops::BitOrAssign for IMPLTYPEFLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for IMPLTYPEFLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for IMPLTYPEFLAGS {
@@ -12044,12 +12044,12 @@ impl core::ops::BitAnd for REGCLS {
 }
 impl core::ops::BitOrAssign for REGCLS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for REGCLS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for REGCLS {
@@ -12089,12 +12089,12 @@ impl core::ops::BitAnd for ROT_FLAGS {
 }
 impl core::ops::BitOrAssign for ROT_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for ROT_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for ROT_FLAGS {
@@ -12289,12 +12289,12 @@ impl core::ops::BitAnd for STGC {
 }
 impl core::ops::BitOrAssign for STGC {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for STGC {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for STGC {
@@ -12330,12 +12330,12 @@ impl core::ops::BitAnd for STGM {
 }
 impl core::ops::BitOrAssign for STGM {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for STGM {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for STGM {
@@ -12566,12 +12566,12 @@ impl core::ops::BitAnd for URI_CREATE_FLAGS {
 }
 impl core::ops::BitOrAssign for URI_CREATE_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for URI_CREATE_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for URI_CREATE_FLAGS {

--- a/crates/libs/windows/src/Windows/Win32/System/Console/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Console/mod.rs
@@ -892,12 +892,12 @@ impl core::ops::BitAnd for CONSOLE_CHARACTER_ATTRIBUTES {
 }
 impl core::ops::BitOrAssign for CONSOLE_CHARACTER_ATTRIBUTES {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CONSOLE_CHARACTER_ATTRIBUTES {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CONSOLE_CHARACTER_ATTRIBUTES {
@@ -987,12 +987,12 @@ impl core::ops::BitAnd for CONSOLE_MODE {
 }
 impl core::ops::BitOrAssign for CONSOLE_MODE {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CONSOLE_MODE {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CONSOLE_MODE {

--- a/crates/libs/windows/src/Windows/Win32/System/DataExchange/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/DataExchange/mod.rs
@@ -513,12 +513,12 @@ impl core::ops::BitAnd for CONVINFO_STATUS {
 }
 impl core::ops::BitOrAssign for CONVINFO_STATUS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CONVINFO_STATUS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CONVINFO_STATUS {
@@ -644,12 +644,12 @@ impl core::ops::BitAnd for DDE_INITIALIZE_COMMAND {
 }
 impl core::ops::BitOrAssign for DDE_INITIALIZE_COMMAND {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for DDE_INITIALIZE_COMMAND {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for DDE_INITIALIZE_COMMAND {

--- a/crates/libs/windows/src/Windows/Win32/System/Diagnostics/Debug/ActiveScript/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Diagnostics/Debug/ActiveScript/mod.rs
@@ -10716,12 +10716,12 @@ impl core::ops::BitAnd for PROFILER_EVENT_MASK {
 }
 impl core::ops::BitOrAssign for PROFILER_EVENT_MASK {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for PROFILER_EVENT_MASK {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for PROFILER_EVENT_MASK {
@@ -10757,12 +10757,12 @@ impl core::ops::BitAnd for PROFILER_HEAP_ENUM_FLAGS {
 }
 impl core::ops::BitOrAssign for PROFILER_HEAP_ENUM_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for PROFILER_HEAP_ENUM_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for PROFILER_HEAP_ENUM_FLAGS {
@@ -10823,12 +10823,12 @@ impl core::ops::BitAnd for PROFILER_HEAP_OBJECT_FLAGS {
 }
 impl core::ops::BitOrAssign for PROFILER_HEAP_OBJECT_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for PROFILER_HEAP_OBJECT_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for PROFILER_HEAP_OBJECT_FLAGS {
@@ -10958,12 +10958,12 @@ impl core::ops::BitAnd for PROFILER_HEAP_OBJECT_RELATIONSHIP_FLAGS {
 }
 impl core::ops::BitOrAssign for PROFILER_HEAP_OBJECT_RELATIONSHIP_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for PROFILER_HEAP_OBJECT_RELATIONSHIP_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for PROFILER_HEAP_OBJECT_RELATIONSHIP_FLAGS {
@@ -11162,12 +11162,12 @@ impl core::ops::BitAnd for SCRIPT_DEBUGGER_OPTIONS {
 }
 impl core::ops::BitOrAssign for SCRIPT_DEBUGGER_OPTIONS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for SCRIPT_DEBUGGER_OPTIONS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for SCRIPT_DEBUGGER_OPTIONS {

--- a/crates/libs/windows/src/Windows/Win32/System/Diagnostics/Debug/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Diagnostics/Debug/mod.rs
@@ -2744,12 +2744,12 @@ impl core::ops::BitAnd for CONTEXT_FLAGS {
 }
 impl core::ops::BitOrAssign for CONTEXT_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CONTEXT_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CONTEXT_FLAGS {
@@ -2908,12 +2908,12 @@ impl core::ops::BitAnd for DBGPROP_ATTRIB_FLAGS {
 }
 impl core::ops::BitOrAssign for DBGPROP_ATTRIB_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for DBGPROP_ATTRIB_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for DBGPROP_ATTRIB_FLAGS {
@@ -2965,12 +2965,12 @@ impl core::ops::BitAnd for DBGPROP_INFO {
 }
 impl core::ops::BitOrAssign for DBGPROP_INFO {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for DBGPROP_INFO {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for DBGPROP_INFO {
@@ -3700,12 +3700,12 @@ impl core::ops::BitAnd for FORMAT_MESSAGE_OPTIONS {
 }
 impl core::ops::BitOrAssign for FORMAT_MESSAGE_OPTIONS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for FORMAT_MESSAGE_OPTIONS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for FORMAT_MESSAGE_OPTIONS {
@@ -4994,12 +4994,12 @@ impl core::ops::BitAnd for IMAGE_DLL_CHARACTERISTICS {
 }
 impl core::ops::BitOrAssign for IMAGE_DLL_CHARACTERISTICS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for IMAGE_DLL_CHARACTERISTICS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for IMAGE_DLL_CHARACTERISTICS {
@@ -5038,12 +5038,12 @@ impl core::ops::BitAnd for IMAGE_FILE_CHARACTERISTICS {
 }
 impl core::ops::BitOrAssign for IMAGE_FILE_CHARACTERISTICS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for IMAGE_FILE_CHARACTERISTICS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for IMAGE_FILE_CHARACTERISTICS {
@@ -5074,12 +5074,12 @@ impl core::ops::BitAnd for IMAGE_FILE_CHARACTERISTICS2 {
 }
 impl core::ops::BitOrAssign for IMAGE_FILE_CHARACTERISTICS2 {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for IMAGE_FILE_CHARACTERISTICS2 {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for IMAGE_FILE_CHARACTERISTICS2 {
@@ -5483,12 +5483,12 @@ impl core::ops::BitAnd for IMAGE_SECTION_CHARACTERISTICS {
 }
 impl core::ops::BitOrAssign for IMAGE_SECTION_CHARACTERISTICS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for IMAGE_SECTION_CHARACTERISTICS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for IMAGE_SECTION_CHARACTERISTICS {
@@ -6666,12 +6666,12 @@ impl core::ops::BitAnd for MINIDUMP_MISC_INFO_FLAGS {
 }
 impl core::ops::BitOrAssign for MINIDUMP_MISC_INFO_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for MINIDUMP_MISC_INFO_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for MINIDUMP_MISC_INFO_FLAGS {
@@ -7300,12 +7300,12 @@ impl core::ops::BitAnd for MINIDUMP_TYPE {
 }
 impl core::ops::BitOrAssign for MINIDUMP_TYPE {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for MINIDUMP_TYPE {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for MINIDUMP_TYPE {
@@ -8181,12 +8181,12 @@ impl core::ops::BitAnd for SYMBOL_INFO_FLAGS {
 }
 impl core::ops::BitOrAssign for SYMBOL_INFO_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for SYMBOL_INFO_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for SYMBOL_INFO_FLAGS {
@@ -8389,12 +8389,12 @@ impl core::ops::BitAnd for SYM_LOAD_FLAGS {
 }
 impl core::ops::BitOrAssign for SYM_LOAD_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for SYM_LOAD_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for SYM_LOAD_FLAGS {
@@ -8463,12 +8463,12 @@ impl core::ops::BitAnd for THREAD_ERROR_MODE {
 }
 impl core::ops::BitOrAssign for THREAD_ERROR_MODE {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for THREAD_ERROR_MODE {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for THREAD_ERROR_MODE {
@@ -9377,12 +9377,12 @@ impl core::ops::BitAnd for WOW64_CONTEXT_FLAGS {
 }
 impl core::ops::BitOrAssign for WOW64_CONTEXT_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for WOW64_CONTEXT_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for WOW64_CONTEXT_FLAGS {

--- a/crates/libs/windows/src/Windows/Win32/System/Diagnostics/Etw/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Diagnostics/Etw/mod.rs
@@ -681,12 +681,12 @@ impl core::ops::BitAnd for ETW_CONTEXT_REGISTER_TYPES {
 }
 impl core::ops::BitOrAssign for ETW_CONTEXT_REGISTER_TYPES {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for ETW_CONTEXT_REGISTER_TYPES {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for ETW_CONTEXT_REGISTER_TYPES {
@@ -1424,12 +1424,12 @@ impl core::ops::BitAnd for EVENT_TRACE_FLAG {
 }
 impl core::ops::BitOrAssign for EVENT_TRACE_FLAG {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for EVENT_TRACE_FLAG {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for EVENT_TRACE_FLAG {
@@ -2968,12 +2968,12 @@ impl core::ops::BitAnd for TRACE_LBR_CONFIGURATION {
 }
 impl core::ops::BitOrAssign for TRACE_LBR_CONFIGURATION {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for TRACE_LBR_CONFIGURATION {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for TRACE_LBR_CONFIGURATION {
@@ -3249,12 +3249,12 @@ impl core::ops::BitAnd for TRACE_MESSAGE_FLAGS {
 }
 impl core::ops::BitOrAssign for TRACE_MESSAGE_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for TRACE_MESSAGE_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for TRACE_MESSAGE_FLAGS {

--- a/crates/libs/windows/src/Windows/Win32/System/Diagnostics/ProcessSnapshotting/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Diagnostics/ProcessSnapshotting/mod.rs
@@ -140,12 +140,12 @@ impl core::ops::BitAnd for PSS_CAPTURE_FLAGS {
 }
 impl core::ops::BitOrAssign for PSS_CAPTURE_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for PSS_CAPTURE_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for PSS_CAPTURE_FLAGS {
@@ -199,12 +199,12 @@ impl core::ops::BitAnd for PSS_DUPLICATE_FLAGS {
 }
 impl core::ops::BitOrAssign for PSS_DUPLICATE_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for PSS_DUPLICATE_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for PSS_DUPLICATE_FLAGS {
@@ -341,12 +341,12 @@ impl core::ops::BitAnd for PSS_HANDLE_FLAGS {
 }
 impl core::ops::BitOrAssign for PSS_HANDLE_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for PSS_HANDLE_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for PSS_HANDLE_FLAGS {
@@ -420,12 +420,12 @@ impl core::ops::BitAnd for PSS_PROCESS_FLAGS {
 }
 impl core::ops::BitOrAssign for PSS_PROCESS_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for PSS_PROCESS_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for PSS_PROCESS_FLAGS {
@@ -538,12 +538,12 @@ impl core::ops::BitAnd for PSS_THREAD_FLAGS {
 }
 impl core::ops::BitOrAssign for PSS_THREAD_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for PSS_THREAD_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for PSS_THREAD_FLAGS {

--- a/crates/libs/windows/src/Windows/Win32/System/Diagnostics/ToolHelp/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Diagnostics/ToolHelp/mod.rs
@@ -101,12 +101,12 @@ impl core::ops::BitAnd for CREATE_TOOLHELP_SNAPSHOT_FLAGS {
 }
 impl core::ops::BitOrAssign for CREATE_TOOLHELP_SNAPSHOT_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CREATE_TOOLHELP_SNAPSHOT_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CREATE_TOOLHELP_SNAPSHOT_FLAGS {

--- a/crates/libs/windows/src/Windows/Win32/System/ErrorReporting/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/ErrorReporting/mod.rs
@@ -464,12 +464,12 @@ impl core::ops::BitAnd for WER_FAULT_REPORTING {
 }
 impl core::ops::BitOrAssign for WER_FAULT_REPORTING {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for WER_FAULT_REPORTING {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for WER_FAULT_REPORTING {
@@ -511,12 +511,12 @@ impl core::ops::BitAnd for WER_FILE {
 }
 impl core::ops::BitOrAssign for WER_FILE {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for WER_FILE {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for WER_FILE {
@@ -775,12 +775,12 @@ impl core::ops::BitAnd for WER_SUBMIT_FLAGS {
 }
 impl core::ops::BitOrAssign for WER_SUBMIT_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for WER_SUBMIT_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for WER_SUBMIT_FLAGS {

--- a/crates/libs/windows/src/Windows/Win32/System/EventLog/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/EventLog/mod.rs
@@ -789,12 +789,12 @@ impl core::ops::BitAnd for READ_EVENT_LOG_READ_FLAGS {
 }
 impl core::ops::BitOrAssign for READ_EVENT_LOG_READ_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for READ_EVENT_LOG_READ_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for READ_EVENT_LOG_READ_FLAGS {

--- a/crates/libs/windows/src/Windows/Win32/System/GroupPolicy/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/GroupPolicy/mod.rs
@@ -403,12 +403,12 @@ impl core::ops::BitAnd for GPO_OPTIONS {
 }
 impl core::ops::BitOrAssign for GPO_OPTIONS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for GPO_OPTIONS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for GPO_OPTIONS {

--- a/crates/libs/windows/src/Windows/Win32/System/HostComputeSystem/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/HostComputeSystem/mod.rs
@@ -612,12 +612,12 @@ impl core::ops::BitAnd for HCS_EVENT_OPTIONS {
 }
 impl core::ops::BitOrAssign for HCS_EVENT_OPTIONS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for HCS_EVENT_OPTIONS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for HCS_EVENT_OPTIONS {
@@ -683,12 +683,12 @@ impl core::ops::BitAnd for HCS_OPERATION_OPTIONS {
 }
 impl core::ops::BitOrAssign for HCS_OPERATION_OPTIONS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for HCS_OPERATION_OPTIONS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for HCS_OPERATION_OPTIONS {

--- a/crates/libs/windows/src/Windows/Win32/System/Hypervisor/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Hypervisor/mod.rs
@@ -874,12 +874,12 @@ impl core::ops::BitAnd for HDV_DEVICE_HOST_FLAGS {
 }
 impl core::ops::BitOrAssign for HDV_DEVICE_HOST_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for HDV_DEVICE_HOST_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for HDV_DEVICE_HOST_FLAGS {
@@ -922,12 +922,12 @@ impl core::ops::BitAnd for HDV_MMIO_MAPPING_FLAGS {
 }
 impl core::ops::BitOrAssign for HDV_MMIO_MAPPING_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for HDV_MMIO_MAPPING_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for HDV_MMIO_MAPPING_FLAGS {
@@ -1271,12 +1271,12 @@ impl core::ops::BitAnd for WHV_ALLOCATE_VPCI_RESOURCE_FLAGS {
 }
 impl core::ops::BitOrAssign for WHV_ALLOCATE_VPCI_RESOURCE_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for WHV_ALLOCATE_VPCI_RESOURCE_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for WHV_ALLOCATE_VPCI_RESOURCE_FLAGS {
@@ -1373,12 +1373,12 @@ impl core::ops::BitAnd for WHV_CREATE_VPCI_DEVICE_FLAGS {
 }
 impl core::ops::BitOrAssign for WHV_CREATE_VPCI_DEVICE_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for WHV_CREATE_VPCI_DEVICE_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for WHV_CREATE_VPCI_DEVICE_FLAGS {
@@ -1541,12 +1541,12 @@ impl core::ops::BitAnd for WHV_MAP_GPA_RANGE_FLAGS {
 }
 impl core::ops::BitOrAssign for WHV_MAP_GPA_RANGE_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for WHV_MAP_GPA_RANGE_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for WHV_MAP_GPA_RANGE_FLAGS {
@@ -2068,12 +2068,12 @@ impl core::ops::BitAnd for WHV_TRANSLATE_GVA_FLAGS {
 }
 impl core::ops::BitOrAssign for WHV_TRANSLATE_GVA_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for WHV_TRANSLATE_GVA_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for WHV_TRANSLATE_GVA_FLAGS {
@@ -2257,12 +2257,12 @@ impl core::ops::BitAnd for WHV_VPCI_INTERRUPT_TARGET_FLAGS {
 }
 impl core::ops::BitOrAssign for WHV_VPCI_INTERRUPT_TARGET_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for WHV_VPCI_INTERRUPT_TARGET_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for WHV_VPCI_INTERRUPT_TARGET_FLAGS {
@@ -2307,12 +2307,12 @@ impl core::ops::BitAnd for WHV_VPCI_MMIO_RANGE_FLAGS {
 }
 impl core::ops::BitOrAssign for WHV_VPCI_MMIO_RANGE_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for WHV_VPCI_MMIO_RANGE_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for WHV_VPCI_MMIO_RANGE_FLAGS {
@@ -2465,12 +2465,12 @@ impl core::ops::BitAnd for WHV_X64_CPUID_RESULT2_FLAGS {
 }
 impl core::ops::BitOrAssign for WHV_X64_CPUID_RESULT2_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for WHV_X64_CPUID_RESULT2_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for WHV_X64_CPUID_RESULT2_FLAGS {

--- a/crates/libs/windows/src/Windows/Win32/System/Ioctl/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Ioctl/mod.rs
@@ -168,12 +168,12 @@ impl core::ops::BitAnd for CHANGER_ELEMENT_STATUS_FLAGS {
 }
 impl core::ops::BitOrAssign for CHANGER_ELEMENT_STATUS_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CHANGER_ELEMENT_STATUS_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CHANGER_ELEMENT_STATUS_FLAGS {
@@ -215,12 +215,12 @@ impl core::ops::BitAnd for CHANGER_FEATURES {
 }
 impl core::ops::BitOrAssign for CHANGER_FEATURES {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CHANGER_FEATURES {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CHANGER_FEATURES {
@@ -2363,12 +2363,12 @@ impl core::ops::BitAnd for FILE_STORAGE_TIER_FLAGS {
 }
 impl core::ops::BitOrAssign for FILE_STORAGE_TIER_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for FILE_STORAGE_TIER_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for FILE_STORAGE_TIER_FLAGS {
@@ -2871,12 +2871,12 @@ impl core::ops::BitAnd for FS_BPIO_INFLAGS {
 }
 impl core::ops::BitOrAssign for FS_BPIO_INFLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for FS_BPIO_INFLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for FS_BPIO_INFLAGS {
@@ -2939,12 +2939,12 @@ impl core::ops::BitAnd for FS_BPIO_OUTFLAGS {
 }
 impl core::ops::BitOrAssign for FS_BPIO_OUTFLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for FS_BPIO_OUTFLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for FS_BPIO_OUTFLAGS {
@@ -3095,12 +3095,12 @@ impl core::ops::BitAnd for GET_CHANGER_PARAMETERS_FEATURES1 {
 }
 impl core::ops::BitOrAssign for GET_CHANGER_PARAMETERS_FEATURES1 {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for GET_CHANGER_PARAMETERS_FEATURES1 {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for GET_CHANGER_PARAMETERS_FEATURES1 {
@@ -3188,12 +3188,12 @@ impl core::ops::BitAnd for GPT_ATTRIBUTES {
 }
 impl core::ops::BitOrAssign for GPT_ATTRIBUTES {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for GPT_ATTRIBUTES {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for GPT_ATTRIBUTES {
@@ -7522,12 +7522,12 @@ impl core::ops::BitAnd for TXFS_RMF_LAGS {
 }
 impl core::ops::BitOrAssign for TXFS_RMF_LAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for TXFS_RMF_LAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for TXFS_RMF_LAGS {
@@ -7661,12 +7661,12 @@ impl core::ops::BitAnd for USN_DELETE_FLAGS {
 }
 impl core::ops::BitOrAssign for USN_DELETE_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for USN_DELETE_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for USN_DELETE_FLAGS {

--- a/crates/libs/windows/src/Windows/Win32/System/JobObjects/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/JobObjects/mod.rs
@@ -476,12 +476,12 @@ impl core::ops::BitAnd for JOB_OBJECT_CPU_RATE_CONTROL {
 }
 impl core::ops::BitOrAssign for JOB_OBJECT_CPU_RATE_CONTROL {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for JOB_OBJECT_CPU_RATE_CONTROL {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for JOB_OBJECT_CPU_RATE_CONTROL {
@@ -520,12 +520,12 @@ impl core::ops::BitAnd for JOB_OBJECT_IO_RATE_CONTROL_FLAGS {
 }
 impl core::ops::BitOrAssign for JOB_OBJECT_IO_RATE_CONTROL_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for JOB_OBJECT_IO_RATE_CONTROL_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for JOB_OBJECT_IO_RATE_CONTROL_FLAGS {
@@ -560,12 +560,12 @@ impl core::ops::BitAnd for JOB_OBJECT_LIMIT {
 }
 impl core::ops::BitOrAssign for JOB_OBJECT_LIMIT {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for JOB_OBJECT_LIMIT {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for JOB_OBJECT_LIMIT {
@@ -622,12 +622,12 @@ impl core::ops::BitAnd for JOB_OBJECT_NET_RATE_CONTROL_FLAGS {
 }
 impl core::ops::BitOrAssign for JOB_OBJECT_NET_RATE_CONTROL_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for JOB_OBJECT_NET_RATE_CONTROL_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for JOB_OBJECT_NET_RATE_CONTROL_FLAGS {
@@ -662,12 +662,12 @@ impl core::ops::BitAnd for JOB_OBJECT_SECURITY {
 }
 impl core::ops::BitOrAssign for JOB_OBJECT_SECURITY {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for JOB_OBJECT_SECURITY {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for JOB_OBJECT_SECURITY {
@@ -707,12 +707,12 @@ impl core::ops::BitAnd for JOB_OBJECT_UILIMIT {
 }
 impl core::ops::BitOrAssign for JOB_OBJECT_UILIMIT {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for JOB_OBJECT_UILIMIT {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for JOB_OBJECT_UILIMIT {

--- a/crates/libs/windows/src/Windows/Win32/System/LibraryLoader/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/LibraryLoader/mod.rs
@@ -411,12 +411,12 @@ impl core::ops::BitAnd for LOAD_LIBRARY_FLAGS {
 }
 impl core::ops::BitOrAssign for LOAD_LIBRARY_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for LOAD_LIBRARY_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for LOAD_LIBRARY_FLAGS {

--- a/crates/libs/windows/src/Windows/Win32/System/Memory/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Memory/mod.rs
@@ -629,12 +629,12 @@ impl core::ops::BitAnd for FILE_MAP {
 }
 impl core::ops::BitOrAssign for FILE_MAP {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for FILE_MAP {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for FILE_MAP {
@@ -674,12 +674,12 @@ impl core::ops::BitAnd for GLOBAL_ALLOC_FLAGS {
 }
 impl core::ops::BitOrAssign for GLOBAL_ALLOC_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for GLOBAL_ALLOC_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for GLOBAL_ALLOC_FLAGS {
@@ -720,12 +720,12 @@ impl core::ops::BitAnd for HEAP_FLAGS {
 }
 impl core::ops::BitOrAssign for HEAP_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for HEAP_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for HEAP_FLAGS {
@@ -788,12 +788,12 @@ impl core::ops::BitAnd for LOCAL_ALLOC_FLAGS {
 }
 impl core::ops::BitOrAssign for LOCAL_ALLOC_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for LOCAL_ALLOC_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for LOCAL_ALLOC_FLAGS {
@@ -1036,12 +1036,12 @@ impl core::ops::BitAnd for PAGE_PROTECTION_FLAGS {
 }
 impl core::ops::BitOrAssign for PAGE_PROTECTION_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for PAGE_PROTECTION_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for PAGE_PROTECTION_FLAGS {
@@ -1077,12 +1077,12 @@ impl core::ops::BitAnd for PAGE_TYPE {
 }
 impl core::ops::BitOrAssign for PAGE_TYPE {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for PAGE_TYPE {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for PAGE_TYPE {
@@ -1173,12 +1173,12 @@ impl core::ops::BitAnd for SECTION_FLAGS {
 }
 impl core::ops::BitOrAssign for SECTION_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for SECTION_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for SECTION_FLAGS {
@@ -1225,12 +1225,12 @@ impl core::ops::BitAnd for SETPROCESSWORKINGSETSIZEEX_FLAGS {
 }
 impl core::ops::BitOrAssign for SETPROCESSWORKINGSETSIZEEX_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for SETPROCESSWORKINGSETSIZEEX_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for SETPROCESSWORKINGSETSIZEEX_FLAGS {
@@ -1264,12 +1264,12 @@ impl core::ops::BitAnd for VIRTUAL_ALLOCATION_TYPE {
 }
 impl core::ops::BitOrAssign for VIRTUAL_ALLOCATION_TYPE {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for VIRTUAL_ALLOCATION_TYPE {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for VIRTUAL_ALLOCATION_TYPE {

--- a/crates/libs/windows/src/Windows/Win32/System/MessageQueuing/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/MessageQueuing/mod.rs
@@ -14244,12 +14244,12 @@ impl core::ops::BitAnd for MQQUEUEACCESSMASK {
 }
 impl core::ops::BitOrAssign for MQQUEUEACCESSMASK {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for MQQUEUEACCESSMASK {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for MQQUEUEACCESSMASK {

--- a/crates/libs/windows/src/Windows/Win32/System/Ole/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Ole/mod.rs
@@ -3656,12 +3656,12 @@ impl core::ops::BitAnd for ACTIVEOBJECT_FLAGS {
 }
 impl core::ops::BitOrAssign for ACTIVEOBJECT_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for ACTIVEOBJECT_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for ACTIVEOBJECT_FLAGS {
@@ -3714,12 +3714,12 @@ impl core::ops::BitAnd for BUSY_DIALOG_FLAGS {
 }
 impl core::ops::BitOrAssign for BUSY_DIALOG_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for BUSY_DIALOG_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for BUSY_DIALOG_FLAGS {
@@ -3834,12 +3834,12 @@ impl core::ops::BitAnd for CHANGE_ICON_FLAGS {
 }
 impl core::ops::BitOrAssign for CHANGE_ICON_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CHANGE_ICON_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CHANGE_ICON_FLAGS {
@@ -3870,12 +3870,12 @@ impl core::ops::BitAnd for CHANGE_SOURCE_FLAGS {
 }
 impl core::ops::BitOrAssign for CHANGE_SOURCE_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CHANGE_SOURCE_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CHANGE_SOURCE_FLAGS {
@@ -4095,12 +4095,12 @@ impl core::ops::BitAnd for DROPEFFECT {
 }
 impl core::ops::BitOrAssign for DROPEFFECT {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for DROPEFFECT {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for DROPEFFECT {
@@ -4158,12 +4158,12 @@ impl core::ops::BitAnd for EDIT_LINKS_FLAGS {
 }
 impl core::ops::BitOrAssign for EDIT_LINKS_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for EDIT_LINKS_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for EDIT_LINKS_FLAGS {
@@ -4201,12 +4201,12 @@ impl core::ops::BitAnd for EMBDHLP_FLAGS {
 }
 impl core::ops::BitOrAssign for EMBDHLP_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for EMBDHLP_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for EMBDHLP_FLAGS {
@@ -4242,12 +4242,12 @@ impl core::ops::BitAnd for FDEX_PROP_FLAGS {
 }
 impl core::ops::BitOrAssign for FDEX_PROP_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for FDEX_PROP_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for FDEX_PROP_FLAGS {
@@ -7118,12 +7118,12 @@ impl core::ops::BitAnd for INSERT_OBJECT_FLAGS {
 }
 impl core::ops::BitOrAssign for INSERT_OBJECT_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for INSERT_OBJECT_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for INSERT_OBJECT_FLAGS {
@@ -13947,12 +13947,12 @@ impl core::ops::BitAnd for KEYMODIFIERS {
 }
 impl core::ops::BitOrAssign for KEYMODIFIERS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for KEYMODIFIERS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for KEYMODIFIERS {
@@ -14000,12 +14000,12 @@ impl core::ops::BitAnd for LOAD_PICTURE_FLAGS {
 }
 impl core::ops::BitOrAssign for LOAD_PICTURE_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for LOAD_PICTURE_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for LOAD_PICTURE_FLAGS {
@@ -14095,12 +14095,12 @@ impl core::ops::BitAnd for NUMPARSE_FLAGS {
 }
 impl core::ops::BitOrAssign for NUMPARSE_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for NUMPARSE_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for NUMPARSE_FLAGS {
@@ -14159,12 +14159,12 @@ impl core::ops::BitAnd for OBJECT_PROPERTIES_FLAGS {
 }
 impl core::ops::BitOrAssign for OBJECT_PROPERTIES_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for OBJECT_PROPERTIES_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for OBJECT_PROPERTIES_FLAGS {
@@ -15296,12 +15296,12 @@ impl core::ops::BitAnd for PARAMFLAGS {
 }
 impl core::ops::BitOrAssign for PARAMFLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for PARAMFLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for PARAMFLAGS {
@@ -15340,12 +15340,12 @@ impl core::ops::BitAnd for PASTE_SPECIAL_FLAGS {
 }
 impl core::ops::BitOrAssign for PASTE_SPECIAL_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for PASTE_SPECIAL_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for PASTE_SPECIAL_FLAGS {
@@ -15463,12 +15463,12 @@ impl core::ops::BitAnd for PRINTFLAG {
 }
 impl core::ops::BitOrAssign for PRINTFLAG {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for PRINTFLAG {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for PRINTFLAG {
@@ -15777,12 +15777,12 @@ impl core::ops::BitAnd for UI_CONVERT_FLAGS {
 }
 impl core::ops::BitOrAssign for UI_CONVERT_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for UI_CONVERT_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for UI_CONVERT_FLAGS {
@@ -15815,12 +15815,12 @@ impl core::ops::BitAnd for UPDFCACHE_FLAGS {
 }
 impl core::ops::BitOrAssign for UPDFCACHE_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for UPDFCACHE_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for UPDFCACHE_FLAGS {
@@ -15933,12 +15933,12 @@ impl core::ops::BitAnd for VIEW_OBJECT_PROPERTIES_FLAGS {
 }
 impl core::ops::BitOrAssign for VIEW_OBJECT_PROPERTIES_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for VIEW_OBJECT_PROPERTIES_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for VIEW_OBJECT_PROPERTIES_FLAGS {

--- a/crates/libs/windows/src/Windows/Win32/System/Pipes/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Pipes/mod.rs
@@ -154,12 +154,12 @@ impl core::ops::BitAnd for NAMED_PIPE_MODE {
 }
 impl core::ops::BitOrAssign for NAMED_PIPE_MODE {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for NAMED_PIPE_MODE {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for NAMED_PIPE_MODE {

--- a/crates/libs/windows/src/Windows/Win32/System/Power/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Power/mod.rs
@@ -910,12 +910,12 @@ impl core::ops::BitAnd for DEVICE_POWER_CAPABILITIES {
 }
 impl core::ops::BitOrAssign for DEVICE_POWER_CAPABILITIES {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for DEVICE_POWER_CAPABILITIES {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for DEVICE_POWER_CAPABILITIES {
@@ -1034,12 +1034,12 @@ impl core::ops::BitAnd for EXECUTION_STATE {
 }
 impl core::ops::BitOrAssign for EXECUTION_STATE {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for EXECUTION_STATE {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for EXECUTION_STATE {
@@ -1344,12 +1344,12 @@ impl core::ops::BitAnd for POWER_ACTION_POLICY_EVENT_CODE {
 }
 impl core::ops::BitOrAssign for POWER_ACTION_POLICY_EVENT_CODE {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for POWER_ACTION_POLICY_EVENT_CODE {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for POWER_ACTION_POLICY_EVENT_CODE {

--- a/crates/libs/windows/src/Windows/Win32/System/Recovery/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Recovery/mod.rs
@@ -68,12 +68,12 @@ impl core::ops::BitAnd for REGISTER_APPLICATION_RESTART_FLAGS {
 }
 impl core::ops::BitOrAssign for REGISTER_APPLICATION_RESTART_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for REGISTER_APPLICATION_RESTART_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for REGISTER_APPLICATION_RESTART_FLAGS {

--- a/crates/libs/windows/src/Windows/Win32/System/Registry/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Registry/mod.rs
@@ -1645,12 +1645,12 @@ impl core::ops::BitAnd for REG_NOTIFY_FILTER {
 }
 impl core::ops::BitOrAssign for REG_NOTIFY_FILTER {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for REG_NOTIFY_FILTER {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for REG_NOTIFY_FILTER {
@@ -1684,12 +1684,12 @@ impl core::ops::BitAnd for REG_OPEN_CREATE_OPTIONS {
 }
 impl core::ops::BitOrAssign for REG_OPEN_CREATE_OPTIONS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for REG_OPEN_CREATE_OPTIONS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for REG_OPEN_CREATE_OPTIONS {
@@ -1750,12 +1750,12 @@ impl core::ops::BitAnd for REG_ROUTINE_FLAGS {
 }
 impl core::ops::BitOrAssign for REG_ROUTINE_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for REG_ROUTINE_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for REG_ROUTINE_FLAGS {
@@ -1786,12 +1786,12 @@ impl core::ops::BitAnd for REG_SAM_FLAGS {
 }
 impl core::ops::BitOrAssign for REG_SAM_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for REG_SAM_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for REG_SAM_FLAGS {

--- a/crates/libs/windows/src/Windows/Win32/System/RemoteDesktop/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/RemoteDesktop/mod.rs
@@ -11699,12 +11699,12 @@ impl core::ops::BitAnd for WTS_SECURITY_FLAGS {
 }
 impl core::ops::BitOrAssign for WTS_SECURITY_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for WTS_SECURITY_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for WTS_SECURITY_FLAGS {

--- a/crates/libs/windows/src/Windows/Win32/System/Rpc/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Rpc/mod.rs
@@ -4323,12 +4323,12 @@ impl core::ops::BitAnd for RPC_BINDING_HANDLE_OPTIONS_FLAGS {
 }
 impl core::ops::BitOrAssign for RPC_BINDING_HANDLE_OPTIONS_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for RPC_BINDING_HANDLE_OPTIONS_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for RPC_BINDING_HANDLE_OPTIONS_FLAGS {
@@ -4718,12 +4718,12 @@ impl core::ops::BitAnd for RPC_C_HTTP_AUTHN_TARGET {
 }
 impl core::ops::BitOrAssign for RPC_C_HTTP_AUTHN_TARGET {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for RPC_C_HTTP_AUTHN_TARGET {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for RPC_C_HTTP_AUTHN_TARGET {
@@ -4756,12 +4756,12 @@ impl core::ops::BitAnd for RPC_C_HTTP_FLAGS {
 }
 impl core::ops::BitOrAssign for RPC_C_HTTP_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for RPC_C_HTTP_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for RPC_C_HTTP_FLAGS {
@@ -4857,12 +4857,12 @@ impl core::ops::BitAnd for RPC_C_QOS_CAPABILITIES {
 }
 impl core::ops::BitOrAssign for RPC_C_QOS_CAPABILITIES {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for RPC_C_QOS_CAPABILITIES {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for RPC_C_QOS_CAPABILITIES {

--- a/crates/libs/windows/src/Windows/Win32/System/Search/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Search/mod.rs
@@ -1842,12 +1842,12 @@ impl core::ops::BitAnd for CONDITION_CREATION_OPTIONS {
 }
 impl core::ops::BitOrAssign for CONDITION_CREATION_OPTIONS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CONDITION_CREATION_OPTIONS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CONDITION_CREATION_OPTIONS {
@@ -21959,12 +21959,12 @@ impl core::ops::BitAnd for STRUCTURED_QUERY_RESOLVE_OPTION {
 }
 impl core::ops::BitOrAssign for STRUCTURED_QUERY_RESOLVE_OPTION {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for STRUCTURED_QUERY_RESOLVE_OPTION {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for STRUCTURED_QUERY_RESOLVE_OPTION {

--- a/crates/libs/windows/src/Windows/Win32/System/Services/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Services/mod.rs
@@ -436,12 +436,12 @@ impl core::ops::BitAnd for ENUM_SERVICE_TYPE {
 }
 impl core::ops::BitOrAssign for ENUM_SERVICE_TYPE {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for ENUM_SERVICE_TYPE {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for ENUM_SERVICE_TYPE {
@@ -775,12 +775,12 @@ impl core::ops::BitAnd for SERVICE_NOTIFY {
 }
 impl core::ops::BitOrAssign for SERVICE_NOTIFY {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for SERVICE_NOTIFY {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for SERVICE_NOTIFY {

--- a/crates/libs/windows/src/Windows/Win32/System/Shutdown/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Shutdown/mod.rs
@@ -136,12 +136,12 @@ impl core::ops::BitAnd for EXIT_WINDOWS_FLAGS {
 }
 impl core::ops::BitOrAssign for EXIT_WINDOWS_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for EXIT_WINDOWS_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for EXIT_WINDOWS_FLAGS {
@@ -234,12 +234,12 @@ impl core::ops::BitAnd for SHUTDOWN_FLAGS {
 }
 impl core::ops::BitOrAssign for SHUTDOWN_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for SHUTDOWN_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for SHUTDOWN_FLAGS {
@@ -278,12 +278,12 @@ impl core::ops::BitAnd for SHUTDOWN_REASON {
 }
 impl core::ops::BitOrAssign for SHUTDOWN_REASON {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for SHUTDOWN_REASON {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for SHUTDOWN_REASON {

--- a/crates/libs/windows/src/Windows/Win32/System/StationsAndDesktops/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/StationsAndDesktops/mod.rs
@@ -229,12 +229,12 @@ impl core::ops::BitAnd for BROADCAST_SYSTEM_MESSAGE_FLAGS {
 }
 impl core::ops::BitOrAssign for BROADCAST_SYSTEM_MESSAGE_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for BROADCAST_SYSTEM_MESSAGE_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for BROADCAST_SYSTEM_MESSAGE_FLAGS {
@@ -265,12 +265,12 @@ impl core::ops::BitAnd for BROADCAST_SYSTEM_MESSAGE_INFO {
 }
 impl core::ops::BitOrAssign for BROADCAST_SYSTEM_MESSAGE_INFO {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for BROADCAST_SYSTEM_MESSAGE_INFO {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for BROADCAST_SYSTEM_MESSAGE_INFO {

--- a/crates/libs/windows/src/Windows/Win32/System/SubsystemForLinux/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/SubsystemForLinux/mod.rs
@@ -85,12 +85,12 @@ impl core::ops::BitAnd for WSL_DISTRIBUTION_FLAGS {
 }
 impl core::ops::BitOrAssign for WSL_DISTRIBUTION_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for WSL_DISTRIBUTION_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for WSL_DISTRIBUTION_FLAGS {

--- a/crates/libs/windows/src/Windows/Win32/System/SystemInformation/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/SystemInformation/mod.rs
@@ -1261,12 +1261,12 @@ impl core::ops::BitAnd for VER_FLAGS {
 }
 impl core::ops::BitOrAssign for VER_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for VER_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for VER_FLAGS {

--- a/crates/libs/windows/src/Windows/Win32/System/SystemServices/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/SystemServices/mod.rs
@@ -217,12 +217,12 @@ impl core::ops::BitAnd for ATF_FLAGS {
 }
 impl core::ops::BitOrAssign for ATF_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for ATF_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for ATF_FLAGS {
@@ -292,12 +292,12 @@ impl core::ops::BitAnd for CFE_UNDERLINE {
 }
 impl core::ops::BitOrAssign for CFE_UNDERLINE {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CFE_UNDERLINE {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CFE_UNDERLINE {
@@ -912,12 +912,12 @@ impl core::ops::BitAnd for GESTURECONFIG_FLAGS {
 }
 impl core::ops::BitOrAssign for GESTURECONFIG_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for GESTURECONFIG_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for GESTURECONFIG_FLAGS {
@@ -3098,12 +3098,12 @@ impl core::ops::BitAnd for MODIFIERKEYS_FLAGS {
 }
 impl core::ops::BitOrAssign for MODIFIERKEYS_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for MODIFIERKEYS_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for MODIFIERKEYS_FLAGS {
@@ -4065,12 +4065,12 @@ impl core::ops::BitAnd for RECO_FLAGS {
 }
 impl core::ops::BitOrAssign for RECO_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for RECO_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for RECO_FLAGS {
@@ -4754,12 +4754,12 @@ impl core::ops::BitAnd for SFGAO_FLAGS {
 }
 impl core::ops::BitOrAssign for SFGAO_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for SFGAO_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for SFGAO_FLAGS {
@@ -5294,12 +5294,12 @@ impl core::ops::BitAnd for TAPE_GET_DRIVE_PARAMETERS_FEATURES_HIGH {
 }
 impl core::ops::BitOrAssign for TAPE_GET_DRIVE_PARAMETERS_FEATURES_HIGH {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for TAPE_GET_DRIVE_PARAMETERS_FEATURES_HIGH {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for TAPE_GET_DRIVE_PARAMETERS_FEATURES_HIGH {
@@ -5638,12 +5638,12 @@ impl core::ops::BitAnd for WORD_WHEEL_OPEN_FLAGS {
 }
 impl core::ops::BitOrAssign for WORD_WHEEL_OPEN_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for WORD_WHEEL_OPEN_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for WORD_WHEEL_OPEN_FLAGS {

--- a/crates/libs/windows/src/Windows/Win32/System/Threading/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Threading/mod.rs
@@ -2112,12 +2112,12 @@ impl core::ops::BitAnd for CREATE_EVENT {
 }
 impl core::ops::BitOrAssign for CREATE_EVENT {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CREATE_EVENT {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CREATE_EVENT {
@@ -2486,12 +2486,12 @@ impl core::ops::BitAnd for MACHINE_ATTRIBUTES {
 }
 impl core::ops::BitOrAssign for MACHINE_ATTRIBUTES {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for MACHINE_ATTRIBUTES {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for MACHINE_ATTRIBUTES {
@@ -2692,12 +2692,12 @@ impl core::ops::BitAnd for PROCESS_ACCESS_RIGHTS {
 }
 impl core::ops::BitOrAssign for PROCESS_ACCESS_RIGHTS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for PROCESS_ACCESS_RIGHTS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for PROCESS_ACCESS_RIGHTS {
@@ -2761,12 +2761,12 @@ impl core::ops::BitAnd for PROCESS_CREATION_FLAGS {
 }
 impl core::ops::BitOrAssign for PROCESS_CREATION_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for PROCESS_CREATION_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for PROCESS_CREATION_FLAGS {
@@ -2963,12 +2963,12 @@ impl core::ops::BitAnd for PROCESS_DEP_FLAGS {
 }
 impl core::ops::BitOrAssign for PROCESS_DEP_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for PROCESS_DEP_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for PROCESS_DEP_FLAGS {
@@ -3534,12 +3534,12 @@ impl core::ops::BitAnd for STARTUPINFOW_FLAGS {
 }
 impl core::ops::BitOrAssign for STARTUPINFOW_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for STARTUPINFOW_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for STARTUPINFOW_FLAGS {
@@ -3570,12 +3570,12 @@ impl core::ops::BitAnd for SYNCHRONIZATION_ACCESS_RIGHTS {
 }
 impl core::ops::BitOrAssign for SYNCHRONIZATION_ACCESS_RIGHTS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for SYNCHRONIZATION_ACCESS_RIGHTS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for SYNCHRONIZATION_ACCESS_RIGHTS {
@@ -3649,12 +3649,12 @@ impl core::ops::BitAnd for THREAD_ACCESS_RIGHTS {
 }
 impl core::ops::BitOrAssign for THREAD_ACCESS_RIGHTS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for THREAD_ACCESS_RIGHTS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for THREAD_ACCESS_RIGHTS {
@@ -3688,12 +3688,12 @@ impl core::ops::BitAnd for THREAD_CREATION_FLAGS {
 }
 impl core::ops::BitOrAssign for THREAD_CREATION_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for THREAD_CREATION_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for THREAD_CREATION_FLAGS {
@@ -3882,12 +3882,12 @@ impl core::ops::BitAnd for WORKER_THREAD_FLAGS {
 }
 impl core::ops::BitOrAssign for WORKER_THREAD_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for WORKER_THREAD_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for WORKER_THREAD_FLAGS {

--- a/crates/libs/windows/src/Windows/Win32/System/Variant/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Variant/mod.rs
@@ -650,12 +650,12 @@ impl core::ops::BitAnd for DRAWPROGRESSFLAGS {
 }
 impl core::ops::BitOrAssign for DRAWPROGRESSFLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for DRAWPROGRESSFLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for DRAWPROGRESSFLAGS {
@@ -688,12 +688,12 @@ impl core::ops::BitAnd for PSTIME_FLAGS {
 }
 impl core::ops::BitOrAssign for PSTIME_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for PSTIME_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for PSTIME_FLAGS {
@@ -724,12 +724,12 @@ impl core::ops::BitAnd for VARENUM {
 }
 impl core::ops::BitOrAssign for VARENUM {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for VARENUM {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for VARENUM {
@@ -893,12 +893,12 @@ impl core::ops::BitAnd for VAR_CHANGE_FLAGS {
 }
 impl core::ops::BitOrAssign for VAR_CHANGE_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for VAR_CHANGE_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for VAR_CHANGE_FLAGS {

--- a/crates/libs/windows/src/Windows/Win32/System/WinRT/Storage/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WinRT/Storage/mod.rs
@@ -20,12 +20,12 @@ impl core::ops::BitAnd for HANDLE_ACCESS_OPTIONS {
 }
 impl core::ops::BitOrAssign for HANDLE_ACCESS_OPTIONS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for HANDLE_ACCESS_OPTIONS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for HANDLE_ACCESS_OPTIONS {
@@ -59,12 +59,12 @@ impl core::ops::BitAnd for HANDLE_OPTIONS {
 }
 impl core::ops::BitOrAssign for HANDLE_OPTIONS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for HANDLE_OPTIONS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for HANDLE_OPTIONS {
@@ -95,12 +95,12 @@ impl core::ops::BitAnd for HANDLE_SHARING_OPTIONS {
 }
 impl core::ops::BitOrAssign for HANDLE_SHARING_OPTIONS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for HANDLE_SHARING_OPTIONS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for HANDLE_SHARING_OPTIONS {

--- a/crates/libs/windows/src/Windows/Win32/System/WinRT/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WinRT/mod.rs
@@ -2545,12 +2545,12 @@ impl core::ops::BitAnd for RO_ERROR_REPORTING_FLAGS {
 }
 impl core::ops::BitOrAssign for RO_ERROR_REPORTING_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for RO_ERROR_REPORTING_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for RO_ERROR_REPORTING_FLAGS {

--- a/crates/libs/windows/src/Windows/Win32/System/WindowsProgramming/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WindowsProgramming/mod.rs
@@ -3881,12 +3881,12 @@ impl core::ops::BitAnd for WLDP_EXECUTION_EVALUATION_OPTIONS {
 }
 impl core::ops::BitOrAssign for WLDP_EXECUTION_EVALUATION_OPTIONS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for WLDP_EXECUTION_EVALUATION_OPTIONS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for WLDP_EXECUTION_EVALUATION_OPTIONS {

--- a/crates/libs/windows/src/Windows/Win32/System/Wmi/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Wmi/mod.rs
@@ -11542,12 +11542,12 @@ impl core::ops::BitAnd for WBEM_GENERIC_FLAG_TYPE {
 }
 impl core::ops::BitOrAssign for WBEM_GENERIC_FLAG_TYPE {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for WBEM_GENERIC_FLAG_TYPE {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for WBEM_GENERIC_FLAG_TYPE {

--- a/crates/libs/windows/src/Windows/Win32/UI/Accessibility/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Accessibility/mod.rs
@@ -754,12 +754,12 @@ impl core::ops::BitAnd for ACC_UTILITY_STATE_FLAGS {
 }
 impl core::ops::BitOrAssign for ACC_UTILITY_STATE_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for ACC_UTILITY_STATE_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for ACC_UTILITY_STATE_FLAGS {
@@ -1122,12 +1122,12 @@ impl core::ops::BitAnd for HIGHCONTRASTW_FLAGS {
 }
 impl core::ops::BitOrAssign for HIGHCONTRASTW_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for HIGHCONTRASTW_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for HIGHCONTRASTW_FLAGS {
@@ -19809,12 +19809,12 @@ impl core::ops::BitAnd for ProviderOptions {
 }
 impl core::ops::BitOrAssign for ProviderOptions {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for ProviderOptions {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for ProviderOptions {
@@ -19969,12 +19969,12 @@ impl core::ops::BitAnd for SERIALKEYS_FLAGS {
 }
 impl core::ops::BitOrAssign for SERIALKEYS_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for SERIALKEYS_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for SERIALKEYS_FLAGS {
@@ -20067,12 +20067,12 @@ impl core::ops::BitAnd for SOUNDSENTRY_FLAGS {
 }
 impl core::ops::BitOrAssign for SOUNDSENTRY_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for SOUNDSENTRY_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for SOUNDSENTRY_FLAGS {
@@ -20134,12 +20134,12 @@ impl core::ops::BitAnd for STICKYKEYS_FLAGS {
 }
 impl core::ops::BitOrAssign for STICKYKEYS_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for STICKYKEYS_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for STICKYKEYS_FLAGS {
@@ -20308,12 +20308,12 @@ impl core::ops::BitAnd for SynchronizedInputType {
 }
 impl core::ops::BitOrAssign for SynchronizedInputType {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for SynchronizedInputType {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for SynchronizedInputType {
@@ -20952,12 +20952,12 @@ impl core::ops::BitAnd for UIAutomationType {
 }
 impl core::ops::BitOrAssign for UIAutomationType {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for UIAutomationType {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for UIAutomationType {

--- a/crates/libs/windows/src/Windows/Win32/UI/Animation/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Animation/mod.rs
@@ -4037,12 +4037,12 @@ impl core::ops::BitAnd for UI_ANIMATION_DEPENDENCIES {
 }
 impl core::ops::BitOrAssign for UI_ANIMATION_DEPENDENCIES {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for UI_ANIMATION_DEPENDENCIES {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for UI_ANIMATION_DEPENDENCIES {

--- a/crates/libs/windows/src/Windows/Win32/UI/Controls/Dialogs/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Controls/Dialogs/mod.rs
@@ -295,12 +295,12 @@ impl core::ops::BitAnd for CHOOSECOLOR_FLAGS {
 }
 impl core::ops::BitOrAssign for CHOOSECOLOR_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CHOOSECOLOR_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CHOOSECOLOR_FLAGS {
@@ -447,12 +447,12 @@ impl core::ops::BitAnd for CHOOSEFONT_FLAGS {
 }
 impl core::ops::BitOrAssign for CHOOSEFONT_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CHOOSEFONT_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CHOOSEFONT_FLAGS {
@@ -483,12 +483,12 @@ impl core::ops::BitAnd for CHOOSEFONT_FONT_TYPE {
 }
 impl core::ops::BitOrAssign for CHOOSEFONT_FONT_TYPE {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CHOOSEFONT_FONT_TYPE {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CHOOSEFONT_FONT_TYPE {
@@ -645,12 +645,12 @@ impl core::ops::BitAnd for FINDREPLACE_FLAGS {
 }
 impl core::ops::BitOrAssign for FINDREPLACE_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for FINDREPLACE_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for FINDREPLACE_FLAGS {
@@ -1238,12 +1238,12 @@ impl core::ops::BitAnd for OPEN_FILENAME_FLAGS {
 }
 impl core::ops::BitOrAssign for OPEN_FILENAME_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for OPEN_FILENAME_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for OPEN_FILENAME_FLAGS {
@@ -1274,12 +1274,12 @@ impl core::ops::BitAnd for OPEN_FILENAME_FLAGS_EX {
 }
 impl core::ops::BitOrAssign for OPEN_FILENAME_FLAGS_EX {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for OPEN_FILENAME_FLAGS_EX {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for OPEN_FILENAME_FLAGS_EX {
@@ -1386,12 +1386,12 @@ impl core::ops::BitAnd for PAGESETUPDLG_FLAGS {
 }
 impl core::ops::BitOrAssign for PAGESETUPDLG_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for PAGESETUPDLG_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for PAGESETUPDLG_FLAGS {
@@ -1650,12 +1650,12 @@ impl core::ops::BitAnd for PRINTDLGEX_FLAGS {
 }
 impl core::ops::BitOrAssign for PRINTDLGEX_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for PRINTDLGEX_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for PRINTDLGEX_FLAGS {

--- a/crates/libs/windows/src/Windows/Win32/UI/Controls/RichEdit/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Controls/RichEdit/mod.rs
@@ -83,12 +83,12 @@ impl core::ops::BitAnd for CFE_EFFECTS {
 }
 impl core::ops::BitOrAssign for CFE_EFFECTS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CFE_EFFECTS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CFE_EFFECTS {
@@ -163,12 +163,12 @@ impl core::ops::BitAnd for CFM_MASK {
 }
 impl core::ops::BitOrAssign for CFM_MASK {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CFM_MASK {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CFM_MASK {
@@ -907,12 +907,12 @@ impl core::ops::BitAnd for GETTEXTLENGTHEX_FLAGS {
 }
 impl core::ops::BitOrAssign for GETTEXTLENGTHEX_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for GETTEXTLENGTHEX_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for GETTEXTLENGTHEX_FLAGS {
@@ -10655,12 +10655,12 @@ impl core::ops::BitAnd for PARAFORMAT_BORDERS {
 }
 impl core::ops::BitOrAssign for PARAFORMAT_BORDERS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for PARAFORMAT_BORDERS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for PARAFORMAT_BORDERS {
@@ -10698,12 +10698,12 @@ impl core::ops::BitAnd for PARAFORMAT_MASK {
 }
 impl core::ops::BitOrAssign for PARAFORMAT_MASK {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for PARAFORMAT_MASK {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for PARAFORMAT_MASK {
@@ -10734,12 +10734,12 @@ impl core::ops::BitAnd for PARAFORMAT_NUMBERING {
 }
 impl core::ops::BitOrAssign for PARAFORMAT_NUMBERING {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for PARAFORMAT_NUMBERING {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for PARAFORMAT_NUMBERING {
@@ -10879,12 +10879,12 @@ impl core::ops::BitAnd for REOBJECT_FLAGS {
 }
 impl core::ops::BitOrAssign for REOBJECT_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for REOBJECT_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for REOBJECT_FLAGS {
@@ -11000,12 +11000,12 @@ impl core::ops::BitAnd for RICH_EDIT_GET_CONTEXT_MENU_SEL_TYPE {
 }
 impl core::ops::BitOrAssign for RICH_EDIT_GET_CONTEXT_MENU_SEL_TYPE {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for RICH_EDIT_GET_CONTEXT_MENU_SEL_TYPE {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for RICH_EDIT_GET_CONTEXT_MENU_SEL_TYPE {
@@ -11036,12 +11036,12 @@ impl core::ops::BitAnd for RICH_EDIT_GET_OBJECT_FLAGS {
 }
 impl core::ops::BitOrAssign for RICH_EDIT_GET_OBJECT_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for RICH_EDIT_GET_OBJECT_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for RICH_EDIT_GET_OBJECT_FLAGS {

--- a/crates/libs/windows/src/Windows/Win32/UI/Controls/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Controls/mod.rs
@@ -1456,12 +1456,12 @@ impl core::ops::BitAnd for BP_PAINTPARAMS_FLAGS {
 }
 impl core::ops::BitOrAssign for BP_PAINTPARAMS_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for BP_PAINTPARAMS_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for BP_PAINTPARAMS_FLAGS {
@@ -1926,12 +1926,12 @@ impl core::ops::BitAnd for COMBOBOX_EX_ITEM_FLAGS {
 }
 impl core::ops::BitOrAssign for COMBOBOX_EX_ITEM_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for COMBOBOX_EX_ITEM_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for COMBOBOX_EX_ITEM_FLAGS {
@@ -2128,12 +2128,12 @@ impl core::ops::BitAnd for DLG_DIR_LIST_FILE_TYPE {
 }
 impl core::ops::BitOrAssign for DLG_DIR_LIST_FILE_TYPE {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for DLG_DIR_LIST_FILE_TYPE {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for DLG_DIR_LIST_FILE_TYPE {
@@ -2257,12 +2257,12 @@ impl core::ops::BitAnd for DRAW_THEME_PARENT_BACKGROUND_FLAGS {
 }
 impl core::ops::BitOrAssign for DRAW_THEME_PARENT_BACKGROUND_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for DRAW_THEME_PARENT_BACKGROUND_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for DRAW_THEME_PARENT_BACKGROUND_FLAGS {
@@ -2386,12 +2386,12 @@ impl core::ops::BitAnd for DTTOPTS_FLAGS {
 }
 impl core::ops::BitOrAssign for DTTOPTS_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for DTTOPTS_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for DTTOPTS_FLAGS {
@@ -2893,12 +2893,12 @@ impl core::ops::BitAnd for HDI_MASK {
 }
 impl core::ops::BitOrAssign for HDI_MASK {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for HDI_MASK {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for HDI_MASK {
@@ -3132,12 +3132,12 @@ impl core::ops::BitAnd for HEADER_HITTEST_INFO_FLAGS {
 }
 impl core::ops::BitOrAssign for HEADER_HITTEST_INFO_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for HEADER_HITTEST_INFO_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for HEADER_HITTEST_INFO_FLAGS {
@@ -4196,12 +4196,12 @@ impl core::ops::BitAnd for IMAGELIST_CREATION_FLAGS {
 }
 impl core::ops::BitOrAssign for IMAGELIST_CREATION_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for IMAGELIST_CREATION_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for IMAGELIST_CREATION_FLAGS {
@@ -4238,12 +4238,12 @@ impl core::ops::BitAnd for IMAGE_LIST_DRAW_STYLE {
 }
 impl core::ops::BitOrAssign for IMAGE_LIST_DRAW_STYLE {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for IMAGE_LIST_DRAW_STYLE {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for IMAGE_LIST_DRAW_STYLE {
@@ -4277,12 +4277,12 @@ impl core::ops::BitAnd for IMAGE_LIST_WRITE_STREAM_FLAGS {
 }
 impl core::ops::BitOrAssign for IMAGE_LIST_WRITE_STREAM_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for IMAGE_LIST_WRITE_STREAM_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for IMAGE_LIST_WRITE_STREAM_FLAGS {
@@ -4320,12 +4320,12 @@ impl core::ops::BitAnd for INITCOMMONCONTROLSEX_ICC {
 }
 impl core::ops::BitOrAssign for INITCOMMONCONTROLSEX_ICC {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for INITCOMMONCONTROLSEX_ICC {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for INITCOMMONCONTROLSEX_ICC {
@@ -4457,12 +4457,12 @@ impl core::ops::BitAnd for LIST_ITEM_FLAGS {
 }
 impl core::ops::BitOrAssign for LIST_ITEM_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for LIST_ITEM_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for LIST_ITEM_FLAGS {
@@ -4493,12 +4493,12 @@ impl core::ops::BitAnd for LIST_ITEM_STATE_FLAGS {
 }
 impl core::ops::BitOrAssign for LIST_ITEM_STATE_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for LIST_ITEM_STATE_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for LIST_ITEM_STATE_FLAGS {
@@ -4529,12 +4529,12 @@ impl core::ops::BitAnd for LIST_VIEW_BACKGROUND_IMAGE_FLAGS {
 }
 impl core::ops::BitOrAssign for LIST_VIEW_BACKGROUND_IMAGE_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for LIST_VIEW_BACKGROUND_IMAGE_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for LIST_VIEW_BACKGROUND_IMAGE_FLAGS {
@@ -4565,12 +4565,12 @@ impl core::ops::BitAnd for LIST_VIEW_GROUP_ALIGN_FLAGS {
 }
 impl core::ops::BitOrAssign for LIST_VIEW_GROUP_ALIGN_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for LIST_VIEW_GROUP_ALIGN_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for LIST_VIEW_GROUP_ALIGN_FLAGS {
@@ -4601,12 +4601,12 @@ impl core::ops::BitAnd for LIST_VIEW_GROUP_STATE_FLAGS {
 }
 impl core::ops::BitOrAssign for LIST_VIEW_GROUP_STATE_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for LIST_VIEW_GROUP_STATE_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for LIST_VIEW_GROUP_STATE_FLAGS {
@@ -4637,12 +4637,12 @@ impl core::ops::BitAnd for LIST_VIEW_ITEM_COLUMN_FORMAT_FLAGS {
 }
 impl core::ops::BitOrAssign for LIST_VIEW_ITEM_COLUMN_FORMAT_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for LIST_VIEW_ITEM_COLUMN_FORMAT_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for LIST_VIEW_ITEM_COLUMN_FORMAT_FLAGS {
@@ -4673,12 +4673,12 @@ impl core::ops::BitAnd for LIST_VIEW_ITEM_FLAGS {
 }
 impl core::ops::BitOrAssign for LIST_VIEW_ITEM_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for LIST_VIEW_ITEM_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for LIST_VIEW_ITEM_FLAGS {
@@ -4856,12 +4856,12 @@ impl core::ops::BitAnd for LVCOLUMNW_FORMAT {
 }
 impl core::ops::BitOrAssign for LVCOLUMNW_FORMAT {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for LVCOLUMNW_FORMAT {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for LVCOLUMNW_FORMAT {
@@ -4892,12 +4892,12 @@ impl core::ops::BitAnd for LVCOLUMNW_MASK {
 }
 impl core::ops::BitOrAssign for LVCOLUMNW_MASK {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for LVCOLUMNW_MASK {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for LVCOLUMNW_MASK {
@@ -4952,12 +4952,12 @@ impl core::ops::BitAnd for LVFINDINFOW_FLAGS {
 }
 impl core::ops::BitOrAssign for LVFINDINFOW_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for LVFINDINFOW_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for LVFINDINFOW_FLAGS {
@@ -5123,12 +5123,12 @@ impl core::ops::BitAnd for LVGROUP_MASK {
 }
 impl core::ops::BitOrAssign for LVGROUP_MASK {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for LVGROUP_MASK {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for LVGROUP_MASK {
@@ -5177,12 +5177,12 @@ impl core::ops::BitAnd for LVHITTESTINFO_FLAGS {
 }
 impl core::ops::BitOrAssign for LVHITTESTINFO_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for LVHITTESTINFO_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for LVHITTESTINFO_FLAGS {
@@ -5650,12 +5650,12 @@ impl core::ops::BitAnd for LVTILEVIEWINFO_FLAGS {
 }
 impl core::ops::BitOrAssign for LVTILEVIEWINFO_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for LVTILEVIEWINFO_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for LVTILEVIEWINFO_FLAGS {
@@ -5686,12 +5686,12 @@ impl core::ops::BitAnd for LVTILEVIEWINFO_MASK {
 }
 impl core::ops::BitOrAssign for LVTILEVIEWINFO_MASK {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for LVTILEVIEWINFO_MASK {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for LVTILEVIEWINFO_MASK {
@@ -5826,12 +5826,12 @@ impl core::ops::BitAnd for MCGRIDINFO_FLAGS {
 }
 impl core::ops::BitOrAssign for MCGRIDINFO_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for MCGRIDINFO_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for MCGRIDINFO_FLAGS {
@@ -5877,12 +5877,12 @@ impl core::ops::BitAnd for MCHITTESTINFO_HIT_FLAGS {
 }
 impl core::ops::BitOrAssign for MCHITTESTINFO_HIT_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for MCHITTESTINFO_HIT_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for MCHITTESTINFO_HIT_FLAGS {
@@ -6310,12 +6310,12 @@ impl core::ops::BitAnd for NMCUSTOMDRAW_DRAW_STATE_FLAGS {
 }
 impl core::ops::BitOrAssign for NMCUSTOMDRAW_DRAW_STATE_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for NMCUSTOMDRAW_DRAW_STATE_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for NMCUSTOMDRAW_DRAW_STATE_FLAGS {
@@ -6761,12 +6761,12 @@ impl core::ops::BitAnd for NMPGSCROLL_KEYS {
 }
 impl core::ops::BitOrAssign for NMPGSCROLL_KEYS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for NMPGSCROLL_KEYS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for NMPGSCROLL_KEYS {
@@ -6851,12 +6851,12 @@ impl core::ops::BitAnd for NMREBAR_MASK_FLAGS {
 }
 impl core::ops::BitOrAssign for NMREBAR_MASK_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for NMREBAR_MASK_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for NMREBAR_MASK_FLAGS {
@@ -6943,12 +6943,12 @@ impl core::ops::BitAnd for NMTBDISPINFOW_MASK {
 }
 impl core::ops::BitOrAssign for NMTBDISPINFOW_MASK {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for NMTBDISPINFOW_MASK {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for NMTBDISPINFOW_MASK {
@@ -7005,12 +7005,12 @@ impl core::ops::BitAnd for NMTBHOTITEM_FLAGS {
 }
 impl core::ops::BitOrAssign for NMTBHOTITEM_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for NMTBHOTITEM_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for NMTBHOTITEM_FLAGS {
@@ -7301,12 +7301,12 @@ impl core::ops::BitAnd for NM_TREEVIEW_ACTION {
 }
 impl core::ops::BitOrAssign for NM_TREEVIEW_ACTION {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for NM_TREEVIEW_ACTION {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for NM_TREEVIEW_ACTION {
@@ -7381,12 +7381,12 @@ impl core::ops::BitAnd for OPEN_THEME_DATA_FLAGS {
 }
 impl core::ops::BitOrAssign for OPEN_THEME_DATA_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for OPEN_THEME_DATA_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for OPEN_THEME_DATA_FLAGS {
@@ -8748,12 +8748,12 @@ impl core::ops::BitAnd for SET_THEME_APP_PROPERTIES_FLAGS {
 }
 impl core::ops::BitOrAssign for SET_THEME_APP_PROPERTIES_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for SET_THEME_APP_PROPERTIES_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for SET_THEME_APP_PROPERTIES_FLAGS {
@@ -9086,12 +9086,12 @@ impl core::ops::BitAnd for TASKDIALOG_COMMON_BUTTON_FLAGS {
 }
 impl core::ops::BitOrAssign for TASKDIALOG_COMMON_BUTTON_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for TASKDIALOG_COMMON_BUTTON_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for TASKDIALOG_COMMON_BUTTON_FLAGS {
@@ -9125,12 +9125,12 @@ impl core::ops::BitAnd for TASKDIALOG_FLAGS {
 }
 impl core::ops::BitOrAssign for TASKDIALOG_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for TASKDIALOG_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for TASKDIALOG_FLAGS {
@@ -9193,12 +9193,12 @@ impl core::ops::BitAnd for TA_PROPERTY_FLAG {
 }
 impl core::ops::BitOrAssign for TA_PROPERTY_FLAG {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for TA_PROPERTY_FLAG {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for TA_PROPERTY_FLAG {
@@ -9270,12 +9270,12 @@ impl core::ops::BitAnd for TA_TRANSFORM_FLAG {
 }
 impl core::ops::BitOrAssign for TA_TRANSFORM_FLAG {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for TA_TRANSFORM_FLAG {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for TA_TRANSFORM_FLAG {
@@ -9387,12 +9387,12 @@ impl core::ops::BitAnd for TBBUTTONINFOW_MASK {
 }
 impl core::ops::BitOrAssign for TBBUTTONINFOW_MASK {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for TBBUTTONINFOW_MASK {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for TBBUTTONINFOW_MASK {
@@ -9789,12 +9789,12 @@ impl core::ops::BitAnd for TCITEMHEADERA_MASK {
 }
 impl core::ops::BitOrAssign for TCITEMHEADERA_MASK {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for TCITEMHEADERA_MASK {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for TCITEMHEADERA_MASK {
@@ -10367,12 +10367,12 @@ impl core::ops::BitAnd for TOOLTIP_FLAGS {
 }
 impl core::ops::BitOrAssign for TOOLTIP_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for TOOLTIP_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for TOOLTIP_FLAGS {
@@ -10789,12 +10789,12 @@ impl core::ops::BitAnd for TVHITTESTINFO_FLAGS {
 }
 impl core::ops::BitOrAssign for TVHITTESTINFO_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for TVHITTESTINFO_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for TVHITTESTINFO_FLAGS {
@@ -10979,12 +10979,12 @@ impl core::ops::BitAnd for TVITEM_MASK {
 }
 impl core::ops::BitOrAssign for TVITEM_MASK {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for TVITEM_MASK {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for TVITEM_MASK {

--- a/crates/libs/windows/src/Windows/Win32/UI/HiDpi/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/HiDpi/mod.rs
@@ -182,12 +182,12 @@ impl core::ops::BitAnd for DIALOG_CONTROL_DPI_CHANGE_BEHAVIORS {
 }
 impl core::ops::BitOrAssign for DIALOG_CONTROL_DPI_CHANGE_BEHAVIORS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for DIALOG_CONTROL_DPI_CHANGE_BEHAVIORS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for DIALOG_CONTROL_DPI_CHANGE_BEHAVIORS {
@@ -218,12 +218,12 @@ impl core::ops::BitAnd for DIALOG_DPI_CHANGE_BEHAVIORS {
 }
 impl core::ops::BitOrAssign for DIALOG_DPI_CHANGE_BEHAVIORS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for DIALOG_DPI_CHANGE_BEHAVIORS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for DIALOG_DPI_CHANGE_BEHAVIORS {

--- a/crates/libs/windows/src/Windows/Win32/UI/Input/GameInput/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Input/GameInput/mod.rs
@@ -47,12 +47,12 @@ impl core::ops::BitAnd for GameInputArcadeStickButtons {
 }
 impl core::ops::BitOrAssign for GameInputArcadeStickButtons {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for GameInputArcadeStickButtons {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for GameInputArcadeStickButtons {
@@ -199,12 +199,12 @@ impl core::ops::BitAnd for GameInputDeviceCapabilities {
 }
 impl core::ops::BitOrAssign for GameInputDeviceCapabilities {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for GameInputDeviceCapabilities {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for GameInputDeviceCapabilities {
@@ -306,12 +306,12 @@ impl core::ops::BitAnd for GameInputDeviceStatus {
 }
 impl core::ops::BitOrAssign for GameInputDeviceStatus {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for GameInputDeviceStatus {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for GameInputDeviceStatus {
@@ -360,12 +360,12 @@ impl core::ops::BitAnd for GameInputFeedbackAxes {
 }
 impl core::ops::BitOrAssign for GameInputFeedbackAxes {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for GameInputFeedbackAxes {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for GameInputFeedbackAxes {
@@ -410,12 +410,12 @@ impl core::ops::BitAnd for GameInputFlightStickButtons {
 }
 impl core::ops::BitOrAssign for GameInputFlightStickButtons {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for GameInputFlightStickButtons {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for GameInputFlightStickButtons {
@@ -470,12 +470,12 @@ impl core::ops::BitAnd for GameInputFocusPolicy {
 }
 impl core::ops::BitOrAssign for GameInputFocusPolicy {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for GameInputFocusPolicy {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for GameInputFocusPolicy {
@@ -628,12 +628,12 @@ impl core::ops::BitAnd for GameInputGamepadButtons {
 }
 impl core::ops::BitOrAssign for GameInputGamepadButtons {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for GameInputGamepadButtons {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for GameInputGamepadButtons {
@@ -770,12 +770,12 @@ impl core::ops::BitAnd for GameInputKind {
 }
 impl core::ops::BitOrAssign for GameInputKind {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for GameInputKind {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for GameInputKind {
@@ -1000,12 +1000,12 @@ impl core::ops::BitAnd for GameInputMouseButtons {
 }
 impl core::ops::BitOrAssign for GameInputMouseButtons {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for GameInputMouseButtons {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for GameInputMouseButtons {
@@ -1091,12 +1091,12 @@ impl core::ops::BitAnd for GameInputRacingWheelButtons {
 }
 impl core::ops::BitOrAssign for GameInputRacingWheelButtons {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for GameInputRacingWheelButtons {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for GameInputRacingWheelButtons {
@@ -1206,12 +1206,12 @@ impl core::ops::BitAnd for GameInputRawDeviceReportItemFlags {
 }
 impl core::ops::BitOrAssign for GameInputRawDeviceReportItemFlags {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for GameInputRawDeviceReportItemFlags {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for GameInputRawDeviceReportItemFlags {
@@ -1277,12 +1277,12 @@ impl core::ops::BitAnd for GameInputRumbleMotors {
 }
 impl core::ops::BitOrAssign for GameInputRumbleMotors {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for GameInputRumbleMotors {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for GameInputRumbleMotors {
@@ -1350,12 +1350,12 @@ impl core::ops::BitAnd for GameInputSystemButtons {
 }
 impl core::ops::BitOrAssign for GameInputSystemButtons {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for GameInputSystemButtons {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for GameInputSystemButtons {
@@ -1430,12 +1430,12 @@ impl core::ops::BitAnd for GameInputUiNavigationButtons {
 }
 impl core::ops::BitOrAssign for GameInputUiNavigationButtons {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for GameInputUiNavigationButtons {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for GameInputUiNavigationButtons {

--- a/crates/libs/windows/src/Windows/Win32/UI/Input/Ime/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Input/Ime/mod.rs
@@ -5378,12 +5378,12 @@ impl core::ops::BitAnd for IME_COMPOSITION_STRING {
 }
 impl core::ops::BitOrAssign for IME_COMPOSITION_STRING {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for IME_COMPOSITION_STRING {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for IME_COMPOSITION_STRING {
@@ -5417,12 +5417,12 @@ impl core::ops::BitAnd for IME_CONVERSION_MODE {
 }
 impl core::ops::BitOrAssign for IME_CONVERSION_MODE {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for IME_CONVERSION_MODE {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for IME_CONVERSION_MODE {
@@ -5504,12 +5504,12 @@ impl core::ops::BitAnd for IME_SENTENCE_MODE {
 }
 impl core::ops::BitOrAssign for IME_SENTENCE_MODE {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for IME_SENTENCE_MODE {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for IME_SENTENCE_MODE {

--- a/crates/libs/windows/src/Windows/Win32/UI/Input/KeyboardAndMouse/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Input/KeyboardAndMouse/mod.rs
@@ -361,12 +361,12 @@ impl core::ops::BitAnd for HOT_KEY_MODIFIERS {
 }
 impl core::ops::BitOrAssign for HOT_KEY_MODIFIERS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for HOT_KEY_MODIFIERS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for HOT_KEY_MODIFIERS {
@@ -538,12 +538,12 @@ impl core::ops::BitAnd for KEYBD_EVENT_FLAGS {
 }
 impl core::ops::BitOrAssign for KEYBD_EVENT_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for KEYBD_EVENT_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for KEYBD_EVENT_FLAGS {
@@ -728,12 +728,12 @@ impl core::ops::BitAnd for MOUSE_EVENT_FLAGS {
 }
 impl core::ops::BitOrAssign for MOUSE_EVENT_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for MOUSE_EVENT_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for MOUSE_EVENT_FLAGS {
@@ -813,12 +813,12 @@ impl core::ops::BitAnd for TRACKMOUSEEVENT_FLAGS {
 }
 impl core::ops::BitOrAssign for TRACKMOUSEEVENT_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for TRACKMOUSEEVENT_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for TRACKMOUSEEVENT_FLAGS {

--- a/crates/libs/windows/src/Windows/Win32/UI/Input/Pointer/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Input/Pointer/mod.rs
@@ -326,12 +326,12 @@ impl core::ops::BitAnd for POINTER_FLAGS {
 }
 impl core::ops::BitOrAssign for POINTER_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for POINTER_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for POINTER_FLAGS {

--- a/crates/libs/windows/src/Windows/Win32/UI/Input/Touch/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Input/Touch/mod.rs
@@ -77,12 +77,12 @@ impl core::ops::BitAnd for GESTURECONFIG_ID {
 }
 impl core::ops::BitOrAssign for GESTURECONFIG_ID {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for GESTURECONFIG_ID {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for GESTURECONFIG_ID {
@@ -1375,12 +1375,12 @@ impl core::ops::BitAnd for MANIPULATION_PROCESSOR_MANIPULATIONS {
 }
 impl core::ops::BitOrAssign for MANIPULATION_PROCESSOR_MANIPULATIONS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for MANIPULATION_PROCESSOR_MANIPULATIONS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for MANIPULATION_PROCESSOR_MANIPULATIONS {
@@ -1420,12 +1420,12 @@ impl core::ops::BitAnd for TOUCHEVENTF_FLAGS {
 }
 impl core::ops::BitOrAssign for TOUCHEVENTF_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for TOUCHEVENTF_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for TOUCHEVENTF_FLAGS {
@@ -1479,12 +1479,12 @@ impl core::ops::BitAnd for TOUCHINPUTMASKF_MASK {
 }
 impl core::ops::BitOrAssign for TOUCHINPUTMASKF_MASK {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for TOUCHINPUTMASKF_MASK {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for TOUCHINPUTMASKF_MASK {

--- a/crates/libs/windows/src/Windows/Win32/UI/Input/XboxController/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Input/XboxController/mod.rs
@@ -122,12 +122,12 @@ impl core::ops::BitAnd for XINPUT_CAPABILITIES_FLAGS {
 }
 impl core::ops::BitOrAssign for XINPUT_CAPABILITIES_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for XINPUT_CAPABILITIES_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for XINPUT_CAPABILITIES_FLAGS {
@@ -184,12 +184,12 @@ impl core::ops::BitAnd for XINPUT_FLAG {
 }
 impl core::ops::BitOrAssign for XINPUT_FLAG {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for XINPUT_FLAG {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for XINPUT_FLAG {
@@ -236,12 +236,12 @@ impl core::ops::BitAnd for XINPUT_GAMEPAD_BUTTON_FLAGS {
 }
 impl core::ops::BitOrAssign for XINPUT_GAMEPAD_BUTTON_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for XINPUT_GAMEPAD_BUTTON_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for XINPUT_GAMEPAD_BUTTON_FLAGS {
@@ -295,12 +295,12 @@ impl core::ops::BitAnd for XINPUT_KEYSTROKE_FLAGS {
 }
 impl core::ops::BitOrAssign for XINPUT_KEYSTROKE_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for XINPUT_KEYSTROKE_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for XINPUT_KEYSTROKE_FLAGS {

--- a/crates/libs/windows/src/Windows/Win32/UI/Input/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Input/mod.rs
@@ -178,12 +178,12 @@ impl core::ops::BitAnd for RAWINPUTDEVICE_FLAGS {
 }
 impl core::ops::BitOrAssign for RAWINPUTDEVICE_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for RAWINPUTDEVICE_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for RAWINPUTDEVICE_FLAGS {

--- a/crates/libs/windows/src/Windows/Win32/UI/InteractionContext/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/InteractionContext/mod.rs
@@ -202,12 +202,12 @@ impl core::ops::BitAnd for CROSS_SLIDE_FLAGS {
 }
 impl core::ops::BitOrAssign for CROSS_SLIDE_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CROSS_SLIDE_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CROSS_SLIDE_FLAGS {
@@ -318,12 +318,12 @@ impl core::ops::BitAnd for INTERACTION_CONFIGURATION_FLAGS {
 }
 impl core::ops::BitOrAssign for INTERACTION_CONFIGURATION_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for INTERACTION_CONFIGURATION_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for INTERACTION_CONFIGURATION_FLAGS {
@@ -463,12 +463,12 @@ impl core::ops::BitAnd for INTERACTION_FLAGS {
 }
 impl core::ops::BitOrAssign for INTERACTION_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for INTERACTION_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for INTERACTION_FLAGS {

--- a/crates/libs/windows/src/Windows/Win32/UI/Ribbon/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Ribbon/mod.rs
@@ -926,12 +926,12 @@ impl core::ops::BitAnd for UI_INVALIDATIONS {
 }
 impl core::ops::BitOrAssign for UI_INVALIDATIONS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for UI_INVALIDATIONS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for UI_INVALIDATIONS {

--- a/crates/libs/windows/src/Windows/Win32/UI/Shell/PropertiesSystem/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Shell/PropertiesSystem/mod.rs
@@ -742,12 +742,12 @@ impl core::ops::BitAnd for GETPROPERTYSTOREFLAGS {
 }
 impl core::ops::BitOrAssign for GETPROPERTYSTOREFLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for GETPROPERTYSTOREFLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for GETPROPERTYSTOREFLAGS {
@@ -3235,12 +3235,12 @@ impl core::ops::BitAnd for PKA_FLAGS {
 }
 impl core::ops::BitOrAssign for PKA_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for PKA_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for PKA_FLAGS {
@@ -3273,12 +3273,12 @@ impl core::ops::BitAnd for PLACEHOLDER_STATES {
 }
 impl core::ops::BitOrAssign for PLACEHOLDER_STATES {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for PLACEHOLDER_STATES {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for PLACEHOLDER_STATES {
@@ -3324,12 +3324,12 @@ impl core::ops::BitAnd for PROPDESC_FORMAT_FLAGS {
 }
 impl core::ops::BitOrAssign for PROPDESC_FORMAT_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for PROPDESC_FORMAT_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for PROPDESC_FORMAT_FLAGS {
@@ -3366,12 +3366,12 @@ impl core::ops::BitAnd for PROPDESC_SEARCHINFO_FLAGS {
 }
 impl core::ops::BitOrAssign for PROPDESC_SEARCHINFO_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for PROPDESC_SEARCHINFO_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for PROPDESC_SEARCHINFO_FLAGS {
@@ -3405,12 +3405,12 @@ impl core::ops::BitAnd for PROPDESC_TYPE_FLAGS {
 }
 impl core::ops::BitOrAssign for PROPDESC_TYPE_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for PROPDESC_TYPE_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for PROPDESC_TYPE_FLAGS {
@@ -3441,12 +3441,12 @@ impl core::ops::BitAnd for PROPDESC_VIEW_FLAGS {
 }
 impl core::ops::BitOrAssign for PROPDESC_VIEW_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for PROPDESC_VIEW_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for PROPDESC_VIEW_FLAGS {
@@ -3480,12 +3480,12 @@ impl core::ops::BitAnd for PROPERTYUI_FLAGS {
 }
 impl core::ops::BitOrAssign for PROPERTYUI_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for PROPERTYUI_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for PROPERTYUI_FLAGS {
@@ -3516,12 +3516,12 @@ impl core::ops::BitAnd for PROPERTYUI_FORMAT_FLAGS {
 }
 impl core::ops::BitOrAssign for PROPERTYUI_FORMAT_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for PROPERTYUI_FORMAT_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for PROPERTYUI_FORMAT_FLAGS {
@@ -3552,12 +3552,12 @@ impl core::ops::BitAnd for PROPERTYUI_NAME_FLAGS {
 }
 impl core::ops::BitOrAssign for PROPERTYUI_NAME_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for PROPERTYUI_NAME_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for PROPERTYUI_NAME_FLAGS {
@@ -3660,12 +3660,12 @@ impl core::ops::BitAnd for SYNC_ENGINE_STATE_FLAGS {
 }
 impl core::ops::BitOrAssign for SYNC_ENGINE_STATE_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for SYNC_ENGINE_STATE_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for SYNC_ENGINE_STATE_FLAGS {
@@ -3696,12 +3696,12 @@ impl core::ops::BitAnd for SYNC_TRANSFER_STATUS {
 }
 impl core::ops::BitOrAssign for SYNC_TRANSFER_STATUS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for SYNC_TRANSFER_STATUS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for SYNC_TRANSFER_STATUS {

--- a/crates/libs/windows/src/Windows/Win32/UI/Shell/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Shell/mod.rs
@@ -5477,12 +5477,12 @@ impl core::ops::BitAnd for ACTIVATEOPTIONS {
 }
 impl core::ops::BitOrAssign for ACTIVATEOPTIONS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for ACTIVATEOPTIONS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for ACTIVATEOPTIONS {
@@ -5517,12 +5517,12 @@ impl core::ops::BitAnd for ADJACENT_DISPLAY_EDGES {
 }
 impl core::ops::BitOrAssign for ADJACENT_DISPLAY_EDGES {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for ADJACENT_DISPLAY_EDGES {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for ADJACENT_DISPLAY_EDGES {
@@ -5569,12 +5569,12 @@ impl core::ops::BitAnd for AHTYPE {
 }
 impl core::ops::BitOrAssign for AHTYPE {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for AHTYPE {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for AHTYPE {
@@ -5787,12 +5787,12 @@ impl core::ops::BitAnd for ASSOCF {
 }
 impl core::ops::BitOrAssign for ASSOCF {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for ASSOCF {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for ASSOCF {
@@ -5901,12 +5901,12 @@ impl core::ops::BitAnd for ASSOC_FILTER {
 }
 impl core::ops::BitOrAssign for ASSOC_FILTER {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for ASSOC_FILTER {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for ASSOC_FILTER {
@@ -6293,12 +6293,12 @@ impl core::ops::BitAnd for CATEGORYINFO_FLAGS {
 }
 impl core::ops::BitOrAssign for CATEGORYINFO_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CATEGORYINFO_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CATEGORYINFO_FLAGS {
@@ -6360,12 +6360,12 @@ impl core::ops::BitAnd for CATSORT_FLAGS {
 }
 impl core::ops::BitOrAssign for CATSORT_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CATSORT_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CATSORT_FLAGS {
@@ -6421,12 +6421,12 @@ impl core::ops::BitAnd for CDCONTROLSTATEF {
 }
 impl core::ops::BitOrAssign for CDCONTROLSTATEF {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CDCONTROLSTATEF {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CDCONTROLSTATEF {
@@ -6725,12 +6725,12 @@ impl core::ops::BitAnd for CM_ENUM_FLAGS {
 }
 impl core::ops::BitOrAssign for CM_ENUM_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CM_ENUM_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CM_ENUM_FLAGS {
@@ -6762,12 +6762,12 @@ impl core::ops::BitAnd for CM_MASK {
 }
 impl core::ops::BitOrAssign for CM_MASK {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CM_MASK {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CM_MASK {
@@ -6806,12 +6806,12 @@ impl core::ops::BitAnd for CM_STATE {
 }
 impl core::ops::BitOrAssign for CM_STATE {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CM_STATE {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CM_STATE {
@@ -7064,12 +7064,12 @@ impl core::ops::BitAnd for CREDENTIAL_PROVIDER_ACCOUNT_OPTIONS {
 }
 impl core::ops::BitOrAssign for CREDENTIAL_PROVIDER_ACCOUNT_OPTIONS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CREDENTIAL_PROVIDER_ACCOUNT_OPTIONS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CREDENTIAL_PROVIDER_ACCOUNT_OPTIONS {
@@ -7100,12 +7100,12 @@ impl core::ops::BitAnd for CREDENTIAL_PROVIDER_CREDENTIAL_FIELD_OPTIONS {
 }
 impl core::ops::BitOrAssign for CREDENTIAL_PROVIDER_CREDENTIAL_FIELD_OPTIONS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CREDENTIAL_PROVIDER_CREDENTIAL_FIELD_OPTIONS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CREDENTIAL_PROVIDER_CREDENTIAL_FIELD_OPTIONS {
@@ -7287,12 +7287,12 @@ impl core::ops::BitAnd for DATAOBJ_GET_ITEM_FLAGS {
 }
 impl core::ops::BitOrAssign for DATAOBJ_GET_ITEM_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for DATAOBJ_GET_ITEM_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for DATAOBJ_GET_ITEM_FLAGS {
@@ -7371,12 +7371,12 @@ impl core::ops::BitAnd for DEFAULT_FOLDER_MENU_RESTRICTIONS {
 }
 impl core::ops::BitOrAssign for DEFAULT_FOLDER_MENU_RESTRICTIONS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for DEFAULT_FOLDER_MENU_RESTRICTIONS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for DEFAULT_FOLDER_MENU_RESTRICTIONS {
@@ -7468,12 +7468,12 @@ impl core::ops::BitAnd for DESKTOP_SLIDESHOW_OPTIONS {
 }
 impl core::ops::BitOrAssign for DESKTOP_SLIDESHOW_OPTIONS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for DESKTOP_SLIDESHOW_OPTIONS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for DESKTOP_SLIDESHOW_OPTIONS {
@@ -7504,12 +7504,12 @@ impl core::ops::BitAnd for DESKTOP_SLIDESHOW_STATE {
 }
 impl core::ops::BitOrAssign for DESKTOP_SLIDESHOW_STATE {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for DESKTOP_SLIDESHOW_STATE {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for DESKTOP_SLIDESHOW_STATE {
@@ -7850,12 +7850,12 @@ impl core::ops::BitAnd for DSH_FLAGS {
 }
 impl core::ops::BitOrAssign for DSH_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for DSH_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for DSH_FLAGS {
@@ -8121,12 +8121,12 @@ impl core::ops::BitAnd for EXPLORER_BROWSER_FILL_FLAGS {
 }
 impl core::ops::BitOrAssign for EXPLORER_BROWSER_FILL_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for EXPLORER_BROWSER_FILL_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for EXPLORER_BROWSER_FILL_FLAGS {
@@ -8157,12 +8157,12 @@ impl core::ops::BitAnd for EXPLORER_BROWSER_OPTIONS {
 }
 impl core::ops::BitOrAssign for EXPLORER_BROWSER_OPTIONS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for EXPLORER_BROWSER_OPTIONS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for EXPLORER_BROWSER_OPTIONS {
@@ -8427,12 +8427,12 @@ impl core::ops::BitAnd for FILEOPENDIALOGOPTIONS {
 }
 impl core::ops::BitOrAssign for FILEOPENDIALOGOPTIONS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for FILEOPENDIALOGOPTIONS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for FILEOPENDIALOGOPTIONS {
@@ -8463,12 +8463,12 @@ impl core::ops::BitAnd for FILEOPERATION_FLAGS {
 }
 impl core::ops::BitOrAssign for FILEOPERATION_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for FILEOPERATION_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for FILEOPERATION_FLAGS {
@@ -8499,12 +8499,12 @@ impl core::ops::BitAnd for FILETYPEATTRIBUTEFLAGS {
 }
 impl core::ops::BitOrAssign for FILETYPEATTRIBUTEFLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for FILETYPEATTRIBUTEFLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for FILETYPEATTRIBUTEFLAGS {
@@ -8548,12 +8548,12 @@ impl core::ops::BitAnd for FILE_OPERATION_FLAGS2 {
 }
 impl core::ops::BitOrAssign for FILE_OPERATION_FLAGS2 {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for FILE_OPERATION_FLAGS2 {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for FILE_OPERATION_FLAGS2 {
@@ -8648,12 +8648,12 @@ impl core::ops::BitAnd for FOLDERFLAGS {
 }
 impl core::ops::BitOrAssign for FOLDERFLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for FOLDERFLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for FOLDERFLAGS {
@@ -8882,12 +8882,12 @@ impl core::ops::BitAnd for FOLDERVIEWOPTIONS {
 }
 impl core::ops::BitOrAssign for FOLDERVIEWOPTIONS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for FOLDERVIEWOPTIONS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for FOLDERVIEWOPTIONS {
@@ -10596,12 +10596,12 @@ impl core::ops::BitAnd for HLBWIF_FLAGS {
 }
 impl core::ops::BitOrAssign for HLBWIF_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for HLBWIF_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for HLBWIF_FLAGS {
@@ -10646,12 +10646,12 @@ impl core::ops::BitAnd for HLFNAMEF {
 }
 impl core::ops::BitOrAssign for HLFNAMEF {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for HLFNAMEF {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for HLFNAMEF {
@@ -10725,12 +10725,12 @@ impl core::ops::BitAnd for HLNF {
 }
 impl core::ops::BitOrAssign for HLNF {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for HLNF {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for HLNF {
@@ -10813,12 +10813,12 @@ impl core::ops::BitAnd for HOMEGROUPSHARINGCHOICES {
 }
 impl core::ops::BitOrAssign for HOMEGROUPSHARINGCHOICES {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for HOMEGROUPSHARINGCHOICES {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for HOMEGROUPSHARINGCHOICES {
@@ -51758,12 +51758,12 @@ impl core::ops::BitAnd for KNOWN_FOLDER_FLAG {
 }
 impl core::ops::BitOrAssign for KNOWN_FOLDER_FLAG {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for KNOWN_FOLDER_FLAG {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for KNOWN_FOLDER_FLAG {
@@ -51801,12 +51801,12 @@ impl core::ops::BitAnd for LIBRARYMANAGEDIALOGOPTIONS {
 }
 impl core::ops::BitOrAssign for LIBRARYMANAGEDIALOGOPTIONS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for LIBRARYMANAGEDIALOGOPTIONS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for LIBRARYMANAGEDIALOGOPTIONS {
@@ -51837,12 +51837,12 @@ impl core::ops::BitAnd for LIBRARYOPTIONFLAGS {
 }
 impl core::ops::BitOrAssign for LIBRARYOPTIONFLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for LIBRARYOPTIONFLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for LIBRARYOPTIONFLAGS {
@@ -51873,12 +51873,12 @@ impl core::ops::BitAnd for LIBRARYSAVEFLAGS {
 }
 impl core::ops::BitOrAssign for LIBRARYSAVEFLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for LIBRARYSAVEFLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for LIBRARYSAVEFLAGS {
@@ -51955,12 +51955,12 @@ impl core::ops::BitAnd for MM_FLAGS {
 }
 impl core::ops::BitOrAssign for MM_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for MM_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for MM_FLAGS {
@@ -52044,12 +52044,12 @@ impl core::ops::BitAnd for NAMESPACEWALKFLAG {
 }
 impl core::ops::BitOrAssign for NAMESPACEWALKFLAG {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for NAMESPACEWALKFLAG {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for NAMESPACEWALKFLAG {
@@ -52371,12 +52371,12 @@ impl core::ops::BitAnd for NOTIFY_ICON_DATA_FLAGS {
 }
 impl core::ops::BitOrAssign for NOTIFY_ICON_DATA_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for NOTIFY_ICON_DATA_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for NOTIFY_ICON_DATA_FLAGS {
@@ -52407,12 +52407,12 @@ impl core::ops::BitAnd for NOTIFY_ICON_INFOTIP_FLAGS {
 }
 impl core::ops::BitOrAssign for NOTIFY_ICON_INFOTIP_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for NOTIFY_ICON_INFOTIP_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for NOTIFY_ICON_INFOTIP_FLAGS {
@@ -52446,12 +52446,12 @@ impl core::ops::BitAnd for NOTIFY_ICON_STATE {
 }
 impl core::ops::BitOrAssign for NOTIFY_ICON_STATE {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for NOTIFY_ICON_STATE {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for NOTIFY_ICON_STATE {
@@ -52527,12 +52527,12 @@ impl core::ops::BitAnd for NSTCFOLDERCAPABILITIES {
 }
 impl core::ops::BitOrAssign for NSTCFOLDERCAPABILITIES {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for NSTCFOLDERCAPABILITIES {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for NSTCFOLDERCAPABILITIES {
@@ -52588,12 +52588,12 @@ impl core::ops::BitAnd for NSTCSTYLE2 {
 }
 impl core::ops::BitOrAssign for NSTCSTYLE2 {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for NSTCSTYLE2 {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for NSTCSTYLE2 {
@@ -52714,12 +52714,12 @@ impl core::ops::BitAnd for NWMF {
 }
 impl core::ops::BitOrAssign for NWMF {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for NWMF {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for NWMF {
@@ -52802,12 +52802,12 @@ impl core::ops::BitAnd for OPEN_AS_INFO_FLAGS {
 }
 impl core::ops::BitOrAssign for OPEN_AS_INFO_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for OPEN_AS_INFO_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for OPEN_AS_INFO_FLAGS {
@@ -52983,12 +52983,12 @@ impl core::ops::BitAnd for PATHCCH_OPTIONS {
 }
 impl core::ops::BitOrAssign for PATHCCH_OPTIONS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for PATHCCH_OPTIONS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for PATHCCH_OPTIONS {
@@ -53023,12 +53023,12 @@ impl core::ops::BitAnd for PCS_RET {
 }
 impl core::ops::BitOrAssign for PCS_RET {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for PCS_RET {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for PCS_RET {
@@ -53108,12 +53108,12 @@ impl core::ops::BitAnd for PIDISF_FLAGS {
 }
 impl core::ops::BitOrAssign for PIDISF_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for PIDISF_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for PIDISF_FLAGS {
@@ -53273,12 +53273,12 @@ impl core::ops::BitAnd for PRF_FLAGS {
 }
 impl core::ops::BitOrAssign for PRF_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for PRF_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for PRF_FLAGS {
@@ -53446,12 +53446,12 @@ impl core::ops::BitAnd for QITIPF_FLAGS {
 }
 impl core::ops::BitOrAssign for QITIPF_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for QITIPF_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for QITIPF_FLAGS {
@@ -53706,12 +53706,12 @@ impl core::ops::BitAnd for SCALE_CHANGE_FLAGS {
 }
 impl core::ops::BitOrAssign for SCALE_CHANGE_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for SCALE_CHANGE_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for SCALE_CHANGE_FLAGS {
@@ -53993,12 +53993,12 @@ impl core::ops::BitAnd for SHCNE_ID {
 }
 impl core::ops::BitOrAssign for SHCNE_ID {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for SHCNE_ID {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for SHCNE_ID {
@@ -54043,12 +54043,12 @@ impl core::ops::BitAnd for SHCNF_FLAGS {
 }
 impl core::ops::BitOrAssign for SHCNF_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for SHCNF_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for SHCNF_FLAGS {
@@ -54093,12 +54093,12 @@ impl core::ops::BitAnd for SHCNRF_SOURCE {
 }
 impl core::ops::BitOrAssign for SHCNRF_SOURCE {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for SHCNRF_SOURCE {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for SHCNRF_SOURCE {
@@ -54535,12 +54535,12 @@ impl core::ops::BitAnd for SHELL_AUTOCOMPLETE_FLAGS {
 }
 impl core::ops::BitOrAssign for SHELL_AUTOCOMPLETE_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for SHELL_AUTOCOMPLETE_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for SHELL_AUTOCOMPLETE_FLAGS {
@@ -54583,12 +54583,12 @@ impl core::ops::BitAnd for SHELL_LINK_DATA_FLAGS {
 }
 impl core::ops::BitOrAssign for SHELL_LINK_DATA_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for SHELL_LINK_DATA_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for SHELL_LINK_DATA_FLAGS {
@@ -54783,12 +54783,12 @@ impl core::ops::BitAnd for SHFMT_OPT {
 }
 impl core::ops::BitOrAssign for SHFMT_OPT {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for SHFMT_OPT {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for SHFMT_OPT {
@@ -54868,12 +54868,12 @@ impl core::ops::BitAnd for SHGFI_FLAGS {
 }
 impl core::ops::BitOrAssign for SHGFI_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for SHGFI_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for SHGFI_FLAGS {
@@ -54931,12 +54931,12 @@ impl core::ops::BitAnd for SHGSI_FLAGS {
 }
 impl core::ops::BitOrAssign for SHGSI_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for SHGSI_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for SHGSI_FLAGS {
@@ -55035,12 +55035,12 @@ impl core::ops::BitAnd for SHOP_TYPE {
 }
 impl core::ops::BitOrAssign for SHOP_TYPE {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for SHOP_TYPE {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for SHOP_TYPE {
@@ -55157,12 +55157,12 @@ impl core::ops::BitAnd for SIATTRIBFLAGS {
 }
 impl core::ops::BitOrAssign for SIATTRIBFLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for SIATTRIBFLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for SIATTRIBFLAGS {
@@ -55333,12 +55333,12 @@ impl core::ops::BitAnd for SIIGBF {
 }
 impl core::ops::BitOrAssign for SIIGBF {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for SIIGBF {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for SIIGBF {
@@ -55415,12 +55415,12 @@ impl core::ops::BitAnd for SLGP_FLAGS {
 }
 impl core::ops::BitOrAssign for SLGP_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for SLGP_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for SLGP_FLAGS {
@@ -55464,12 +55464,12 @@ impl core::ops::BitAnd for SLR_FLAGS {
 }
 impl core::ops::BitOrAssign for SLR_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for SLR_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for SLR_FLAGS {
@@ -55722,12 +55722,12 @@ impl core::ops::BitAnd for SSF_MASK {
 }
 impl core::ops::BitOrAssign for SSF_MASK {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for SSF_MASK {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for SSF_MASK {
@@ -55792,12 +55792,12 @@ impl core::ops::BitAnd for STORAGE_PROVIDER_FILE_FLAGS {
 }
 impl core::ops::BitOrAssign for STORAGE_PROVIDER_FILE_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for STORAGE_PROVIDER_FILE_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for STORAGE_PROVIDER_FILE_FLAGS {
@@ -55829,12 +55829,12 @@ impl core::ops::BitAnd for STPFLAG {
 }
 impl core::ops::BitOrAssign for STPFLAG {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for STPFLAG {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for STPFLAG {
@@ -56361,12 +56361,12 @@ impl core::ops::BitAnd for TBPFLAG {
 }
 impl core::ops::BitOrAssign for TBPFLAG {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for TBPFLAG {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for TBPFLAG {
@@ -56430,12 +56430,12 @@ impl core::ops::BitAnd for THUMBBUTTONFLAGS {
 }
 impl core::ops::BitOrAssign for THUMBBUTTONFLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for THUMBBUTTONFLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for THUMBBUTTONFLAGS {
@@ -56466,12 +56466,12 @@ impl core::ops::BitAnd for THUMBBUTTONMASK {
 }
 impl core::ops::BitOrAssign for THUMBBUTTONMASK {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for THUMBBUTTONMASK {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for THUMBBUTTONMASK {
@@ -56559,12 +56559,12 @@ impl core::ops::BitAnd for ThumbnailStreamCacheOptions {
 }
 impl core::ops::BitOrAssign for ThumbnailStreamCacheOptions {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for ThumbnailStreamCacheOptions {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for ThumbnailStreamCacheOptions {
@@ -56712,12 +56712,12 @@ impl core::ops::BitAnd for VALIDATEUNC_OPTION {
 }
 impl core::ops::BitOrAssign for VALIDATEUNC_OPTION {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for VALIDATEUNC_OPTION {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for VALIDATEUNC_OPTION {
@@ -56778,12 +56778,12 @@ impl core::ops::BitAnd for VPWATERMARKFLAGS {
 }
 impl core::ops::BitOrAssign for VPWATERMARKFLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for VPWATERMARKFLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for VPWATERMARKFLAGS {
@@ -56858,12 +56858,12 @@ impl core::ops::BitAnd for WTS_CACHEFLAGS {
 }
 impl core::ops::BitOrAssign for WTS_CACHEFLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for WTS_CACHEFLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for WTS_CACHEFLAGS {
@@ -56894,12 +56894,12 @@ impl core::ops::BitAnd for WTS_CONTEXTFLAGS {
 }
 impl core::ops::BitOrAssign for WTS_CONTEXTFLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for WTS_CONTEXTFLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for WTS_CONTEXTFLAGS {
@@ -56944,12 +56944,12 @@ impl core::ops::BitAnd for WTS_FLAGS {
 }
 impl core::ops::BitOrAssign for WTS_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for WTS_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for WTS_FLAGS {
@@ -57012,12 +57012,12 @@ impl core::ops::BitAnd for _EXPCMDFLAGS {
 }
 impl core::ops::BitOrAssign for _EXPCMDFLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for _EXPCMDFLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for _EXPCMDFLAGS {
@@ -57048,12 +57048,12 @@ impl core::ops::BitAnd for _EXPCMDSTATE {
 }
 impl core::ops::BitOrAssign for _EXPCMDSTATE {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for _EXPCMDSTATE {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for _EXPCMDSTATE {
@@ -57141,12 +57141,12 @@ impl core::ops::BitAnd for _SVGIO {
 }
 impl core::ops::BitOrAssign for _SVGIO {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for _SVGIO {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for _SVGIO {

--- a/crates/libs/windows/src/Windows/Win32/UI/TextServices/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/TextServices/mod.rs
@@ -35,12 +35,12 @@ impl core::ops::BitAnd for ANCHOR_CHANGE_HISTORY_FLAGS {
 }
 impl core::ops::BitOrAssign for ANCHOR_CHANGE_HISTORY_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for ANCHOR_CHANGE_HISTORY_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for ANCHOR_CHANGE_HISTORY_FLAGS {
@@ -97,12 +97,12 @@ impl core::ops::BitAnd for GET_TEXT_AND_PROPERTY_UPDATES_FLAGS {
 }
 impl core::ops::BitOrAssign for GET_TEXT_AND_PROPERTY_UPDATES_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for GET_TEXT_AND_PROPERTY_UPDATES_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for GET_TEXT_AND_PROPERTY_UPDATES_FLAGS {
@@ -14484,12 +14484,12 @@ impl core::ops::BitAnd for TEXT_STORE_CHANGE_FLAGS {
 }
 impl core::ops::BitOrAssign for TEXT_STORE_CHANGE_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for TEXT_STORE_CHANGE_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for TEXT_STORE_CHANGE_FLAGS {
@@ -14523,12 +14523,12 @@ impl core::ops::BitAnd for TEXT_STORE_TEXT_CHANGE_FLAGS {
 }
 impl core::ops::BitOrAssign for TEXT_STORE_TEXT_CHANGE_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for TEXT_STORE_TEXT_CHANGE_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for TEXT_STORE_TEXT_CHANGE_FLAGS {
@@ -14580,12 +14580,12 @@ impl core::ops::BitAnd for TF_CONTEXT_EDIT_CONTEXT_FLAGS {
 }
 impl core::ops::BitOrAssign for TF_CONTEXT_EDIT_CONTEXT_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for TF_CONTEXT_EDIT_CONTEXT_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for TF_CONTEXT_EDIT_CONTEXT_FLAGS {

--- a/crates/libs/windows/src/Windows/Win32/UI/WindowsAndMessaging/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/WindowsAndMessaging/mod.rs
@@ -2562,12 +2562,12 @@ impl core::ops::BitAnd for ACCEL_VIRT_FLAGS {
 }
 impl core::ops::BitOrAssign for ACCEL_VIRT_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for ACCEL_VIRT_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for ACCEL_VIRT_FLAGS {
@@ -2611,12 +2611,12 @@ impl core::ops::BitAnd for ANIMATE_WINDOW_FLAGS {
 }
 impl core::ops::BitOrAssign for ANIMATE_WINDOW_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for ANIMATE_WINDOW_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for ANIMATE_WINDOW_FLAGS {
@@ -2739,12 +2739,12 @@ impl core::ops::BitAnd for CASCADE_WINDOWS_HOW {
 }
 impl core::ops::BitOrAssign for CASCADE_WINDOWS_HOW {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CASCADE_WINDOWS_HOW {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CASCADE_WINDOWS_HOW {
@@ -3002,12 +3002,12 @@ impl core::ops::BitAnd for CWP_FLAGS {
 }
 impl core::ops::BitOrAssign for CWP_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for CWP_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for CWP_FLAGS {
@@ -3297,12 +3297,12 @@ impl core::ops::BitAnd for DI_FLAGS {
 }
 impl core::ops::BitOrAssign for DI_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for DI_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for DI_FLAGS {
@@ -3576,12 +3576,12 @@ impl core::ops::BitAnd for FLASHWINFO_FLAGS {
 }
 impl core::ops::BitOrAssign for FLASHWINFO_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for FLASHWINFO_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for FLASHWINFO_FLAGS {
@@ -3678,12 +3678,12 @@ impl core::ops::BitAnd for GET_MENU_DEFAULT_ITEM_FLAGS {
 }
 impl core::ops::BitOrAssign for GET_MENU_DEFAULT_ITEM_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for GET_MENU_DEFAULT_ITEM_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for GET_MENU_DEFAULT_ITEM_FLAGS {
@@ -3776,12 +3776,12 @@ impl core::ops::BitAnd for GUITHREADINFO_FLAGS {
 }
 impl core::ops::BitOrAssign for GUITHREADINFO_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for GUITHREADINFO_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for GUITHREADINFO_FLAGS {
@@ -4261,12 +4261,12 @@ impl core::ops::BitAnd for IMAGE_FLAGS {
 }
 impl core::ops::BitOrAssign for IMAGE_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for IMAGE_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for IMAGE_FLAGS {
@@ -4328,12 +4328,12 @@ impl core::ops::BitAnd for KBDLLHOOKSTRUCT_FLAGS {
 }
 impl core::ops::BitOrAssign for KBDLLHOOKSTRUCT_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for KBDLLHOOKSTRUCT_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for KBDLLHOOKSTRUCT_FLAGS {
@@ -4371,12 +4371,12 @@ impl core::ops::BitAnd for LAYERED_WINDOW_ATTRIBUTES_FLAGS {
 }
 impl core::ops::BitOrAssign for LAYERED_WINDOW_ATTRIBUTES_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for LAYERED_WINDOW_ATTRIBUTES_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for LAYERED_WINDOW_ATTRIBUTES_FLAGS {
@@ -4477,12 +4477,12 @@ impl core::ops::BitAnd for LEGACY_TOUCHPAD_FEATURES {
 }
 impl core::ops::BitOrAssign for LEGACY_TOUCHPAD_FEATURES {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for LEGACY_TOUCHPAD_FEATURES {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for LEGACY_TOUCHPAD_FEATURES {
@@ -4691,12 +4691,12 @@ impl core::ops::BitAnd for MENUINFO_MASK {
 }
 impl core::ops::BitOrAssign for MENUINFO_MASK {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for MENUINFO_MASK {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for MENUINFO_MASK {
@@ -4727,12 +4727,12 @@ impl core::ops::BitAnd for MENUINFO_STYLE {
 }
 impl core::ops::BitOrAssign for MENUINFO_STYLE {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for MENUINFO_STYLE {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for MENUINFO_STYLE {
@@ -4866,12 +4866,12 @@ impl core::ops::BitAnd for MENU_ITEM_FLAGS {
 }
 impl core::ops::BitOrAssign for MENU_ITEM_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for MENU_ITEM_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for MENU_ITEM_FLAGS {
@@ -4902,12 +4902,12 @@ impl core::ops::BitAnd for MENU_ITEM_MASK {
 }
 impl core::ops::BitOrAssign for MENU_ITEM_MASK {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for MENU_ITEM_MASK {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for MENU_ITEM_MASK {
@@ -4938,12 +4938,12 @@ impl core::ops::BitAnd for MENU_ITEM_STATE {
 }
 impl core::ops::BitOrAssign for MENU_ITEM_STATE {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for MENU_ITEM_STATE {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for MENU_ITEM_STATE {
@@ -4974,12 +4974,12 @@ impl core::ops::BitAnd for MENU_ITEM_TYPE {
 }
 impl core::ops::BitOrAssign for MENU_ITEM_TYPE {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for MENU_ITEM_TYPE {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for MENU_ITEM_TYPE {
@@ -5017,12 +5017,12 @@ impl core::ops::BitAnd for MESSAGEBOX_STYLE {
 }
 impl core::ops::BitOrAssign for MESSAGEBOX_STYLE {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for MESSAGEBOX_STYLE {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for MESSAGEBOX_STYLE {
@@ -5279,12 +5279,12 @@ impl core::ops::BitAnd for MSG_WAIT_FOR_MULTIPLE_OBJECTS_EX_FLAGS {
 }
 impl core::ops::BitOrAssign for MSG_WAIT_FOR_MULTIPLE_OBJECTS_EX_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for MSG_WAIT_FOR_MULTIPLE_OBJECTS_EX_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for MSG_WAIT_FOR_MULTIPLE_OBJECTS_EX_FLAGS {
@@ -5564,12 +5564,12 @@ impl core::ops::BitAnd for PEEK_MESSAGE_REMOVE_TYPE {
 }
 impl core::ops::BitOrAssign for PEEK_MESSAGE_REMOVE_TYPE {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for PEEK_MESSAGE_REMOVE_TYPE {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for PEEK_MESSAGE_REMOVE_TYPE {
@@ -5682,12 +5682,12 @@ impl core::ops::BitAnd for QUEUE_STATUS_FLAGS {
 }
 impl core::ops::BitOrAssign for QUEUE_STATUS_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for QUEUE_STATUS_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for QUEUE_STATUS_FLAGS {
@@ -5718,12 +5718,12 @@ impl core::ops::BitAnd for REGISTER_NOTIFICATION_FLAGS {
 }
 impl core::ops::BitOrAssign for REGISTER_NOTIFICATION_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for REGISTER_NOTIFICATION_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for REGISTER_NOTIFICATION_FLAGS {
@@ -5862,12 +5862,12 @@ impl core::ops::BitAnd for SCROLLBAR_CONSTANTS {
 }
 impl core::ops::BitOrAssign for SCROLLBAR_CONSTANTS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for SCROLLBAR_CONSTANTS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for SCROLLBAR_CONSTANTS {
@@ -5909,12 +5909,12 @@ impl core::ops::BitAnd for SCROLLINFO_MASK {
 }
 impl core::ops::BitOrAssign for SCROLLINFO_MASK {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for SCROLLINFO_MASK {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for SCROLLINFO_MASK {
@@ -5945,12 +5945,12 @@ impl core::ops::BitAnd for SCROLL_WINDOW_FLAGS {
 }
 impl core::ops::BitOrAssign for SCROLL_WINDOW_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for SCROLL_WINDOW_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for SCROLL_WINDOW_FLAGS {
@@ -6003,12 +6003,12 @@ impl core::ops::BitAnd for SEND_MESSAGE_TIMEOUT_FLAGS {
 }
 impl core::ops::BitOrAssign for SEND_MESSAGE_TIMEOUT_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for SEND_MESSAGE_TIMEOUT_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for SEND_MESSAGE_TIMEOUT_FLAGS {
@@ -6039,12 +6039,12 @@ impl core::ops::BitAnd for SET_WINDOW_POS_FLAGS {
 }
 impl core::ops::BitOrAssign for SET_WINDOW_POS_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for SET_WINDOW_POS_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for SET_WINDOW_POS_FLAGS {
@@ -6573,12 +6573,12 @@ impl core::ops::BitAnd for SYSTEM_PARAMETERS_INFO_ACTION {
 }
 impl core::ops::BitOrAssign for SYSTEM_PARAMETERS_INFO_ACTION {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for SYSTEM_PARAMETERS_INFO_ACTION {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for SYSTEM_PARAMETERS_INFO_ACTION {
@@ -6609,12 +6609,12 @@ impl core::ops::BitAnd for SYSTEM_PARAMETERS_INFO_UPDATE_FLAGS {
 }
 impl core::ops::BitOrAssign for SYSTEM_PARAMETERS_INFO_UPDATE_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for SYSTEM_PARAMETERS_INFO_UPDATE_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for SYSTEM_PARAMETERS_INFO_UPDATE_FLAGS {
@@ -6772,12 +6772,12 @@ impl core::ops::BitAnd for TRACK_POPUP_MENU_FLAGS {
 }
 impl core::ops::BitOrAssign for TRACK_POPUP_MENU_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for TRACK_POPUP_MENU_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for TRACK_POPUP_MENU_FLAGS {
@@ -6933,12 +6933,12 @@ impl core::ops::BitAnd for WINDOWPLACEMENT_FLAGS {
 }
 impl core::ops::BitOrAssign for WINDOWPLACEMENT_FLAGS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for WINDOWPLACEMENT_FLAGS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for WINDOWPLACEMENT_FLAGS {
@@ -6999,12 +6999,12 @@ impl core::ops::BitAnd for WINDOW_ACTION_KINDS {
 }
 impl core::ops::BitOrAssign for WINDOW_ACTION_KINDS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for WINDOW_ACTION_KINDS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for WINDOW_ACTION_KINDS {
@@ -7035,12 +7035,12 @@ impl core::ops::BitAnd for WINDOW_ACTION_MODIFIERS {
 }
 impl core::ops::BitOrAssign for WINDOW_ACTION_MODIFIERS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for WINDOW_ACTION_MODIFIERS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for WINDOW_ACTION_MODIFIERS {
@@ -7074,12 +7074,12 @@ impl core::ops::BitAnd for WINDOW_EX_STYLE {
 }
 impl core::ops::BitOrAssign for WINDOW_EX_STYLE {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for WINDOW_EX_STYLE {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for WINDOW_EX_STYLE {
@@ -7119,12 +7119,12 @@ impl core::ops::BitAnd for WINDOW_STYLE {
 }
 impl core::ops::BitOrAssign for WINDOW_STYLE {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for WINDOW_STYLE {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for WINDOW_STYLE {
@@ -7498,12 +7498,12 @@ impl core::ops::BitAnd for WNDCLASS_STYLES {
 }
 impl core::ops::BitOrAssign for WNDCLASS_STYLES {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for WNDCLASS_STYLES {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for WNDCLASS_STYLES {

--- a/crates/samples/windows/direct3d12/src/main.rs
+++ b/crates/samples/windows/direct3d12/src/main.rs
@@ -326,7 +326,7 @@ mod imp {
                                 D3D12_CPU_DESCRIPTOR_HANDLE {
                                     ptr: rtv_handle.ptr + i * rtv_descriptor_size,
                                 },
-                            )
+                            );
                         };
                         Ok(render_target)
                     })?;
@@ -742,7 +742,7 @@ mod imp {
                     D3D12_RESOURCE_STATE_GENERIC_READ,
                     None,
                     &mut vertex_buffer,
-                )?
+                )?;
             };
             let vertex_buffer = vertex_buffer.unwrap();
 

--- a/crates/samples/windows/privileges/src/main.rs
+++ b/crates/samples/windows/privileges/src/main.rs
@@ -38,7 +38,7 @@ fn main() -> windows::core::Result<()> {
             let name = PWSTR(name.as_mut_ptr());
             LookupPrivilegeNameW(None, &privilege.Luid, Some(name), &mut name_len)?;
 
-            println!("{}", name.display())
+            println!("{}", name.display());
         }
 
         Ok(())

--- a/crates/samples/windows/webview/src/bindings.rs
+++ b/crates/samples/windows/webview/src/bindings.rs
@@ -415,12 +415,12 @@ impl core::ops::BitAnd for COREWEBVIEW2_BROWSING_DATA_KINDS {
 }
 impl core::ops::BitOrAssign for COREWEBVIEW2_BROWSING_DATA_KINDS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for COREWEBVIEW2_BROWSING_DATA_KINDS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for COREWEBVIEW2_BROWSING_DATA_KINDS {
@@ -732,12 +732,12 @@ impl core::ops::BitAnd for COREWEBVIEW2_MOUSE_EVENT_VIRTUAL_KEYS {
 }
 impl core::ops::BitOrAssign for COREWEBVIEW2_MOUSE_EVENT_VIRTUAL_KEYS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for COREWEBVIEW2_MOUSE_EVENT_VIRTUAL_KEYS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for COREWEBVIEW2_MOUSE_EVENT_VIRTUAL_KEYS {
@@ -817,12 +817,12 @@ impl core::ops::BitAnd for COREWEBVIEW2_PDF_TOOLBAR_ITEMS {
 }
 impl core::ops::BitOrAssign for COREWEBVIEW2_PDF_TOOLBAR_ITEMS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for COREWEBVIEW2_PDF_TOOLBAR_ITEMS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for COREWEBVIEW2_PDF_TOOLBAR_ITEMS {
@@ -1069,12 +1069,12 @@ impl core::ops::BitAnd for COREWEBVIEW2_RELEASE_CHANNELS {
 }
 impl core::ops::BitOrAssign for COREWEBVIEW2_RELEASE_CHANNELS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for COREWEBVIEW2_RELEASE_CHANNELS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for COREWEBVIEW2_RELEASE_CHANNELS {
@@ -1274,12 +1274,12 @@ impl core::ops::BitAnd for COREWEBVIEW2_WEB_RESOURCE_REQUEST_SOURCE_KINDS {
 }
 impl core::ops::BitOrAssign for COREWEBVIEW2_WEB_RESOURCE_REQUEST_SOURCE_KINDS {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for COREWEBVIEW2_WEB_RESOURCE_REQUEST_SOURCE_KINDS {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for COREWEBVIEW2_WEB_RESOURCE_REQUEST_SOURCE_KINDS {

--- a/crates/tests/misc/component/Cargo.toml
+++ b/crates/tests/misc/component/Cargo.toml
@@ -11,6 +11,7 @@ doctest = false
 
 [dependencies.windows-core]
 workspace = true
+default-features = true
 
 [dependencies.windows]
 workspace = true

--- a/crates/tests/misc/component/src/bindings.rs
+++ b/crates/tests/misc/component/src/bindings.rs
@@ -230,12 +230,12 @@ impl core::ops::BitAnd for Flags {
 }
 impl core::ops::BitOrAssign for Flags {
     fn bitor_assign(&mut self, other: Self) {
-        self.0.bitor_assign(other.0)
+        self.0.bitor_assign(other.0);
     }
 }
 impl core::ops::BitAndAssign for Flags {
     fn bitand_assign(&mut self, other: Self) {
-        self.0.bitand_assign(other.0)
+        self.0.bitand_assign(other.0);
     }
 }
 impl core::ops::Not for Flags {


### PR DESCRIPTION
This includes updates to `windows-bindgen` so that downstream bindings comply.