### PR TITLE
Fix RichEditBox feedback loop on text change

### DIFF
--- a/crates/libs/reactor/src/winui/backend/mod.rs
+++ b/crates/libs/reactor/src/winui/backend/mod.rs
@@ -2319,9 +2319,13 @@ impl Backend for WinUIBackend {
                     }
                     Ok(())
                 }
-                // ── RichEditBox ───────────────────────────────────────────────
                 (Prop::RichEditBoxText, PropValue::Str(s), Handle::RichEditBox(reb)) => {
                     let doc = reb.get_Document()?;
+                    let mut current = windows_core::HSTRING::default();
+                    doc.GetText(Xaml::TextGetOptions::None, &mut current).ok();
+                    if current == s.as_str() {
+                        return Ok(());
+                    }
                     doc.SetText(Xaml::TextSetOptions::None, s.as_str())
                 }
                 (Prop::Placeholder, PropValue::Str(s), Handle::RichEditBox(reb)) => {


### PR DESCRIPTION
`RichEditBox` was calling `SetText` unconditionally on every render, which fired `TextChanged`, updated state, triggered another render, etc. Fixed by reading the current document text first and skipping `SetText` when it hasn't changed, matching `TextBox` behavior.

Fixes #4492 