### PR TITLE
Support Rust edition 2024 for Windows Reactor

### DIFF
--- a/crates/libs/reactor/build.rs
+++ b/crates/libs/reactor/build.rs
@@ -48,7 +48,7 @@ fn main() {
         return;
     }
 
-    let workspace_root = PathBuf::from("/git/windows-rs/");
+    let workspace_root = PathBuf::from(env::var("CARGO_WORKSPACE_DIR").unwrap());
     let temp_dir = workspace_root.join("temp");
     fs::create_dir_all(&temp_dir).expect("Failed to create temp directory");
 

--- a/crates/libs/reactor/build.rs
+++ b/crates/libs/reactor/build.rs
@@ -48,7 +48,7 @@ fn main() {
         return;
     }
 
-    let workspace_root = PathBuf::from(env::var("CARGO_WORKSPACE_DIR").unwrap());
+    let workspace_root = PathBuf::from("/git/windows-rs/");
     let temp_dir = workspace_root.join("temp");
     fs::create_dir_all(&temp_dir).expect("Failed to create temp directory");
 

--- a/crates/libs/reactor/src/app.rs
+++ b/crates/libs/reactor/src/app.rs
@@ -210,44 +210,45 @@ impl App {
     /// Convenience entry point that accepts a render function directly,
     /// avoiding the empty-struct `Component` pattern.
     ///
-    /// The render function can return any type that implements `Into<Element>`
-    /// — widget builders, `Element`, layout containers, etc.
+    /// The render function should return `Element`. Use `.into()` to convert
+    /// widget builders into `Element`:
     ///
     /// ```ignore
-    /// fn app(cx: &mut RenderCx) -> impl Into<Element> {
+    /// fn app(cx: &mut RenderCx) -> Element {
     ///     let (count, set_count) = cx.use_state(0);
     ///     button(format!("Clicks: {count}"))
     ///         .on_click(move || set_count.call(count + 1))
+    ///         .into()
     /// }
     ///
     /// fn main() -> Result<()> {
     ///     App::new().render(app)
     /// }
     /// ```
-    pub fn render<F, R>(self, f: F) -> Result<()>
+    pub fn render<F>(self, f: F) -> Result<()>
     where
-        F: Fn(&mut crate::core::render_context::RenderCx) -> R + Send + 'static,
-        R: Into<crate::core::element::Element>,
+        F: Fn(&mut crate::core::render_context::RenderCx) -> crate::core::element::Element
+            + Send
+            + 'static,
     {
         self.run(move || RenderFn(f))
     }
 }
 
-/// Internal wrapper: adapts `Fn(&mut RenderCx) -> impl Into<Element>` into
-/// `Component<()>` so it can be used with the existing host machinery.
+/// Internal wrapper: adapts `Fn(&mut RenderCx) -> Element` into `Component<()>`
+/// so it can be used with the existing host machinery.
 struct RenderFn<F>(F);
 
-impl<F, R> crate::core::component::Component for RenderFn<F>
+impl<F> crate::core::component::Component for RenderFn<F>
 where
-    F: Fn(&mut crate::core::render_context::RenderCx) -> R + 'static,
-    R: Into<crate::core::element::Element>,
+    F: Fn(&mut crate::core::render_context::RenderCx) -> crate::core::element::Element + 'static,
 {
     fn render(
         &self,
         _props: &(),
         cx: &mut crate::core::render_context::RenderCx,
     ) -> crate::core::element::Element {
-        (self.0)(cx).into()
+        (self.0)(cx)
     }
 }
 

--- a/crates/libs/reactor/src/core/component.rs
+++ b/crates/libs/reactor/src/core/component.rs
@@ -26,22 +26,21 @@ where
     fn on_disappeared(&self, _props: &P, _cx: &mut RenderCx) {}
 }
 
-/// Blanket impl: any `Fn(&P, &mut RenderCx) -> impl Into<Element>` is a [`Component<P>`].
+/// Blanket impl: any `Fn(&P, &mut RenderCx) -> Element` is a [`Component<P>`].
 ///
 /// ```ignore
-/// fn greeting(props: &GreetingProps, _cx: &mut RenderCx) -> impl Into<Element> {
-///     text_block(format!("Hello, {}!", props.name))
+/// fn greeting(props: &GreetingProps, _cx: &mut RenderCx) -> Element {
+///     text_block(format!("Hello, {}!", props.name)).into()
 /// }
 /// ```
 ///
-/// For unit-props, use `fn(_: &(), cx: &mut RenderCx) -> impl Into<Element>`.
-impl<F, P, R> Component<P> for F
+/// For unit-props, use `fn(_: &(), cx: &mut RenderCx) -> Element`.
+impl<F, P> Component<P> for F
 where
-    F: Fn(&P, &mut RenderCx) -> R + 'static,
-    R: Into<Element>,
+    F: Fn(&P, &mut RenderCx) -> Element + 'static,
     P: Clone + PartialEq + 'static,
 {
     fn render(&self, props: &P, cx: &mut RenderCx) -> Element {
-        (self)(props, cx).into()
+        (self)(props, cx)
     }
 }

--- a/crates/samples/reactor/apps/examples/diagnostics_demo.rs
+++ b/crates/samples/reactor/apps/examples/diagnostics_demo.rs
@@ -6,7 +6,7 @@
 
 use windows_reactor::*;
 
-fn app(cx: &mut RenderCx) -> impl Into<Element> {
+fn app(cx: &mut RenderCx) -> Element {
     let (status, set_status) = cx.use_state(String::from("Ready"));
 
     vstack((
@@ -28,6 +28,7 @@ fn app(cx: &mut RenderCx) -> impl Into<Element> {
     ))
     .spacing(8.0)
     .padding(Thickness::uniform(24.0))
+    .into()
 }
 
 fn main() -> Result<()> {

--- a/crates/samples/reactor/apps/examples/dotsweeper.rs
+++ b/crates/samples/reactor/apps/examples/dotsweeper.rs
@@ -737,7 +737,7 @@ fn status_subtitle(state: &AppState) -> String {
 
 // ─── The component ────────────────────────────────────────────────────
 
-fn app(cx: &mut RenderCx) -> impl Into<Element> {
+fn app(cx: &mut RenderCx) -> Element {
     let (state, update) = cx.use_reducer(AppState::initial(Difficulty::BEGINNER, fresh_seed()));
 
     // Left-tap on a covered cell → reveal.
@@ -925,6 +925,7 @@ fn app(cx: &mut RenderCx) -> impl Into<Element> {
         ))
         .spacing(8.0),
     ))
+    .into()
 }
 
 fn main() -> Result<()> {

--- a/crates/samples/reactor/apps/examples/minesweeper.rs
+++ b/crates/samples/reactor/apps/examples/minesweeper.rs
@@ -374,7 +374,7 @@ fn reduce(state: Game, action: Action) -> Game {
     }
 }
 
-fn app(cx: &mut RenderCx) -> impl Into<Element> {
+fn app(cx: &mut RenderCx) -> Element {
     let (game, dispatch) = cx.use_reducer_fn(reduce, Game::new());
 
     let reset_handler = {
@@ -404,7 +404,7 @@ fn app(cx: &mut RenderCx) -> impl Into<Element> {
     let board = build_board(&game, reveal_handler, flag_handler);
 
     let title_bar = TitleBar::new("windows_reactor — minesweeper");
-    vstack((title_bar, vstack((header, board)).spacing(12.0)))
+    vstack((title_bar, vstack((header, board)).spacing(12.0))).into()
 }
 
 fn build_board(

--- a/crates/samples/reactor/apps/examples/notepad.rs
+++ b/crates/samples/reactor/apps/examples/notepad.rs
@@ -2,7 +2,7 @@
 
 use windows_reactor::*;
 
-fn app(cx: &mut RenderCx) -> impl Into<Element> {
+fn app(cx: &mut RenderCx) -> Element {
     let (text, set_text) = cx.use_state(String::new());
 
     text_box(text)
@@ -11,6 +11,7 @@ fn app(cx: &mut RenderCx) -> impl Into<Element> {
         .on_changed(set_text)
         .horizontal_alignment(HorizontalAlignment::Stretch)
         .vertical_alignment(VerticalAlignment::Stretch)
+        .into()
 }
 
 fn main() -> Result<()> {

--- a/crates/samples/reactor/apps/examples/solitaire.rs
+++ b/crates/samples/reactor/apps/examples/solitaire.rs
@@ -447,7 +447,7 @@ fn foundation_x(f: usize) -> f64 {
     pile_x(PILES - FOUNDATIONS + f)
 }
 
-fn app(cx: &mut RenderCx) -> impl Into<Element> {
+fn app(cx: &mut RenderCx) -> Element {
     let (game, update) = cx.use_reducer(Game::new(current_seed()));
 
     let click_handler = {
@@ -487,7 +487,9 @@ fn app(cx: &mut RenderCx) -> impl Into<Element> {
 
     let board = viewbox(build_board(&game, click_handler));
 
-    vstack((title_bar, header, board)).background(Color::rgb(20, 100, 60))
+    vstack((title_bar, header, board))
+        .background(Color::rgb(20, 100, 60))
+        .into()
 }
 
 fn status_line(game: &Game) -> String {

--- a/crates/samples/reactor/apps/examples/tictactoe.rs
+++ b/crates/samples/reactor/apps/examples/tictactoe.rs
@@ -150,7 +150,7 @@ fn status_line(game: &Game) -> String {
     }
 }
 
-fn app(cx: &mut RenderCx) -> impl Into<Element> {
+fn app(cx: &mut RenderCx) -> Element {
     let (game, set_game) = cx.use_state(Game::new());
 
     let reset_handler = make_reset_handler(set_game.clone());
@@ -176,7 +176,7 @@ fn app(cx: &mut RenderCx) -> impl Into<Element> {
 
     let title_bar = TitleBar::new("windows_reactor — tictactoe");
 
-    vstack((title_bar, vstack((header, board)).spacing(12.0)))
+    vstack((title_bar, vstack((header, board)).spacing(12.0))).into()
 }
 
 fn build_board(game: &Game, click_handler: impl Fn(usize) + Clone + 'static) -> Element {

--- a/crates/samples/reactor/gallery/src/controls.rs
+++ b/crates/samples/reactor/gallery/src/controls.rs
@@ -130,6 +130,7 @@ pub fn card_grid(items: &[CardItem], on_click: impl Fn(String) + 'static) -> Ele
     })
     .with_key_selector(|item| item.key.clone())
     .build()
+    .into()
 }
 
 /// Wraps page content in a ScrollView with header + sample cards (matches C# PageContent).

--- a/crates/samples/reactor/gallery/src/controls.rs
+++ b/crates/samples/reactor/gallery/src/controls.rs
@@ -130,7 +130,6 @@ pub fn card_grid(items: &[CardItem], on_click: impl Fn(String) + 'static) -> Ele
     })
     .with_key_selector(|item| item.key.clone())
     .build()
-    .into()
 }
 
 /// Wraps page content in a ScrollView with header + sample cards (matches C# PageContent).

--- a/crates/samples/reactor/gallery/src/pages/basic_input/button.rs
+++ b/crates/samples/reactor/gallery/src/pages/basic_input/button.rs
@@ -1,7 +1,7 @@
 use crate::controls::*;
 use windows_reactor::*;
 
-pub fn button_page(_: &(), cx: &mut RenderCx) -> impl Into<Element> {
+pub fn button_page(_: &(), cx: &mut RenderCx) -> Element {
     let (basic_output, set_basic_output) = cx.use_state(String::from("Ready"));
     let (accent_output, set_accent_output) = cx.use_state(String::from("Ready"));
     let (subtle_output, set_subtle_output) = cx.use_state(String::from("Ready"));
@@ -76,4 +76,5 @@ pub fn button_page(_: &(), cx: &mut RenderCx) -> impl Into<Element> {
             ),
         ],
     )
+    .into()
 }

--- a/crates/samples/reactor/gallery/src/pages/basic_input/button.rs
+++ b/crates/samples/reactor/gallery/src/pages/basic_input/button.rs
@@ -76,5 +76,4 @@ pub fn button_page(_: &(), cx: &mut RenderCx) -> Element {
             ),
         ],
     )
-    .into()
 }

--- a/crates/samples/reactor/gallery/src/pages/basic_input/check_box.rs
+++ b/crates/samples/reactor/gallery/src/pages/basic_input/check_box.rs
@@ -1,7 +1,7 @@
 use crate::controls::*;
 use windows_reactor::*;
 
-pub fn check_box_page(_: &(), cx: &mut RenderCx) -> impl Into<Element> {
+pub fn check_box_page(_: &(), cx: &mut RenderCx) -> Element {
     let (accepted, set_accepted) = cx.use_state(false);
     let (email_opt_in, set_email) = cx.use_state(true);
     let (sms_opt_in, set_sms) = cx.use_state(false);
@@ -79,4 +79,5 @@ check_box(push).label("Push").on_changed(handler)"#,
             ),
         ],
     )
+    .into()
 }

--- a/crates/samples/reactor/gallery/src/pages/basic_input/check_box.rs
+++ b/crates/samples/reactor/gallery/src/pages/basic_input/check_box.rs
@@ -79,5 +79,4 @@ check_box(push).label("Push").on_changed(handler)"#,
             ),
         ],
     )
-    .into()
 }

--- a/crates/samples/reactor/gallery/src/pages/basic_input/color_picker.rs
+++ b/crates/samples/reactor/gallery/src/pages/basic_input/color_picker.rs
@@ -31,5 +31,5 @@ pub fn color_picker_page(_: &(), cx: &mut RenderCx) -> Element {
                 r#"color_picker(c).hex_input_visible(false).color_channel_text_input_visible(false)"#,
             ),
         ],
-    ).into()
+    )
 }

--- a/crates/samples/reactor/gallery/src/pages/basic_input/color_picker.rs
+++ b/crates/samples/reactor/gallery/src/pages/basic_input/color_picker.rs
@@ -1,7 +1,7 @@
 use crate::controls::*;
 use windows_reactor::*;
 
-pub fn color_picker_page(_: &(), cx: &mut RenderCx) -> impl Into<Element> {
+pub fn color_picker_page(_: &(), cx: &mut RenderCx) -> Element {
     let (color, set_color) = cx.use_state((50_u8, 120_u8, 200_u8, 255_u8));
 
     page_content(
@@ -31,5 +31,5 @@ pub fn color_picker_page(_: &(), cx: &mut RenderCx) -> impl Into<Element> {
                 r#"color_picker(c).hex_input_visible(false).color_channel_text_input_visible(false)"#,
             ),
         ],
-    )
+    ).into()
 }

--- a/crates/samples/reactor/gallery/src/pages/basic_input/combo_box.rs
+++ b/crates/samples/reactor/gallery/src/pages/basic_input/combo_box.rs
@@ -38,5 +38,4 @@ pub fn combo_box_page(_: &(), cx: &mut RenderCx) -> Element {
             ),
         ],
     )
-    .into()
 }

--- a/crates/samples/reactor/gallery/src/pages/basic_input/combo_box.rs
+++ b/crates/samples/reactor/gallery/src/pages/basic_input/combo_box.rs
@@ -1,7 +1,7 @@
 use crate::controls::*;
 use windows_reactor::*;
 
-pub fn combo_box_page(_: &(), cx: &mut RenderCx) -> impl Into<Element> {
+pub fn combo_box_page(_: &(), cx: &mut RenderCx) -> Element {
     let (selected, set_selected) = cx.use_state(-1_i32);
 
     let colors = ["Red", "Green", "Blue", "Yellow"];
@@ -38,4 +38,5 @@ pub fn combo_box_page(_: &(), cx: &mut RenderCx) -> impl Into<Element> {
             ),
         ],
     )
+    .into()
 }

--- a/crates/samples/reactor/gallery/src/pages/basic_input/drop_down_button.rs
+++ b/crates/samples/reactor/gallery/src/pages/basic_input/drop_down_button.rs
@@ -37,5 +37,4 @@ pub fn drop_down_button_page(_: &(), cx: &mut RenderCx) -> Element {
             ),
         ],
     )
-    .into()
 }

--- a/crates/samples/reactor/gallery/src/pages/basic_input/drop_down_button.rs
+++ b/crates/samples/reactor/gallery/src/pages/basic_input/drop_down_button.rs
@@ -1,7 +1,7 @@
 use crate::controls::*;
 use windows_reactor::*;
 
-pub fn drop_down_button_page(_: &(), cx: &mut RenderCx) -> impl Into<Element> {
+pub fn drop_down_button_page(_: &(), cx: &mut RenderCx) -> Element {
     let (selected, set_selected) = cx.use_state(String::from("(none)"));
 
     page_content(
@@ -37,4 +37,5 @@ pub fn drop_down_button_page(_: &(), cx: &mut RenderCx) -> impl Into<Element> {
             ),
         ],
     )
+    .into()
 }

--- a/crates/samples/reactor/gallery/src/pages/basic_input/hyperlink_button.rs
+++ b/crates/samples/reactor/gallery/src/pages/basic_input/hyperlink_button.rs
@@ -1,7 +1,7 @@
 use crate::controls::*;
 use windows_reactor::*;
 
-pub fn hyperlink_button_page(_: &(), cx: &mut RenderCx) -> impl Into<Element> {
+pub fn hyperlink_button_page(_: &(), cx: &mut RenderCx) -> Element {
     let (clicks, set_clicks) = cx.use_state(0_i32);
 
     page_content(
@@ -25,4 +25,5 @@ pub fn hyperlink_button_page(_: &(), cx: &mut RenderCx) -> impl Into<Element> {
             ),
         ],
     )
+    .into()
 }

--- a/crates/samples/reactor/gallery/src/pages/basic_input/hyperlink_button.rs
+++ b/crates/samples/reactor/gallery/src/pages/basic_input/hyperlink_button.rs
@@ -25,5 +25,4 @@ pub fn hyperlink_button_page(_: &(), cx: &mut RenderCx) -> Element {
             ),
         ],
     )
-    .into()
 }

--- a/crates/samples/reactor/gallery/src/pages/basic_input/number_box.rs
+++ b/crates/samples/reactor/gallery/src/pages/basic_input/number_box.rs
@@ -1,7 +1,7 @@
 use crate::controls::*;
 use windows_reactor::*;
 
-pub fn number_box_page(_: &(), cx: &mut RenderCx) -> impl Into<Element> {
+pub fn number_box_page(_: &(), cx: &mut RenderCx) -> Element {
     let (value, set_value) = cx.use_state(42.0_f64);
     let (clamped, set_clamped) = cx.use_state(5.0_f64);
 
@@ -40,4 +40,5 @@ pub fn number_box_page(_: &(), cx: &mut RenderCx) -> impl Into<Element> {
             ),
         ],
     )
+    .into()
 }

--- a/crates/samples/reactor/gallery/src/pages/basic_input/number_box.rs
+++ b/crates/samples/reactor/gallery/src/pages/basic_input/number_box.rs
@@ -40,5 +40,4 @@ pub fn number_box_page(_: &(), cx: &mut RenderCx) -> Element {
             ),
         ],
     )
-    .into()
 }

--- a/crates/samples/reactor/gallery/src/pages/basic_input/password_box.rs
+++ b/crates/samples/reactor/gallery/src/pages/basic_input/password_box.rs
@@ -42,5 +42,4 @@ pub fn password_box_page(_: &(), cx: &mut RenderCx) -> Element {
             ),
         ],
     )
-    .into()
 }

--- a/crates/samples/reactor/gallery/src/pages/basic_input/password_box.rs
+++ b/crates/samples/reactor/gallery/src/pages/basic_input/password_box.rs
@@ -1,7 +1,7 @@
 use crate::controls::*;
 use windows_reactor::*;
 
-pub fn password_box_page(_: &(), cx: &mut RenderCx) -> impl Into<Element> {
+pub fn password_box_page(_: &(), cx: &mut RenderCx) -> Element {
     let (password, set_password) = cx.use_state(String::new());
 
     page_content(
@@ -42,4 +42,5 @@ pub fn password_box_page(_: &(), cx: &mut RenderCx) -> impl Into<Element> {
             ),
         ],
     )
+    .into()
 }

--- a/crates/samples/reactor/gallery/src/pages/basic_input/radio_button.rs
+++ b/crates/samples/reactor/gallery/src/pages/basic_input/radio_button.rs
@@ -1,7 +1,7 @@
 use crate::controls::*;
 use windows_reactor::*;
 
-pub fn radio_button_page(_: &(), cx: &mut RenderCx) -> impl Into<Element> {
+pub fn radio_button_page(_: &(), cx: &mut RenderCx) -> Element {
     let (selected, set_selected) = cx.use_state(0_i32);
 
     let options = ["Option A", "Option B", "Option C"];
@@ -34,5 +34,5 @@ pub fn radio_button_page(_: &(), cx: &mut RenderCx) -> impl Into<Element> {
                 r#"RadioButtons::new(sizes).header("T-shirt size").selected_index(1)"#,
             ),
         ],
-    )
+    ).into()
 }

--- a/crates/samples/reactor/gallery/src/pages/basic_input/radio_button.rs
+++ b/crates/samples/reactor/gallery/src/pages/basic_input/radio_button.rs
@@ -34,5 +34,5 @@ pub fn radio_button_page(_: &(), cx: &mut RenderCx) -> Element {
                 r#"RadioButtons::new(sizes).header("T-shirt size").selected_index(1)"#,
             ),
         ],
-    ).into()
+    )
 }

--- a/crates/samples/reactor/gallery/src/pages/basic_input/rating_control.rs
+++ b/crates/samples/reactor/gallery/src/pages/basic_input/rating_control.rs
@@ -36,5 +36,4 @@ pub fn rating_control_page(_: &(), cx: &mut RenderCx) -> Element {
             ),
         ],
     )
-    .into()
 }

--- a/crates/samples/reactor/gallery/src/pages/basic_input/rating_control.rs
+++ b/crates/samples/reactor/gallery/src/pages/basic_input/rating_control.rs
@@ -1,7 +1,7 @@
 use crate::controls::*;
 use windows_reactor::*;
 
-pub fn rating_control_page(_: &(), cx: &mut RenderCx) -> impl Into<Element> {
+pub fn rating_control_page(_: &(), cx: &mut RenderCx) -> Element {
     let (rating, set_rating) = cx.use_state(3.0_f64);
 
     page_content(
@@ -36,4 +36,5 @@ pub fn rating_control_page(_: &(), cx: &mut RenderCx) -> impl Into<Element> {
             ),
         ],
     )
+    .into()
 }

--- a/crates/samples/reactor/gallery/src/pages/basic_input/repeat_button.rs
+++ b/crates/samples/reactor/gallery/src/pages/basic_input/repeat_button.rs
@@ -1,7 +1,7 @@
 use crate::controls::*;
 use windows_reactor::*;
 
-pub fn repeat_button_page(_: &(), cx: &mut RenderCx) -> impl Into<Element> {
+pub fn repeat_button_page(_: &(), cx: &mut RenderCx) -> Element {
     let (count, set_count) = cx.use_state(0_i32);
     let (fast_count, set_fast) = cx.use_state(0_i32);
 
@@ -35,4 +35,5 @@ pub fn repeat_button_page(_: &(), cx: &mut RenderCx) -> impl Into<Element> {
             ),
         ],
     )
+    .into()
 }

--- a/crates/samples/reactor/gallery/src/pages/basic_input/repeat_button.rs
+++ b/crates/samples/reactor/gallery/src/pages/basic_input/repeat_button.rs
@@ -35,5 +35,4 @@ pub fn repeat_button_page(_: &(), cx: &mut RenderCx) -> Element {
             ),
         ],
     )
-    .into()
 }

--- a/crates/samples/reactor/gallery/src/pages/basic_input/slider.rs
+++ b/crates/samples/reactor/gallery/src/pages/basic_input/slider.rs
@@ -1,7 +1,7 @@
 use crate::controls::*;
 use windows_reactor::*;
 
-pub fn slider_page(_: &(), cx: &mut RenderCx) -> impl Into<Element> {
+pub fn slider_page(_: &(), cx: &mut RenderCx) -> Element {
     let (volume, set_volume) = cx.use_state(35.0_f64);
     let (brightness, set_brightness) = cx.use_state(60.0_f64);
     let (temperature, set_temperature) = cx.use_state(21.0_f64);
@@ -77,4 +77,5 @@ pub fn slider_page(_: &(), cx: &mut RenderCx) -> impl Into<Element> {
             ),
         ],
     )
+    .into()
 }

--- a/crates/samples/reactor/gallery/src/pages/basic_input/slider.rs
+++ b/crates/samples/reactor/gallery/src/pages/basic_input/slider.rs
@@ -77,5 +77,4 @@ pub fn slider_page(_: &(), cx: &mut RenderCx) -> Element {
             ),
         ],
     )
-    .into()
 }

--- a/crates/samples/reactor/gallery/src/pages/basic_input/split_button.rs
+++ b/crates/samples/reactor/gallery/src/pages/basic_input/split_button.rs
@@ -1,7 +1,7 @@
 use crate::controls::*;
 use windows_reactor::*;
 
-pub fn split_button_page(_: &(), cx: &mut RenderCx) -> impl Into<Element> {
+pub fn split_button_page(_: &(), cx: &mut RenderCx) -> Element {
     let (clicks, set_clicks) = cx.use_state(0_u32);
 
     page_content(
@@ -27,4 +27,5 @@ pub fn split_button_page(_: &(), cx: &mut RenderCx) -> impl Into<Element> {
             ),
         ],
     )
+    .into()
 }

--- a/crates/samples/reactor/gallery/src/pages/basic_input/split_button.rs
+++ b/crates/samples/reactor/gallery/src/pages/basic_input/split_button.rs
@@ -27,5 +27,4 @@ pub fn split_button_page(_: &(), cx: &mut RenderCx) -> Element {
             ),
         ],
     )
-    .into()
 }

--- a/crates/samples/reactor/gallery/src/pages/basic_input/text_box.rs
+++ b/crates/samples/reactor/gallery/src/pages/basic_input/text_box.rs
@@ -42,5 +42,4 @@ pub fn text_box_page(_: &(), cx: &mut RenderCx) -> Element {
             ),
         ],
     )
-    .into()
 }

--- a/crates/samples/reactor/gallery/src/pages/basic_input/text_box.rs
+++ b/crates/samples/reactor/gallery/src/pages/basic_input/text_box.rs
@@ -1,7 +1,7 @@
 use crate::controls::*;
 use windows_reactor::*;
 
-pub fn text_box_page(_: &(), cx: &mut RenderCx) -> impl Into<Element> {
+pub fn text_box_page(_: &(), cx: &mut RenderCx) -> Element {
     let (text, set_text) = cx.use_state(String::new());
     let (multi_text, set_multi) = cx.use_state(String::from("Hello\nWorld"));
 
@@ -42,4 +42,5 @@ pub fn text_box_page(_: &(), cx: &mut RenderCx) -> impl Into<Element> {
             ),
         ],
     )
+    .into()
 }

--- a/crates/samples/reactor/gallery/src/pages/basic_input/toggle_button.rs
+++ b/crates/samples/reactor/gallery/src/pages/basic_input/toggle_button.rs
@@ -38,5 +38,4 @@ pub fn toggle_button_page(_: &(), cx: &mut RenderCx) -> Element {
             ),
         ],
     )
-    .into()
 }

--- a/crates/samples/reactor/gallery/src/pages/basic_input/toggle_button.rs
+++ b/crates/samples/reactor/gallery/src/pages/basic_input/toggle_button.rs
@@ -1,7 +1,7 @@
 use crate::controls::*;
 use windows_reactor::*;
 
-pub fn toggle_button_page(_: &(), cx: &mut RenderCx) -> impl Into<Element> {
+pub fn toggle_button_page(_: &(), cx: &mut RenderCx) -> Element {
     let (bold, set_bold) = cx.use_state(false);
     let (italic, set_italic) = cx.use_state(false);
 
@@ -38,4 +38,5 @@ pub fn toggle_button_page(_: &(), cx: &mut RenderCx) -> impl Into<Element> {
             ),
         ],
     )
+    .into()
 }

--- a/crates/samples/reactor/gallery/src/pages/basic_input/toggle_switch.rs
+++ b/crates/samples/reactor/gallery/src/pages/basic_input/toggle_switch.rs
@@ -87,5 +87,4 @@ pub fn toggle_switch_page(_: &(), cx: &mut RenderCx) -> Element {
             ),
         ],
     )
-    .into()
 }

--- a/crates/samples/reactor/gallery/src/pages/basic_input/toggle_switch.rs
+++ b/crates/samples/reactor/gallery/src/pages/basic_input/toggle_switch.rs
@@ -1,7 +1,7 @@
 use crate::controls::*;
 use windows_reactor::*;
 
-pub fn toggle_switch_page(_: &(), cx: &mut RenderCx) -> impl Into<Element> {
+pub fn toggle_switch_page(_: &(), cx: &mut RenderCx) -> Element {
     let (wifi_on, set_wifi_on) = cx.use_state(true);
     let (notifications_on, set_notifications_on) = cx.use_state(false);
     let (automation_enabled, set_automation_enabled) = cx.use_state(false);
@@ -87,4 +87,5 @@ pub fn toggle_switch_page(_: &(), cx: &mut RenderCx) -> impl Into<Element> {
             ),
         ],
     )
+    .into()
 }

--- a/crates/samples/reactor/gallery/src/pages/collections/flip_view.rs
+++ b/crates/samples/reactor/gallery/src/pages/collections/flip_view.rs
@@ -30,5 +30,4 @@ pub fn flip_view_page(_: &(), cx: &mut RenderCx) -> Element {
             r#"flip_view(items, |item, idx| ...).on_selection_changed(move |idx| set.call(idx))"#,
         )],
     )
-    .into()
 }

--- a/crates/samples/reactor/gallery/src/pages/collections/flip_view.rs
+++ b/crates/samples/reactor/gallery/src/pages/collections/flip_view.rs
@@ -1,7 +1,7 @@
 use crate::controls::*;
 use windows_reactor::*;
 
-pub fn flip_view_page(_: &(), cx: &mut RenderCx) -> impl Into<Element> {
+pub fn flip_view_page(_: &(), cx: &mut RenderCx) -> Element {
     let (selected, set_selected) = cx.use_state(0_i32);
     let items = vec!["Welcome", "Features", "Getting Started", "Resources"];
 
@@ -30,4 +30,5 @@ pub fn flip_view_page(_: &(), cx: &mut RenderCx) -> impl Into<Element> {
             r#"flip_view(items, |item, idx| ...).on_selection_changed(move |idx| set.call(idx))"#,
         )],
     )
+    .into()
 }

--- a/crates/samples/reactor/gallery/src/pages/collections/grid_view.rs
+++ b/crates/samples/reactor/gallery/src/pages/collections/grid_view.rs
@@ -1,7 +1,7 @@
 use crate::controls::*;
 use windows_reactor::*;
 
-pub fn grid_view_page(_: &(), cx: &mut RenderCx) -> impl Into<Element> {
+pub fn grid_view_page(_: &(), cx: &mut RenderCx) -> Element {
     let (selected, set_selected) = cx.use_state(-1_i32);
     let items: Vec<String> = (1..=12).map(|i| format!("Item {i}")).collect();
 
@@ -29,4 +29,5 @@ pub fn grid_view_page(_: &(), cx: &mut RenderCx) -> impl Into<Element> {
             r#"grid_view(items, |item, _| ...).on_selection_changed(move |idx| set.call(idx))"#,
         )],
     )
+    .into()
 }

--- a/crates/samples/reactor/gallery/src/pages/collections/grid_view.rs
+++ b/crates/samples/reactor/gallery/src/pages/collections/grid_view.rs
@@ -29,5 +29,4 @@ pub fn grid_view_page(_: &(), cx: &mut RenderCx) -> Element {
             r#"grid_view(items, |item, _| ...).on_selection_changed(move |idx| set.call(idx))"#,
         )],
     )
-    .into()
 }

--- a/crates/samples/reactor/gallery/src/pages/collections/list_box.rs
+++ b/crates/samples/reactor/gallery/src/pages/collections/list_box.rs
@@ -36,5 +36,5 @@ pub fn list_box_page(_: &(), cx: &mut RenderCx) -> Element {
                 r#"list_box().items(items).enabled(false)"#,
             ),
         ],
-    ).into()
+    )
 }

--- a/crates/samples/reactor/gallery/src/pages/collections/list_box.rs
+++ b/crates/samples/reactor/gallery/src/pages/collections/list_box.rs
@@ -1,7 +1,7 @@
 use crate::controls::*;
 use windows_reactor::*;
 
-pub fn list_box_page(_: &(), cx: &mut RenderCx) -> impl Into<Element> {
+pub fn list_box_page(_: &(), cx: &mut RenderCx) -> Element {
     let (selected, set_selected) = cx.use_state(-1_i32);
 
     let fruits = ["Apple", "Banana", "Cherry", "Date", "Elderberry"];
@@ -36,5 +36,5 @@ pub fn list_box_page(_: &(), cx: &mut RenderCx) -> impl Into<Element> {
                 r#"list_box().items(items).enabled(false)"#,
             ),
         ],
-    )
+    ).into()
 }

--- a/crates/samples/reactor/gallery/src/pages/collections/list_view.rs
+++ b/crates/samples/reactor/gallery/src/pages/collections/list_view.rs
@@ -103,5 +103,4 @@ pub fn list_view_page(_: &(), cx: &mut RenderCx) -> Element {
             ),
         ],
     )
-    .into()
 }

--- a/crates/samples/reactor/gallery/src/pages/collections/list_view.rs
+++ b/crates/samples/reactor/gallery/src/pages/collections/list_view.rs
@@ -1,7 +1,7 @@
 use crate::controls::*;
 use windows_reactor::*;
 
-pub fn list_view_page(_: &(), cx: &mut RenderCx) -> impl Into<Element> {
+pub fn list_view_page(_: &(), cx: &mut RenderCx) -> Element {
     let (selected_contact, set_selected_contact) = cx.use_state(1_i32);
     let (selected_playlist, set_selected_playlist) = cx.use_state(0_i32);
 
@@ -103,4 +103,5 @@ pub fn list_view_page(_: &(), cx: &mut RenderCx) -> impl Into<Element> {
             ),
         ],
     )
+    .into()
 }

--- a/crates/samples/reactor/gallery/src/pages/collections/tree_view.rs
+++ b/crates/samples/reactor/gallery/src/pages/collections/tree_view.rs
@@ -1,7 +1,7 @@
 use crate::controls::*;
 use windows_reactor::*;
 
-pub fn tree_view_page(_: &(), cx: &mut RenderCx) -> impl Into<Element> {
+pub fn tree_view_page(_: &(), cx: &mut RenderCx) -> Element {
     let (invoked, set_invoked) = cx.use_state(String::from("(none)"));
 
     let file_system = vec![
@@ -37,4 +37,5 @@ pub fn tree_view_page(_: &(), cx: &mut RenderCx) -> impl Into<Element> {
             ),
         ],
     )
+    .into()
 }

--- a/crates/samples/reactor/gallery/src/pages/collections/tree_view.rs
+++ b/crates/samples/reactor/gallery/src/pages/collections/tree_view.rs
@@ -37,5 +37,4 @@ pub fn tree_view_page(_: &(), cx: &mut RenderCx) -> Element {
             ),
         ],
     )
-    .into()
 }

--- a/crates/samples/reactor/gallery/src/pages/date_time/calendar_date_picker.rs
+++ b/crates/samples/reactor/gallery/src/pages/date_time/calendar_date_picker.rs
@@ -41,5 +41,4 @@ pub fn calendar_date_picker_page(_: &(), cx: &mut RenderCx) -> Element {
             ),
         ],
     )
-    .into()
 }

--- a/crates/samples/reactor/gallery/src/pages/date_time/calendar_date_picker.rs
+++ b/crates/samples/reactor/gallery/src/pages/date_time/calendar_date_picker.rs
@@ -1,7 +1,7 @@
 use crate::controls::*;
 use windows_reactor::*;
 
-pub fn calendar_date_picker_page(_: &(), cx: &mut RenderCx) -> impl Into<Element> {
+pub fn calendar_date_picker_page(_: &(), cx: &mut RenderCx) -> Element {
     let (selected_date, set_selected_date) = cx.use_state(String::from("No date selected"));
 
     page_content(
@@ -41,4 +41,5 @@ pub fn calendar_date_picker_page(_: &(), cx: &mut RenderCx) -> impl Into<Element
             ),
         ],
     )
+    .into()
 }

--- a/crates/samples/reactor/gallery/src/pages/date_time/calendar_view.rs
+++ b/crates/samples/reactor/gallery/src/pages/date_time/calendar_view.rs
@@ -42,5 +42,4 @@ calendar_view()
             ),
         ],
     )
-    .into()
 }

--- a/crates/samples/reactor/gallery/src/pages/date_time/calendar_view.rs
+++ b/crates/samples/reactor/gallery/src/pages/date_time/calendar_view.rs
@@ -1,7 +1,7 @@
 use crate::controls::*;
 use windows_reactor::*;
 
-pub fn calendar_view_page(_: &(), cx: &mut RenderCx) -> impl Into<Element> {
+pub fn calendar_view_page(_: &(), cx: &mut RenderCx) -> Element {
     let (today_highlighted, set_today_highlighted) = cx.use_state(true);
     let (selection_changes, set_selection_changes) = cx.use_state(0_u32);
 
@@ -42,4 +42,5 @@ calendar_view()
             ),
         ],
     )
+    .into()
 }

--- a/crates/samples/reactor/gallery/src/pages/date_time/date_picker.rs
+++ b/crates/samples/reactor/gallery/src/pages/date_time/date_picker.rs
@@ -29,5 +29,4 @@ pub fn date_picker_page(_: &(), cx: &mut RenderCx) -> Element {
             ),
         ],
     )
-    .into()
 }

--- a/crates/samples/reactor/gallery/src/pages/date_time/date_picker.rs
+++ b/crates/samples/reactor/gallery/src/pages/date_time/date_picker.rs
@@ -1,7 +1,7 @@
 use crate::controls::*;
 use windows_reactor::*;
 
-pub fn date_picker_page(_: &(), cx: &mut RenderCx) -> impl Into<Element> {
+pub fn date_picker_page(_: &(), cx: &mut RenderCx) -> Element {
     let (selected_date, set_selected_date) = cx.use_state(String::from("No date selected"));
 
     page_content(
@@ -29,4 +29,5 @@ pub fn date_picker_page(_: &(), cx: &mut RenderCx) -> impl Into<Element> {
             ),
         ],
     )
+    .into()
 }

--- a/crates/samples/reactor/gallery/src/pages/date_time/time_picker.rs
+++ b/crates/samples/reactor/gallery/src/pages/date_time/time_picker.rs
@@ -33,5 +33,4 @@ pub fn time_picker_page(_: &(), cx: &mut RenderCx) -> Element {
             ),
         ],
     )
-    .into()
 }

--- a/crates/samples/reactor/gallery/src/pages/date_time/time_picker.rs
+++ b/crates/samples/reactor/gallery/src/pages/date_time/time_picker.rs
@@ -1,7 +1,7 @@
 use crate::controls::*;
 use windows_reactor::*;
 
-pub fn time_picker_page(_: &(), cx: &mut RenderCx) -> impl Into<Element> {
+pub fn time_picker_page(_: &(), cx: &mut RenderCx) -> Element {
     let (selected_time, set_selected_time) = cx.use_state(String::from("No time selected"));
 
     page_content(
@@ -33,4 +33,5 @@ pub fn time_picker_page(_: &(), cx: &mut RenderCx) -> impl Into<Element> {
             ),
         ],
     )
+    .into()
 }

--- a/crates/samples/reactor/gallery/src/pages/design/color.rs
+++ b/crates/samples/reactor/gallery/src/pages/design/color.rs
@@ -50,5 +50,4 @@ pub fn color_page(_: &(), _cx: &mut RenderCx) -> Element {
         "System accent and semantic colors used across WinUI 3 apps.",
         vec![color_grid.into()],
     )
-    .into()
 }

--- a/crates/samples/reactor/gallery/src/pages/design/color.rs
+++ b/crates/samples/reactor/gallery/src/pages/design/color.rs
@@ -1,7 +1,7 @@
 use crate::controls::page_content;
 use windows_reactor::*;
 
-pub fn color_page(_: &(), _cx: &mut RenderCx) -> impl Into<Element> {
+pub fn color_page(_: &(), _cx: &mut RenderCx) -> Element {
     let swatches = [
         ("Accent", Color::rgb(0, 120, 212)),
         ("Accent Light 1", Color::rgb(51, 143, 221)),
@@ -50,4 +50,5 @@ pub fn color_page(_: &(), _cx: &mut RenderCx) -> impl Into<Element> {
         "System accent and semantic colors used across WinUI 3 apps.",
         vec![color_grid.into()],
     )
+    .into()
 }

--- a/crates/samples/reactor/gallery/src/pages/design/geometry.rs
+++ b/crates/samples/reactor/gallery/src/pages/design/geometry.rs
@@ -1,7 +1,7 @@
 use crate::controls::*;
 use windows_reactor::*;
 
-pub fn geometry_page(_: &(), _cx: &mut RenderCx) -> impl Into<Element> {
+pub fn geometry_page(_: &(), _cx: &mut RenderCx) -> Element {
     page_content(
         "Geometry",
         "WinUI defines shared corner radius values so controls and surfaces have a consistent shape language.",
@@ -102,7 +102,7 @@ Overlay").font_size(11.0).opacity(0.6),
     .corner_radius(4.0)  // vs .corner_radius(8.0)"#,
             ),
         ],
-    )
+    ).into()
 }
 
 fn radius_row(name: &str, value: f64, recommendation: &str) -> Element {

--- a/crates/samples/reactor/gallery/src/pages/design/geometry.rs
+++ b/crates/samples/reactor/gallery/src/pages/design/geometry.rs
@@ -102,7 +102,7 @@ Overlay").font_size(11.0).opacity(0.6),
     .corner_radius(4.0)  // vs .corner_radius(8.0)"#,
             ),
         ],
-    ).into()
+    )
 }
 
 fn radius_row(name: &str, value: f64, recommendation: &str) -> Element {

--- a/crates/samples/reactor/gallery/src/pages/design/iconography.rs
+++ b/crates/samples/reactor/gallery/src/pages/design/iconography.rs
@@ -1,7 +1,7 @@
 use crate::controls::page_content;
 use windows_reactor::*;
 
-pub fn iconography_page(_: &(), _cx: &mut RenderCx) -> impl Into<Element> {
+pub fn iconography_page(_: &(), _cx: &mut RenderCx) -> Element {
     let icons: Vec<(&str, SymbolGlyph)> = vec![
         ("Home", SymbolGlyph::Home),
         ("Setting", SymbolGlyph::Setting),
@@ -58,4 +58,5 @@ pub fn iconography_page(_: &(), _cx: &mut RenderCx) -> impl Into<Element> {
         "Segoe MDL2 Assets icons available through the SymbolGlyph enum.",
         vec![icons_grid.into()],
     )
+    .into()
 }

--- a/crates/samples/reactor/gallery/src/pages/design/iconography.rs
+++ b/crates/samples/reactor/gallery/src/pages/design/iconography.rs
@@ -58,5 +58,4 @@ pub fn iconography_page(_: &(), _cx: &mut RenderCx) -> Element {
         "Segoe MDL2 Assets icons available through the SymbolGlyph enum.",
         vec![icons_grid.into()],
     )
-    .into()
 }

--- a/crates/samples/reactor/gallery/src/pages/design/materials.rs
+++ b/crates/samples/reactor/gallery/src/pages/design/materials.rs
@@ -76,5 +76,5 @@ App::new(root).backdrop(Backdrop::Mica).run()
 set_backdrop(Some(Backdrop::Acrylic));"#,
             ),
         ],
-    ).into()
+    )
 }

--- a/crates/samples/reactor/gallery/src/pages/design/materials.rs
+++ b/crates/samples/reactor/gallery/src/pages/design/materials.rs
@@ -1,7 +1,7 @@
 use crate::controls::*;
 use windows_reactor::*;
 
-pub fn materials_page(_: &(), cx: &mut RenderCx) -> impl Into<Element> {
+pub fn materials_page(_: &(), cx: &mut RenderCx) -> Element {
     let (selected, set_selected) = cx.use_state(0_i32);
 
     let options: Vec<String> = ["Mica", "Mica Alt", "Acrylic", "None (solid)"]
@@ -76,5 +76,5 @@ App::new(root).backdrop(Backdrop::Mica).run()
 set_backdrop(Some(Backdrop::Acrylic));"#,
             ),
         ],
-    )
+    ).into()
 }

--- a/crates/samples/reactor/gallery/src/pages/design/spacing.rs
+++ b/crates/samples/reactor/gallery/src/pages/design/spacing.rs
@@ -1,7 +1,7 @@
 use crate::controls::page_content;
 use windows_reactor::*;
 
-pub fn spacing_page(_: &(), _cx: &mut RenderCx) -> impl Into<Element> {
+pub fn spacing_page(_: &(), _cx: &mut RenderCx) -> Element {
     let spacings = [
         ("XXSmall", 2.0),
         ("XSmall", 4.0),
@@ -23,6 +23,7 @@ pub fn spacing_page(_: &(), _cx: &mut RenderCx) -> impl Into<Element> {
         "Standard spacing values used to create consistent layouts in WinUI 3.",
         vec![vstack(samples).spacing(8.0).into()],
     )
+    .into()
 }
 
 fn spacing_row(name: &str, size: f64) -> Element {

--- a/crates/samples/reactor/gallery/src/pages/design/spacing.rs
+++ b/crates/samples/reactor/gallery/src/pages/design/spacing.rs
@@ -23,7 +23,6 @@ pub fn spacing_page(_: &(), _cx: &mut RenderCx) -> Element {
         "Standard spacing values used to create consistent layouts in WinUI 3.",
         vec![vstack(samples).spacing(8.0).into()],
     )
-    .into()
 }
 
 fn spacing_row(name: &str, size: f64) -> Element {

--- a/crates/samples/reactor/gallery/src/pages/design/theme.rs
+++ b/crates/samples/reactor/gallery/src/pages/design/theme.rs
@@ -1,7 +1,7 @@
 use crate::controls::*;
 use windows_reactor::*;
 
-pub fn theme_page(_: &(), _cx: &mut RenderCx) -> impl Into<Element> {
+pub fn theme_page(_: &(), _cx: &mut RenderCx) -> Element {
     page_content(
         "Theme",
         "Guidance on applying light, dark, and high-contrast themes using WinUI theme resources.",
@@ -68,7 +68,7 @@ ThemeRef::SystemSuccessBackground  // background"#,
     .border_thickness(Thickness::uniform(1.0))"#,
             ),
         ],
-    )
+    ).into()
 }
 
 fn token_row(name: &str, theme_ref: ThemeRef, description: &str) -> Element {

--- a/crates/samples/reactor/gallery/src/pages/design/theme.rs
+++ b/crates/samples/reactor/gallery/src/pages/design/theme.rs
@@ -68,7 +68,7 @@ ThemeRef::SystemSuccessBackground  // background"#,
     .border_thickness(Thickness::uniform(1.0))"#,
             ),
         ],
-    ).into()
+    )
 }
 
 fn token_row(name: &str, theme_ref: ThemeRef, description: &str) -> Element {

--- a/crates/samples/reactor/gallery/src/pages/design/typography.rs
+++ b/crates/samples/reactor/gallery/src/pages/design/typography.rs
@@ -1,7 +1,7 @@
 use crate::controls::page_content;
 use windows_reactor::*;
 
-pub fn typography_page(_: &(), _cx: &mut RenderCx) -> impl Into<Element> {
+pub fn typography_page(_: &(), _cx: &mut RenderCx) -> Element {
     let samples: Vec<Element> = vec![
         type_sample("Caption", 12.0, false),
         type_sample("Body", 14.0, false),
@@ -19,6 +19,7 @@ pub fn typography_page(_: &(), _cx: &mut RenderCx) -> impl Into<Element> {
         "The WinUI 3 type ramp provides a set of named text styles for consistent hierarchy.",
         vec![ramp],
     )
+    .into()
 }
 
 fn type_sample(name: &str, size: f64, bold: bool) -> Element {

--- a/crates/samples/reactor/gallery/src/pages/design/typography.rs
+++ b/crates/samples/reactor/gallery/src/pages/design/typography.rs
@@ -19,7 +19,6 @@ pub fn typography_page(_: &(), _cx: &mut RenderCx) -> Element {
         "The WinUI 3 type ramp provides a set of named text styles for consistent hierarchy.",
         vec![ramp],
     )
-    .into()
 }
 
 fn type_sample(name: &str, size: f64, bold: bool) -> Element {

--- a/crates/samples/reactor/gallery/src/pages/dialogs/command_bar_flyout.rs
+++ b/crates/samples/reactor/gallery/src/pages/dialogs/command_bar_flyout.rs
@@ -1,7 +1,7 @@
 use crate::controls::*;
 use windows_reactor::*;
 
-pub fn command_bar_flyout_page(_: &(), cx: &mut RenderCx) -> impl Into<Element> {
+pub fn command_bar_flyout_page(_: &(), cx: &mut RenderCx) -> Element {
     let (last_action, set_last_action) = cx.use_state(String::from("(none)"));
 
     page_content(
@@ -57,4 +57,5 @@ pub fn command_bar_flyout_page(_: &(), cx: &mut RenderCx) -> impl Into<Element> 
             ),
         ],
     )
+    .into()
 }

--- a/crates/samples/reactor/gallery/src/pages/dialogs/command_bar_flyout.rs
+++ b/crates/samples/reactor/gallery/src/pages/dialogs/command_bar_flyout.rs
@@ -57,5 +57,4 @@ pub fn command_bar_flyout_page(_: &(), cx: &mut RenderCx) -> Element {
             ),
         ],
     )
-    .into()
 }

--- a/crates/samples/reactor/gallery/src/pages/dialogs/content_dialog.rs
+++ b/crates/samples/reactor/gallery/src/pages/dialogs/content_dialog.rs
@@ -55,5 +55,5 @@ pub fn content_dialog_page(_: &(), cx: &mut RenderCx) -> Element {
                 r#"ContentDialog::new("Save?").primary_button_text("Save").secondary_button_text("Don't Save")"#,
             ),
         ],
-    ).into()
+    )
 }

--- a/crates/samples/reactor/gallery/src/pages/dialogs/content_dialog.rs
+++ b/crates/samples/reactor/gallery/src/pages/dialogs/content_dialog.rs
@@ -1,7 +1,7 @@
 use crate::controls::*;
 use windows_reactor::*;
 
-pub fn content_dialog_page(_: &(), cx: &mut RenderCx) -> impl Into<Element> {
+pub fn content_dialog_page(_: &(), cx: &mut RenderCx) -> Element {
     let (open, set_open) = cx.use_state(false);
     let (result_text, set_result) = cx.use_state(String::from("(none)"));
     let (open2, set_open2) = cx.use_state(false);
@@ -55,5 +55,5 @@ pub fn content_dialog_page(_: &(), cx: &mut RenderCx) -> impl Into<Element> {
                 r#"ContentDialog::new("Save?").primary_button_text("Save").secondary_button_text("Don't Save")"#,
             ),
         ],
-    )
+    ).into()
 }

--- a/crates/samples/reactor/gallery/src/pages/dialogs/flyout.rs
+++ b/crates/samples/reactor/gallery/src/pages/dialogs/flyout.rs
@@ -46,5 +46,4 @@ pub fn flyout_page(_: &(), cx: &mut RenderCx) -> Element {
             ),
         ],
     )
-    .into()
 }

--- a/crates/samples/reactor/gallery/src/pages/dialogs/flyout.rs
+++ b/crates/samples/reactor/gallery/src/pages/dialogs/flyout.rs
@@ -1,7 +1,7 @@
 use crate::controls::*;
 use windows_reactor::*;
 
-pub fn flyout_page(_: &(), cx: &mut RenderCx) -> impl Into<Element> {
+pub fn flyout_page(_: &(), cx: &mut RenderCx) -> Element {
     let (deleted, set_deleted) = cx.use_state(false);
 
     page_content(
@@ -46,4 +46,5 @@ pub fn flyout_page(_: &(), cx: &mut RenderCx) -> impl Into<Element> {
             ),
         ],
     )
+    .into()
 }

--- a/crates/samples/reactor/gallery/src/pages/dialogs/menu_flyout.rs
+++ b/crates/samples/reactor/gallery/src/pages/dialogs/menu_flyout.rs
@@ -65,5 +65,4 @@ pub fn menu_flyout_page(_: &(), cx: &mut RenderCx) -> Element {
             ),
         ],
     )
-    .into()
 }

--- a/crates/samples/reactor/gallery/src/pages/dialogs/menu_flyout.rs
+++ b/crates/samples/reactor/gallery/src/pages/dialogs/menu_flyout.rs
@@ -1,7 +1,7 @@
 use crate::controls::*;
 use windows_reactor::*;
 
-pub fn menu_flyout_page(_: &(), cx: &mut RenderCx) -> impl Into<Element> {
+pub fn menu_flyout_page(_: &(), cx: &mut RenderCx) -> Element {
     let (last_action, set_action) = cx.use_state(String::from("(none)"));
 
     page_content(
@@ -65,4 +65,5 @@ pub fn menu_flyout_page(_: &(), cx: &mut RenderCx) -> impl Into<Element> {
             ),
         ],
     )
+    .into()
 }

--- a/crates/samples/reactor/gallery/src/pages/dialogs/teaching_tip.rs
+++ b/crates/samples/reactor/gallery/src/pages/dialogs/teaching_tip.rs
@@ -1,7 +1,7 @@
 use crate::controls::*;
 use windows_reactor::*;
 
-pub fn teaching_tip_page(_: &(), cx: &mut RenderCx) -> impl Into<Element> {
+pub fn teaching_tip_page(_: &(), cx: &mut RenderCx) -> Element {
     let (show_basic, set_basic) = cx.use_state(false);
     let (show_action, set_action) = cx.use_state(false);
     let (action_count, set_count) = cx.use_state(0_i32);
@@ -46,4 +46,5 @@ pub fn teaching_tip_page(_: &(), cx: &mut RenderCx) -> impl Into<Element> {
             ),
         ],
     )
+    .into()
 }

--- a/crates/samples/reactor/gallery/src/pages/dialogs/teaching_tip.rs
+++ b/crates/samples/reactor/gallery/src/pages/dialogs/teaching_tip.rs
@@ -46,5 +46,4 @@ pub fn teaching_tip_page(_: &(), cx: &mut RenderCx) -> Element {
             ),
         ],
     )
-    .into()
 }

--- a/crates/samples/reactor/gallery/src/pages/home.rs
+++ b/crates/samples/reactor/gallery/src/pages/home.rs
@@ -2,7 +2,7 @@ use crate::controls::{card_grid, CardItem};
 use crate::registry::{self, CATEGORIES};
 use windows_reactor::*;
 
-pub fn home_page(on_navigate: impl Fn(String) + Clone + 'static) -> impl Into<Element> {
+pub fn home_page(on_navigate: impl Fn(String) + Clone + 'static) -> Element {
     let items: Vec<CardItem> = CATEGORIES
         .iter()
         .map(|&category| {
@@ -46,10 +46,12 @@ pub fn home_page(on_navigate: impl Fn(String) + Clone + 'static) -> impl Into<El
     .columns([GridLength::Star(1.0)])
     .row_spacing(32.0);
 
-    border(root).padding(Thickness {
-        left: 36.0,
-        top: 40.0,
-        right: 36.0,
-        bottom: 36.0,
-    })
+    border(root)
+        .padding(Thickness {
+            left: 36.0,
+            top: 40.0,
+            right: 36.0,
+            bottom: 36.0,
+        })
+        .into()
 }

--- a/crates/samples/reactor/gallery/src/pages/layout/border.rs
+++ b/crates/samples/reactor/gallery/src/pages/layout/border.rs
@@ -52,5 +52,4 @@ pub fn border_page(_: &(), cx: &mut RenderCx) -> Element {
             ),
         ],
     )
-    .into()
 }

--- a/crates/samples/reactor/gallery/src/pages/layout/border.rs
+++ b/crates/samples/reactor/gallery/src/pages/layout/border.rs
@@ -1,7 +1,7 @@
 use crate::controls::*;
 use windows_reactor::*;
 
-pub fn border_page(_: &(), cx: &mut RenderCx) -> impl Into<Element> {
+pub fn border_page(_: &(), cx: &mut RenderCx) -> Element {
     let (radius, set_radius) = cx.use_state(8.0_f64);
     let (thick, set_thick) = cx.use_state(false);
 
@@ -52,4 +52,5 @@ pub fn border_page(_: &(), cx: &mut RenderCx) -> impl Into<Element> {
             ),
         ],
     )
+    .into()
 }

--- a/crates/samples/reactor/gallery/src/pages/layout/canvas.rs
+++ b/crates/samples/reactor/gallery/src/pages/layout/canvas.rs
@@ -39,5 +39,4 @@ pub fn canvas_page(_: &(), cx: &mut RenderCx) -> Element {
             r#"Canvas::new([el.canvas_left(x).canvas_top(y)]) // x, y from sliders"#,
         )],
     )
-    .into()
 }

--- a/crates/samples/reactor/gallery/src/pages/layout/canvas.rs
+++ b/crates/samples/reactor/gallery/src/pages/layout/canvas.rs
@@ -1,7 +1,7 @@
 use crate::controls::*;
 use windows_reactor::*;
 
-pub fn canvas_page(_: &(), cx: &mut RenderCx) -> impl Into<Element> {
+pub fn canvas_page(_: &(), cx: &mut RenderCx) -> Element {
     let (x, set_x) = cx.use_state(100.0_f64);
     let (y, set_y) = cx.use_state(80.0_f64);
 
@@ -39,4 +39,5 @@ pub fn canvas_page(_: &(), cx: &mut RenderCx) -> impl Into<Element> {
             r#"Canvas::new([el.canvas_left(x).canvas_top(y)]) // x, y from sliders"#,
         )],
     )
+    .into()
 }

--- a/crates/samples/reactor/gallery/src/pages/layout/expander.rs
+++ b/crates/samples/reactor/gallery/src/pages/layout/expander.rs
@@ -1,7 +1,7 @@
 use crate::controls::*;
 use windows_reactor::*;
 
-pub fn expander_page(_: &(), cx: &mut RenderCx) -> impl Into<Element> {
+pub fn expander_page(_: &(), cx: &mut RenderCx) -> Element {
     let (is_expanded, set_expanded) = cx.use_state(true);
 
     page_content(
@@ -39,4 +39,5 @@ pub fn expander_page(_: &(), cx: &mut RenderCx) -> impl Into<Element> {
             ),
         ],
     )
+    .into()
 }

--- a/crates/samples/reactor/gallery/src/pages/layout/expander.rs
+++ b/crates/samples/reactor/gallery/src/pages/layout/expander.rs
@@ -39,5 +39,4 @@ pub fn expander_page(_: &(), cx: &mut RenderCx) -> Element {
             ),
         ],
     )
-    .into()
 }

--- a/crates/samples/reactor/gallery/src/pages/layout/grid.rs
+++ b/crates/samples/reactor/gallery/src/pages/layout/grid.rs
@@ -1,7 +1,7 @@
 use crate::controls::*;
 use windows_reactor::*;
 
-pub fn grid_page(_: &(), cx: &mut RenderCx) -> impl Into<Element> {
+pub fn grid_page(_: &(), cx: &mut RenderCx) -> Element {
     let (wide, set_wide) = cx.use_state(false);
 
     let basic_grid = {
@@ -186,4 +186,5 @@ if wide { grid with 3 columns } else { grid with 2×2 }"#,
             ),
         ],
     )
+    .into()
 }

--- a/crates/samples/reactor/gallery/src/pages/layout/grid.rs
+++ b/crates/samples/reactor/gallery/src/pages/layout/grid.rs
@@ -186,5 +186,4 @@ if wide { grid with 3 columns } else { grid with 2×2 }"#,
             ),
         ],
     )
-    .into()
 }

--- a/crates/samples/reactor/gallery/src/pages/layout/relative_panel.rs
+++ b/crates/samples/reactor/gallery/src/pages/layout/relative_panel.rs
@@ -1,7 +1,7 @@
 use crate::controls::*;
 use windows_reactor::*;
 
-pub fn relative_panel_page(_: &(), cx: &mut RenderCx) -> impl Into<Element> {
+pub fn relative_panel_page(_: &(), cx: &mut RenderCx) -> Element {
     let (show_alt_layout, set_show_alt_layout) = cx.use_state(false);
 
     let dynamic_items: Vec<Element> = if show_alt_layout {
@@ -65,4 +65,5 @@ pub fn relative_panel_page(_: &(), cx: &mut RenderCx) -> impl Into<Element> {
             ),
         ],
     )
+    .into()
 }

--- a/crates/samples/reactor/gallery/src/pages/layout/relative_panel.rs
+++ b/crates/samples/reactor/gallery/src/pages/layout/relative_panel.rs
@@ -65,5 +65,4 @@ pub fn relative_panel_page(_: &(), cx: &mut RenderCx) -> Element {
             ),
         ],
     )
-    .into()
 }

--- a/crates/samples/reactor/gallery/src/pages/layout/scroll_view.rs
+++ b/crates/samples/reactor/gallery/src/pages/layout/scroll_view.rs
@@ -32,5 +32,4 @@ pub fn scroll_view_page(_: &(), cx: &mut RenderCx) -> Element {
             r#"scroll_view(vstack(items).spacing(4.0)).height(200.0)"#,
         )],
     )
-    .into()
 }

--- a/crates/samples/reactor/gallery/src/pages/layout/scroll_view.rs
+++ b/crates/samples/reactor/gallery/src/pages/layout/scroll_view.rs
@@ -1,7 +1,7 @@
 use crate::controls::*;
 use windows_reactor::*;
 
-pub fn scroll_view_page(_: &(), cx: &mut RenderCx) -> impl Into<Element> {
+pub fn scroll_view_page(_: &(), cx: &mut RenderCx) -> Element {
     let (count, set_count) = cx.use_state(30_i32);
 
     let items: Vec<Element> = (1..=count)
@@ -32,4 +32,5 @@ pub fn scroll_view_page(_: &(), cx: &mut RenderCx) -> impl Into<Element> {
             r#"scroll_view(vstack(items).spacing(4.0)).height(200.0)"#,
         )],
     )
+    .into()
 }

--- a/crates/samples/reactor/gallery/src/pages/layout/split_view.rs
+++ b/crates/samples/reactor/gallery/src/pages/layout/split_view.rs
@@ -1,7 +1,7 @@
 use crate::controls::*;
 use windows_reactor::*;
 
-pub fn split_view_page(_: &(), cx: &mut RenderCx) -> impl Into<Element> {
+pub fn split_view_page(_: &(), cx: &mut RenderCx) -> Element {
     let (open, set_open) = cx.use_state(true);
 
     page_content(
@@ -21,4 +21,5 @@ pub fn split_view_page(_: &(), cx: &mut RenderCx) -> impl Into<Element> {
             r#"split_view(content).pane(pane).is_pane_open(open)"#,
         )],
     )
+    .into()
 }

--- a/crates/samples/reactor/gallery/src/pages/layout/split_view.rs
+++ b/crates/samples/reactor/gallery/src/pages/layout/split_view.rs
@@ -21,5 +21,4 @@ pub fn split_view_page(_: &(), cx: &mut RenderCx) -> Element {
             r#"split_view(content).pane(pane).is_pane_open(open)"#,
         )],
     )
-    .into()
 }

--- a/crates/samples/reactor/gallery/src/pages/layout/stack_panel.rs
+++ b/crates/samples/reactor/gallery/src/pages/layout/stack_panel.rs
@@ -1,7 +1,7 @@
 use crate::controls::*;
 use windows_reactor::*;
 
-pub fn stack_panel_page(_: &(), cx: &mut RenderCx) -> impl Into<Element> {
+pub fn stack_panel_page(_: &(), cx: &mut RenderCx) -> Element {
     let (item_count, set_count) = cx.use_state(3_i32);
 
     let items: Vec<Element> = (1..=item_count)
@@ -52,4 +52,5 @@ pub fn stack_panel_page(_: &(), cx: &mut RenderCx) -> impl Into<Element> {
             ),
         ],
     )
+    .into()
 }

--- a/crates/samples/reactor/gallery/src/pages/layout/stack_panel.rs
+++ b/crates/samples/reactor/gallery/src/pages/layout/stack_panel.rs
@@ -52,5 +52,4 @@ pub fn stack_panel_page(_: &(), cx: &mut RenderCx) -> Element {
             ),
         ],
     )
-    .into()
 }

--- a/crates/samples/reactor/gallery/src/pages/layout/viewbox.rs
+++ b/crates/samples/reactor/gallery/src/pages/layout/viewbox.rs
@@ -1,7 +1,7 @@
 use crate::controls::*;
 use windows_reactor::*;
 
-pub fn viewbox_page(_: &(), cx: &mut RenderCx) -> impl Into<Element> {
+pub fn viewbox_page(_: &(), cx: &mut RenderCx) -> Element {
     let (content_size, set_content_size) = cx.use_state(120.0_f64);
 
     page_content(
@@ -34,4 +34,5 @@ pub fn viewbox_page(_: &(), cx: &mut RenderCx) -> impl Into<Element> {
             r#"viewbox(content).width(200.0).height(100.0) // content size comes from state"#,
         )],
     )
+    .into()
 }

--- a/crates/samples/reactor/gallery/src/pages/layout/viewbox.rs
+++ b/crates/samples/reactor/gallery/src/pages/layout/viewbox.rs
@@ -34,5 +34,4 @@ pub fn viewbox_page(_: &(), cx: &mut RenderCx) -> Element {
             r#"viewbox(content).width(200.0).height(100.0) // content size comes from state"#,
         )],
     )
-    .into()
 }

--- a/crates/samples/reactor/gallery/src/pages/media/image.rs
+++ b/crates/samples/reactor/gallery/src/pages/media/image.rs
@@ -56,5 +56,4 @@ pub fn image_page(_: &(), cx: &mut RenderCx) -> Element {
             r#"Image::new(uri).stretch(ImageStretch::Uniform).width(300.0).height(150.0)"#,
         )],
     )
-    .into()
 }

--- a/crates/samples/reactor/gallery/src/pages/media/image.rs
+++ b/crates/samples/reactor/gallery/src/pages/media/image.rs
@@ -1,7 +1,7 @@
 use crate::controls::*;
 use windows_reactor::*;
 
-pub fn image_page(_: &(), cx: &mut RenderCx) -> impl Into<Element> {
+pub fn image_page(_: &(), cx: &mut RenderCx) -> Element {
     let (stretch_idx, set_stretch) = cx.use_state(0_i32);
 
     let stretch = match stretch_idx {
@@ -56,4 +56,5 @@ pub fn image_page(_: &(), cx: &mut RenderCx) -> impl Into<Element> {
             r#"Image::new(uri).stretch(ImageStretch::Uniform).width(300.0).height(150.0)"#,
         )],
     )
+    .into()
 }

--- a/crates/samples/reactor/gallery/src/pages/media/person_picture.rs
+++ b/crates/samples/reactor/gallery/src/pages/media/person_picture.rs
@@ -45,5 +45,4 @@ PersonPicture::new().display_name("Alice Smith")
 PersonPicture::new().initials("AS")"#,
         )],
     )
-    .into()
 }

--- a/crates/samples/reactor/gallery/src/pages/media/person_picture.rs
+++ b/crates/samples/reactor/gallery/src/pages/media/person_picture.rs
@@ -1,7 +1,7 @@
 use crate::controls::*;
 use windows_reactor::*;
 
-pub fn person_picture_page(_: &(), cx: &mut RenderCx) -> impl Into<Element> {
+pub fn person_picture_page(_: &(), cx: &mut RenderCx) -> Element {
     let (show_display_names, set_show_display_names) = cx.use_state(true);
 
     let pictures: Element = if show_display_names {
@@ -45,4 +45,5 @@ PersonPicture::new().display_name("Alice Smith")
 PersonPicture::new().initials("AS")"#,
         )],
     )
+    .into()
 }

--- a/crates/samples/reactor/gallery/src/pages/menus/command_bar.rs
+++ b/crates/samples/reactor/gallery/src/pages/menus/command_bar.rs
@@ -53,5 +53,5 @@ pub fn command_bar_page(_: &(), cx: &mut RenderCx) -> Element {
                 r#"command_bar(vec![CommandBarCommandDef::Button { label, icon }])"#,
             ),
         ],
-    ).into()
+    )
 }

--- a/crates/samples/reactor/gallery/src/pages/menus/command_bar.rs
+++ b/crates/samples/reactor/gallery/src/pages/menus/command_bar.rs
@@ -1,7 +1,7 @@
 use crate::controls::*;
 use windows_reactor::*;
 
-pub fn command_bar_page(_: &(), cx: &mut RenderCx) -> impl Into<Element> {
+pub fn command_bar_page(_: &(), cx: &mut RenderCx) -> Element {
     let (status, set_status) = cx.use_state(String::from("Choose a command"));
 
     page_content(
@@ -53,5 +53,5 @@ pub fn command_bar_page(_: &(), cx: &mut RenderCx) -> impl Into<Element> {
                 r#"command_bar(vec![CommandBarCommandDef::Button { label, icon }])"#,
             ),
         ],
-    )
+    ).into()
 }

--- a/crates/samples/reactor/gallery/src/pages/menus/menu_bar.rs
+++ b/crates/samples/reactor/gallery/src/pages/menus/menu_bar.rs
@@ -50,5 +50,4 @@ pub fn menu_bar_page(_: &(), cx: &mut RenderCx) -> Element {
     .on_item_click(|label| set_status.call(format!(\"Last clicked: {label}\")))"#,
         )],
     )
-    .into()
 }

--- a/crates/samples/reactor/gallery/src/pages/menus/menu_bar.rs
+++ b/crates/samples/reactor/gallery/src/pages/menus/menu_bar.rs
@@ -1,7 +1,7 @@
 use crate::controls::*;
 use windows_reactor::*;
 
-pub fn menu_bar_page(_: &(), cx: &mut RenderCx) -> impl Into<Element> {
+pub fn menu_bar_page(_: &(), cx: &mut RenderCx) -> Element {
     let (status, set_status) = cx.use_state(String::from("Last clicked: (none)"));
 
     page_content(
@@ -50,4 +50,5 @@ pub fn menu_bar_page(_: &(), cx: &mut RenderCx) -> impl Into<Element> {
     .on_item_click(|label| set_status.call(format!(\"Last clicked: {label}\")))"#,
         )],
     )
+    .into()
 }

--- a/crates/samples/reactor/gallery/src/pages/menus/selector_bar.rs
+++ b/crates/samples/reactor/gallery/src/pages/menus/selector_bar.rs
@@ -1,7 +1,7 @@
 use crate::controls::*;
 use windows_reactor::*;
 
-pub fn selector_bar_page(_: &(), cx: &mut RenderCx) -> impl Into<Element> {
+pub fn selector_bar_page(_: &(), cx: &mut RenderCx) -> Element {
     let (selected, set_selected) = cx.use_state(String::from("Recent"));
 
     let cb = set_selected;
@@ -23,4 +23,5 @@ pub fn selector_bar_page(_: &(), cx: &mut RenderCx) -> impl Into<Element> {
             r#"selector_bar(vec![selector_bar_item("Recent"), ...]).on_selection_changed(h)"#,
         )],
     )
+    .into()
 }

--- a/crates/samples/reactor/gallery/src/pages/menus/selector_bar.rs
+++ b/crates/samples/reactor/gallery/src/pages/menus/selector_bar.rs
@@ -23,5 +23,4 @@ pub fn selector_bar_page(_: &(), cx: &mut RenderCx) -> Element {
             r#"selector_bar(vec![selector_bar_item("Recent"), ...]).on_selection_changed(h)"#,
         )],
     )
-    .into()
 }

--- a/crates/samples/reactor/gallery/src/pages/navigation/breadcrumb_bar.rs
+++ b/crates/samples/reactor/gallery/src/pages/navigation/breadcrumb_bar.rs
@@ -25,5 +25,4 @@ pub fn breadcrumb_bar_page(_: &(), cx: &mut RenderCx) -> Element {
             ),
         ],
     )
-    .into()
 }

--- a/crates/samples/reactor/gallery/src/pages/navigation/breadcrumb_bar.rs
+++ b/crates/samples/reactor/gallery/src/pages/navigation/breadcrumb_bar.rs
@@ -1,7 +1,7 @@
 use crate::controls::*;
 use windows_reactor::*;
 
-pub fn breadcrumb_bar_page(_: &(), cx: &mut RenderCx) -> impl Into<Element> {
+pub fn breadcrumb_bar_page(_: &(), cx: &mut RenderCx) -> Element {
     let (clicked, set_clicked) = cx.use_state(-1_i32);
 
     page_content(
@@ -25,4 +25,5 @@ pub fn breadcrumb_bar_page(_: &(), cx: &mut RenderCx) -> impl Into<Element> {
             ),
         ],
     )
+    .into()
 }

--- a/crates/samples/reactor/gallery/src/pages/navigation/navigation_view.rs
+++ b/crates/samples/reactor/gallery/src/pages/navigation/navigation_view.rs
@@ -72,5 +72,4 @@ pub fn navigation_view_page(_: &(), cx: &mut RenderCx) -> Element {
             ),
         ],
     )
-    .into()
 }

--- a/crates/samples/reactor/gallery/src/pages/navigation/navigation_view.rs
+++ b/crates/samples/reactor/gallery/src/pages/navigation/navigation_view.rs
@@ -1,7 +1,7 @@
 use crate::controls::*;
 use windows_reactor::*;
 
-pub fn navigation_view_page(_: &(), cx: &mut RenderCx) -> impl Into<Element> {
+pub fn navigation_view_page(_: &(), cx: &mut RenderCx) -> Element {
     let (selected, set_selected) = cx.use_state(String::from("page1"));
     let (top_selected, set_top_selected) = cx.use_state(String::from("home"));
 
@@ -72,4 +72,5 @@ pub fn navigation_view_page(_: &(), cx: &mut RenderCx) -> impl Into<Element> {
             ),
         ],
     )
+    .into()
 }

--- a/crates/samples/reactor/gallery/src/pages/navigation/pivot.rs
+++ b/crates/samples/reactor/gallery/src/pages/navigation/pivot.rs
@@ -34,5 +34,4 @@ pub fn pivot_page(_: &(), cx: &mut RenderCx) -> Element {
             ),
         ],
     )
-    .into()
 }

--- a/crates/samples/reactor/gallery/src/pages/navigation/pivot.rs
+++ b/crates/samples/reactor/gallery/src/pages/navigation/pivot.rs
@@ -1,7 +1,7 @@
 use crate::controls::*;
 use windows_reactor::*;
 
-pub fn pivot_page(_: &(), cx: &mut RenderCx) -> impl Into<Element> {
+pub fn pivot_page(_: &(), cx: &mut RenderCx) -> Element {
     let (tab_idx, set_tab) = cx.use_state(0_i32);
 
     page_content(
@@ -34,4 +34,5 @@ pub fn pivot_page(_: &(), cx: &mut RenderCx) -> impl Into<Element> {
             ),
         ],
     )
+    .into()
 }

--- a/crates/samples/reactor/gallery/src/pages/navigation/tab_view.rs
+++ b/crates/samples/reactor/gallery/src/pages/navigation/tab_view.rs
@@ -1,7 +1,7 @@
 use crate::controls::*;
 use windows_reactor::*;
 
-pub fn tab_view_page(_: &(), cx: &mut RenderCx) -> impl Into<Element> {
+pub fn tab_view_page(_: &(), cx: &mut RenderCx) -> Element {
     let (selected, set_selected) = cx.use_state(0_i32);
     let (tab_count, set_tab_count) = cx.use_state(3_i32);
 
@@ -75,4 +75,5 @@ TabView::new(tabs)"#,
             ),
         ],
     )
+    .into()
 }

--- a/crates/samples/reactor/gallery/src/pages/navigation/tab_view.rs
+++ b/crates/samples/reactor/gallery/src/pages/navigation/tab_view.rs
@@ -75,5 +75,4 @@ TabView::new(tabs)"#,
             ),
         ],
     )
-    .into()
 }

--- a/crates/samples/reactor/gallery/src/pages/navigation/title_bar.rs
+++ b/crates/samples/reactor/gallery/src/pages/navigation/title_bar.rs
@@ -11,5 +11,5 @@ pub fn title_bar_page(_: &(), _cx: &mut RenderCx) -> Element {
                     ,
                 r#"App::new().title("My App").run(|| Shell)"#,
             )],
-        ).into()
+        )
 }

--- a/crates/samples/reactor/gallery/src/pages/navigation/title_bar.rs
+++ b/crates/samples/reactor/gallery/src/pages/navigation/title_bar.rs
@@ -1,7 +1,7 @@
 use crate::controls::*;
 use windows_reactor::*;
 
-pub fn title_bar_page(_: &(), _cx: &mut RenderCx) -> impl Into<Element> {
+pub fn title_bar_page(_: &(), _cx: &mut RenderCx) -> Element {
     page_content(
             "TitleBar",
             "A customizable application title bar.",
@@ -11,5 +11,5 @@ pub fn title_bar_page(_: &(), _cx: &mut RenderCx) -> impl Into<Element> {
                     ,
                 r#"App::new().title("My App").run(|| Shell)"#,
             )],
-        )
+        ).into()
 }

--- a/crates/samples/reactor/gallery/src/pages/settings.rs
+++ b/crates/samples/reactor/gallery/src/pages/settings.rs
@@ -1,6 +1,6 @@
 use windows_reactor::*;
 
-pub fn settings_page(_: &(), _cx: &mut RenderCx) -> impl Into<Element> {
+pub fn settings_page(_: &(), _cx: &mut RenderCx) -> Element {
     let content: Element = vstack((
         text_block("Settings").font_size(28.0).bold(),
         vstack((
@@ -38,5 +38,5 @@ pub fn settings_page(_: &(), _cx: &mut RenderCx) -> impl Into<Element> {
     })
     .horizontal_alignment(HorizontalAlignment::Stretch)
     .into();
-    scroll_view(content)
+    scroll_view(content).into()
 }

--- a/crates/samples/reactor/gallery/src/pages/status/info_badge.rs
+++ b/crates/samples/reactor/gallery/src/pages/status/info_badge.rs
@@ -52,5 +52,4 @@ pub fn info_badge_page(_: &(), cx: &mut RenderCx) -> Element {
             ),
         ],
     )
-    .into()
 }

--- a/crates/samples/reactor/gallery/src/pages/status/info_badge.rs
+++ b/crates/samples/reactor/gallery/src/pages/status/info_badge.rs
@@ -1,7 +1,7 @@
 use crate::controls::*;
 use windows_reactor::*;
 
-pub fn info_badge_page(_: &(), cx: &mut RenderCx) -> impl Into<Element> {
+pub fn info_badge_page(_: &(), cx: &mut RenderCx) -> Element {
     let (count, set_count) = cx.use_state(3_i32);
 
     page_content(
@@ -52,4 +52,5 @@ pub fn info_badge_page(_: &(), cx: &mut RenderCx) -> impl Into<Element> {
             ),
         ],
     )
+    .into()
 }

--- a/crates/samples/reactor/gallery/src/pages/status/info_bar.rs
+++ b/crates/samples/reactor/gallery/src/pages/status/info_bar.rs
@@ -47,5 +47,4 @@ pub fn info_bar_page(_: &(), cx: &mut RenderCx) -> Element {
             ),
         ],
     )
-    .into()
 }

--- a/crates/samples/reactor/gallery/src/pages/status/info_bar.rs
+++ b/crates/samples/reactor/gallery/src/pages/status/info_bar.rs
@@ -1,7 +1,7 @@
 use crate::controls::*;
 use windows_reactor::*;
 
-pub fn info_bar_page(_: &(), cx: &mut RenderCx) -> impl Into<Element> {
+pub fn info_bar_page(_: &(), cx: &mut RenderCx) -> Element {
     let (visible, set_visible) = cx.use_state(true);
 
     page_content(
@@ -47,4 +47,5 @@ pub fn info_bar_page(_: &(), cx: &mut RenderCx) -> impl Into<Element> {
             ),
         ],
     )
+    .into()
 }

--- a/crates/samples/reactor/gallery/src/pages/status/progress_bar.rs
+++ b/crates/samples/reactor/gallery/src/pages/status/progress_bar.rs
@@ -45,5 +45,4 @@ Slider::new(value).range(0.0, 100.0).on_changed(handler)"#,
             ),
         ],
     )
-    .into()
 }

--- a/crates/samples/reactor/gallery/src/pages/status/progress_bar.rs
+++ b/crates/samples/reactor/gallery/src/pages/status/progress_bar.rs
@@ -1,7 +1,7 @@
 use crate::controls::*;
 use windows_reactor::*;
 
-pub fn progress_bar_page(_: &(), cx: &mut RenderCx) -> impl Into<Element> {
+pub fn progress_bar_page(_: &(), cx: &mut RenderCx) -> Element {
     let (value, set_value) = cx.use_state(60.0_f64);
     let (loading, set_loading) = cx.use_state(true);
 
@@ -45,4 +45,5 @@ Slider::new(value).range(0.0, 100.0).on_changed(handler)"#,
             ),
         ],
     )
+    .into()
 }

--- a/crates/samples/reactor/gallery/src/pages/status/progress_ring.rs
+++ b/crates/samples/reactor/gallery/src/pages/status/progress_ring.rs
@@ -1,7 +1,7 @@
 use crate::controls::*;
 use windows_reactor::*;
 
-pub fn progress_ring_page(_: &(), cx: &mut RenderCx) -> impl Into<Element> {
+pub fn progress_ring_page(_: &(), cx: &mut RenderCx) -> Element {
     let (value, set_value) = cx.use_state(75.0_f64);
 
     page_content(
@@ -27,4 +27,5 @@ pub fn progress_ring_page(_: &(), cx: &mut RenderCx) -> impl Into<Element> {
             ),
         ],
     )
+    .into()
 }

--- a/crates/samples/reactor/gallery/src/pages/status/progress_ring.rs
+++ b/crates/samples/reactor/gallery/src/pages/status/progress_ring.rs
@@ -27,5 +27,4 @@ pub fn progress_ring_page(_: &(), cx: &mut RenderCx) -> Element {
             ),
         ],
     )
-    .into()
 }

--- a/crates/samples/reactor/gallery/src/pages/status/tool_tip.rs
+++ b/crates/samples/reactor/gallery/src/pages/status/tool_tip.rs
@@ -54,5 +54,4 @@ pub fn tool_tip_page(_: &(), cx: &mut RenderCx) -> Element {
             ),
         ],
     )
-    .into()
 }

--- a/crates/samples/reactor/gallery/src/pages/status/tool_tip.rs
+++ b/crates/samples/reactor/gallery/src/pages/status/tool_tip.rs
@@ -1,7 +1,7 @@
 use crate::controls::*;
 use windows_reactor::*;
 
-pub fn tool_tip_page(_: &(), cx: &mut RenderCx) -> impl Into<Element> {
+pub fn tool_tip_page(_: &(), cx: &mut RenderCx) -> Element {
     let (hover_count, set_hover_count) = cx.use_state(0_i32);
 
     let rich_tooltip = Tooltip::rich(
@@ -54,4 +54,5 @@ pub fn tool_tip_page(_: &(), cx: &mut RenderCx) -> impl Into<Element> {
             ),
         ],
     )
+    .into()
 }

--- a/crates/samples/reactor/gallery/src/pages/text/auto_suggest_box.rs
+++ b/crates/samples/reactor/gallery/src/pages/text/auto_suggest_box.rs
@@ -26,5 +26,4 @@ pub fn auto_suggest_box_page(_: &(), cx: &mut RenderCx) -> Element {
             r#"auto_suggest_box(query).items(suggestions).on_text_changed(handler)"#,
         )],
     )
-    .into()
 }

--- a/crates/samples/reactor/gallery/src/pages/text/auto_suggest_box.rs
+++ b/crates/samples/reactor/gallery/src/pages/text/auto_suggest_box.rs
@@ -1,7 +1,7 @@
 use crate::controls::*;
 use windows_reactor::*;
 
-pub fn auto_suggest_box_page(_: &(), cx: &mut RenderCx) -> impl Into<Element> {
+pub fn auto_suggest_box_page(_: &(), cx: &mut RenderCx) -> Element {
     let (query, set_query) = cx.use_state(String::new());
 
     let suggestions: Vec<String> = ["Apple", "Banana", "Cherry", "Date", "Elderberry"]
@@ -26,4 +26,5 @@ pub fn auto_suggest_box_page(_: &(), cx: &mut RenderCx) -> impl Into<Element> {
             r#"auto_suggest_box(query).items(suggestions).on_text_changed(handler)"#,
         )],
     )
+    .into()
 }

--- a/crates/samples/reactor/gallery/src/pages/text/rich_edit_box.rs
+++ b/crates/samples/reactor/gallery/src/pages/text/rich_edit_box.rs
@@ -32,5 +32,4 @@ pub fn rich_edit_box_page(_: &(), cx: &mut RenderCx) -> Element {
     .on_changed(|text| set_editor_text.call(text))"#,
         )],
     )
-    .into()
 }

--- a/crates/samples/reactor/gallery/src/pages/text/rich_edit_box.rs
+++ b/crates/samples/reactor/gallery/src/pages/text/rich_edit_box.rs
@@ -1,7 +1,7 @@
 use crate::controls::*;
 use windows_reactor::*;
 
-pub fn rich_edit_box_page(_: &(), cx: &mut RenderCx) -> impl Into<Element> {
+pub fn rich_edit_box_page(_: &(), cx: &mut RenderCx) -> Element {
     let (editor_text, set_editor_text) = cx.use_state(String::new());
 
     page_content(
@@ -32,4 +32,5 @@ pub fn rich_edit_box_page(_: &(), cx: &mut RenderCx) -> impl Into<Element> {
     .on_changed(|text| set_editor_text.call(text))"#,
         )],
     )
+    .into()
 }

--- a/crates/samples/reactor/gallery/src/pages/text/rich_text_block.rs
+++ b/crates/samples/reactor/gallery/src/pages/text/rich_text_block.rs
@@ -95,5 +95,5 @@ pub fn rich_text_block_page(_: &(), cx: &mut RenderCx) -> Element {
     .wrap()"#,
                 ),
             ],
-        ).into()
+        )
 }

--- a/crates/samples/reactor/gallery/src/pages/text/rich_text_block.rs
+++ b/crates/samples/reactor/gallery/src/pages/text/rich_text_block.rs
@@ -2,7 +2,7 @@ use crate::controls::*;
 use windows_reactor::core::{RichTextBlock, RichTextInline, RichTextParagraph, RichTextRun};
 use windows_reactor::*;
 
-pub fn rich_text_block_page(_: &(), cx: &mut RenderCx) -> impl Into<Element> {
+pub fn rich_text_block_page(_: &(), cx: &mut RenderCx) -> Element {
     let (font_size, set_font_size) = cx.use_state(14.0);
 
     page_content(
@@ -95,5 +95,5 @@ pub fn rich_text_block_page(_: &(), cx: &mut RenderCx) -> impl Into<Element> {
     .wrap()"#,
                 ),
             ],
-        )
+        ).into()
 }

--- a/crates/samples/reactor/gallery/src/pages/text/type_ramp.rs
+++ b/crates/samples/reactor/gallery/src/pages/text/type_ramp.rs
@@ -1,7 +1,7 @@
 use crate::controls::*;
 use windows_reactor::*;
 
-pub fn type_ramp_page(_: &(), _cx: &mut RenderCx) -> impl Into<Element> {
+pub fn type_ramp_page(_: &(), _cx: &mut RenderCx) -> Element {
     page_content(
         "Type Ramp",
         "Named text factories for the WinUI 3 type ramp.",
@@ -61,4 +61,5 @@ text_block("Huge").font_size(36.0)"#,
             ),
         ],
     )
+    .into()
 }

--- a/crates/samples/reactor/gallery/src/pages/text/type_ramp.rs
+++ b/crates/samples/reactor/gallery/src/pages/text/type_ramp.rs
@@ -61,5 +61,4 @@ text_block("Huge").font_size(36.0)"#,
             ),
         ],
     )
-    .into()
 }

--- a/crates/samples/reactor/gallery/src/router.rs
+++ b/crates/samples/reactor/gallery/src/router.rs
@@ -99,4 +99,5 @@ pub fn route(tag: &str) -> Element {
             .opacity(0.6)
             .into(),
     }
+    .into()
 }

--- a/crates/samples/reactor/gallery/src/router.rs
+++ b/crates/samples/reactor/gallery/src/router.rs
@@ -99,5 +99,4 @@ pub fn route(tag: &str) -> Element {
             .opacity(0.6)
             .into(),
     }
-    .into()
 }

--- a/crates/samples/reactor/gallery/src/shell.rs
+++ b/crates/samples/reactor/gallery/src/shell.rs
@@ -47,7 +47,6 @@ pub fn gallery_shell(cx: &mut RenderCx) -> Element {
                 set_nav.call((key, h));
             }
         })
-        .into()
     } else if selected_tag.eq_ignore_ascii_case("settings") {
         component(crate::pages::settings::settings_page, ())
     } else if category_tags.contains(&selected_tag) {

--- a/crates/samples/reactor/gallery/src/shell.rs
+++ b/crates/samples/reactor/gallery/src/shell.rs
@@ -3,7 +3,7 @@ use crate::registry::{self, ControlInfo, CATEGORIES};
 use crate::router;
 use windows_reactor::*;
 
-pub fn gallery_shell(cx: &mut RenderCx) -> impl Into<Element> {
+pub fn gallery_shell(cx: &mut RenderCx) -> Element {
     let (nav, set_nav) = cx.use_state((String::from("home"), Vec::<String>::new()));
     let (is_pane_open, set_pane_open) = cx.use_state(true);
     let (search_text, set_search_text) = cx.use_state(String::new());
@@ -161,6 +161,7 @@ pub fn gallery_shell(cx: &mut RenderCx) -> impl Into<Element> {
     grid((title_bar.grid_row(0), nav_view.grid_row(1)))
         .rows([GridLength::Auto, GridLength::Star(1.0)])
         .columns([GridLength::Star(1.0)])
+        .into()
 }
 
 fn category_icon(category: &str) -> SymbolGlyph {

--- a/crates/samples/reactor/minimal/examples/async_state.rs
+++ b/crates/samples/reactor/minimal/examples/async_state.rs
@@ -8,7 +8,7 @@ use std::time::Duration;
 
 use windows_reactor::*;
 
-fn app(cx: &mut RenderCx) -> impl Into<Element> {
+fn app(cx: &mut RenderCx) -> Element {
     let (count, set_count) = cx.use_async_state(0_i32);
     let (busy, set_busy) = cx.use_async_state(false);
 
@@ -42,6 +42,7 @@ fn app(cx: &mut RenderCx) -> impl Into<Element> {
         button("Bump (off-thread)").on_click(bump).enabled(!busy),
     ))
     .spacing(8.0)
+    .into()
 }
 
 fn main() -> Result<()> {

--- a/crates/samples/reactor/minimal/examples/auto_suggest_box.rs
+++ b/crates/samples/reactor/minimal/examples/auto_suggest_box.rs
@@ -19,7 +19,7 @@ const FRUITS: &[&str] = &[
     "Watermelon",
 ];
 
-fn app(cx: &mut RenderCx) -> impl Into<Element> {
+fn app(cx: &mut RenderCx) -> Element {
     let (query, set_query) = cx.use_state(String::new());
     let (chosen, set_chosen) = cx.use_state(String::new());
 
@@ -50,6 +50,7 @@ fn app(cx: &mut RenderCx) -> impl Into<Element> {
         }),
     ))
     .spacing(12.0)
+    .into()
 }
 
 fn main() -> Result<()> {

--- a/crates/samples/reactor/minimal/examples/background_brush.rs
+++ b/crates/samples/reactor/minimal/examples/background_brush.rs
@@ -2,8 +2,10 @@
 
 use windows_reactor::*;
 
-fn app(_cx: &mut RenderCx) -> impl Into<Element> {
-    grid([TextBlock::new("Sample")]).background(Color::rgb(255, 0, 0))
+fn app(_cx: &mut RenderCx) -> Element {
+    grid([TextBlock::new("Sample")])
+        .background(Color::rgb(255, 0, 0))
+        .into()
 }
 
 fn main() -> Result<()> {

--- a/crates/samples/reactor/minimal/examples/border.rs
+++ b/crates/samples/reactor/minimal/examples/border.rs
@@ -2,7 +2,7 @@
 
 use windows_reactor::*;
 
-fn app(_cx: &mut RenderCx) -> impl Into<Element> {
+fn app(_cx: &mut RenderCx) -> Element {
     vstack((
         border(text_block("Boxed text").foreground(Color::rgb(255, 255, 255)))
             .background(Color::rgb(60, 100, 180))
@@ -18,6 +18,7 @@ fn app(_cx: &mut RenderCx) -> impl Into<Element> {
         .max_width(280.0),
     ))
     .spacing(8.0)
+    .into()
 }
 
 fn main() -> Result<()> {

--- a/crates/samples/reactor/minimal/examples/breadcrumb_bar.rs
+++ b/crates/samples/reactor/minimal/examples/breadcrumb_bar.rs
@@ -2,7 +2,7 @@
 
 use windows_reactor::*;
 
-fn app(_cx: &mut RenderCx) -> impl Into<Element> {
+fn app(_cx: &mut RenderCx) -> Element {
     vstack((
         text_block("Multi-segment trail"),
         BreadcrumbBar::new(["Home", "Documents", "Projects", "windows-reactor-rs"]),
@@ -10,6 +10,7 @@ fn app(_cx: &mut RenderCx) -> impl Into<Element> {
         BreadcrumbBar::new(["Home", "Settings"]),
     ))
     .spacing(8.0)
+    .into()
 }
 
 fn main() -> Result<()> {

--- a/crates/samples/reactor/minimal/examples/button.rs
+++ b/crates/samples/reactor/minimal/examples/button.rs
@@ -2,7 +2,7 @@
 
 use windows_reactor::*;
 
-fn app(cx: &mut RenderCx) -> impl Into<Element> {
+fn app(cx: &mut RenderCx) -> Element {
     let (clicks, set_clicks) = cx.use_state(0_u32);
 
     let bump = move || set_clicks.call(clicks + 1);
@@ -13,6 +13,7 @@ fn app(cx: &mut RenderCx) -> impl Into<Element> {
         button("Accent (Primary Action)").accent(),
     ))
     .spacing(8.0)
+    .into()
 }
 
 fn main() -> Result<()> {

--- a/crates/samples/reactor/minimal/examples/button_icon.rs
+++ b/crates/samples/reactor/minimal/examples/button_icon.rs
@@ -2,7 +2,7 @@
 
 use windows_reactor::*;
 
-fn app(cx: &mut RenderCx) -> impl Into<Element> {
+fn app(cx: &mut RenderCx) -> Element {
     let (count, set_count) = cx.use_state(0u32);
 
     vstack((
@@ -22,6 +22,7 @@ fn app(cx: &mut RenderCx) -> impl Into<Element> {
         text_block(format!("Count: {count}")),
     ))
     .spacing(8.0)
+    .into()
 }
 
 fn main() -> Result<()> {

--- a/crates/samples/reactor/minimal/examples/button_icon_dynamic.rs
+++ b/crates/samples/reactor/minimal/examples/button_icon_dynamic.rs
@@ -6,7 +6,7 @@
 
 use windows_reactor::*;
 
-fn app(cx: &mut RenderCx) -> impl Into<Element> {
+fn app(cx: &mut RenderCx) -> Element {
     let (count, set_count) = cx.use_state(0u32);
     let label = format!("Clicked {count} times");
 
@@ -25,6 +25,7 @@ fn app(cx: &mut RenderCx) -> impl Into<Element> {
         text_block("Click the buttons — the icons should remain visible.").opacity(0.6),
     ))
     .spacing(12.0)
+    .into()
 }
 
 fn main() -> Result<()> {

--- a/crates/samples/reactor/minimal/examples/button_icon_glyph_change.rs
+++ b/crates/samples/reactor/minimal/examples/button_icon_glyph_change.rs
@@ -7,7 +7,7 @@
 
 use windows_reactor::*;
 
-fn app(cx: &mut RenderCx) -> impl Into<Element> {
+fn app(cx: &mut RenderCx) -> Element {
     let (toggled, set_toggled) = cx.use_state(false);
     let icon = if toggled {
         SymbolGlyph::Save
@@ -25,6 +25,7 @@ fn app(cx: &mut RenderCx) -> impl Into<Element> {
         text_block("Click the button — the icon should change but the label stays.").opacity(0.4),
     ))
     .spacing(12.0)
+    .into()
 }
 
 fn main() -> Result<()> {

--- a/crates/samples/reactor/minimal/examples/calendar_date_picker.rs
+++ b/crates/samples/reactor/minimal/examples/calendar_date_picker.rs
@@ -5,7 +5,7 @@
 
 use windows_reactor::*;
 
-fn app(cx: &mut RenderCx) -> impl Into<Element> {
+fn app(cx: &mut RenderCx) -> Element {
     let (label, set_label) = cx.use_state(String::from("Pick a date to see days from today"));
 
     let on_date = move |date: Option<DateTime>| {
@@ -39,6 +39,7 @@ fn app(cx: &mut RenderCx) -> impl Into<Element> {
         text_block(&*label),
     ))
     .spacing(8.0)
+    .into()
 }
 
 fn main() -> Result<()> {

--- a/crates/samples/reactor/minimal/examples/calendar_view.rs
+++ b/crates/samples/reactor/minimal/examples/calendar_view.rs
@@ -2,7 +2,7 @@
 
 use windows_reactor::*;
 
-fn app(cx: &mut RenderCx) -> impl Into<Element> {
+fn app(cx: &mut RenderCx) -> Element {
     let (count, set_count) = cx.use_state(0_u32);
 
     let bump = move || set_count.call(count + 1);
@@ -12,6 +12,7 @@ fn app(cx: &mut RenderCx) -> impl Into<Element> {
         text_block(format!("Selection changed {count} time(s)")),
     ))
     .spacing(8.0)
+    .into()
 }
 
 fn main() -> Result<()> {

--- a/crates/samples/reactor/minimal/examples/canvas.rs
+++ b/crates/samples/reactor/minimal/examples/canvas.rs
@@ -4,7 +4,7 @@
 
 use windows_reactor::*;
 
-fn app(_cx: &mut RenderCx) -> impl Into<Element> {
+fn app(_cx: &mut RenderCx) -> Element {
     Canvas::new([
         Shape::rectangle()
             .stroke(Color::rgb(128, 128, 128))
@@ -28,6 +28,7 @@ fn app(_cx: &mut RenderCx) -> impl Into<Element> {
     ])
     .width(260.0)
     .height(120.0)
+    .into()
 }
 
 fn main() -> Result<()> {

--- a/crates/samples/reactor/minimal/examples/card.rs
+++ b/crates/samples/reactor/minimal/examples/card.rs
@@ -4,7 +4,7 @@
 
 use windows_reactor::*;
 
-fn app(_cx: &mut RenderCx) -> impl Into<Element> {
+fn app(_cx: &mut RenderCx) -> Element {
     let card = |title: &str, body: &str, radius: f64, stroke: f64| -> Element {
         border(
             vstack((
@@ -41,6 +41,7 @@ fn app(_cx: &mut RenderCx) -> impl Into<Element> {
     ])
     .column_spacing(12.0)
     .padding(Thickness::uniform(24.0))
+    .into()
 }
 
 fn main() -> Result<()> {

--- a/crates/samples/reactor/minimal/examples/check_box.rs
+++ b/crates/samples/reactor/minimal/examples/check_box.rs
@@ -2,7 +2,7 @@
 
 use windows_reactor::*;
 
-fn app(cx: &mut RenderCx) -> impl Into<Element> {
+fn app(cx: &mut RenderCx) -> Element {
     let (checked, set_checked) = cx.use_state(false);
 
     let toggle = move |v| set_checked.call(v);
@@ -19,6 +19,7 @@ fn app(cx: &mut RenderCx) -> impl Into<Element> {
         check_box(true).label("Disabled (always on)").enabled(false),
     ))
     .spacing(8.0)
+    .into()
 }
 
 fn main() -> Result<()> {

--- a/crates/samples/reactor/minimal/examples/color_picker.rs
+++ b/crates/samples/reactor/minimal/examples/color_picker.rs
@@ -2,7 +2,7 @@
 
 use windows_reactor::*;
 
-fn app(cx: &mut RenderCx) -> impl Into<Element> {
+fn app(cx: &mut RenderCx) -> Element {
     let (color, set_color) = cx.use_state((255_u8, 0_u8, 120_u8, 215_u8));
 
     let update = move |argb: (u8, u8, u8, u8)| set_color.call(argb);
@@ -17,6 +17,7 @@ fn app(cx: &mut RenderCx) -> impl Into<Element> {
         text_block(format!("Hex: #{r:02X}{g:02X}{b:02X}")),
     ))
     .spacing(8.0)
+    .into()
 }
 
 fn main() -> Result<()> {

--- a/crates/samples/reactor/minimal/examples/combo_box.rs
+++ b/crates/samples/reactor/minimal/examples/combo_box.rs
@@ -2,7 +2,7 @@
 
 use windows_reactor::*;
 
-fn app(cx: &mut RenderCx) -> impl Into<Element> {
+fn app(cx: &mut RenderCx) -> Element {
     let (selected, set_selected) = cx.use_state(-1_i32);
 
     let update_selected = move |i: i32| set_selected.call(i);
@@ -35,6 +35,7 @@ fn app(cx: &mut RenderCx) -> impl Into<Element> {
     ))
     .spacing(8.0)
     .max_width(320.0)
+    .into()
 }
 
 fn main() -> Result<()> {

--- a/crates/samples/reactor/minimal/examples/command_bar.rs
+++ b/crates/samples/reactor/minimal/examples/command_bar.rs
@@ -2,7 +2,7 @@
 
 use windows_reactor::*;
 
-fn app(cx: &mut RenderCx) -> impl Into<Element> {
+fn app(cx: &mut RenderCx) -> Element {
     let (last_click, set_last_click) = cx.use_state(String::from("(none)"));
 
     vstack((
@@ -18,6 +18,7 @@ fn app(cx: &mut RenderCx) -> impl Into<Element> {
         text_block(format!("Last clicked: {last_click}")),
     ))
     .spacing(12.0)
+    .into()
 }
 
 fn main() -> Result<()> {

--- a/crates/samples/reactor/minimal/examples/command_bar_flyout.rs
+++ b/crates/samples/reactor/minimal/examples/command_bar_flyout.rs
@@ -2,7 +2,7 @@
 
 use windows_reactor::*;
 
-fn app(cx: &mut RenderCx) -> impl Into<Element> {
+fn app(cx: &mut RenderCx) -> Element {
     let (last_action, set_action) = cx.use_state("(none)".to_string());
 
     let on_cmd = move |label: String| set_action.call(label);
@@ -22,6 +22,7 @@ fn app(cx: &mut RenderCx) -> impl Into<Element> {
         text_block(format!("Last action: {last_action}")),
     ))
     .spacing(8.0)
+    .into()
 }
 
 fn main() -> Result<()> {

--- a/crates/samples/reactor/minimal/examples/component_props.rs
+++ b/crates/samples/reactor/minimal/examples/component_props.rs
@@ -10,16 +10,17 @@ struct GreetingProps {
     clicks: u32,
 }
 
-fn greeting(props: &GreetingProps, _cx: &mut RenderCx) -> impl Into<Element> {
+fn greeting(props: &GreetingProps, _cx: &mut RenderCx) -> Element {
     let GreetingProps { name, clicks } = props;
     vstack((
         text_block(format!("Hello, {name}!")).bold().font_size(20.0),
         text_block(format!("You have clicked the button {clicks} times.")),
     ))
     .spacing(4.0)
+    .into()
 }
 
-fn app(cx: &mut RenderCx) -> impl Into<Element> {
+fn app(cx: &mut RenderCx) -> Element {
     let (name, _set_name) = cx.use_state(String::from("world"));
     let (clicks, set_clicks) = cx.use_state(0_u32);
 
@@ -32,6 +33,7 @@ fn app(cx: &mut RenderCx) -> impl Into<Element> {
     ))
     .spacing(12.0)
     .padding(Thickness::uniform(16.0))
+    .into()
 }
 
 fn main() -> Result<()> {

--- a/crates/samples/reactor/minimal/examples/composition.rs
+++ b/crates/samples/reactor/minimal/examples/composition.rs
@@ -77,7 +77,7 @@ impl From<BadgeButton> for Element {
     }
 }
 
-fn app(cx: &mut RenderCx) -> impl Into<Element> {
+fn app(cx: &mut RenderCx) -> Element {
     let (inbox_count, set_inbox) = cx.use_state(3_u32);
     let (drafts_count, set_drafts) = cx.use_state(1_u32);
     let inbox_for_inc = inbox_count;
@@ -108,6 +108,7 @@ fn app(cx: &mut RenderCx) -> impl Into<Element> {
     ))
     .spacing(12.0)
     .padding(Thickness::uniform(16.0))
+    .into()
 }
 
 fn main() -> Result<()> {

--- a/crates/samples/reactor/minimal/examples/content_dialog.rs
+++ b/crates/samples/reactor/minimal/examples/content_dialog.rs
@@ -2,7 +2,7 @@
 
 use windows_reactor::*;
 
-fn app(cx: &mut RenderCx) -> impl Into<Element> {
+fn app(cx: &mut RenderCx) -> Element {
     let (open, set_open) = cx.use_state(false);
     let (result, set_result) = cx.use_state::<Option<ContentDialogResult>>(None);
 
@@ -35,6 +35,7 @@ fn app(cx: &mut RenderCx) -> impl Into<Element> {
     ))
     .spacing(8.0)
     .max_width(320.0)
+    .into()
 }
 
 fn main() -> Result<()> {

--- a/crates/samples/reactor/minimal/examples/context.rs
+++ b/crates/samples/reactor/minimal/examples/context.rs
@@ -10,7 +10,7 @@ use windows_reactor::*;
 
 static THEME: LazyLock<Context<String>> = LazyLock::new(|| Context::new("light".to_string()));
 
-fn leaf(_: &(), cx: &mut RenderCx) -> impl Into<Element> {
+fn leaf(_: &(), cx: &mut RenderCx) -> Element {
     let theme = cx.use_context(&THEME);
     let (bg, fg) = match theme.as_str() {
         "dark" => (Color::rgb(30, 30, 30), Color::rgb(255, 255, 255)),
@@ -24,9 +24,10 @@ fn leaf(_: &(), cx: &mut RenderCx) -> impl Into<Element> {
             .padding(Thickness::uniform(16.0)),
     )
     .background(bg)
+    .into()
 }
 
-fn app(cx: &mut RenderCx) -> impl Into<Element> {
+fn app(cx: &mut RenderCx) -> Element {
     let (theme, set_theme) = cx.use_state("light".to_string());
 
     let pick = |name: &'static str| {

--- a/crates/samples/reactor/minimal/examples/counter.rs
+++ b/crates/samples/reactor/minimal/examples/counter.rs
@@ -2,7 +2,7 @@
 
 use windows_reactor::*;
 
-fn app(cx: &mut RenderCx) -> impl Into<Element> {
+fn app(cx: &mut RenderCx) -> Element {
     let (count, set_count) = cx.use_state(0_i32);
 
     let dec = {
@@ -47,6 +47,7 @@ fn app(cx: &mut RenderCx) -> impl Into<Element> {
         .spacing(8.0),
     ))
     .spacing(12.0)
+    .into()
 }
 
 fn main() -> Result<()> {

--- a/crates/samples/reactor/minimal/examples/date_picker.rs
+++ b/crates/samples/reactor/minimal/examples/date_picker.rs
@@ -2,7 +2,7 @@
 
 use windows_reactor::*;
 
-fn app(cx: &mut RenderCx) -> impl Into<Element> {
+fn app(cx: &mut RenderCx) -> Element {
     let (label, set_label) = cx.use_state(String::from("No date picked"));
 
     let on_date = move |dt: DateTime| {
@@ -14,6 +14,7 @@ fn app(cx: &mut RenderCx) -> impl Into<Element> {
         text_block(&*label),
     ))
     .spacing(8.0)
+    .into()
 }
 
 fn main() -> Result<()> {

--- a/crates/samples/reactor/minimal/examples/drop_down_button.rs
+++ b/crates/samples/reactor/minimal/examples/drop_down_button.rs
@@ -2,7 +2,7 @@
 
 use windows_reactor::*;
 
-fn app(cx: &mut RenderCx) -> impl Into<Element> {
+fn app(cx: &mut RenderCx) -> Element {
     let (clicks, set_clicks) = cx.use_state(0_u32);
 
     let bump = move || set_clicks.call(clicks + 1);
@@ -12,6 +12,7 @@ fn app(cx: &mut RenderCx) -> impl Into<Element> {
         text_block(format!("Clicked {clicks} time(s)")),
     ))
     .spacing(8.0)
+    .into()
 }
 
 fn main() -> Result<()> {

--- a/crates/samples/reactor/minimal/examples/error_boundary.rs
+++ b/crates/samples/reactor/minimal/examples/error_boundary.rs
@@ -11,15 +11,17 @@ struct PanicMaybeProps {
     should_panic: bool,
 }
 
-fn panic_maybe(props: &PanicMaybeProps, _cx: &mut RenderCx) -> impl Into<Element> {
+fn panic_maybe(props: &PanicMaybeProps, _cx: &mut RenderCx) -> Element {
     assert!(
         !props.should_panic,
         "intentional render failure for the error-boundary demo"
     );
-    text_block("Healthy child renders normally.").font_size(14.0)
+    text_block("Healthy child renders normally.")
+        .font_size(14.0)
+        .into()
 }
 
-fn app(cx: &mut RenderCx) -> impl Into<Element> {
+fn app(cx: &mut RenderCx) -> Element {
     let (should_panic, set_should_panic) = cx.use_state(false);
 
     let toggle = move || set_should_panic.call(!should_panic);
@@ -47,7 +49,7 @@ fn app(cx: &mut RenderCx) -> impl Into<Element> {
         boundary,
     ))
     .spacing(12.0)
-    .padding(Thickness::uniform(16.0))
+    .padding(Thickness::uniform(16.0)).into()
 }
 
 fn main() -> Result<()> {

--- a/crates/samples/reactor/minimal/examples/expander.rs
+++ b/crates/samples/reactor/minimal/examples/expander.rs
@@ -2,7 +2,7 @@
 
 use windows_reactor::*;
 
-fn app(_cx: &mut RenderCx) -> impl Into<Element> {
+fn app(_cx: &mut RenderCx) -> Element {
     vstack((
         Expander::new(
             vstack((
@@ -29,6 +29,7 @@ fn app(_cx: &mut RenderCx) -> impl Into<Element> {
     ))
     .spacing(8.0)
     .max_width(400.0)
+    .into()
 }
 
 fn main() -> Result<()> {

--- a/crates/samples/reactor/minimal/examples/flip_view.rs
+++ b/crates/samples/reactor/minimal/examples/flip_view.rs
@@ -2,7 +2,7 @@
 
 use windows_reactor::*;
 
-fn app(cx: &mut RenderCx) -> impl Into<Element> {
+fn app(cx: &mut RenderCx) -> Element {
     let (page, set_page) = cx.use_state(0_i32);
 
     let items: Vec<String> = ["Red", "Green", "Blue"]
@@ -43,6 +43,7 @@ fn app(cx: &mut RenderCx) -> impl Into<Element> {
     ))
     .spacing(8.0)
     .max_width(360.0)
+    .into()
 }
 
 fn main() -> Result<()> {

--- a/crates/samples/reactor/minimal/examples/flyout.rs
+++ b/crates/samples/reactor/minimal/examples/flyout.rs
@@ -2,7 +2,7 @@
 
 use windows_reactor::*;
 
-fn app(cx: &mut RenderCx) -> impl Into<Element> {
+fn app(cx: &mut RenderCx) -> Element {
     let (count, set_count) = cx.use_state(0_u32);
 
     let bump = move || set_count.call(count + 1);
@@ -14,6 +14,7 @@ fn app(cx: &mut RenderCx) -> impl Into<Element> {
         button("Increment").on_click(bump),
     ))
     .spacing(8.0)
+    .into()
 }
 
 fn main() -> Result<()> {

--- a/crates/samples/reactor/minimal/examples/function_component.rs
+++ b/crates/samples/reactor/minimal/examples/function_component.rs
@@ -1,12 +1,12 @@
 //! Minimal sample demonstrating function components.
 //!
-//! Define a function with signature `fn(&P, &mut RenderCx) -> impl Into<Element>`
+//! Define a function with signature `fn(&P, &mut RenderCx) -> Element`
 //! and compose with `component(f, props)`.
 
 use windows_reactor::*;
 
 /// A function component — no struct needed.
-fn counter(_: &(), cx: &mut RenderCx) -> impl Into<Element> {
+fn counter(_: &(), cx: &mut RenderCx) -> Element {
     let (count, set_count) = cx.use_state(0_i32);
 
     let bump = move || set_count.call(count + 1);
@@ -18,6 +18,7 @@ fn counter(_: &(), cx: &mut RenderCx) -> impl Into<Element> {
         button("Increment").on_click(bump),
     ))
     .spacing(8.0)
+    .into()
 }
 
 /// A function component with typed props.
@@ -26,14 +27,15 @@ struct GreetingProps {
     name: String,
 }
 
-fn greeting(props: &GreetingProps, _cx: &mut RenderCx) -> impl Into<Element> {
+fn greeting(props: &GreetingProps, _cx: &mut RenderCx) -> Element {
     text_block(format!("Hello, {}!", props.name))
         .font_size(20.0)
         .bold()
+        .into()
 }
 
 /// Root component that composes both function components.
-fn app(cx: &mut RenderCx) -> impl Into<Element> {
+fn app(cx: &mut RenderCx) -> Element {
     let (name, set_name) = cx.use_state(String::from("world"));
 
     vstack((
@@ -45,6 +47,7 @@ fn app(cx: &mut RenderCx) -> impl Into<Element> {
         component(counter, ()),
     ))
     .spacing(12.0)
+    .into()
 }
 
 fn main() -> Result<()> {

--- a/crates/samples/reactor/minimal/examples/grid.rs
+++ b/crates/samples/reactor/minimal/examples/grid.rs
@@ -2,7 +2,7 @@
 
 use windows_reactor::*;
 
-fn app(_cx: &mut RenderCx) -> impl Into<Element> {
+fn app(_cx: &mut RenderCx) -> Element {
     let cell = |label: &str, color: Color| -> Element {
         border(
             text_block(label)
@@ -33,6 +33,7 @@ fn app(_cx: &mut RenderCx) -> impl Into<Element> {
     .row_spacing(6.0)
     .column_spacing(6.0)
     .max_width(360.0)
+    .into()
 }
 
 fn main() -> Result<()> {

--- a/crates/samples/reactor/minimal/examples/grid_view.rs
+++ b/crates/samples/reactor/minimal/examples/grid_view.rs
@@ -2,7 +2,7 @@
 
 use windows_reactor::*;
 
-fn app(_cx: &mut RenderCx) -> impl Into<Element> {
+fn app(_cx: &mut RenderCx) -> Element {
     let items: Vec<String> = ["Red", "Green", "Blue", "Yellow", "Magenta", "Cyan"]
         .iter()
         .map(|s| (*s).to_string())
@@ -17,6 +17,7 @@ fn app(_cx: &mut RenderCx) -> impl Into<Element> {
     })
     .with_key_selector(|s| s.clone())
     .height(220.0)
+    .into()
 }
 
 fn main() -> Result<()> {

--- a/crates/samples/reactor/minimal/examples/hyperlink_button.rs
+++ b/crates/samples/reactor/minimal/examples/hyperlink_button.rs
@@ -2,7 +2,7 @@
 
 use windows_reactor::*;
 
-fn app(cx: &mut RenderCx) -> impl Into<Element> {
+fn app(cx: &mut RenderCx) -> Element {
     let (clicks, set_clicks) = cx.use_state(0_u32);
 
     let bump = move || set_clicks.call(clicks + 1);
@@ -16,6 +16,7 @@ fn app(cx: &mut RenderCx) -> impl Into<Element> {
             .enabled(false),
     ))
     .spacing(8.0)
+    .into()
 }
 
 fn main() -> Result<()> {

--- a/crates/samples/reactor/minimal/examples/image.rs
+++ b/crates/samples/reactor/minimal/examples/image.rs
@@ -2,7 +2,7 @@
 
 use windows_reactor::*;
 
-fn app(_cx: &mut RenderCx) -> impl Into<Element> {
+fn app(_cx: &mut RenderCx) -> Element {
     let source = format!(
         "file:///{}/examples/image.png",
         env!("CARGO_MANIFEST_DIR").replace('\\', "/"),
@@ -28,6 +28,7 @@ fn app(_cx: &mut RenderCx) -> impl Into<Element> {
             .height(60.0),
     ))
     .spacing(8.0)
+    .into()
 }
 
 fn main() -> Result<()> {

--- a/crates/samples/reactor/minimal/examples/info_badge.rs
+++ b/crates/samples/reactor/minimal/examples/info_badge.rs
@@ -2,7 +2,7 @@
 
 use windows_reactor::*;
 
-fn app(_cx: &mut RenderCx) -> impl Into<Element> {
+fn app(_cx: &mut RenderCx) -> Element {
     vstack((
         text_block("Dot (attention indicator)"),
         InfoBadge::dot(),
@@ -16,6 +16,7 @@ fn app(_cx: &mut RenderCx) -> impl Into<Element> {
         .spacing(12.0),
     ))
     .spacing(8.0)
+    .into()
 }
 
 fn main() -> Result<()> {

--- a/crates/samples/reactor/minimal/examples/info_bar.rs
+++ b/crates/samples/reactor/minimal/examples/info_bar.rs
@@ -2,7 +2,7 @@
 
 use windows_reactor::*;
 
-fn app(_cx: &mut RenderCx) -> impl Into<Element> {
+fn app(_cx: &mut RenderCx) -> Element {
     vstack((
         InfoBar::new("Did you know?")
             .message("This is an informational notice.")
@@ -27,6 +27,7 @@ fn app(_cx: &mut RenderCx) -> impl Into<Element> {
     ))
     .spacing(8.0)
     .max_width(360.0)
+    .into()
 }
 
 fn main() -> Result<()> {

--- a/crates/samples/reactor/minimal/examples/list_box.rs
+++ b/crates/samples/reactor/minimal/examples/list_box.rs
@@ -2,7 +2,7 @@
 
 use windows_reactor::*;
 
-fn app(cx: &mut RenderCx) -> impl Into<Element> {
+fn app(cx: &mut RenderCx) -> Element {
     let (selected, set_selected) = cx.use_state(-1_i32);
 
     let on_sel = move |idx: i32| set_selected.call(idx);
@@ -20,6 +20,7 @@ fn app(cx: &mut RenderCx) -> impl Into<Element> {
         text_block(label),
     ))
     .spacing(8.0)
+    .into()
 }
 
 fn main() -> Result<()> {

--- a/crates/samples/reactor/minimal/examples/list_view.rs
+++ b/crates/samples/reactor/minimal/examples/list_view.rs
@@ -2,7 +2,7 @@
 
 use windows_reactor::*;
 
-fn app(cx: &mut RenderCx) -> impl Into<Element> {
+fn app(cx: &mut RenderCx) -> Element {
     let (selected, set_selected) = cx.use_state(-1_i32);
     let (mode_idx, set_mode_idx) = cx.use_state(1_i32); // default = Single
 
@@ -57,6 +57,7 @@ fn app(cx: &mut RenderCx) -> impl Into<Element> {
     ))
     .spacing(8.0)
     .max_width(320.0)
+    .into()
 }
 
 fn main() -> Result<()> {

--- a/crates/samples/reactor/minimal/examples/menu_bar.rs
+++ b/crates/samples/reactor/minimal/examples/menu_bar.rs
@@ -2,7 +2,7 @@
 
 use windows_reactor::*;
 
-fn app(cx: &mut RenderCx) -> impl Into<Element> {
+fn app(cx: &mut RenderCx) -> Element {
     let (last_click, set_last_click) = cx.use_state(String::from("(none)"));
 
     let on_item = {
@@ -41,6 +41,7 @@ fn app(cx: &mut RenderCx) -> impl Into<Element> {
         text_block(format!("Last clicked: {last_click}")),
     ))
     .spacing(12.0)
+    .into()
 }
 
 fn main() -> Result<()> {

--- a/crates/samples/reactor/minimal/examples/menu_flyout.rs
+++ b/crates/samples/reactor/minimal/examples/menu_flyout.rs
@@ -2,7 +2,7 @@
 
 use windows_reactor::*;
 
-fn app(cx: &mut RenderCx) -> impl Into<Element> {
+fn app(cx: &mut RenderCx) -> Element {
     let (last_action, set_action) = cx.use_state("(none)".to_string());
 
     let on_item = move |text: String| set_action.call(text);
@@ -23,6 +23,7 @@ fn app(cx: &mut RenderCx) -> impl Into<Element> {
         text_block(format!("Last action: {last_action}")),
     ))
     .spacing(8.0)
+    .into()
 }
 
 fn main() -> Result<()> {

--- a/crates/samples/reactor/minimal/examples/navigation.rs
+++ b/crates/samples/reactor/minimal/examples/navigation.rs
@@ -34,13 +34,14 @@ impl Page {
     }
 }
 
-fn home_page(_: &(), _cx: &mut RenderCx) -> impl Into<Element> {
+fn home_page(_: &(), _cx: &mut RenderCx) -> Element {
     vstack((
         text_block("Welcome Home").font_size(28.0).bold(),
         text_block("This is the landing page of the app."),
         text_block("Use the navigation pane to switch between pages.").opacity(0.6),
     ))
     .spacing(8.0)
+    .into()
 }
 
 fn fetch_stats(_: ()) -> std::result::Result<Vec<String>, String> {
@@ -53,7 +54,7 @@ fn fetch_stats(_: ()) -> std::result::Result<Vec<String>, String> {
     ])
 }
 
-fn dashboard_page(_: &(), cx: &mut RenderCx) -> impl Into<Element> {
+fn dashboard_page(_: &(), cx: &mut RenderCx) -> Element {
     let stats = cx.use_resource(fetch_stats, ());
 
     let content: Element = stats
@@ -73,9 +74,10 @@ fn dashboard_page(_: &(), cx: &mut RenderCx) -> impl Into<Element> {
         content,
     ))
     .spacing(8.0)
+    .into()
 }
 
-fn settings_page(_: &(), cx: &mut RenderCx) -> impl Into<Element> {
+fn settings_page(_: &(), cx: &mut RenderCx) -> Element {
     let (dark_mode, set_dark) = cx.use_state(false);
     let (notifications, set_notif) = cx.use_state(true);
 
@@ -95,9 +97,10 @@ fn settings_page(_: &(), cx: &mut RenderCx) -> impl Into<Element> {
         .opacity(0.6),
     ))
     .spacing(12.0)
+    .into()
 }
 
-fn app(cx: &mut RenderCx) -> impl Into<Element> {
+fn app(cx: &mut RenderCx) -> Element {
     let (page, set_page) = cx.use_state(Page::Home);
 
     let menu_items = [
@@ -121,6 +124,7 @@ fn app(cx: &mut RenderCx) -> impl Into<Element> {
         .on_selection_changed(move |tag: String| set_page.call(Page::from_tag(&tag)))
         .pane_display_mode(NavViewPaneDisplayMode::Left)
         .pane_title("My App")
+        .into()
 }
 
 fn main() -> Result<()> {

--- a/crates/samples/reactor/minimal/examples/navigation_view.rs
+++ b/crates/samples/reactor/minimal/examples/navigation_view.rs
@@ -2,7 +2,7 @@
 
 use windows_reactor::*;
 
-fn app(cx: &mut RenderCx) -> impl Into<Element> {
+fn app(cx: &mut RenderCx) -> Element {
     let (page, set_page) = cx.use_state("home".to_string());
 
     let menu_items = [
@@ -24,6 +24,7 @@ fn app(cx: &mut RenderCx) -> impl Into<Element> {
         .pane_title("Demo")
         .header(format!("page: {page}"))
         .settings_visible(false)
+        .into()
 }
 
 fn main() -> Result<()> {

--- a/crates/samples/reactor/minimal/examples/navigation_view_icons.rs
+++ b/crates/samples/reactor/minimal/examples/navigation_view_icons.rs
@@ -2,7 +2,7 @@
 
 use windows_reactor::*;
 
-fn app(cx: &mut RenderCx) -> impl Into<Element> {
+fn app(cx: &mut RenderCx) -> Element {
     let (page, set_page) = cx.use_state(String::from("home"));
 
     let content = match page.as_str() {
@@ -28,6 +28,7 @@ fn app(cx: &mut RenderCx) -> impl Into<Element> {
     )
     .selected_tag(&*page)
     .on_selection_changed(move |tag: String| set_page.call(tag))
+    .into()
 }
 
 fn main() -> Result<()> {

--- a/crates/samples/reactor/minimal/examples/number_box.rs
+++ b/crates/samples/reactor/minimal/examples/number_box.rs
@@ -2,7 +2,7 @@
 
 use windows_reactor::*;
 
-fn app(cx: &mut RenderCx) -> impl Into<Element> {
+fn app(cx: &mut RenderCx) -> Element {
     let (quantity, set_quantity) = cx.use_state(3.0_f64);
 
     let update_quantity = move |v: f64| set_quantity.call(v);
@@ -17,6 +17,7 @@ fn app(cx: &mut RenderCx) -> impl Into<Element> {
     ))
     .spacing(8.0)
     .max_width(320.0)
+    .into()
 }
 
 fn main() -> Result<()> {

--- a/crates/samples/reactor/minimal/examples/opacity_transition.rs
+++ b/crates/samples/reactor/minimal/examples/opacity_transition.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 
 use windows_reactor::*;
 
-fn app(cx: &mut RenderCx) -> impl Into<Element> {
+fn app(cx: &mut RenderCx) -> Element {
     let (visible, set_visible) = cx.use_state(true);
 
     let toggle = move || set_visible.call(!visible);
@@ -28,6 +28,7 @@ fn app(cx: &mut RenderCx) -> impl Into<Element> {
         swatch,
     ))
     .spacing(12.0)
+    .into()
 }
 
 fn main() -> Result<()> {

--- a/crates/samples/reactor/minimal/examples/password_box.rs
+++ b/crates/samples/reactor/minimal/examples/password_box.rs
@@ -2,7 +2,7 @@
 
 use windows_reactor::*;
 
-fn app(cx: &mut RenderCx) -> impl Into<Element> {
+fn app(cx: &mut RenderCx) -> Element {
     let (password, set_password) = cx.use_state(String::new());
 
     let update_password = move |v: String| set_password.call(v);
@@ -22,6 +22,7 @@ fn app(cx: &mut RenderCx) -> impl Into<Element> {
     ))
     .spacing(8.0)
     .max_width(320.0)
+    .into()
 }
 
 fn main() -> Result<()> {

--- a/crates/samples/reactor/minimal/examples/person_picture.rs
+++ b/crates/samples/reactor/minimal/examples/person_picture.rs
@@ -2,7 +2,7 @@
 
 use windows_reactor::*;
 
-fn app(_cx: &mut RenderCx) -> impl Into<Element> {
+fn app(_cx: &mut RenderCx) -> Element {
     vstack((
         text_block("Default (placeholder glyph)"),
         PersonPicture::new(),
@@ -17,6 +17,7 @@ fn app(_cx: &mut RenderCx) -> impl Into<Element> {
         PersonPicture::new().initials("WR"),
     ))
     .spacing(8.0)
+    .into()
 }
 
 fn main() -> Result<()> {

--- a/crates/samples/reactor/minimal/examples/pivot.rs
+++ b/crates/samples/reactor/minimal/examples/pivot.rs
@@ -2,7 +2,7 @@
 
 use windows_reactor::*;
 
-fn app(cx: &mut RenderCx) -> impl Into<Element> {
+fn app(cx: &mut RenderCx) -> Element {
     let (selected, set_selected) = cx.use_state(0i32);
 
     vstack((
@@ -26,6 +26,7 @@ fn app(cx: &mut RenderCx) -> impl Into<Element> {
         text_block(format!("selected_index = {selected}")),
     ))
     .spacing(8.0)
+    .into()
 }
 
 fn main() -> Result<()> {

--- a/crates/samples/reactor/minimal/examples/progress_bar.rs
+++ b/crates/samples/reactor/minimal/examples/progress_bar.rs
@@ -2,7 +2,7 @@
 
 use windows_reactor::*;
 
-fn app(_cx: &mut RenderCx) -> impl Into<Element> {
+fn app(_cx: &mut RenderCx) -> Element {
     vstack((
         text_block("Determinate (65%)"),
         ProgressBar::new(65.0).range(0.0, 100.0),
@@ -13,6 +13,7 @@ fn app(_cx: &mut RenderCx) -> impl Into<Element> {
     ))
     .spacing(8.0)
     .max_width(320.0)
+    .into()
 }
 
 fn main() -> Result<()> {

--- a/crates/samples/reactor/minimal/examples/progress_ring.rs
+++ b/crates/samples/reactor/minimal/examples/progress_ring.rs
@@ -2,7 +2,7 @@
 
 use windows_reactor::*;
 
-fn app(_cx: &mut RenderCx) -> impl Into<Element> {
+fn app(_cx: &mut RenderCx) -> Element {
     vstack((
         text_block("Determinate (40%)"),
         ProgressRing::new(40.0),
@@ -10,6 +10,7 @@ fn app(_cx: &mut RenderCx) -> impl Into<Element> {
         ProgressRing::indeterminate(),
     ))
     .spacing(8.0)
+    .into()
 }
 
 fn main() -> Result<()> {

--- a/crates/samples/reactor/minimal/examples/radio_button.rs
+++ b/crates/samples/reactor/minimal/examples/radio_button.rs
@@ -13,7 +13,7 @@ enum Size {
     Large,
 }
 
-fn app(cx: &mut RenderCx) -> impl Into<Element> {
+fn app(cx: &mut RenderCx) -> Element {
     let (size, set_size) = cx.use_state(Size::default());
 
     let choose = |value: Size| {
@@ -47,6 +47,7 @@ fn app(cx: &mut RenderCx) -> impl Into<Element> {
             .enabled(false),
     ))
     .spacing(4.0)
+    .into()
 }
 
 fn main() -> Result<()> {

--- a/crates/samples/reactor/minimal/examples/radio_buttons.rs
+++ b/crates/samples/reactor/minimal/examples/radio_buttons.rs
@@ -2,7 +2,7 @@
 
 use windows_reactor::*;
 
-fn app(cx: &mut RenderCx) -> impl Into<Element> {
+fn app(cx: &mut RenderCx) -> Element {
     let (selected, set_selected) = cx.use_state(0_i32);
 
     let update_selected = move |i: i32| set_selected.call(i);
@@ -19,6 +19,7 @@ fn app(cx: &mut RenderCx) -> impl Into<Element> {
         text_block(format!("selected_index = {selected} ({label})")),
     ))
     .spacing(8.0)
+    .into()
 }
 
 fn main() -> Result<()> {

--- a/crates/samples/reactor/minimal/examples/rating_control.rs
+++ b/crates/samples/reactor/minimal/examples/rating_control.rs
@@ -2,7 +2,7 @@
 
 use windows_reactor::*;
 
-fn app(cx: &mut RenderCx) -> impl Into<Element> {
+fn app(cx: &mut RenderCx) -> Element {
     let (rating, set_rating) = cx.use_state(3.0_f64);
 
     let update = move |v: f64| set_rating.call(v);
@@ -14,6 +14,7 @@ fn app(cx: &mut RenderCx) -> impl Into<Element> {
         RatingControl::new(2.5).read_only(),
     ))
     .spacing(8.0)
+    .into()
 }
 
 fn main() -> Result<()> {

--- a/crates/samples/reactor/minimal/examples/relative_panel.rs
+++ b/crates/samples/reactor/minimal/examples/relative_panel.rs
@@ -5,7 +5,7 @@
 
 use windows_reactor::*;
 
-fn app(_cx: &mut RenderCx) -> impl Into<Element> {
+fn app(_cx: &mut RenderCx) -> Element {
     relative_panel([
         // Top-left (default position).
         text_block("Top Left"),
@@ -28,6 +28,7 @@ fn app(_cx: &mut RenderCx) -> impl Into<Element> {
     ])
     .width(300.0)
     .height(200.0)
+    .into()
 }
 
 fn main() -> Result<()> {

--- a/crates/samples/reactor/minimal/examples/render_fn.rs
+++ b/crates/samples/reactor/minimal/examples/render_fn.rs
@@ -4,7 +4,7 @@
 
 use windows_reactor::*;
 
-fn app(cx: &mut RenderCx) -> impl Into<Element> {
+fn app(cx: &mut RenderCx) -> Element {
     let (count, set_count) = cx.use_state(0_i32);
 
     vstack((
@@ -19,6 +19,7 @@ fn app(cx: &mut RenderCx) -> impl Into<Element> {
         .spacing(8.0),
     ))
     .spacing(12.0)
+    .into()
 }
 
 fn main() -> Result<()> {

--- a/crates/samples/reactor/minimal/examples/repeat_button.rs
+++ b/crates/samples/reactor/minimal/examples/repeat_button.rs
@@ -2,7 +2,7 @@
 
 use windows_reactor::*;
 
-fn app(cx: &mut RenderCx) -> impl Into<Element> {
+fn app(cx: &mut RenderCx) -> Element {
     let (count, set_count) = cx.use_state(0_i32);
 
     let set_inc = set_count.clone();
@@ -22,6 +22,7 @@ fn app(cx: &mut RenderCx) -> impl Into<Element> {
         repeat_button("Disabled").enabled(false),
     ))
     .spacing(8.0)
+    .into()
 }
 
 fn main() -> Result<()> {

--- a/crates/samples/reactor/minimal/examples/rich_edit_box.rs
+++ b/crates/samples/reactor/minimal/examples/rich_edit_box.rs
@@ -2,7 +2,7 @@
 
 use windows_reactor::*;
 
-fn app(cx: &mut RenderCx) -> impl Into<Element> {
+fn app(cx: &mut RenderCx) -> Element {
     let (text, set_text) = cx.use_state(String::new());
 
     let on_changed = move |v: String| set_text.call(v);
@@ -20,6 +20,7 @@ fn app(cx: &mut RenderCx) -> impl Into<Element> {
             .height(100.0),
     ))
     .spacing(8.0)
+    .into()
 }
 
 fn main() -> Result<()> {

--- a/crates/samples/reactor/minimal/examples/rich_text.rs
+++ b/crates/samples/reactor/minimal/examples/rich_text.rs
@@ -5,7 +5,7 @@ use windows_reactor::core::rich_text::{
 };
 use windows_reactor::*;
 
-fn app(_cx: &mut RenderCx) -> impl Into<Element> {
+fn app(_cx: &mut RenderCx) -> Element {
     let mixed = RichTextBlock::single_paragraph(vec![
         RichTextInline::Run(RichTextRun::plain("Plain, ")),
         RichTextInline::Run(RichTextRun {
@@ -54,6 +54,7 @@ fn app(_cx: &mut RenderCx) -> impl Into<Element> {
         multi,
     ))
     .spacing(8.0)
+    .into()
 }
 
 fn main() -> Result<()> {

--- a/crates/samples/reactor/minimal/examples/scale_transition.rs
+++ b/crates/samples/reactor/minimal/examples/scale_transition.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 
 use windows_reactor::*;
 
-fn app(cx: &mut RenderCx) -> impl Into<Element> {
+fn app(cx: &mut RenderCx) -> Element {
     let (big, set_big) = cx.use_state(false);
 
     let toggle = move || set_big.call(!big);
@@ -35,6 +35,7 @@ fn app(cx: &mut RenderCx) -> impl Into<Element> {
         swatch,
     ))
     .spacing(12.0)
+    .into()
 }
 
 fn main() -> Result<()> {

--- a/crates/samples/reactor/minimal/examples/scroll_view.rs
+++ b/crates/samples/reactor/minimal/examples/scroll_view.rs
@@ -2,7 +2,7 @@
 
 use windows_reactor::*;
 
-fn app(_cx: &mut RenderCx) -> impl Into<Element> {
+fn app(_cx: &mut RenderCx) -> Element {
     let tall_body = vstack(
         (1..=30)
             .map(|i| text_block(format!("Line {i}")).font_size(13.0).into())
@@ -27,6 +27,7 @@ fn app(_cx: &mut RenderCx) -> impl Into<Element> {
             .max_height(80.0),
     ))
     .spacing(8.0)
+    .into()
 }
 
 fn main() -> Result<()> {

--- a/crates/samples/reactor/minimal/examples/scroll_viewer.rs
+++ b/crates/samples/reactor/minimal/examples/scroll_viewer.rs
@@ -2,7 +2,7 @@
 
 use windows_reactor::*;
 
-fn app(_cx: &mut RenderCx) -> impl Into<Element> {
+fn app(_cx: &mut RenderCx) -> Element {
     let tall_body = vstack(
         (1..=30)
             .map(|i| text_block(format!("Line {i}")).font_size(13.0).into())
@@ -27,6 +27,7 @@ fn app(_cx: &mut RenderCx) -> impl Into<Element> {
             .max_height(80.0),
     ))
     .spacing(8.0)
+    .into()
 }
 
 fn main() -> Result<()> {

--- a/crates/samples/reactor/minimal/examples/selector_bar.rs
+++ b/crates/samples/reactor/minimal/examples/selector_bar.rs
@@ -2,7 +2,7 @@
 
 use windows_reactor::*;
 
-fn app(cx: &mut RenderCx) -> impl Into<Element> {
+fn app(cx: &mut RenderCx) -> Element {
     let (selected, set_selected) = cx.use_state(String::from("Recent"));
 
     vstack((
@@ -15,6 +15,7 @@ fn app(cx: &mut RenderCx) -> impl Into<Element> {
         text_block(format!("Selected: {selected}")),
     ))
     .spacing(12.0)
+    .into()
 }
 
 fn main() -> Result<()> {

--- a/crates/samples/reactor/minimal/examples/shape.rs
+++ b/crates/samples/reactor/minimal/examples/shape.rs
@@ -2,7 +2,7 @@
 
 use windows_reactor::*;
 
-fn app(_cx: &mut RenderCx) -> impl Into<Element> {
+fn app(_cx: &mut RenderCx) -> Element {
     vstack((
         text_block("Rectangle (fill + corner_radius)"),
         Shape::rectangle()
@@ -27,6 +27,7 @@ fn app(_cx: &mut RenderCx) -> impl Into<Element> {
             .height(48.0),
     ))
     .spacing(8.0)
+    .into()
 }
 
 fn main() -> Result<()> {

--- a/crates/samples/reactor/minimal/examples/slider.rs
+++ b/crates/samples/reactor/minimal/examples/slider.rs
@@ -2,7 +2,7 @@
 
 use windows_reactor::*;
 
-fn app(cx: &mut RenderCx) -> impl Into<Element> {
+fn app(cx: &mut RenderCx) -> Element {
     let (volume, set_volume) = cx.use_state(35.0_f64);
 
     let update_volume = move |v: f64| set_volume.call(v);
@@ -26,6 +26,7 @@ fn app(cx: &mut RenderCx) -> impl Into<Element> {
     ))
     .spacing(8.0)
     .max_width(320.0)
+    .into()
 }
 
 fn main() -> Result<()> {

--- a/crates/samples/reactor/minimal/examples/split_button.rs
+++ b/crates/samples/reactor/minimal/examples/split_button.rs
@@ -2,7 +2,7 @@
 
 use windows_reactor::*;
 
-fn app(cx: &mut RenderCx) -> impl Into<Element> {
+fn app(cx: &mut RenderCx) -> Element {
     let (clicks, set_clicks) = cx.use_state(0_u32);
 
     let bump = move || set_clicks.call(clicks + 1);
@@ -12,6 +12,7 @@ fn app(cx: &mut RenderCx) -> impl Into<Element> {
         split_button("Disabled").enabled(false),
     ))
     .spacing(8.0)
+    .into()
 }
 
 fn main() -> Result<()> {

--- a/crates/samples/reactor/minimal/examples/split_view.rs
+++ b/crates/samples/reactor/minimal/examples/split_view.rs
@@ -2,7 +2,7 @@
 
 use windows_reactor::*;
 
-fn app(cx: &mut RenderCx) -> impl Into<Element> {
+fn app(cx: &mut RenderCx) -> Element {
     let (open, set_open) = cx.use_state(true);
 
     let toggle = {
@@ -33,6 +33,7 @@ fn app(cx: &mut RenderCx) -> impl Into<Element> {
     .is_pane_open(open)
     .open_pane_length(200.0)
     .on_pane_closed(on_closed)
+    .into()
 }
 
 fn main() -> Result<()> {

--- a/crates/samples/reactor/minimal/examples/stack.rs
+++ b/crates/samples/reactor/minimal/examples/stack.rs
@@ -2,7 +2,7 @@
 
 use windows_reactor::*;
 
-fn app(_cx: &mut RenderCx) -> impl Into<Element> {
+fn app(_cx: &mut RenderCx) -> Element {
     vstack((
         text_block("vstack — vertical orientation"),
         hstack((
@@ -14,6 +14,7 @@ fn app(_cx: &mut RenderCx) -> impl Into<Element> {
         text_block("…back to the vstack"),
     ))
     .spacing(12.0)
+    .into()
 }
 
 fn main() -> Result<()> {

--- a/crates/samples/reactor/minimal/examples/tab_view.rs
+++ b/crates/samples/reactor/minimal/examples/tab_view.rs
@@ -2,7 +2,7 @@
 
 use windows_reactor::*;
 
-fn app(cx: &mut RenderCx) -> impl Into<Element> {
+fn app(cx: &mut RenderCx) -> Element {
     let (tabs, set_tabs) = cx.use_state(vec![
         ("overview", "Overview"),
         ("badges", "Badges"),
@@ -52,6 +52,7 @@ fn app(cx: &mut RenderCx) -> impl Into<Element> {
         )),
     ))
     .spacing(8.0)
+    .into()
 }
 
 fn main() -> Result<()> {

--- a/crates/samples/reactor/minimal/examples/teaching_tip.rs
+++ b/crates/samples/reactor/minimal/examples/teaching_tip.rs
@@ -2,7 +2,7 @@
 
 use windows_reactor::*;
 
-fn app(cx: &mut RenderCx) -> impl Into<Element> {
+fn app(cx: &mut RenderCx) -> Element {
     let (is_open, set_is_open) = cx.use_state(false);
     let (status, set_status) = cx.use_state(String::from("(tip closed)"));
 
@@ -35,6 +35,7 @@ fn app(cx: &mut RenderCx) -> impl Into<Element> {
             }),
     ))
     .spacing(12.0)
+    .into()
 }
 
 fn main() -> Result<()> {

--- a/crates/samples/reactor/minimal/examples/text.rs
+++ b/crates/samples/reactor/minimal/examples/text.rs
@@ -2,13 +2,14 @@
 
 use windows_reactor::*;
 
-fn app(_cx: &mut RenderCx) -> impl Into<Element> {
+fn app(_cx: &mut RenderCx) -> Element {
     vstack((
         text_block("Plain text"),
         text_block("Larger text").font_size(20.0),
         text_block("Bold + larger").bold().font_size(28.0),
     ))
     .spacing(8.0)
+    .into()
 }
 
 fn main() -> Result<()> {

--- a/crates/samples/reactor/minimal/examples/text_box.rs
+++ b/crates/samples/reactor/minimal/examples/text_box.rs
@@ -2,7 +2,7 @@
 
 use windows_reactor::*;
 
-fn app(cx: &mut RenderCx) -> impl Into<Element> {
+fn app(cx: &mut RenderCx) -> Element {
     let (name, set_name) = cx.use_state(String::new());
     let (notes, set_notes) = cx.use_state(String::new());
 
@@ -31,6 +31,7 @@ fn app(cx: &mut RenderCx) -> impl Into<Element> {
         text_box("read-only").header("Disabled").enabled(false),
     ))
     .spacing(8.0)
+    .into()
 }
 
 fn main() -> Result<()> {

--- a/crates/samples/reactor/minimal/examples/theme_brush.rs
+++ b/crates/samples/reactor/minimal/examples/theme_brush.rs
@@ -5,7 +5,7 @@
 
 use windows_reactor::*;
 
-fn app(_cx: &mut RenderCx) -> impl Into<Element> {
+fn app(_cx: &mut RenderCx) -> Element {
     let swatch = |label: &str, bg: ThemeRef, fg: ThemeRef| -> Element {
         border(
             text_block(label)
@@ -38,6 +38,7 @@ fn app(_cx: &mut RenderCx) -> impl Into<Element> {
     ))
     .spacing(6.0)
     .max_width(420.0)
+    .into()
 }
 
 fn main() -> Result<()> {

--- a/crates/samples/reactor/minimal/examples/time_picker.rs
+++ b/crates/samples/reactor/minimal/examples/time_picker.rs
@@ -2,7 +2,7 @@
 
 use windows_reactor::*;
 
-fn app(cx: &mut RenderCx) -> impl Into<Element> {
+fn app(cx: &mut RenderCx) -> Element {
     let (label, set_label) = cx.use_state(String::from("No time picked"));
 
     let on_time = move |ts: TimeSpan| {
@@ -19,6 +19,7 @@ fn app(cx: &mut RenderCx) -> impl Into<Element> {
         text_block(&*label),
     ))
     .spacing(8.0)
+    .into()
 }
 
 fn main() -> Result<()> {

--- a/crates/samples/reactor/minimal/examples/title_bar.rs
+++ b/crates/samples/reactor/minimal/examples/title_bar.rs
@@ -2,7 +2,7 @@
 
 use windows_reactor::*;
 
-fn app(cx: &mut RenderCx) -> impl Into<Element> {
+fn app(cx: &mut RenderCx) -> Element {
     let (back_clicks, set_back) = cx.use_state(0i32);
     let (pane_clicks, set_pane) = cx.use_state(0i32);
 
@@ -19,6 +19,7 @@ fn app(cx: &mut RenderCx) -> impl Into<Element> {
         )),
     ))
     .spacing(8.0)
+    .into()
 }
 
 fn main() -> Result<()> {

--- a/crates/samples/reactor/minimal/examples/toggle_button.rs
+++ b/crates/samples/reactor/minimal/examples/toggle_button.rs
@@ -2,7 +2,7 @@
 
 use windows_reactor::*;
 
-fn app(cx: &mut RenderCx) -> impl Into<Element> {
+fn app(cx: &mut RenderCx) -> Element {
     let (is_bold, set_bold) = cx.use_state(false);
     let (is_italic, set_italic) = cx.use_state(false);
 
@@ -22,6 +22,7 @@ fn app(cx: &mut RenderCx) -> impl Into<Element> {
         text_block(format!("Style: {style_label}")),
     ))
     .spacing(8.0)
+    .into()
 }
 
 fn main() -> Result<()> {

--- a/crates/samples/reactor/minimal/examples/toggle_switch.rs
+++ b/crates/samples/reactor/minimal/examples/toggle_switch.rs
@@ -2,7 +2,7 @@
 
 use windows_reactor::*;
 
-fn app(cx: &mut RenderCx) -> impl Into<Element> {
+fn app(cx: &mut RenderCx) -> Element {
     let (on, set_on) = cx.use_state(true);
 
     let toggle = move |v| set_on.call(v);
@@ -23,6 +23,7 @@ fn app(cx: &mut RenderCx) -> impl Into<Element> {
             .enabled(false),
     ))
     .spacing(8.0)
+    .into()
 }
 
 fn main() -> Result<()> {

--- a/crates/samples/reactor/minimal/examples/tooltip.rs
+++ b/crates/samples/reactor/minimal/examples/tooltip.rs
@@ -2,12 +2,13 @@
 
 use windows_reactor::*;
 
-fn app(_cx: &mut RenderCx) -> impl Into<Element> {
+fn app(_cx: &mut RenderCx) -> Element {
     vstack((
         button("Hover me").tooltip("This is a tooltip"),
         text_block("Plain text also tips").tooltip("Even on TextBlock"),
     ))
     .spacing(12.0)
+    .into()
 }
 
 fn main() -> Result<()> {

--- a/crates/samples/reactor/minimal/examples/tooltip_placement.rs
+++ b/crates/samples/reactor/minimal/examples/tooltip_placement.rs
@@ -2,7 +2,7 @@
 
 use windows_reactor::*;
 
-fn app(_cx: &mut RenderCx) -> impl Into<Element> {
+fn app(_cx: &mut RenderCx) -> Element {
     vstack((
         button("Top")
             .tooltip_with(Tooltip::text("Anchored above").placement(TooltipPlacement::Top)),
@@ -17,6 +17,7 @@ fn app(_cx: &mut RenderCx) -> impl Into<Element> {
             .tooltip_with(Tooltip::text("Follows the cursor").placement(TooltipPlacement::Mouse)),
     ))
     .spacing(8.0)
+    .into()
 }
 
 fn main() -> Result<()> {

--- a/crates/samples/reactor/minimal/examples/tooltip_rich.rs
+++ b/crates/samples/reactor/minimal/examples/tooltip_rich.rs
@@ -2,7 +2,7 @@
 
 use windows_reactor::*;
 
-fn app(_cx: &mut RenderCx) -> impl Into<Element> {
+fn app(_cx: &mut RenderCx) -> Element {
     let rich_panel = vstack((
         text_block("Action: Save").bold(),
         text_block("Writes the current document to disk."),
@@ -14,6 +14,7 @@ fn app(_cx: &mut RenderCx) -> impl Into<Element> {
         button("Open").tooltip("Opens a document"),
     ))
     .spacing(8.0)
+    .into()
 }
 
 fn main() -> Result<()> {

--- a/crates/samples/reactor/minimal/examples/tree_view.rs
+++ b/crates/samples/reactor/minimal/examples/tree_view.rs
@@ -2,7 +2,7 @@
 
 use windows_reactor::*;
 
-fn app(cx: &mut RenderCx) -> impl Into<Element> {
+fn app(cx: &mut RenderCx) -> Element {
     let (last_invoked, set_last_invoked) = cx.use_state(String::from("(none)"));
 
     let nodes = vec![
@@ -19,6 +19,7 @@ fn app(cx: &mut RenderCx) -> impl Into<Element> {
         text_block(format!("Last invoked: {last_invoked}")),
     ))
     .spacing(12.0)
+    .into()
 }
 
 fn main() -> Result<()> {

--- a/crates/samples/reactor/minimal/examples/type_ramp.rs
+++ b/crates/samples/reactor/minimal/examples/type_ramp.rs
@@ -2,7 +2,7 @@
 
 use windows_reactor::*;
 
-fn app(_cx: &mut RenderCx) -> impl Into<Element> {
+fn app(_cx: &mut RenderCx) -> Element {
     vstack((
         title("Title — 28px Semibold"),
         subtitle("Subtitle — 20px Semibold"),
@@ -13,6 +13,7 @@ fn app(_cx: &mut RenderCx) -> impl Into<Element> {
         text_block("Custom weight").font_weight(300),
     ))
     .spacing(8.0)
+    .into()
 }
 
 fn main() -> Result<()> {

--- a/crates/samples/reactor/minimal/examples/use_callback.rs
+++ b/crates/samples/reactor/minimal/examples/use_callback.rs
@@ -5,7 +5,7 @@
 
 use windows_reactor::*;
 
-fn app(cx: &mut RenderCx) -> impl Into<Element> {
+fn app(cx: &mut RenderCx) -> Element {
     let (rerenders, set_rerenders) = cx.use_state(0_u32);
 
     let fires = cx.use_ref(0_u32);
@@ -39,6 +39,7 @@ fn app(cx: &mut RenderCx) -> impl Into<Element> {
         .spacing(8.0),
     ))
     .spacing(8.0)
+    .into()
 }
 
 fn main() -> Result<()> {

--- a/crates/samples/reactor/minimal/examples/use_color_scheme.rs
+++ b/crates/samples/reactor/minimal/examples/use_color_scheme.rs
@@ -5,7 +5,7 @@
 
 use windows_reactor::*;
 
-fn app(cx: &mut RenderCx) -> impl Into<Element> {
+fn app(cx: &mut RenderCx) -> Element {
     let scheme = cx.use_color_scheme();
     let is_dark = matches!(scheme, ColorScheme::Dark);
 
@@ -28,6 +28,7 @@ fn app(cx: &mut RenderCx) -> impl Into<Element> {
         .foreground(ThemeRef::PrimaryText),
     ))
     .spacing(8.0)
+    .into()
 }
 
 fn main() -> Result<()> {

--- a/crates/samples/reactor/minimal/examples/use_effect.rs
+++ b/crates/samples/reactor/minimal/examples/use_effect.rs
@@ -5,7 +5,7 @@
 
 use windows_reactor::*;
 
-fn app(cx: &mut RenderCx) -> impl Into<Element> {
+fn app(cx: &mut RenderCx) -> Element {
     let (count, set_count) = cx.use_state(0_i32);
     let (flag, set_flag) = cx.use_state(false);
 
@@ -40,6 +40,7 @@ fn app(cx: &mut RenderCx) -> impl Into<Element> {
             .opacity(0.7),
     ))
     .spacing(8.0)
+    .into()
 }
 
 fn main() -> Result<()> {

--- a/crates/samples/reactor/minimal/examples/use_memo.rs
+++ b/crates/samples/reactor/minimal/examples/use_memo.rs
@@ -5,7 +5,7 @@
 
 use windows_reactor::*;
 
-fn app(cx: &mut RenderCx) -> impl Into<Element> {
+fn app(cx: &mut RenderCx) -> Element {
     let (n, set_n) = cx.use_state(3_i32);
     let (show_hint, set_hint) = cx.use_state(false);
 
@@ -55,6 +55,7 @@ fn app(cx: &mut RenderCx) -> impl Into<Element> {
         },
     ))
     .spacing(8.0)
+    .into()
 }
 
 fn main() -> Result<()> {

--- a/crates/samples/reactor/minimal/examples/use_mutation.rs
+++ b/crates/samples/reactor/minimal/examples/use_mutation.rs
@@ -15,7 +15,7 @@ fn save_data(name: &str) -> std::result::Result<String, String> {
     }
 }
 
-fn app(cx: &mut RenderCx) -> impl Into<Element> {
+fn app(cx: &mut RenderCx) -> Element {
     let (name, set_name) = cx.use_state("Hello".to_string());
     let (save_state, save_trigger) = cx.use_mutation::<String>();
 
@@ -58,6 +58,7 @@ fn app(cx: &mut RenderCx) -> impl Into<Element> {
         status,
     ))
     .spacing(12.0)
+    .into()
 }
 
 fn main() -> Result<()> {

--- a/crates/samples/reactor/minimal/examples/use_reducer.rs
+++ b/crates/samples/reactor/minimal/examples/use_reducer.rs
@@ -25,7 +25,7 @@ fn reducer(state: CounterState, action: Action) -> CounterState {
     }
 }
 
-fn app(cx: &mut RenderCx) -> impl Into<Element> {
+fn app(cx: &mut RenderCx) -> Element {
     let (state, dispatch) = cx.use_reducer_fn(reducer, CounterState::default());
 
     let inc = {
@@ -50,6 +50,7 @@ fn app(cx: &mut RenderCx) -> impl Into<Element> {
         .spacing(8.0),
     ))
     .spacing(8.0)
+    .into()
 }
 
 fn main() -> Result<()> {

--- a/crates/samples/reactor/minimal/examples/use_ref.rs
+++ b/crates/samples/reactor/minimal/examples/use_ref.rs
@@ -5,7 +5,7 @@
 
 use windows_reactor::*;
 
-fn app(cx: &mut RenderCx) -> impl Into<Element> {
+fn app(cx: &mut RenderCx) -> Element {
     let (clicks, set_clicks) = cx.use_state(0_u32);
 
     let render_count = cx.use_ref(0_u64);
@@ -26,6 +26,7 @@ fn app(cx: &mut RenderCx) -> impl Into<Element> {
         .opacity(0.7),
     ))
     .spacing(8.0)
+    .into()
 }
 
 fn main() -> Result<()> {

--- a/crates/samples/reactor/minimal/examples/use_resource.rs
+++ b/crates/samples/reactor/minimal/examples/use_resource.rs
@@ -13,7 +13,7 @@ fn fetch_page(page: i32) -> std::result::Result<Vec<String>, String> {
         .collect())
 }
 
-fn app(cx: &mut RenderCx) -> impl Into<Element> {
+fn app(cx: &mut RenderCx) -> Element {
     let (page, set_page) = cx.use_state(0_i32);
 
     let items = cx.use_resource(fetch_page, page);
@@ -53,6 +53,7 @@ fn app(cx: &mut RenderCx) -> impl Into<Element> {
         )),
     ))
     .spacing(12.0)
+    .into()
 }
 
 fn main() -> Result<()> {

--- a/crates/samples/reactor/minimal/examples/use_resource_retry.rs
+++ b/crates/samples/reactor/minimal/examples/use_resource_retry.rs
@@ -17,7 +17,7 @@ fn fetch_weather(attempt: i32) -> std::result::Result<String, String> {
     }
 }
 
-fn app(cx: &mut RenderCx) -> impl Into<Element> {
+fn app(cx: &mut RenderCx) -> Element {
     let (attempt, set_attempt) = cx.use_state(0_i32);
 
     let weather = cx.use_resource(fetch_weather, attempt);
@@ -45,6 +45,7 @@ fn app(cx: &mut RenderCx) -> impl Into<Element> {
         button("Refresh").on_click(retry),
     ))
     .spacing(8.0)
+    .into()
 }
 
 fn main() -> Result<()> {

--- a/crates/samples/reactor/minimal/examples/use_state.rs
+++ b/crates/samples/reactor/minimal/examples/use_state.rs
@@ -6,7 +6,7 @@ fn main() -> Result<()> {
     App::new().title("sample").render(app)
 }
 
-fn app(cx: &mut RenderCx) -> impl Into<Element> {
+fn app(cx: &mut RenderCx) -> Element {
     let (count, set_count) = cx.use_state(0);
     let click = move || set_count.call(count + 1);
 
@@ -16,4 +16,5 @@ fn app(cx: &mut RenderCx) -> impl Into<Element> {
             .font_size(18.0)
             .bold(),
     ))
+    .into()
 }

--- a/crates/samples/reactor/minimal/examples/window.rs
+++ b/crates/samples/reactor/minimal/examples/window.rs
@@ -1,6 +1,6 @@
 use windows_reactor::*;
 
-fn app(cx: &mut RenderCx) -> impl Into<Element> {
+fn app(cx: &mut RenderCx) -> Element {
     let window_size = cx.use_inner_size();
 
     let mut children = create_arrows();
@@ -18,6 +18,7 @@ fn app(cx: &mut RenderCx) -> impl Into<Element> {
     grid(children)
         .vertical_alignment(VerticalAlignment::Stretch)
         .horizontal_alignment(HorizontalAlignment::Stretch)
+        .into()
 }
 
 fn create_arrows() -> Vec<Element> {


### PR DESCRIPTION
Rust edition 2024 changed `impl Trait` in return position to capture all input lifetimes by default (RFC 3498). This means a function like `fn app(cx: &mut RenderCx) -> impl Into<Element>` now produces a return type that is tied to the lifetime of `cx`. The `App::render` and `Component<P>` blanket `impl` bounds desugar to higher-ranked trait bounds (`for<'a> Fn(&'a mut RenderCx) -> R`), which require `R` to be a single type independent of any lifetime — a constraint that `impl Into<Element>` no longer satisfies in edition 2024. By changing the API to accept `Fn(&mut RenderCx) -> Element` directly, the return type is a concrete owned type with no lifetime parameter, eliminating the conflict entirely. Callers simply add `.into()` at the end of their render function body.

A small tradeoff but overall doesn't increase tokens and we need to support edition 2024...