### PR TITLE
Harden `cargo doc` validation

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -27,6 +27,8 @@ jobs:
   windows:
     name: windows
     runs-on: windows-2025-vs2026
+    env:
+      RUSTDOCFLAGS: -Dwarnings
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -36,6 +38,8 @@ jobs:
   windows-sys:
     name: windows-sys
     runs-on: windows-2025-vs2026
+    env:
+      RUSTDOCFLAGS: -Dwarnings
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -45,6 +49,8 @@ jobs:
   other-crates:
     name: other-crates
     runs-on: windows-2025-vs2026
+    env:
+      RUSTDOCFLAGS: -Dwarnings
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -71,6 +77,7 @@ jobs:
     runs-on: ubuntu-24.04
     env:
       RUSTFLAGS: -D warnings
+      RUSTDOCFLAGS: -Dwarnings
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/crates/libs/bindgen/src/lib.rs
+++ b/crates/libs/bindgen/src/lib.rs
@@ -761,9 +761,9 @@ impl Bindgen {
     /// matching `--sys`).
     ///
     /// Event accessor pairs (`add_*`/`remove_*`) are replaced by a single
-    /// auto-revoking wrapper that returns a [`windows_core::EventRevoker`].
+    /// auto-revoking wrapper that returns a `windows_core::EventRevoker`.
     /// The `Remove*` wrapper is suppressed. Callers can call
-    /// [`windows_core::EventRevoker::into_token`] to recover the raw token when interoperating
+    /// `windows_core::EventRevoker::into_token` to recover the raw token when interoperating
     /// with code that manages registration tokens directly.
     ///
     /// This is a build-time / disk / memory optimization: the generated source


### PR DESCRIPTION
I noticed we weren't checking the docs with warnings as errors. 

https://github.com/microsoft/windows-rs/actions/runs/26594266919/job/78360909698

