### PR TITLE
`windows-reactor` `is_text_selection_enabled` support on `TextBlock`

### DIFF
--- a/crates/libs/reactor/src/bindings.rs
+++ b/crates/libs/reactor/src/bindings.rs
@@ -15889,6 +15889,15 @@ impl ITextBlock {
             .ok()
         }
     }
+    pub fn put_IsTextSelectionEnabled(&self, value: bool) -> windows_core::Result<()> {
+        unsafe {
+            (windows_core::Interface::vtable(self).put_IsTextSelectionEnabled)(
+                windows_core::Interface::as_raw(self),
+                value,
+            )
+            .ok()
+        }
+    }
 }
 #[repr(C)]
 #[doc(hidden)]
@@ -15939,7 +15948,8 @@ pub struct ITextBlock_Vtbl {
     get_LineStackingStrategy: usize,
     put_LineStackingStrategy: usize,
     get_IsTextSelectionEnabled: usize,
-    put_IsTextSelectionEnabled: usize,
+    pub put_IsTextSelectionEnabled:
+        unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
     get_SelectedText: usize,
     get_ContentStart: usize,
     get_ContentEnd: usize,

--- a/crates/libs/reactor/src/core/widgets/text_block.rs
+++ b/crates/libs/reactor/src/core/widgets/text_block.rs
@@ -22,7 +22,7 @@ impl TextBlock {
 impl Widget for TextBlock {
     widget_header!(ControlKind::TextBlock);
     fn bindings(&self) -> PropBindings {
-        let mut out = Vec::with_capacity(4);
+        let mut out = Vec::with_capacity(5);
         out.push(Binding::Prop(
             Prop::Text,
             PropValue::Str(self.content.clone()),

--- a/crates/libs/reactor/src/core/widgets/text_block.rs
+++ b/crates/libs/reactor/src/core/widgets/text_block.rs
@@ -8,6 +8,7 @@ pub struct TextBlock {
     pub font_size: Option<f64>,
     pub font_weight: Option<u16>,
     pub wrap_text: bool,
+    pub is_text_selection_enabled: bool,
 }
 impl TextBlock {
     pub fn new(content: impl Into<String>) -> Self {
@@ -21,7 +22,7 @@ impl TextBlock {
 impl Widget for TextBlock {
     widget_header!(ControlKind::TextBlock);
     fn bindings(&self) -> PropBindings {
-        let mut out = Vec::with_capacity(3);
+        let mut out = Vec::with_capacity(4);
         out.push(Binding::Prop(
             Prop::Text,
             PropValue::Str(self.content.clone()),
@@ -34,6 +35,12 @@ impl Widget for TextBlock {
         }
         if self.wrap_text {
             out.push(Binding::Prop(Prop::TextWrappingWrap, PropValue::Bool(true)));
+        }
+        if self.is_text_selection_enabled {
+            out.push(Binding::Prop(
+                Prop::IsTextSelectionEnabled,
+                PropValue::Bool(true),
+            ));
         }
         out
     }
@@ -62,6 +69,11 @@ impl TextBlock {
 
     pub fn wrap(mut self) -> Self {
         self.wrap_text = true;
+        self
+    }
+
+    pub fn selectable(mut self) -> Self {
+        self.is_text_selection_enabled = true;
         self
     }
 }

--- a/crates/libs/reactor/src/winui/backend/mod.rs
+++ b/crates/libs/reactor/src/winui/backend/mod.rs
@@ -787,8 +787,14 @@ impl Backend for WinUIBackend {
                 (Prop::IsTextSelectionEnabled, PropValue::Bool(v), Handle::RichTextBlock(tb)) => {
                     tb.put_IsTextSelectionEnabled(*v)
                 }
+                (Prop::IsTextSelectionEnabled, PropValue::Unset, Handle::RichTextBlock(tb)) => {
+                    tb.put_IsTextSelectionEnabled(false)
+                }
                 (Prop::IsTextSelectionEnabled, PropValue::Bool(v), Handle::TextBlock(tb)) => {
                     tb.put_IsTextSelectionEnabled(*v)
+                }
+                (Prop::IsTextSelectionEnabled, PropValue::Unset, Handle::TextBlock(tb)) => {
+                    tb.put_IsTextSelectionEnabled(false)
                 }
                 (Prop::TextWrappingWrap, PropValue::Bool(v), Handle::TextBlock(tb)) => {
                     let mode = if *v {

--- a/crates/libs/reactor/src/winui/backend/mod.rs
+++ b/crates/libs/reactor/src/winui/backend/mod.rs
@@ -787,6 +787,9 @@ impl Backend for WinUIBackend {
                 (Prop::IsTextSelectionEnabled, PropValue::Bool(v), Handle::RichTextBlock(tb)) => {
                     tb.put_IsTextSelectionEnabled(*v)
                 }
+                (Prop::IsTextSelectionEnabled, PropValue::Bool(v), Handle::TextBlock(tb)) => {
+                    tb.put_IsTextSelectionEnabled(*v)
+                }
                 (Prop::TextWrappingWrap, PropValue::Bool(v), Handle::TextBlock(tb)) => {
                     let mode = if *v {
                         Xaml::TextWrapping::Wrap

--- a/crates/samples/reactor/minimal/examples/text.rs
+++ b/crates/samples/reactor/minimal/examples/text.rs
@@ -1,4 +1,4 @@
-//! Sample for the `TextBlock` element.
+//! Sample for the `TextBlock` element, including text selection support.
 
 use windows_reactor::*;
 
@@ -7,6 +7,11 @@ fn app(_cx: &mut RenderCx) -> Element {
         text_block("Plain text"),
         text_block("Larger text").font_size(20.0),
         text_block("Bold + larger").bold().font_size(28.0),
+        text_block("Selectable text — try selecting this with your mouse")
+            .selectable(),
+        text_block("Selectable + wrapped text that demonstrates both features working together on a TextBlock element")
+            .selectable()
+            .wrap(),
     ))
     .spacing(8.0)
     .into()

--- a/crates/tests/libs/reactor_selftest/src/bindings.rs
+++ b/crates/tests/libs/reactor_selftest/src/bindings.rs
@@ -18336,6 +18336,15 @@ impl ITextBlock {
             .ok()
         }
     }
+    pub fn put_IsTextSelectionEnabled(&self, value: bool) -> windows_core::Result<()> {
+        unsafe {
+            (windows_core::Interface::vtable(self).put_IsTextSelectionEnabled)(
+                windows_core::Interface::as_raw(self),
+                value,
+            )
+            .ok()
+        }
+    }
 }
 #[repr(C)]
 #[doc(hidden)]
@@ -18386,7 +18395,8 @@ pub struct ITextBlock_Vtbl {
     get_LineStackingStrategy: usize,
     put_LineStackingStrategy: usize,
     get_IsTextSelectionEnabled: usize,
-    put_IsTextSelectionEnabled: usize,
+    pub put_IsTextSelectionEnabled:
+        unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
     get_SelectedText: usize,
     get_ContentStart: usize,
     get_ContentEnd: usize,

--- a/crates/tools/bindings/src/reactor.txt
+++ b/crates/tools/bindings/src/reactor.txt
@@ -187,7 +187,7 @@ Microsoft.UI.Xaml.Controls.ITabViewTabCloseRequestedEventArgs::{get_Tab}
 Microsoft.UI.Xaml.Controls.ITeachingTip::{put_Title, put_Subtitle, put_IsOpen, put_IsLightDismissEnabled, put_PreferredPlacement, put_ActionButtonContent, put_CloseButtonContent, add_Closed, add_ActionButtonClick}
 Microsoft.UI.Xaml.Controls.ItemCollection
 Microsoft.UI.Xaml.Controls.ItemsControl
-Microsoft.UI.Xaml.Controls.ITextBlock::{put_Text, get_Text, put_FontSize, put_FontWeight, put_FontFamily, put_Foreground, put_TextWrapping}
+Microsoft.UI.Xaml.Controls.ITextBlock::{put_Text, get_Text, put_FontSize, put_FontWeight, put_FontFamily, put_Foreground, put_TextWrapping, put_IsTextSelectionEnabled}
 Microsoft.UI.Xaml.Controls.ITextBox::{get_Text, put_Text, put_PlaceholderText, put_Header, put_AcceptsReturn, put_TextWrapping, add_TextChanged}
 Microsoft.UI.Xaml.Controls.ITimePicker::{put_Header, put_ClockIdentifier, put_MinuteIncrement, add_SelectedTimeChanged}
 Microsoft.UI.Xaml.Controls.ITimePickerSelectedValueChangedEventArgs::{get_NewTime}


### PR DESCRIPTION
This is already supported on `RichTextBlock`.

Fixes: #4522