### PR TITLE
Resolve common name collision with `windows-reactor` and `windows-canvas`

### DIFF
--- a/crates/libs/canvas/src/color.rs
+++ b/crates/libs/canvas/src/color.rs
@@ -1,13 +1,18 @@
 /// An RGBA color with f32 components in 0.0–1.0 range.
+///
+/// This is the floating-point color representation used by Direct2D
+/// (`D2D1_COLOR_F`). For the u8 ARGB platform color used by WinUI/XAML,
+/// see `windows_reactor::Color`.
+#[doc(alias = "Color")]
 #[derive(Copy, Clone, Debug, PartialEq, Default)]
-pub struct Color {
+pub struct ColorF {
     pub r: f32,
     pub g: f32,
     pub b: f32,
     pub a: f32,
 }
 
-impl Color {
+impl ColorF {
     /// Create a color from floating-point RGBA (0.0–1.0).
     pub const fn new(r: f32, g: f32, b: f32, a: f32) -> Self {
         Self { r, g, b, a }
@@ -43,8 +48,8 @@ impl Color {
     pub const DARK_SLATE_BLUE: Self = Self::rgb(0.05, 0.05, 0.1);
 }
 
-impl From<Color> for crate::bindings::D2D1_COLOR_F {
-    fn from(c: Color) -> Self {
+impl From<ColorF> for crate::bindings::D2D1_COLOR_F {
+    fn from(c: ColorF) -> Self {
         Self {
             r: c.r,
             g: c.g,

--- a/crates/libs/canvas/src/lib.rs
+++ b/crates/libs/canvas/src/lib.rs
@@ -24,7 +24,7 @@ mod text;
 mod types;
 
 pub use bitmap::Bitmap;
-pub use color::Color;
+pub use color::ColorF;
 pub use device::GpuDevice;
 pub use geometry::{Path, PathBuilder};
 #[cfg(feature = "reactor")]

--- a/crates/libs/canvas/src/reactor.rs
+++ b/crates/libs/canvas/src/reactor.rs
@@ -5,7 +5,7 @@ use windows_reactor::{
     Rendering, SwapChainPanelHandle, SwapChainPanelWidget, on_rendering, swap_chain_panel,
 };
 
-use crate::color::Color;
+use crate::color::ColorF;
 use crate::device::GpuDevice;
 use crate::session::DrawingSession;
 use crate::swap_chain::SwapChain;
@@ -27,7 +27,7 @@ impl<'a> DrawContext<'a> {
     }
 
     /// Clear the render target.
-    pub fn clear(&self, color: Color) {
+    pub fn clear(&self, color: ColorF) {
         self.session.clear(color);
     }
 }
@@ -78,7 +78,7 @@ impl RenderState {
 ///
 /// ```ignore
 /// animated_canvas(|ctx| {
-///     ctx.clear(Color::CORNFLOWER_BLUE);
+///     ctx.clear(ColorF::CORNFLOWER_BLUE);
 ///     ctx.fill_ellipse(&ellipse, &brush);
 /// })
 /// .margin(16.0)

--- a/crates/libs/canvas/src/session.rs
+++ b/crates/libs/canvas/src/session.rs
@@ -2,7 +2,7 @@ use std::cell::Cell;
 
 use crate::bindings::*;
 use crate::bitmap::Bitmap;
-use crate::color::Color;
+use crate::color::ColorF;
 use crate::device_lost;
 use crate::geometry::Path;
 use crate::text::TextFormat;
@@ -34,7 +34,7 @@ impl<'a> DrawingSession<'a> {
     }
 
     /// Clear the render target to the specified color.
-    pub fn clear(&self, color: Color) {
+    pub fn clear(&self, color: ColorF) {
         let c: D2D1_COLOR_F = color.into();
         unsafe { self.context.Clear(Some(&c)) };
     }
@@ -157,7 +157,7 @@ impl<'a> DrawingSession<'a> {
     }
 
     /// Create a solid color brush bound to this session's device context.
-    pub fn create_solid_brush(&self, color: Color) -> windows_core::Result<Brush> {
+    pub fn create_solid_brush(&self, color: ColorF) -> windows_core::Result<Brush> {
         let c: D2D1_COLOR_F = color.into();
         unsafe { self.context.CreateSolidColorBrush(&c, None).map(Brush) }
     }

--- a/crates/libs/canvas/src/swap_chain.rs
+++ b/crates/libs/canvas/src/swap_chain.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 
 use crate::bindings::*;
 use crate::bitmap::Bitmap;
-use crate::color::Color;
+use crate::color::ColorF;
 use crate::device::GpuDevice;
 use crate::device_lost;
 use crate::session::DrawingSession;
@@ -145,7 +145,7 @@ impl SwapChain {
     }
 
     /// Create a solid color brush that can be reused across draw sessions.
-    pub fn create_solid_brush(&self, color: Color) -> windows_core::Result<Brush> {
+    pub fn create_solid_brush(&self, color: ColorF) -> windows_core::Result<Brush> {
         let c: D2D1_COLOR_F = color.into();
         unsafe { self.d2d_context.CreateSolidColorBrush(&c, None).map(Brush) }
     }

--- a/crates/libs/canvas/src/types.rs
+++ b/crates/libs/canvas/src/types.rs
@@ -1,5 +1,5 @@
 use crate::bindings;
-use crate::color::Color;
+use crate::color::ColorF;
 use windows_numerics::Vector2;
 
 /// A rectangle defined by its edges.
@@ -147,7 +147,7 @@ pub struct Brush(pub(crate) bindings::ID2D1SolidColorBrush);
 
 impl Brush {
     /// Change the brush color (zero-cost — no reallocation).
-    pub fn set_color(&self, color: Color) {
+    pub fn set_color(&self, color: ColorF) {
         let c: bindings::D2D1_COLOR_F = color.into();
         unsafe { self.0.SetColor(&c) };
     }
@@ -185,11 +185,11 @@ impl Paint for RadialGradient {
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub struct GradientStop {
     pub position: f32,
-    pub color: Color,
+    pub color: ColorF,
 }
 
 impl GradientStop {
-    pub const fn new(position: f32, color: Color) -> Self {
+    pub const fn new(position: f32, color: ColorF) -> Self {
         Self { position, color }
     }
 

--- a/crates/libs/reactor/src/winui/backend/mod.rs
+++ b/crates/libs/reactor/src/winui/backend/mod.rs
@@ -1138,11 +1138,12 @@ impl Backend for WinUIBackend {
                 (Prop::Padding, PropValue::Unset, Handle::Border(br)) => {
                     br.put_Padding(to_xaml_thickness(Thickness::default()))
                 }
-                (Prop::Padding, PropValue::Thickness(t), _) => {
-                    if let Ok(ctl) = handle.as_framework_element().cast::<Xaml::Control>() {
+                (Prop::Padding, PropValue::Thickness(t), h) => {
+                    if let Ok(ctl) = h.as_framework_element().cast::<Xaml::Control>() {
                         ctl.cast::<Xaml::IControl>()?
                             .put_Padding(to_xaml_thickness(*t))
                     } else {
+                        diag::unhandled_modifier("set_prop", Prop::Padding, h);
                         Ok(())
                     }
                 }

--- a/crates/samples/canvas/circles/src/main.rs
+++ b/crates/samples/canvas/circles/src/main.rs
@@ -9,10 +9,7 @@
 
 #![windows_subsystem = "windows"]
 
-use windows_canvas::{
-    Color, Ellipse, FontWeight, Rect, TextAlignment, TextFormat, Vector2, animated_canvas,
-};
-
+use windows_canvas::*;
 use windows_reactor::*;
 
 fn app(cx: &mut RenderCx) -> Element {
@@ -48,10 +45,10 @@ fn app(cx: &mut RenderCx) -> Element {
                     let cy = ctx.height / 2.0;
                     let orbit = cx.min(cy) * 0.5;
 
-                    ctx.clear(Color::TRANSPARENT);
+                    ctx.clear(ColorF::TRANSPARENT);
 
                     // Create a brush once per frame (cheap — reuse via set_color).
-                    let Ok(brush) = ctx.create_solid_brush(Color::CORNFLOWER_BLUE) else {
+                    let Ok(brush) = ctx.create_solid_brush(ColorF::CORNFLOWER_BLUE) else {
                         return;
                     };
 
@@ -61,7 +58,7 @@ fn app(cx: &mut RenderCx) -> Element {
                         let y = cy + phase.sin() * (orbit * 0.7);
                         let radius = 20.0 + (phase * 0.7).sin().abs() * 30.0;
 
-                        brush.set_color(Color::new(
+                        brush.set_color(ColorF::new(
                             0.3 + (phase * 0.3).sin().abs() * 0.7,
                             0.4 + (phase * 0.5).cos().abs() * 0.5,
                             0.8,
@@ -79,7 +76,7 @@ fn app(cx: &mut RenderCx) -> Element {
                     };
 
                     let label = format!("{count} circles");
-                    brush.set_color(Color::WHITE);
+                    brush.set_color(ColorF::WHITE);
                     let rect = Rect::new(0.0, ctx.height - 40.0, ctx.width, ctx.height);
                     ctx.draw_text(&label, &format, &rect, &brush);
                 }

--- a/crates/samples/canvas/minimal/examples/bitmap.rs
+++ b/crates/samples/canvas/minimal/examples/bitmap.rs
@@ -9,7 +9,7 @@
 use windows_canvas::*;
 
 fn draw(ctx: &DrawContext) {
-    ctx.clear(Color::new(0.1, 0.1, 0.1, 1.0));
+    ctx.clear(ColorF::new(0.1, 0.1, 0.1, 1.0));
 
     let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("examples")

--- a/crates/samples/canvas/minimal/examples/brush.rs
+++ b/crates/samples/canvas/minimal/examples/brush.rs
@@ -1,17 +1,17 @@
-//! Demonstrates brush reuse and color changes.
+//! Demonstrates brush reuse and ColorF changes.
 
 #![windows_subsystem = "windows"]
 
 use windows_canvas::*;
 
 fn draw(ctx: &DrawContext) {
-    ctx.clear(Color::BLACK);
+    ctx.clear(ColorF::BLACK);
 
-    let Ok(brush) = ctx.create_solid_brush(Color::RED) else {
+    let Ok(brush) = ctx.create_solid_brush(ColorF::RED) else {
         return;
     };
 
-    let colors = [Color::RED, Color::GREEN, Color::BLUE, Color::WHITE];
+    let colors = [ColorF::RED, ColorF::GREEN, ColorF::BLUE, ColorF::WHITE];
     let stripe_width = ctx.width / colors.len() as f32;
 
     for (i, color) in colors.iter().enumerate() {

--- a/crates/samples/canvas/minimal/examples/clock.rs
+++ b/crates/samples/canvas/minimal/examples/clock.rs
@@ -25,14 +25,14 @@ thread_local! {
 }
 
 fn draw(ctx: &DrawContext) {
-    ctx.clear(Color::WHITE);
+    ctx.clear(ColorF::WHITE);
 
     let size_x = ctx.width;
     let size_y = ctx.height;
     let radius = size_x.min(size_y).max(200.0) / 2.0 - 50.0;
 
     // Single brush — orange/terracotta at 80% opacity (matching D2D sample).
-    let Ok(brush) = ctx.create_solid_brush(Color::new(0.92, 0.38, 0.208, 0.8)) else {
+    let Ok(brush) = ctx.create_solid_brush(ColorF::new(0.92, 0.38, 0.208, 0.8)) else {
         return;
     };
 

--- a/crates/samples/canvas/minimal/examples/color.rs
+++ b/crates/samples/canvas/minimal/examples/color.rs
@@ -1,13 +1,13 @@
-//! Demonstrates Color constructors and named constants.
+//! Demonstrates ColorF constructors and named constants.
 
 #![windows_subsystem = "windows"]
 
 use windows_canvas::*;
 
 fn draw(ctx: &DrawContext) {
-    ctx.clear(Color::DARK_SLATE_BLUE);
+    ctx.clear(ColorF::DARK_SLATE_BLUE);
 
-    let Ok(brush) = ctx.create_solid_brush(Color::CORNFLOWER_BLUE) else {
+    let Ok(brush) = ctx.create_solid_brush(ColorF::CORNFLOWER_BLUE) else {
         return;
     };
 
@@ -18,15 +18,15 @@ fn draw(ctx: &DrawContext) {
     ctx.fill_rect(&Rect::new(10.0, 10.0, w, h - 5.0), &brush);
 
     // From RGB floats
-    brush.set_color(Color::rgb(0.9, 0.5, 0.1));
+    brush.set_color(ColorF::rgb(0.9, 0.5, 0.1));
     ctx.fill_rect(&Rect::new(10.0, h + 5.0, w, h * 2.0 - 5.0), &brush);
 
     // From u8 values
-    brush.set_color(Color::from_rgb8(128, 0, 255));
+    brush.set_color(ColorF::from_rgb8(128, 0, 255));
     ctx.fill_rect(&Rect::new(10.0, h * 2.0 + 5.0, w, h * 3.0 - 5.0), &brush);
 
     // With alpha
-    brush.set_color(Color::new(1.0, 1.0, 1.0, 0.5));
+    brush.set_color(ColorF::new(1.0, 1.0, 1.0, 0.5));
     ctx.fill_rect(
         &Rect::new(10.0, h * 3.0 + 5.0, w, ctx.height - 10.0),
         &brush,

--- a/crates/samples/canvas/minimal/examples/gradient.rs
+++ b/crates/samples/canvas/minimal/examples/gradient.rs
@@ -5,7 +5,7 @@
 use windows_canvas::*;
 
 fn draw(ctx: &DrawContext) {
-    ctx.clear(Color::BLACK);
+    ctx.clear(ColorF::BLACK);
 
     let margin = 40.0;
     let half = ctx.height / 2.0;
@@ -15,8 +15,8 @@ fn draw(ctx: &DrawContext) {
         Vector2::new(margin, 0.0),
         Vector2::new(ctx.width - margin, 0.0),
         &[
-            GradientStop::new(0.0, Color::CORNFLOWER_BLUE),
-            GradientStop::new(1.0, Color::new(1.0, 0.5, 0.0, 1.0)),
+            GradientStop::new(0.0, ColorF::CORNFLOWER_BLUE),
+            GradientStop::new(1.0, ColorF::new(1.0, 0.5, 0.0, 1.0)),
         ],
     ) else {
         return;
@@ -40,9 +40,9 @@ fn draw(ctx: &DrawContext) {
         r,
         r,
         &[
-            GradientStop::new(0.0, Color::WHITE),
-            GradientStop::new(0.6, Color::CORNFLOWER_BLUE),
-            GradientStop::new(1.0, Color::BLACK),
+            GradientStop::new(0.0, ColorF::WHITE),
+            GradientStop::new(0.6, ColorF::CORNFLOWER_BLUE),
+            GradientStop::new(1.0, ColorF::BLACK),
         ],
     ) else {
         return;

--- a/crates/samples/canvas/minimal/examples/hello.rs
+++ b/crates/samples/canvas/minimal/examples/hello.rs
@@ -5,8 +5,8 @@
 use windows_canvas::*;
 
 fn draw(ctx: &DrawContext) {
-    ctx.clear(Color::DARK_SLATE_BLUE);
-    let Ok(brush) = ctx.create_solid_brush(Color::CORNFLOWER_BLUE) else {
+    ctx.clear(ColorF::DARK_SLATE_BLUE);
+    let Ok(brush) = ctx.create_solid_brush(ColorF::CORNFLOWER_BLUE) else {
         return;
     };
     let r = ctx.width.min(ctx.height) * 0.3;

--- a/crates/samples/canvas/minimal/examples/lines.rs
+++ b/crates/samples/canvas/minimal/examples/lines.rs
@@ -5,9 +5,9 @@
 use windows_canvas::*;
 
 fn draw(ctx: &DrawContext) {
-    ctx.clear(Color::BLACK);
+    ctx.clear(ColorF::BLACK);
 
-    let Ok(brush) = ctx.create_solid_brush(Color::WHITE) else {
+    let Ok(brush) = ctx.create_solid_brush(ColorF::WHITE) else {
         return;
     };
 
@@ -20,7 +20,7 @@ fn draw(ctx: &DrawContext) {
         let width = (i + 1) as f32;
 
         let t = i as f32 / (count - 1) as f32;
-        brush.set_color(Color::new(1.0 - t * 0.7, 1.0 - t * 0.5, 1.0, 1.0));
+        brush.set_color(ColorF::new(1.0 - t * 0.7, 1.0 - t * 0.5, 1.0, 1.0));
 
         ctx.draw_line(
             Vector2::new(margin, y),

--- a/crates/samples/canvas/minimal/examples/path.rs
+++ b/crates/samples/canvas/minimal/examples/path.rs
@@ -5,7 +5,7 @@
 use windows_canvas::*;
 
 fn draw(ctx: &DrawContext) {
-    ctx.clear(Color::DARK_SLATE_BLUE);
+    ctx.clear(ColorF::DARK_SLATE_BLUE);
 
     let cx = ctx.width / 2.0;
     let cy = ctx.height / 2.0;
@@ -22,7 +22,7 @@ fn draw(ctx: &DrawContext) {
         return;
     };
 
-    let Ok(brush) = ctx.create_solid_brush(Color::new(1.0, 0.8, 0.0, 1.0)) else {
+    let Ok(brush) = ctx.create_solid_brush(ColorF::new(1.0, 0.8, 0.0, 1.0)) else {
         return;
     };
     ctx.fill_path(&path, &brush);

--- a/crates/samples/canvas/minimal/examples/shapes.rs
+++ b/crates/samples/canvas/minimal/examples/shapes.rs
@@ -5,9 +5,9 @@
 use windows_canvas::*;
 
 fn draw(ctx: &DrawContext) {
-    ctx.clear(Color::DARK_SLATE_BLUE);
+    ctx.clear(ColorF::DARK_SLATE_BLUE);
 
-    let Ok(brush) = ctx.create_solid_brush(Color::CORNFLOWER_BLUE) else {
+    let Ok(brush) = ctx.create_solid_brush(ColorF::CORNFLOWER_BLUE) else {
         return;
     };
 
@@ -22,7 +22,7 @@ fn draw(ctx: &DrawContext) {
     );
 
     // Outlined rounded rect.
-    brush.set_color(Color::WHITE);
+    brush.set_color(ColorF::WHITE);
     ctx.draw_rounded_rect(
         &RoundedRect::uniform(Rect::new(cx, cy, cx + size, cy + size), 25.0),
         &brush,

--- a/crates/samples/canvas/minimal/examples/text.rs
+++ b/crates/samples/canvas/minimal/examples/text.rs
@@ -5,7 +5,7 @@
 use windows_canvas::*;
 
 fn draw(ctx: &DrawContext) {
-    ctx.clear(Color::BLACK);
+    ctx.clear(ColorF::BLACK);
 
     let Ok(format) = TextFormat::new("Segoe UI", 32.0)
         .map(|f| f.with_alignment(TextAlignment::Center))
@@ -14,7 +14,7 @@ fn draw(ctx: &DrawContext) {
         return;
     };
 
-    let Ok(brush) = ctx.create_solid_brush(Color::WHITE) else {
+    let Ok(brush) = ctx.create_solid_brush(ColorF::WHITE) else {
         return;
     };
 

--- a/crates/samples/canvas/minimal/examples/transform.rs
+++ b/crates/samples/canvas/minimal/examples/transform.rs
@@ -13,9 +13,9 @@ fn draw(ctx: &DrawContext) {
     FRAME.with(|f| f.set(f.get() + 1));
     let t = FRAME.with(|f| f.get()) as f32 * 0.01;
 
-    ctx.clear(Color::BLACK);
+    ctx.clear(ColorF::BLACK);
 
-    let Ok(brush) = ctx.create_solid_brush(Color::CORNFLOWER_BLUE) else {
+    let Ok(brush) = ctx.create_solid_brush(ColorF::CORNFLOWER_BLUE) else {
         return;
     };
 
@@ -36,7 +36,7 @@ fn draw(ctx: &DrawContext) {
         };
 
         let frac = i as f32 / 6.0;
-        brush.set_color(Color::new(0.3 + frac * 0.7, 0.5, 1.0 - frac * 0.5, 0.8));
+        brush.set_color(ColorF::new(0.3 + frac * 0.7, 0.5, 1.0 - frac * 0.5, 0.8));
 
         ctx.with_transform(&transform, || {
             ctx.fill_rect(

--- a/crates/samples/canvas/standalone/src/main.rs
+++ b/crates/samples/canvas/standalone/src/main.rs
@@ -57,8 +57,8 @@ fn main() -> Result<()> {
             let width = chain.width() as f32;
             let height = chain.height() as f32;
             let session = chain.begin_draw()?;
-            session.clear(Color::DARK_SLATE_BLUE);
-            let brush = session.create_solid_brush(Color::CORNFLOWER_BLUE)?;
+            session.clear(ColorF::DARK_SLATE_BLUE);
+            let brush = session.create_solid_brush(ColorF::CORNFLOWER_BLUE)?;
             let r = width.min(height) * 0.3;
 
             session.fill_ellipse(
@@ -66,7 +66,7 @@ fn main() -> Result<()> {
                 &brush,
             );
 
-            brush.set_color(Color::WHITE);
+            brush.set_color(ColorF::WHITE);
 
             let format = TextFormat::new("Segoe UI", 24.0)?
                 .with_alignment(TextAlignment::Center)

--- a/crates/tests/libs/canvas/src/lib.rs
+++ b/crates/tests/libs/canvas/src/lib.rs
@@ -38,7 +38,7 @@ mod tests {
 
         {
             let session = chain.begin_draw().unwrap();
-            session.clear(Color::CORNFLOWER_BLUE);
+            session.clear(ColorF::CORNFLOWER_BLUE);
         }
 
         chain.present().unwrap();
@@ -58,11 +58,11 @@ mod tests {
         let device = GpuDevice::new_warp().unwrap();
         let mut chain = device.create_swap_chain(64, 64).unwrap();
 
-        let brush = chain.create_solid_brush(Color::RED).unwrap();
+        let brush = chain.create_solid_brush(ColorF::RED).unwrap();
 
         for _ in 0..3 {
             let session = chain.begin_draw().unwrap();
-            session.clear(Color::BLACK);
+            session.clear(ColorF::BLACK);
             session.fill_ellipse(&Ellipse::circle(Vector2::new(32.0, 32.0), 16.0), &brush);
             drop(session);
             chain.present().unwrap();
@@ -77,10 +77,10 @@ mod tests {
         let format = TextFormat::new("Segoe UI", 16.0)
             .unwrap()
             .with_alignment(TextAlignment::Center);
-        let brush = chain.create_solid_brush(Color::WHITE).unwrap();
+        let brush = chain.create_solid_brush(ColorF::WHITE).unwrap();
 
         let session = chain.begin_draw().unwrap();
-        session.clear(Color::BLACK);
+        session.clear(ColorF::BLACK);
         session.draw_text("Hello", &format, &Rect::new(0.0, 0.0, 128.0, 64.0), &brush);
         drop(session);
         chain.present().unwrap();
@@ -101,10 +101,10 @@ mod tests {
             .build()
             .unwrap();
 
-        let brush = chain.create_solid_brush(Color::GREEN).unwrap();
+        let brush = chain.create_solid_brush(ColorF::GREEN).unwrap();
 
         let session = chain.begin_draw().unwrap();
-        session.clear(Color::BLACK);
+        session.clear(ColorF::BLACK);
         session.fill_path(&path, &brush);
         session.draw_path(&path, &brush, 2.0);
         drop(session);
@@ -117,7 +117,7 @@ mod tests {
         let mut chain = device.create_swap_chain(64, 64).unwrap();
 
         let session = chain.begin_draw().unwrap();
-        session.clear(Color::BLACK);
+        session.clear(ColorF::BLACK);
         drop(session);
 
         // Normal present should return Ok(true) — device is fine.
@@ -130,12 +130,12 @@ mod tests {
     fn rounded_rect_draw_fill() {
         let device = GpuDevice::new_warp().unwrap();
         let mut chain = device.create_swap_chain(64, 64).unwrap();
-        let brush = chain.create_solid_brush(Color::RED).unwrap();
+        let brush = chain.create_solid_brush(ColorF::RED).unwrap();
 
         let rrect = RoundedRect::uniform(Rect::new(5.0, 5.0, 55.0, 55.0), 8.0);
 
         let session = chain.begin_draw().unwrap();
-        session.clear(Color::BLACK);
+        session.clear(ColorF::BLACK);
         session.fill_rounded_rect(&rrect, &brush);
         session.draw_rounded_rect(&rrect, &brush, 2.0);
         drop(session);
@@ -148,7 +148,7 @@ mod tests {
         let mut chain = device.create_swap_chain(64, 64).unwrap();
 
         let session = chain.begin_draw().unwrap();
-        session.clear(Color::BLACK);
+        session.clear(ColorF::BLACK);
 
         // Default is identity.
         let identity = session.get_transform();
@@ -196,15 +196,15 @@ mod tests {
         let mut chain = device.create_swap_chain(64, 64).unwrap();
 
         let session = chain.begin_draw().unwrap();
-        session.clear(Color::BLACK);
+        session.clear(ColorF::BLACK);
 
         let gradient = session
             .create_linear_gradient(
                 Vector2::new(0.0, 0.0),
                 Vector2::new(64.0, 0.0),
                 &[
-                    GradientStop::new(0.0, Color::RED),
-                    GradientStop::new(1.0, Color::BLUE),
+                    GradientStop::new(0.0, ColorF::RED),
+                    GradientStop::new(1.0, ColorF::BLUE),
                 ],
             )
             .unwrap();
@@ -223,7 +223,7 @@ mod tests {
         let mut chain = device.create_swap_chain(64, 64).unwrap();
 
         let session = chain.begin_draw().unwrap();
-        session.clear(Color::BLACK);
+        session.clear(ColorF::BLACK);
 
         let gradient = session
             .create_radial_gradient(
@@ -231,8 +231,8 @@ mod tests {
                 32.0,
                 32.0,
                 &[
-                    GradientStop::new(0.0, Color::WHITE),
-                    GradientStop::new(1.0, Color::BLACK),
+                    GradientStop::new(0.0, ColorF::WHITE),
+                    GradientStop::new(1.0, ColorF::BLACK),
                 ],
             )
             .unwrap();
@@ -257,7 +257,7 @@ mod tests {
         assert!(bitmap.height() > 0.0);
 
         let session = chain.begin_draw().unwrap();
-        session.clear(Color::BLACK);
+        session.clear(ColorF::BLACK);
         session.draw_bitmap(&bitmap, &Rect::new(0.0, 0.0, 64.0, 64.0), 1.0);
         drop(session);
         chain.present().unwrap();
@@ -297,9 +297,9 @@ mod tests {
             .build()
             .unwrap();
 
-        let brush = chain.create_solid_brush(Color::WHITE).unwrap();
+        let brush = chain.create_solid_brush(ColorF::WHITE).unwrap();
         let session = chain.begin_draw().unwrap();
-        session.clear(Color::BLACK);
+        session.clear(ColorF::BLACK);
         session.draw_path(&path, &brush, 2.0);
         drop(session);
         chain.present().unwrap();
@@ -324,9 +324,9 @@ mod tests {
             .build()
             .unwrap();
 
-        let brush = chain.create_solid_brush(Color::GREEN).unwrap();
+        let brush = chain.create_solid_brush(ColorF::GREEN).unwrap();
         let session = chain.begin_draw().unwrap();
-        session.clear(Color::BLACK);
+        session.clear(ColorF::BLACK);
         session.fill_path(&path, &brush);
         drop(session);
         chain.present().unwrap();
@@ -338,10 +338,10 @@ mod tests {
 
         let device = GpuDevice::new_warp().unwrap();
         let mut chain = device.create_swap_chain(128, 64).unwrap();
-        let brush = chain.create_solid_brush(Color::WHITE).unwrap();
+        let brush = chain.create_solid_brush(ColorF::WHITE).unwrap();
 
         let session = chain.begin_draw().unwrap();
-        session.clear(Color::BLACK);
+        session.clear(ColorF::BLACK);
         session.draw_text("Bold", &format, &Rect::new(0.0, 0.0, 128.0, 64.0), &brush);
         drop(session);
         chain.present().unwrap();
@@ -353,7 +353,7 @@ mod tests {
         let mut chain = device.create_swap_chain(64, 64).unwrap();
 
         let session = chain.begin_draw().unwrap();
-        session.clear(Color::BLACK);
+        session.clear(ColorF::BLACK);
 
         let gradient = session
             .create_radial_gradient(
@@ -361,8 +361,8 @@ mod tests {
                 32.0,
                 32.0,
                 &[
-                    GradientStop::new(0.0, Color::WHITE),
-                    GradientStop::new(1.0, Color::BLACK),
+                    GradientStop::new(0.0, ColorF::WHITE),
+                    GradientStop::new(1.0, ColorF::BLACK),
                 ],
             )
             .unwrap();

--- a/docs/quirks.md
+++ b/docs/quirks.md
@@ -12,10 +12,7 @@ visual effect.
 **Workaround:** Use `.margin(...)` on the stack (or on individual children)
 instead, since `Margin` is defined on `FrameworkElement` and works everywhere.
 
-**TODO:** Consider whether `windows-reactor` should:
-- Emit a compile-time or runtime warning when `.padding()` is applied to a
-  widget that doesn't support it.
-- Silently translate `.padding()` on stacks into child margins or wrap in a
-  `Border` internally.
-- Remove `.padding()` from the `ElementExt` blanket impl and only expose it on
-  widgets where it actually works (buttons, borders, content controls, etc.).
+**Resolution:** The `diagnostics` feature now emits a debug-mode warning via
+`diag::unhandled_modifier` when `.padding()` is applied to an element that
+doesn't inherit from `Control`. This helps developers notice the mistake early
+without breaking existing code.

--- a/docs/reactor-naming.md
+++ b/docs/reactor-naming.md
@@ -1,5 +1,12 @@
 # Reactor / Canvas Naming Collisions
 
+> **Status**: Resolved — canvas's `Color` (f32 RGBA) renamed to `ColorF` to
+> avoid collision with reactor's `Color` (u8 ARGB, matching `Windows.UI.Color`).
+> Reactor keeps the unqualified `Color` name since it is the platform-canonical
+> type. `Ellipse`, `FontWeight`, and `Brush` remain unchanged pending further
+> design work on both sides (reactor's `Brush` enum and canvas's `Brush` handle
+> both need refinement).
+
 ## Problem Statement
 
 `windows-reactor` and `windows-canvas` are companion crates designed to be used

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -11,6 +11,8 @@ This repo is the home of the following crates (and other supporting crates):
 
 * [windows-sys](https://crates.io/crates/windows-sys) - Raw bindings for C-style Windows APIs.
 * [windows](https://crates.io/crates/windows) - Safer bindings including C-style APIs as well as COM and WinRT APIs.
+* [windows-reactor](https://crates.io/crates/windows-reactor) - Declarative UI library for Rust, backed by WinUI 3.
+* [windows-canvas](https://crates.io/crates/windows-canvas) - Idiomatic 2D graphics library built on Direct2D.
 
 * [windows-bindgen](https://crates.io/crates/windows-bindgen) - Code generator for Windows metadata.
 * [windows-collections](https://crates.io/crates/windows-collections) - Windows collection types.

--- a/docs/time.md
+++ b/docs/time.md
@@ -1,5 +1,9 @@
 # `windows-time`: idiomatic `TimeSpan` and `DateTime` for Rust
 
+> **Status**: Shipped as `windows-time` v0.1.0. This document records the
+> design decisions made during development and serves as a reference for the
+> crate's rationale and architecture.
+
 ## Background
 
 `Windows.Foundation.TimeSpan` and `Windows.Foundation.DateTime` are two of the
@@ -324,16 +328,16 @@ For fallible conversions, use the existing `windows_core::Error` /
 
 ### Versioning and rollout
 
-* Land `windows-time` at `0.1.0` alongside the next coordinated release.
+* `windows-time` shipped at `0.1.0` alongside the coordinated release.
 * It is sourced from metadata and re-exported by the umbrella `windows`
-  crate, so for users of the umbrella crate this is a non-breaking change:
+  crate, so for users of the umbrella crate this was a non-breaking change:
   `windows::Foundation::TimeSpan` and `DateTime` keep the same path, same
-  layout, same field names (the generated struct is unchanged), and merely
-  gain new inherent methods and trait impls.
-* The only breaking surface is for callers that depend directly on the buggy
+  layout, same field names (the generated struct is unchanged), and gained
+  new inherent methods and trait impls.
+* The only breaking surface was for callers that depended directly on the buggy
   `From<core::time::Duration> for TimeSpan` / `From<TimeSpan> for
   core::time::Duration` impls in `windows::extensions::Foundation::TimeSpan`,
-  which are replaced by `TryFrom`. Release notes should call this out.
+  which were replaced by `TryFrom`. Release notes called this out.
 * The `windows-reference` crate keeps working: with the bindgen routing
   change above, its `IPropertyValue` / `IReference` bindings reference
   `windows_time::{TimeSpan, DateTime}` instead of locally-emitted copies.

--- a/docs/win2d.md
+++ b/docs/win2d.md
@@ -1,5 +1,12 @@
 # Win2D CanvasControl and windows-canvas
 
+> **Status**: `windows-canvas` is shipped and provides `animated_canvas()`
+> (continuous frame-loop rendering via `SwapChainPanel`). The Win2D-style
+> `CanvasControl` (invalidation-driven, UI-thread rendering via
+> `CanvasImageSource`) is not yet implemented. This document compares the
+> two Win2D controls with the current Rust implementation and outlines the
+> path toward full feature parity.
+
 This document compares Win2D's `CanvasControl` / `CanvasAnimatedControl` with
 the current `windows-canvas` + `windows-reactor` integration and outlines a
 path toward feature parity in idiomatic Rust.


### PR DESCRIPTION
The naming doc highlights some type name collisions but the most obvious is between distinct color types. I'd rather not decorate names too much but this is a big offender and the name follows the pattern established by DX APIs so I think we're in a good shape. 