### PR TITLE
Fix color picker state jumping around after selection

### DIFF
--- a/crates/samples/reactor/gallery/src/pages/basic_input/color_picker.rs
+++ b/crates/samples/reactor/gallery/src/pages/basic_input/color_picker.rs
@@ -13,7 +13,7 @@ pub fn color_picker_page(_: &(), cx: &mut RenderCx) -> Element {
                 vstack((
                     color_picker(ColorArgb::new(color.0, color.1, color.2))
                         .alpha_enabled(true)
-                        .on_changed(move |c| set_color.call(c)),
+                        .on_changed(move |(a, r, g, b)| set_color.call((r, g, b, a))),
                     text_block(format!(
                         "RGBA({}, {}, {}, {})",
                         color.0, color.1, color.2, color.3


### PR DESCRIPTION
The `on_changed` callback returns color channels as `(a, r, g, b)` but the state tuple was being read back as `(r, g, b, a)`, so every selection would snap to a scrambled color on the next render.

Fixes #4490