### PR TITLE
Move the `windows-reactor` Direct2D sample to its own sample crate

### DIFF
--- a/crates/samples/reactor/direct2d/Cargo.toml
+++ b/crates/samples/reactor/direct2d/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "reactor_direct2d"
+version = "0.0.0"
+edition = "2024"
+publish = false
+
+[dependencies]
+windows-reactor = { workspace = true }
+windows-numerics = { workspace = true }
+
+[dependencies.windows]
+workspace = true
+default-features = true
+features = [
+    "Win32_Graphics_Direct2D_Common",
+    "Win32_Graphics_Direct3D",
+    "Win32_Graphics_Direct3D11",
+    "Win32_Graphics_Dxgi_Common",
+]
+
+[build-dependencies]
+windows-reactor-setup = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/samples/reactor/direct2d/build.rs
+++ b/crates/samples/reactor/direct2d/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    windows_reactor_setup::as_self_contained();
+}

--- a/crates/samples/reactor/direct2d/src/main.rs
+++ b/crates/samples/reactor/direct2d/src/main.rs
@@ -422,9 +422,8 @@ fn app(cx: &mut RenderCx) -> Element {
 }
 
 fn main() -> Result<()> {
-    let _bootstrap_handle = windows_reactor::bootstrap::initialize()?;
     App::new()
-        .title("Direct2D SwapChainPanel")
+        .title("Direct2D")
         .backdrop(Backdrop::Mica)
         .render(app)
 }

--- a/crates/samples/reactor/minimal/Cargo.toml
+++ b/crates/samples/reactor/minimal/Cargo.toml
@@ -7,18 +7,8 @@ publish = false
 [dependencies]
 windows-reactor = { workspace = true }
 
-[dev-dependencies.windows]
-workspace = true
-default-features = true
-features = [
-    "Win32_Graphics_Direct2D_Common",
-    "Win32_Graphics_Direct3D",
-    "Win32_Graphics_Direct3D11",
-    "Win32_Graphics_Dxgi_Common",
-]
-
-[dev-dependencies]
-windows-numerics = { workspace = true }
+[build-dependencies]
+windows-reactor-setup = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/samples/reactor/minimal/build.rs
+++ b/crates/samples/reactor/minimal/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    windows_reactor_setup::as_example();
+}


### PR DESCRIPTION
This helps to speed up the build time for the minimal examples as they don't depend on the hefty `windows` crate. 