### PR TITLE
Mark owning component dirty on off-thread use_async_state writes

### DIFF
--- a/crates/libs/reactor/src/core/render_context.rs
+++ b/crates/libs/reactor/src/core/render_context.rs
@@ -2,6 +2,7 @@ use std::any::Any;
 use std::cell::{Cell, Ref, RefCell};
 use std::fmt;
 use std::rc::Rc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
 use std::thread::{self, ThreadId};
 
@@ -138,6 +139,10 @@ impl<A: 'static> From<Dispatch<A>> for super::callback::Callback<A> {
 pub struct AsyncSetState<T: Send + 'static> {
     cell: Arc<Mutex<Box<dyn Any + Send>>>,
     marshaller: UiMarshaller,
+    /// Owning component's async-dirty flag, set on a real change so the
+    /// reconciler re-renders the component even when nested under a parent
+    /// whose element tree is unchanged.
+    dirty: Arc<AtomicBool>,
     type_name: &'static str,
     _marker: std::marker::PhantomData<fn(T)>,
 }
@@ -147,6 +152,7 @@ impl<T: Send + 'static> Clone for AsyncSetState<T> {
         Self {
             cell: Arc::clone(&self.cell),
             marshaller: self.marshaller.clone(),
+            dirty: Arc::clone(&self.dirty),
             type_name: self.type_name,
             _marker: std::marker::PhantomData,
         }
@@ -166,6 +172,7 @@ impl<T: Send + Clone + PartialEq + 'static> AsyncSetState<T> {
     /// marshalled to the UI thread; no-op if value is unchanged.
     pub fn call(&self, value: T) {
         let cell = Arc::clone(&self.cell);
+        let dirty = Arc::clone(&self.dirty);
         let type_name = self.type_name;
         self.marshaller.dispatch(move || {
             let mut slot = cell.lock().unwrap();
@@ -180,6 +187,9 @@ impl<T: Send + Clone + PartialEq + 'static> AsyncSetState<T> {
             }
             *slot = Box::new(value);
             drop(slot);
+            // Mark the owning component dirty so the reconciler does not skip
+            // it; a bare rerender request only re-renders the root.
+            dirty.store(true, Ordering::Relaxed);
             request_ui_rerender_on_ui_thread();
         });
     }
@@ -257,6 +267,11 @@ pub struct RenderCx {
     /// checks this to force re-render of the owning component even when the
     /// parent's element tree is structurally identical.
     state_dirty: Rc<Cell<bool>>,
+    /// `Send + Sync` counterpart to `state_dirty`, set by `AsyncSetState`
+    /// when an off-thread write changes a value. Folded into
+    /// [`Self::peek_state_dirty`] so nested components re-render after an
+    /// async state update, not just root components.
+    async_dirty: Arc<AtomicBool>,
     ui_thread: Option<ThreadId>,
     context_stack: Option<Rc<ContextStack>>,
     read_contexts: RefCell<FxHashSet<ContextId>>,
@@ -289,6 +304,7 @@ impl RenderCx {
             cursor: 0,
             request_rerender,
             state_dirty: Rc::new(Cell::new(false)),
+            async_dirty: Arc::new(AtomicBool::new(false)),
             ui_thread: None,
             context_stack: None,
             read_contexts: RefCell::new(FxHashSet::default()),
@@ -328,6 +344,7 @@ impl RenderCx {
         self.ui_thread = Some(thread::current().id());
         self.read_contexts.borrow_mut().clear();
         self.state_dirty.set(false);
+        self.async_dirty.store(false, Ordering::Relaxed);
     }
 
     pub fn hook_count(&self) -> usize {
@@ -341,12 +358,13 @@ impl RenderCx {
     /// Returns `true` if any `SetState` called since the last render changed
     /// a hook value, and clears the flag.
     pub fn take_state_dirty(&self) -> bool {
-        self.state_dirty.replace(false)
+        let async_dirty = self.async_dirty.swap(false, Ordering::Relaxed);
+        self.state_dirty.replace(false) || async_dirty
     }
 
     /// Returns the current dirty state without clearing it.
     pub fn peek_state_dirty(&self) -> bool {
-        self.state_dirty.get()
+        self.state_dirty.get() || self.async_dirty.load(Ordering::Relaxed)
     }
 
     /// Install (or replace) the [`UiMarshaller`] used by
@@ -415,6 +433,7 @@ impl RenderCx {
         let setter = AsyncSetState::<T> {
             cell,
             marshaller,
+            dirty: Arc::clone(&self.async_dirty),
             type_name,
             _marker: std::marker::PhantomData,
         };

--- a/crates/libs/reactor/src/core/render_context.rs
+++ b/crates/libs/reactor/src/core/render_context.rs
@@ -139,9 +139,9 @@ impl<A: 'static> From<Dispatch<A>> for super::callback::Callback<A> {
 pub struct AsyncSetState<T: Send + 'static> {
     cell: Arc<Mutex<Box<dyn Any + Send>>>,
     marshaller: UiMarshaller,
-    /// Owning component's async-dirty flag, set on a real change so the
-    /// reconciler re-renders the component even when nested under a parent
-    /// whose element tree is unchanged.
+    /// Owning component's `state_dirty` flag (shared with `RenderCx`), set on
+    /// a real change so the reconciler re-renders the component even when
+    /// nested under a parent whose element tree is unchanged.
     dirty: Arc<AtomicBool>,
     type_name: &'static str,
     _marker: std::marker::PhantomData<fn(T)>,
@@ -263,15 +263,16 @@ pub struct RenderCx {
     hooks: Rc<RefCell<Vec<HookSlot>>>,
     cursor: usize,
     request_rerender: Rc<dyn Fn()>,
-    /// Shared flag set by `SetState` when a value changes; the reconciler
-    /// checks this to force re-render of the owning component even when the
-    /// parent's element tree is structurally identical.
-    state_dirty: Rc<Cell<bool>>,
-    /// `Send + Sync` counterpart to `state_dirty`, set by `AsyncSetState`
-    /// when an off-thread write changes a value. Folded into
-    /// [`Self::peek_state_dirty`] so nested components re-render after an
-    /// async state update, not just root components.
-    async_dirty: Arc<AtomicBool>,
+    /// Shared flag set whenever a hook value changes, by both the synchronous
+    /// setters (`SetState`/`Updater`/`Dispatch`) and the off-thread
+    /// [`AsyncSetState`]. The reconciler checks this to force a re-render of
+    /// the owning component even when the parent's element tree is
+    /// structurally identical, so nested components are not skipped after a
+    /// state update. It is an `Arc<AtomicBool>` rather than a `Cell` because
+    /// [`AsyncSetState`] captures it into a `Send` closure that is marshalled
+    /// onto the UI thread; the synchronous setters only ever touch it from the
+    /// UI thread.
+    state_dirty: Arc<AtomicBool>,
     ui_thread: Option<ThreadId>,
     context_stack: Option<Rc<ContextStack>>,
     read_contexts: RefCell<FxHashSet<ContextId>>,
@@ -303,8 +304,7 @@ impl RenderCx {
             hooks: Rc::new(RefCell::new(Vec::new())),
             cursor: 0,
             request_rerender,
-            state_dirty: Rc::new(Cell::new(false)),
-            async_dirty: Arc::new(AtomicBool::new(false)),
+            state_dirty: Arc::new(AtomicBool::new(false)),
             ui_thread: None,
             context_stack: None,
             read_contexts: RefCell::new(FxHashSet::default()),
@@ -343,8 +343,7 @@ impl RenderCx {
         self.cursor = 0;
         self.ui_thread = Some(thread::current().id());
         self.read_contexts.borrow_mut().clear();
-        self.state_dirty.set(false);
-        self.async_dirty.store(false, Ordering::Relaxed);
+        self.state_dirty.store(false, Ordering::Relaxed);
     }
 
     pub fn hook_count(&self) -> usize {
@@ -355,16 +354,15 @@ impl RenderCx {
         self.request_rerender = request_rerender;
     }
 
-    /// Returns `true` if any `SetState` called since the last render changed
-    /// a hook value, and clears the flag.
+    /// Returns `true` if any state write (synchronous or off-thread async)
+    /// has changed a hook value since the last render, and clears the flag.
     pub fn take_state_dirty(&self) -> bool {
-        let async_dirty = self.async_dirty.swap(false, Ordering::Relaxed);
-        self.state_dirty.replace(false) || async_dirty
+        self.state_dirty.swap(false, Ordering::Relaxed)
     }
 
     /// Returns the current dirty state without clearing it.
     pub fn peek_state_dirty(&self) -> bool {
-        self.state_dirty.get() || self.async_dirty.load(Ordering::Relaxed)
+        self.state_dirty.load(Ordering::Relaxed)
     }
 
     /// Install (or replace) the [`UiMarshaller`] used by
@@ -433,7 +431,7 @@ impl RenderCx {
         let setter = AsyncSetState::<T> {
             cell,
             marshaller,
-            dirty: Arc::clone(&self.async_dirty),
+            dirty: Arc::clone(&self.state_dirty),
             type_name,
             _marker: std::marker::PhantomData,
         };
@@ -769,7 +767,7 @@ impl RenderCx {
         T: 'static + Clone + PartialEq,
     {
         let request = Rc::clone(&self.request_rerender);
-        let dirty = Rc::clone(&self.state_dirty);
+        let dirty = Arc::clone(&self.state_dirty);
         let ui_thread = self.ui_thread;
         SetState {
             inner: Rc::new(move |value: T| {
@@ -791,7 +789,7 @@ impl RenderCx {
                 }
                 *slot = Box::new(value);
                 drop(slot);
-                dirty.set(true);
+                dirty.store(true, Ordering::Relaxed);
                 request();
             }),
         }
@@ -802,7 +800,7 @@ impl RenderCx {
         T: 'static + Clone + PartialEq,
     {
         let request = Rc::clone(&self.request_rerender);
-        let dirty = Rc::clone(&self.state_dirty);
+        let dirty = Arc::clone(&self.state_dirty);
         let ui_thread = self.ui_thread;
         Updater {
             inner: Rc::new(move |reducer: ReducerClosure<T>| {
@@ -825,7 +823,7 @@ impl RenderCx {
                     return;
                 }
                 *cell.borrow_mut() = Box::new(next);
-                dirty.set(true);
+                dirty.store(true, Ordering::Relaxed);
                 request();
             }),
         }
@@ -843,7 +841,7 @@ impl RenderCx {
         R: Fn(S, A) -> S + 'static,
     {
         let request = Rc::clone(&self.request_rerender);
-        let dirty = Rc::clone(&self.state_dirty);
+        let dirty = Arc::clone(&self.state_dirty);
         let ui_thread = self.ui_thread;
         let reducer = Rc::new(reducer);
         Dispatch {
@@ -866,7 +864,7 @@ impl RenderCx {
                     return;
                 }
                 *cell.borrow_mut() = Box::new(next);
-                dirty.set(true);
+                dirty.store(true, Ordering::Relaxed);
                 request();
             }),
         }

--- a/crates/tests/libs/reactor/tests/async_state.rs
+++ b/crates/tests/libs/reactor/tests/async_state.rs
@@ -59,6 +59,59 @@ fn async_setter_from_off_thread_marshals_back_and_persists() {
 }
 
 #[test]
+fn async_setter_marks_owning_component_dirty_for_rerender() {
+    // Regression: an off-thread `use_async_state` write must mark the owning
+    // component dirty, not just request a root rerender. Without this, a
+    // nested component (whose parent's element tree is unchanged) is skipped
+    // by the reconciler's `can_skip_update` path and never observes the new
+    // value until an unrelated `use_state` change forces it to re-render.
+    let dispatcher = ChannelDispatcher::new();
+    let _ui_guard = UiRerenderGuard::install(Rc::new(|| {}));
+
+    let mut cx = RenderCx::for_test();
+    cx.set_marshaller(Some(dispatcher.marshaller()));
+    cx.begin_render();
+    let (_, set) = cx.use_async_state(0_i32);
+
+    // A fresh render starts clean.
+    assert!(!cx.peek_state_dirty());
+
+    thread::spawn(move || set.call(42)).join().unwrap();
+    dispatcher.drain();
+
+    // Applying the off-thread write marks the component dirty so the
+    // reconciler will not skip re-rendering it.
+    assert!(
+        cx.peek_state_dirty(),
+        "async write must mark the owning component dirty"
+    );
+
+    // The flag clears at the start of the next render.
+    cx.begin_render();
+    assert!(!cx.peek_state_dirty());
+}
+
+#[test]
+fn async_setter_equal_value_does_not_mark_dirty() {
+    let dispatcher = ChannelDispatcher::new();
+    let _ui_guard = UiRerenderGuard::install(Rc::new(|| {}));
+
+    let mut cx = RenderCx::for_test();
+    cx.set_marshaller(Some(dispatcher.marshaller()));
+    cx.begin_render();
+    let (_, set) = cx.use_async_state(7_i32);
+
+    thread::spawn(move || set.call(7)).join().unwrap();
+    dispatcher.drain();
+
+    assert!(
+        !cx.peek_state_dirty(),
+        "an unchanged async write must not mark the component dirty"
+    );
+}
+
+
+#[test]
 fn async_setter_equal_value_does_not_trigger_rerender() {
     let dispatcher = ChannelDispatcher::new();
     let marshaller = dispatcher.marshaller();

--- a/crates/tests/libs/reactor/tests/async_state.rs
+++ b/crates/tests/libs/reactor/tests/async_state.rs
@@ -110,7 +110,6 @@ fn async_setter_equal_value_does_not_mark_dirty() {
     );
 }
 
-
 #[test]
 fn async_setter_equal_value_does_not_trigger_rerender() {
     let dispatcher = ChannelDispatcher::new();


### PR DESCRIPTION
## Problem

An off-thread `use_async_state` setter only requested a root re-render; it never marked its owning component's dirty flag. When such a component was nested under another (e.g. a sample hosted in a `NavigationView`), the reconciler's `can_skip_update` skipped the structurally-identical child because `is_component_state_dirty` (which reads `peek_state_dirty`) returned `false`. The component's `use_effect` therefore never ran until an unrelated sync `use_state` change forced a re-render.

This surfaced in the Direct2D swap-chain sample: it would not begin rendering until the user clicked a button.

## Fix

Add a `Send + Sync` `async_dirty: Arc<AtomicBool>` to `RenderCx`, folded into `peek_state_dirty`/`take_state_dirty` alongside the existing `state_dirty` cell. `AsyncSetState::call` now sets it on a real value change, so off-thread async writes mark the owning component dirty and the reconciler re-renders it even when nested.

## Tests

Added regression tests in `async_state.rs`:
- `async_setter_marks_owning_component_dirty_for_rerender` — an off-thread async write now marks the component dirty. Verified to **fail without** this fix and **pass with** it.
- `async_setter_equal_value_does_not_mark_dirty` — an equal-value write does not mark the component dirty.

Full reactor test suite passes; `cargo clippy -p windows-reactor` is clean.