### PR TITLE
Tidy up the `windows-canvas` standalone sample

### DIFF
--- a/crates/samples/canvas/standalone/build.rs
+++ b/crates/samples/canvas/standalone/build.rs
@@ -1,33 +1,25 @@
 fn main() {
-    if !cfg!(windows) {
-        return;
-    }
-
-    println!("cargo:rerun-if-changed=build.rs");
-
-    let warnings = windows_bindgen::bindgen([
-        "--out",
-        "src/bindings.rs",
-        "--flat",
-        "--minimal",
-        "--filter",
-        "Windows.Win32.UI.WindowsAndMessaging.RegisterClassA",
-        "Windows.Win32.UI.WindowsAndMessaging.CreateWindowExA",
-        "Windows.Win32.UI.WindowsAndMessaging.DefWindowProcA",
-        "Windows.Win32.UI.WindowsAndMessaging.TranslateMessage",
-        "Windows.Win32.UI.WindowsAndMessaging.DispatchMessageA",
-        "Windows.Win32.UI.WindowsAndMessaging.PeekMessageA",
-        "Windows.Win32.UI.WindowsAndMessaging.PostQuitMessage",
-        "Windows.Win32.UI.WindowsAndMessaging.WM_DESTROY",
-        "Windows.Win32.UI.WindowsAndMessaging.CW_USEDEFAULT",
-        "Windows.Win32.UI.WindowsAndMessaging.WS_OVERLAPPEDWINDOW",
-        "Windows.Win32.UI.WindowsAndMessaging.WS_VISIBLE",
-        "Windows.Win32.UI.WindowsAndMessaging.PM_REMOVE",
-        "Windows.Win32.UI.WindowsAndMessaging.CS_HREDRAW",
-        "Windows.Win32.UI.WindowsAndMessaging.CS_VREDRAW",
-    ]);
-
-    if !warnings.is_empty() {
-        println!("cargo:warning=bindgen warnings: {warnings}");
-    }
+    windows_bindgen::Bindgen::new()
+        .output("src/bindings.rs")
+        .flat()
+        .minimal()
+        .filters([
+            "Windows.Win32.UI.WindowsAndMessaging.RegisterClassA",
+            "Windows.Win32.UI.WindowsAndMessaging.CreateWindowExA",
+            "Windows.Win32.UI.WindowsAndMessaging.DefWindowProcA",
+            "Windows.Win32.UI.WindowsAndMessaging.TranslateMessage",
+            "Windows.Win32.UI.WindowsAndMessaging.DispatchMessageA",
+            "Windows.Win32.UI.WindowsAndMessaging.PeekMessageA",
+            "Windows.Win32.UI.WindowsAndMessaging.PostQuitMessage",
+            "Windows.Win32.UI.WindowsAndMessaging.WM_DESTROY",
+            "Windows.Win32.UI.WindowsAndMessaging.WM_QUIT",
+            "Windows.Win32.UI.WindowsAndMessaging.CW_USEDEFAULT",
+            "Windows.Win32.UI.WindowsAndMessaging.WS_OVERLAPPEDWINDOW",
+            "Windows.Win32.UI.WindowsAndMessaging.WS_VISIBLE",
+            "Windows.Win32.UI.WindowsAndMessaging.PM_REMOVE",
+            "Windows.Win32.UI.WindowsAndMessaging.CS_HREDRAW",
+            "Windows.Win32.UI.WindowsAndMessaging.CS_VREDRAW",
+        ])
+        .write()
+        .unwrap();
 }

--- a/crates/samples/canvas/standalone/src/bindings.rs
+++ b/crates/samples/canvas/standalone/src/bindings.rs
@@ -37,6 +37,7 @@ pub struct POINT {
 pub type WINDOW_EX_STYLE = u32;
 pub type WINDOW_STYLE = u32;
 pub const WM_DESTROY: u32 = 2u32;
+pub const WM_QUIT: u32 = 18u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Default)]
 pub struct WNDCLASSA {

--- a/crates/samples/canvas/standalone/src/main.rs
+++ b/crates/samples/canvas/standalone/src/main.rs
@@ -4,24 +4,17 @@
 //! The build.rs generates minimal window-management bindings via windows-bindgen.
 
 #![windows_subsystem = "windows"]
-#![allow(non_snake_case)]
 
-#[allow(
-    dead_code,
-    non_snake_case,
-    non_upper_case_globals,
-    non_camel_case_types,
-    clippy::upper_case_acronyms
-)]
+#[expect(non_snake_case, non_camel_case_types, clippy::upper_case_acronyms)]
 mod bindings;
 
 use bindings::*;
 use windows_canvas::*;
-use windows_core::PCSTR;
+use windows_core::*;
 
-fn main() -> windows_core::Result<()> {
+fn main() -> Result<()> {
     unsafe {
-        let class_name = PCSTR(b"canvas_standalone\0".as_ptr());
+        let class_name = s!("canvas_standalone");
 
         let wc = WNDCLASSA {
             style: CS_HREDRAW | CS_VREDRAW,
@@ -29,12 +22,13 @@ fn main() -> windows_core::Result<()> {
             lpszClassName: class_name,
             ..Default::default()
         };
+
         RegisterClassA(&wc);
 
-        let hwnd = CreateWindowExA(
+        let window = CreateWindowExA(
             0,
             class_name,
-            PCSTR(b"Canvas Standalone\0".as_ptr()),
+            s!("Canvas Standalone"),
             WS_OVERLAPPEDWINDOW | WS_VISIBLE,
             CW_USEDEFAULT,
             CW_USEDEFAULT,
@@ -47,44 +41,46 @@ fn main() -> windows_core::Result<()> {
         );
 
         let device = GpuDevice::new()?;
-        let mut chain = device.create_swap_chain_for_hwnd(hwnd, 800, 600)?;
-
+        let mut chain = device.create_swap_chain_for_hwnd(window, 800, 600)?;
         let mut msg = MSG::default();
+
         loop {
             while PeekMessageA(&mut msg, std::ptr::null_mut(), 0, 0, PM_REMOVE).as_bool() {
-                if msg.message == 0x0012 {
-                    // WM_QUIT
+                if msg.message == WM_QUIT {
                     return Ok(());
                 }
-                let _ = TranslateMessage(&msg);
+
+                _ = TranslateMessage(&msg);
                 DispatchMessageA(&msg);
             }
 
-            // Render a frame.
-            let w = chain.width() as f32;
-            let h = chain.height() as f32;
+            let width = chain.width() as f32;
+            let height = chain.height() as f32;
             let session = chain.begin_draw()?;
             session.clear(Color::DARK_SLATE_BLUE);
-
             let brush = session.create_solid_brush(Color::CORNFLOWER_BLUE)?;
-            let r = w.min(h) * 0.3;
-            session.fill_ellipse(&Ellipse::circle(Vector2::new(w / 2.0, h / 2.0), r), &brush);
+            let r = width.min(height) * 0.3;
+
+            session.fill_ellipse(
+                &Ellipse::circle(Vector2::new(width / 2.0, height / 2.0), r),
+                &brush,
+            );
 
             brush.set_color(Color::WHITE);
+
             let format = TextFormat::new("Segoe UI", 24.0)?
                 .with_alignment(TextAlignment::Center)
                 .with_paragraph_alignment(ParagraphAlignment::Center);
+
             session.draw_text(
                 "Hello from windows-canvas!",
                 &format,
-                &Rect::new(0.0, 0.0, w, h),
+                &Rect::new(0.0, 0.0, width, height),
                 &brush,
             );
 
             drop(session);
             chain.present()?;
-
-            std::thread::sleep(std::time::Duration::from_millis(1));
         }
     }
 }


### PR DESCRIPTION
This sample just demonstrates how to use the `windows-canvas` library without `windows-reactor`.