### PR TITLE
Avoid deprecated Node.js action in LLVM build dependency

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -26,6 +26,8 @@ concurrency:
 jobs:
   clippy:
     runs-on: windows-2025-vs2026
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -71,6 +71,7 @@ jobs:
     runs-on: ubuntu-24.04
     env:
       RUSTFLAGS: -D warnings
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,6 +49,7 @@ jobs:
 
     env:
       RUSTFLAGS: -D warnings
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Noticed it here:

https://github.com/microsoft/windows-rs/actions/runs/26594266811

