### PR TITLE
Ensure all tests build individually

### DIFF
--- a/crates/libs/threading/examples/threading_bench.rs
+++ b/crates/libs/threading/examples/threading_bench.rs
@@ -16,11 +16,11 @@
 //!
 //! The benchmark prints a small table with three workloads:
 //! - `single`:   submit one closure, wait, repeat, average over 1000 trials —
-//!               approximates the `IAsync*::spawn(...).await` round trip.
+//!   approximates the `IAsync*::spawn(...).await` round trip.
 //! - `burst`:    submit 10 000 closures back-to-back, wait for them all.
 //! - `steady`:   submit 100 000 closures back-to-back, wait for them all
-//!               (warm-up effects amortize, so this is the throughput number
-//!               most representative of sustained load).
+//!   (warm-up effects amortize, so this is the throughput number
+//!   most representative of sustained load).
 //!
 //! Each closure does a single `fetch_add` on a shared counter so the
 //! per-submit dispatch path dominates the measurement.
@@ -63,12 +63,7 @@ mod bench {
         println!("{}", "-".repeat(64));
 
         // (1) Single submit + wait, averaged over many trials.
-        bench_single(
-            "single",
-            1_000,
-            |f| windows_threading::submit(f),
-            "win32-pool",
-        );
+        bench_single("single", 1_000, windows_threading::submit, "win32-pool");
         bench_single(
             "single",
             1_000,
@@ -79,12 +74,7 @@ mod bench {
         );
 
         // (2) Burst.
-        bench_burst(
-            "burst",
-            10_000,
-            |f| windows_threading::submit(f),
-            "win32-pool",
-        );
+        bench_burst("burst", 10_000, windows_threading::submit, "win32-pool");
         bench_burst(
             "burst",
             10_000,
@@ -95,12 +85,7 @@ mod bench {
         );
 
         // (3) Steady-state.
-        bench_burst(
-            "steady",
-            100_000,
-            |f| windows_threading::submit(f),
-            "win32-pool",
-        );
+        bench_burst("steady", 100_000, windows_threading::submit, "win32-pool");
         bench_burst(
             "steady",
             100_000,

--- a/crates/libs/time/src/datetime.rs
+++ b/crates/libs/time/src/datetime.rs
@@ -1,5 +1,5 @@
-use super::timespan::{TimeRangeError, TICKS_PER_DAY, TICKS_PER_SECOND};
-use super::{DateTime, TimeSpan};
+use super::timespan::*;
+use super::*;
 
 /// Number of seconds between 1601-01-01 UTC (the `DateTime` epoch) and
 /// 1970-01-01 UTC (the Unix epoch).

--- a/crates/libs/time/src/timespan.rs
+++ b/crates/libs/time/src/timespan.rs
@@ -1,4 +1,4 @@
-use super::TimeSpan;
+use super::*;
 
 /// Number of 100-nanosecond ticks per microsecond.
 pub const TICKS_PER_MICROSECOND: i64 = 10;

--- a/crates/samples/json/json_validator_winrt/Cargo.toml
+++ b/crates/samples/json/json_validator_winrt/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 jsonschema = { version = "0.23", default-features = false }
 serde_json = { workspace = true }
 windows = { workspace = true, features = ["Win32_System_WinRT"] }
-windows-core = { workspace = true }
+windows-core = { workspace = true , default-features = true }
 
 [build-dependencies]
 windows-rdl = { workspace = true }

--- a/crates/samples/json/json_validator_winrt_client/Cargo.toml
+++ b/crates/samples/json/json_validator_winrt_client/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dev-dependencies]
-windows-core = { workspace = true }
+windows-core = { workspace = true , default-features = true }
 windows = { workspace = true, features = ["Win32_Foundation"] }
 
 [build-dependencies]

--- a/crates/samples/robot/client/Cargo.toml
+++ b/crates/samples/robot/client/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-windows-core = { workspace = true }
+windows-core = { workspace = true , default-features = true }
 robot = { path = "../component" }
 
 [build-dependencies]

--- a/crates/samples/robot/component/Cargo.toml
+++ b/crates/samples/robot/component/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 windows = { workspace = true, features = ["Win32_System_WinRT"] }
-windows-core = { workspace = true }
+windows-core = { workspace = true , default-features = true }
 
 [build-dependencies]
 windows-rdl = { workspace = true }

--- a/crates/samples/windows/bits/Cargo.toml
+++ b/crates/samples/windows/bits/Cargo.toml
@@ -6,6 +6,7 @@ publish = false
 
 [dependencies.windows]
 workspace = true
+default-features = true
 features = [
     "Win32_System_Com",
     "Win32_Networking_BackgroundIntelligentTransferService",

--- a/crates/samples/windows/core_app/Cargo.toml
+++ b/crates/samples/windows/core_app/Cargo.toml
@@ -6,6 +6,7 @@ publish = false
 
 [dependencies.windows]
 workspace = true
+default-features = true
 features = [
     "ApplicationModel_Core",
     "UI_Core",

--- a/crates/samples/windows/dcomp/Cargo.toml
+++ b/crates/samples/windows/dcomp/Cargo.toml
@@ -6,6 +6,7 @@ publish = false
 
 [dependencies.windows]
 workspace = true
+default-features = true
 features = [
     "Win32_Graphics_Direct2D_Common",
     "Win32_Graphics_Direct3D",

--- a/crates/samples/windows/direct2d/Cargo.toml
+++ b/crates/samples/windows/direct2d/Cargo.toml
@@ -6,6 +6,7 @@ publish = false
 
 [dependencies.windows]
 workspace = true
+default-features = true
 features = [
     "Win32_System_Com",
     "Win32_Graphics_Direct2D_Common",

--- a/crates/samples/windows/ocr/Cargo.toml
+++ b/crates/samples/windows/ocr/Cargo.toml
@@ -6,6 +6,7 @@ publish = false
 
 [dependencies.windows]
 workspace = true
+default-features = true
 features = [
     "Media_Ocr",
     "Graphics_Imaging",

--- a/crates/samples/windows/webview/Cargo.toml
+++ b/crates/samples/windows/webview/Cargo.toml
@@ -9,6 +9,7 @@ windows-core = { workspace = true }
 
 [dependencies.windows]
 workspace = true
+default-features = true
 features = [
     "Win32_Foundation",
     "Win32_Graphics_Gdi",

--- a/crates/samples/windows/xaml_app/Cargo.toml
+++ b/crates/samples/windows/xaml_app/Cargo.toml
@@ -12,6 +12,7 @@ windows-numerics = { workspace = true }
 
 [dependencies.windows]
 workspace = true
+default-features = true
 features = [
     "ApplicationModel",
     "ApplicationModel_Activation",

--- a/crates/tests/libs/core/Cargo.toml
+++ b/crates/tests/libs/core/Cargo.toml
@@ -10,6 +10,7 @@ doctest = false
 
 [dependencies.windows]
 workspace = true
+default-features = true
 features = [
     "Win32_System_WinRT",
     "Win32_System_Ole",

--- a/crates/tests/libs/future/Cargo.toml
+++ b/crates/tests/libs/future/Cargo.toml
@@ -10,6 +10,7 @@ doctest = false
 
 [dependencies.windows]
 workspace = true
+default-features = true
 features = [
     "Storage_Streams",
     "System_Threading",

--- a/crates/tests/libs/implement/Cargo.toml
+++ b/crates/tests/libs/implement/Cargo.toml
@@ -10,6 +10,7 @@ doctest = false
 
 [dependencies.windows]
 workspace = true
+default-features = true
 features = [
     "ApplicationModel_Activation",
     "ApplicationModel_Background",

--- a/crates/tests/libs/interface/Cargo.toml
+++ b/crates/tests/libs/interface/Cargo.toml
@@ -10,6 +10,7 @@ doctest = false
 
 [dependencies.windows]
 workspace = true
+default-features = true
 features = [
     "Win32_Graphics_Direct3D",
     "Win32_Graphics_Direct3D10",

--- a/crates/tests/misc/agile_reference/Cargo.toml
+++ b/crates/tests/misc/agile_reference/Cargo.toml
@@ -10,6 +10,7 @@ doctest = false
 
 [dependencies.windows]
 workspace = true
+default-features = true
 features = [
     "Media_Control",
     "Foundation_Collections"

--- a/crates/tests/misc/cfg_generic/Cargo.toml
+++ b/crates/tests/misc/cfg_generic/Cargo.toml
@@ -10,6 +10,7 @@ doctest = false
 
 [dependencies.windows]
 workspace = true
+default-features = true
 features = [
     "Foundation_Collections",
     "Media_Playback",

--- a/crates/tests/misc/component/Cargo.toml
+++ b/crates/tests/misc/component/Cargo.toml
@@ -14,6 +14,7 @@ workspace = true
 
 [dependencies.windows]
 workspace = true
+default-features = true
 features = [
     "Foundation",
     "Win32_System_WinRT",

--- a/crates/tests/misc/component_client/Cargo.toml
+++ b/crates/tests/misc/component_client/Cargo.toml
@@ -12,7 +12,7 @@ doctest = false
 workspace = true
 
 [dependencies]
-windows-core = { workspace = true }
+windows-core = { workspace = true , default-features = true }
 windows = { workspace = true, features = ["Foundation", "Win32_Foundation"] }
 test_component = { path = "../component" }
 

--- a/crates/tests/misc/deprecated/Cargo.toml
+++ b/crates/tests/misc/deprecated/Cargo.toml
@@ -10,6 +10,7 @@ doctest = false
 
 [dependencies.windows]
 workspace = true
+default-features = true
 features = [
     "ApplicationModel_Contacts",
     "Networking_BackgroundTransfer",

--- a/crates/tests/misc/marshal/Cargo.toml
+++ b/crates/tests/misc/marshal/Cargo.toml
@@ -13,6 +13,7 @@ workspace = true
 
 [dependencies.windows]
 workspace = true
+default-features = true
 features = [
     "Foundation",
     "Win32_System_Com_Marshal",

--- a/crates/tests/misc/no_use/Cargo.toml
+++ b/crates/tests/misc/no_use/Cargo.toml
@@ -10,6 +10,7 @@ doctest = false
 
 [dependencies.windows]
 workspace = true
+default-features = true
 features = [
     "Foundation",
 ]

--- a/crates/tests/misc/variant/Cargo.toml
+++ b/crates/tests/misc/variant/Cargo.toml
@@ -13,6 +13,7 @@ workspace = true
 
 [dependencies.windows]
 workspace = true
+default-features = true
 features = [
     "Foundation",
     "Win32_System_Com_Events",

--- a/crates/tests/winrt/activation/Cargo.toml
+++ b/crates/tests/winrt/activation/Cargo.toml
@@ -17,6 +17,7 @@ workspace = true
 
 [dependencies.windows]
 workspace = true
+default-features = true
 features = [
     "Foundation",
     "Win32_System_WinRT",

--- a/crates/tests/winrt/activation_client/Cargo.toml
+++ b/crates/tests/winrt/activation_client/Cargo.toml
@@ -12,7 +12,7 @@ doctest = false
 windows-bindgen = { workspace = true }
 
 [dependencies]
-windows-core = { workspace = true }
+windows-core = { workspace = true , default-features = true }
 windows = { workspace = true, features = ["Foundation", "Win32_Foundation"] }
 test_activation = { path = "../activation" }
 

--- a/crates/tests/winrt/collection_interop/Cargo.toml
+++ b/crates/tests/winrt/collection_interop/Cargo.toml
@@ -10,6 +10,7 @@ doctest = false
 
 [dependencies.windows-core]
 workspace = true
+default-features = true
 
 [dependencies.windows-collections]
 workspace = true

--- a/crates/tests/winrt/composable/Cargo.toml
+++ b/crates/tests/winrt/composable/Cargo.toml
@@ -17,6 +17,7 @@ workspace = true
 
 [dependencies.windows]
 workspace = true
+default-features = true
 features = [
     "Foundation",
     "Win32_System_WinRT",

--- a/crates/tests/winrt/composable_client/Cargo.toml
+++ b/crates/tests/winrt/composable_client/Cargo.toml
@@ -14,7 +14,7 @@ windows-bindgen = { workspace = true }
 cppwinrt = { workspace = true }
 
 [dependencies]
-windows-core = { workspace = true }
+windows-core = { workspace = true , default-features = true }
 windows = { workspace = true, features = ["Foundation", "Win32_Foundation"] }
 test_composable = { path = "../composable" }
 

--- a/crates/tests/winrt/constructors/Cargo.toml
+++ b/crates/tests/winrt/constructors/Cargo.toml
@@ -17,6 +17,7 @@ workspace = true
 
 [dependencies.windows]
 workspace = true
+default-features = true
 features = [
     "Foundation",
     "Win32_System_WinRT",

--- a/crates/tests/winrt/constructors_client/Cargo.toml
+++ b/crates/tests/winrt/constructors_client/Cargo.toml
@@ -14,7 +14,7 @@ windows-bindgen = { workspace = true }
 cppwinrt = { workspace = true }
 
 [dependencies]
-windows-core = { workspace = true }
+windows-core = { workspace = true , default-features = true }
 windows = { workspace = true, features = ["Foundation", "Win32_Foundation"] }
 test_constructors = { path = "../constructors" }
 

--- a/crates/tests/winrt/noexcept/Cargo.toml
+++ b/crates/tests/winrt/noexcept/Cargo.toml
@@ -10,6 +10,7 @@ doctest = false
 
 [dependencies.windows-core]
 workspace = true
+default-features = true
 
 [build-dependencies.windows-bindgen]
 workspace = true

--- a/crates/tests/winrt/overloads/Cargo.toml
+++ b/crates/tests/winrt/overloads/Cargo.toml
@@ -17,6 +17,7 @@ workspace = true
 
 [dependencies.windows]
 workspace = true
+default-features = true
 features = [
     "Foundation",
     "Win32_System_WinRT",

--- a/crates/tests/winrt/overloads_client/Cargo.toml
+++ b/crates/tests/winrt/overloads_client/Cargo.toml
@@ -12,7 +12,7 @@ doctest = false
 windows-bindgen = { workspace = true }
 
 [dependencies]
-windows-core = { workspace = true }
+windows-core = { workspace = true , default-features = true }
 windows = { workspace = true, features = ["Foundation", "Win32_Foundation"] }
 test_overloads = { path = "../overloads" }
 

--- a/crates/tests/winrt/ref_params/Cargo.toml
+++ b/crates/tests/winrt/ref_params/Cargo.toml
@@ -10,6 +10,7 @@ doctest = false
 
 [dependencies.windows-core]
 workspace = true
+default-features = true
 
 [build-dependencies.windows-bindgen]
 workspace = true

--- a/crates/tests/winrt/reference/Cargo.toml
+++ b/crates/tests/winrt/reference/Cargo.toml
@@ -18,6 +18,7 @@ workspace = true
 
 [dependencies.windows]
 workspace = true
+default-features = true
 features = [
     "Foundation",
     "Win32_System_WinRT",

--- a/crates/tests/winrt/reference_client/Cargo.toml
+++ b/crates/tests/winrt/reference_client/Cargo.toml
@@ -12,7 +12,7 @@ doctest = false
 windows-bindgen = { workspace = true }
 
 [dependencies]
-windows-core = { workspace = true }
+windows-core = { workspace = true , default-features = true }
 windows = { workspace = true, features = ["Foundation", "Win32_Foundation"] }
 test_reference = { path = "../reference" }
 

--- a/crates/tests/winrt/reference_float/Cargo.toml
+++ b/crates/tests/winrt/reference_float/Cargo.toml
@@ -24,6 +24,7 @@ workspace = true
 
 [dependencies.windows]
 workspace = true
+default-features = true
 features = [
     "Foundation",
 ]

--- a/crates/tools/clippy_all/Cargo.toml
+++ b/crates/tools/clippy_all/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "tool_clippy_all"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+helpers = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/tools/clippy_all/src/main.rs
+++ b/crates/tools/clippy_all/src/main.rs
@@ -1,0 +1,34 @@
+use std::process::Command;
+
+fn main() {
+    let crates = helpers::crates("crates");
+    let mut failed = vec![];
+
+    for krate in &crates {
+        let name = &krate.package.name;
+
+        println!("clippy: {name}");
+
+        let status = Command::new("cargo")
+            .arg("clippy")
+            .arg("--all-targets")
+            .arg("-p")
+            .arg(name)
+            .status()
+            .expect("failed to run cargo clippy");
+
+        if !status.success() {
+            failed.push(name.clone());
+        }
+    }
+
+    if !failed.is_empty() {
+        eprintln!("\nclippy failed for:");
+        for name in &failed {
+            eprintln!("  {name}");
+        }
+        std::process::exit(1);
+    }
+
+    println!("\nclippy passed for all {} crates", crates.len());
+}


### PR DESCRIPTION
Tests build in aggregate with `cargo test --all-targets` but individually they should also build. This update just ensures that this is the case. 