### PR TITLE
Add minimal string and deref to `windows-bindgen`

### DIFF
--- a/crates/libs/bindgen/src/types/class.rs
+++ b/crates/libs/bindgen/src/types/class.rs
@@ -201,6 +201,20 @@ impl Class {
                     })
             };
 
+            let deref = if config.minimal {
+                quote! {
+                    #cfg
+                    impl core::ops::Deref for #name {
+                        type Target = #default_interface;
+                        fn deref(&self) -> &Self::Target {
+                            unsafe { core::mem::transmute(self) }
+                        }
+                    }
+                }
+            } else {
+                quote! {}
+            };
+
             quote! {
                 #cfg
                 #[repr(transparent)]
@@ -224,6 +238,7 @@ impl Class {
                     type Vtable = <#default_interface as windows_core::Interface>::Vtable;
                     const IID: windows_core::GUID = <#default_interface as windows_core::Interface>::IID;
                 }
+                #deref
                 #runtime_name
                 #agile
                 #into_iterator

--- a/crates/libs/bindgen/src/types/method.rs
+++ b/crates/libs/bindgen/src/types/method.rs
@@ -179,6 +179,8 @@ impl Method {
 
         let return_type_tokens = if self.signature.return_type == Type::Void {
             quote! { () }
+        } else if config.minimal && matches!(self.signature.return_type, Type::String) {
+            quote! { String }
         } else {
             let tokens = self.signature.return_type.write_name(config);
 
@@ -380,6 +382,10 @@ impl Method {
                     quote! { windows_core::Param::param(#local.as_ref()).abi() }
                 } else if param.is_convertible() {
                     quote! { #name.param().abi() }
+                } else if config.minimal && param.is_input() && matches!(param.ty, Type::String) {
+                    // In minimal mode, string params accept &str directly.
+                    // Convert to HSTRING and pass its abi.
+                    quote! { core::mem::transmute_copy(&windows_core::HSTRING::from(#name)) }
                 } else if param.is_copyable(config.reader) {
                     if param.is_const_ref() {
                         quote! { &#name }
@@ -440,6 +446,12 @@ impl Method {
         // (only IReference<HSTRING> sugar; value-like inner doesn't need a generic).
         let is_ireference_string = |param: &Param| -> bool {
             matches!(param.ireference_inner(config.reader), Some(Type::String))
+        };
+
+        // In minimal mode, HSTRING input params accept `&str` directly — the generated
+        // method body handles the conversion to HSTRING internally.
+        let is_string_param = |param: &Param| -> bool {
+            config.minimal && param.is_input() && matches!(param.ty, Type::String)
         };
 
         let generics: Vec<TokenStream> = params
@@ -548,6 +560,8 @@ impl Method {
                     } else if let Some(inner) = param.ireference_inner(config.reader) {
                         let inner_name = inner.write_name(config);
                         quote! { #name: Option<#inner_name>, }
+                    } else if is_string_param(param) {
+                        quote! { #name: &str, }
                     } else if param.is_convertible() {
                         let kind: TokenStream = format!("P{position}").parse().unwrap();
                         quote! { #name: #kind, }
@@ -584,7 +598,10 @@ impl Method {
         let return_type = match &self.signature.return_type {
             Type::Void => quote! { () },
             _ => {
-                let tokens = if let Some(inner) = return_unwrap_inner {
+                let tokens = if config.minimal && matches!(self.signature.return_type, Type::String)
+                {
+                    quote! { String }
+                } else if let Some(inner) = return_unwrap_inner {
                     inner.write_name(config)
                 } else {
                     self.signature.return_type.write_name(config)
@@ -659,6 +676,16 @@ impl Method {
                                 #assert_success
                                 result__
                             }
+                        } else if config.minimal
+                            && matches!(self.signature.return_type, Type::String)
+                        {
+                            quote! {
+                                let mut result__ = core::mem::zeroed();
+                                let hresult__ = #vcall;
+                                #assert_success
+                                let hstring: windows_core::HSTRING = core::mem::transmute(result__);
+                                hstring.to_string_lossy()
+                            }
                         } else {
                             quote! {
                                 let mut result__ = core::mem::zeroed();
@@ -678,6 +705,17 @@ impl Method {
                             quote! {
                                 let mut result__ = core::mem::zeroed();
                                 #vcall.#map.and_then(|r__: #iref| r__.Value())
+                            }
+                        } else if config.minimal
+                            && matches!(self.signature.return_type, Type::String)
+                        {
+                            // In minimal mode, return String instead of HSTRING.
+                            quote! {
+                                let mut result__ = core::mem::zeroed();
+                                #vcall.map(|| {
+                                    let hstring: windows_core::HSTRING = core::mem::transmute(result__);
+                                    hstring.to_string_lossy()
+                                })
                             }
                         } else {
                             quote! {

--- a/crates/libs/bindgen/src/types/method.rs
+++ b/crates/libs/bindgen/src/types/method.rs
@@ -179,8 +179,6 @@ impl Method {
 
         let return_type_tokens = if self.signature.return_type == Type::Void {
             quote! { () }
-        } else if config.minimal && matches!(self.signature.return_type, Type::String) {
-            quote! { String }
         } else {
             let tokens = self.signature.return_type.write_name(config);
 

--- a/crates/tests/libs/bindgen/data/bindgen/minimal/expected.rs
+++ b/crates/tests/libs/bindgen/data/bindgen/minimal/expected.rs
@@ -54,12 +54,18 @@ pub mod Test {
         type Vtable = <IFoo as windows_core::Interface>::Vtable;
         const IID: windows_core::GUID = <IFoo as windows_core::Interface>::IID;
     }
+    impl core::ops::Deref for Foo {
+        type Target = IFoo;
+        fn deref(&self) -> &Self::Target {
+            unsafe { core::mem::transmute(self) }
+        }
+    }
     impl windows_core::RuntimeName for Foo {
         const NAME: &'static str = "Test.Foo";
     }
     pub const Green: Color = 1i32;
     pub type HANDLE = *mut core::ffi::c_void;
-    windows_core::imp::define_interface!(IFoo, IFoo_Vtbl, 0xf05f601f_33d2_54fc_adca_2df8c56fe621);
+    windows_core::imp::define_interface!(IFoo, IFoo_Vtbl, 0x29b2ee6f_e8bf_5d03_8e01_81e8ad109076);
     impl windows_core::RuntimeType for IFoo {
         const SIGNATURE: windows_core::imp::ConstBuffer =
             windows_core::imp::ConstBuffer::for_interface::<Self>();
@@ -75,6 +81,28 @@ pub mod Test {
                 .map(|| result__)
             }
         }
+        pub fn Name(&self) -> windows_result::Result<String> {
+            unsafe {
+                let mut result__ = core::mem::zeroed();
+                (windows_core::Interface::vtable(self).Name)(
+                    windows_core::Interface::as_raw(self),
+                    &mut result__,
+                )
+                .map(|| {
+                    let hstring: windows_core::HSTRING = core::mem::transmute(result__);
+                    hstring.to_string_lossy()
+                })
+            }
+        }
+        pub fn SetName(&self, value: &str) -> windows_result::Result<()> {
+            unsafe {
+                (windows_core::Interface::vtable(self).SetName)(
+                    windows_core::Interface::as_raw(self),
+                    core::mem::transmute_copy(&windows_core::HSTRING::from(value)),
+                )
+                .ok()
+            }
+        }
     }
     #[repr(C)]
     #[doc(hidden)]
@@ -82,6 +110,14 @@ pub mod Test {
         pub base__: windows_core::IInspectable_Vtbl,
         pub Direct:
             unsafe extern "system" fn(*mut core::ffi::c_void, *mut i32) -> windows_result::HRESULT,
+        pub Name: unsafe extern "system" fn(
+            *mut core::ffi::c_void,
+            *mut *mut core::ffi::c_void,
+        ) -> windows_result::HRESULT,
+        pub SetName: unsafe extern "system" fn(
+            *mut core::ffi::c_void,
+            *mut core::ffi::c_void,
+        ) -> windows_result::HRESULT,
     }
     windows_core::imp::define_interface!(IFoo2, IFoo2_Vtbl, 0xd5639aca_50ae_5b48_9f64_938ce24b8683);
     impl windows_core::RuntimeType for IFoo2 {

--- a/crates/tests/libs/bindgen/data/bindgen/minimal/input.rdl
+++ b/crates/tests/libs/bindgen/data/bindgen/minimal/input.rdl
@@ -48,6 +48,7 @@ mod Test {
     #[Windows::Foundation::Metadata::ExclusiveTo(Foo)]
     interface IFoo: IFoo2 {
         fn Direct(&self) -> i32;
+        Name: String;
     }
     interface IFoo2 {
         fn Bar(&self) -> i32;

--- a/crates/tests/winrt/events/Cargo.toml
+++ b/crates/tests/winrt/events/Cargo.toml
@@ -15,6 +15,7 @@ windows-rdl = { workspace = true }
 
 [dependencies.windows-core]
 workspace = true
+default-features = true
 
 [dependencies.windows]
 workspace = true

--- a/crates/tests/winrt/events_client/src/auto_bindings.rs
+++ b/crates/tests/winrt/events_client/src/auto_bindings.rs
@@ -74,6 +74,12 @@ unsafe impl windows_core::Interface for Class {
     type Vtable = <IClass as windows_core::Interface>::Vtable;
     const IID: windows_core::GUID = <IClass as windows_core::Interface>::IID;
 }
+impl core::ops::Deref for Class {
+    type Target = IClass;
+    fn deref(&self) -> &Self::Target {
+        unsafe { core::mem::transmute(self) }
+    }
+}
 impl windows_core::RuntimeName for Class {
     const NAME: &'static str = "test_events.Class";
 }


### PR DESCRIPTION
The minimal option now automatically converts to and from Rust strings and adds `Deref` for a class' default interface to avoid an unnecessary cast. 