### PR TITLE
`windows-reactor` test validation for unhandled properties

### DIFF
--- a/crates/libs/reactor/src/winui/backend/mod.rs
+++ b/crates/libs/reactor/src/winui/backend/mod.rs
@@ -1268,6 +1268,11 @@ impl Backend for WinUIBackend {
                     let tb = string_as_textblock(s)?;
                     ti.put_Header(&tb)
                 }
+                (Prop::Header, PropValue::Str(s), Handle::Expander(e)) => {
+                    let tb = string_as_textblock(s)?;
+                    e.put_Header(&tb)
+                }
+                (Prop::Header, PropValue::Unset, Handle::Expander(e)) => e.put_Header(None),
                 (Prop::ItemKey, PropValue::Str(s), Handle::TabViewItem(ti)) => {
                     let tag = windows_reference::IReference::from(s.as_str());
                     ti.cast::<Xaml::IFrameworkElement>()?.put_Tag(&tag)

--- a/crates/tests/libs/reactor_selftest/src/fixtures/controls.rs
+++ b/crates/tests/libs/reactor_selftest/src/fixtures/controls.rs
@@ -493,6 +493,51 @@ pub fn mount_button(h: Harness) -> FixtureFuture {
     })
 }
 
+pub fn mount_button_accent(h: Harness) -> FixtureFuture {
+    Box::pin(async move {
+        let capture = h.capture_stderr();
+        h.mount(cc(|_| button("Accent").accent().into()));
+        h.render().await;
+        let stderr = capture.finish();
+        assert_present!(h, "Reconciler_Mount_ButtonAccent", bindings::Button);
+        h.check(
+            "Reconciler_Mount_ButtonAccent_HasLabel",
+            h.find_button("Accent").is_some(),
+        );
+        h.check_no_reactor_warnings("Reconciler_Mount_ButtonAccent_NoWarnings", &stderr);
+    })
+}
+
+pub fn mount_button_subtle(h: Harness) -> FixtureFuture {
+    Box::pin(async move {
+        let capture = h.capture_stderr();
+        h.mount(cc(|_| button("Subtle").subtle().into()));
+        h.render().await;
+        let stderr = capture.finish();
+        assert_present!(h, "Reconciler_Mount_ButtonSubtle", bindings::Button);
+        h.check(
+            "Reconciler_Mount_ButtonSubtle_HasLabel",
+            h.find_button("Subtle").is_some(),
+        );
+        h.check_no_reactor_warnings("Reconciler_Mount_ButtonSubtle_NoWarnings", &stderr);
+    })
+}
+
+pub fn mount_button_text_link(h: Harness) -> FixtureFuture {
+    Box::pin(async move {
+        let capture = h.capture_stderr();
+        h.mount(cc(|_| button("Link").text_link().into()));
+        h.render().await;
+        let stderr = capture.finish();
+        assert_present!(h, "Reconciler_Mount_ButtonTextLink", bindings::Button);
+        h.check(
+            "Reconciler_Mount_ButtonTextLink_HasLabel",
+            h.find_button("Link").is_some(),
+        );
+        h.check_no_reactor_warnings("Reconciler_Mount_ButtonTextLink_NoWarnings", &stderr);
+    })
+}
+
 pub fn mount_person_picture(h: Harness) -> FixtureFuture {
     Box::pin(async move {
         h.mount(cc(|_| PersonPicture::new().initials("AB").into()));

--- a/crates/tests/libs/reactor_selftest/src/fixtures/controls.rs
+++ b/crates/tests/libs/reactor_selftest/src/fixtures/controls.rs
@@ -495,46 +495,37 @@ pub fn mount_button(h: Harness) -> FixtureFuture {
 
 pub fn mount_button_accent(h: Harness) -> FixtureFuture {
     Box::pin(async move {
-        let capture = h.capture_stderr();
         h.mount(cc(|_| button("Accent").accent().into()));
         h.render().await;
-        let stderr = capture.finish();
         assert_present!(h, "Reconciler_Mount_ButtonAccent", bindings::Button);
         h.check(
             "Reconciler_Mount_ButtonAccent_HasLabel",
             h.find_button("Accent").is_some(),
         );
-        h.check_no_reactor_warnings("Reconciler_Mount_ButtonAccent_NoWarnings", &stderr);
     })
 }
 
 pub fn mount_button_subtle(h: Harness) -> FixtureFuture {
     Box::pin(async move {
-        let capture = h.capture_stderr();
         h.mount(cc(|_| button("Subtle").subtle().into()));
         h.render().await;
-        let stderr = capture.finish();
         assert_present!(h, "Reconciler_Mount_ButtonSubtle", bindings::Button);
         h.check(
             "Reconciler_Mount_ButtonSubtle_HasLabel",
             h.find_button("Subtle").is_some(),
         );
-        h.check_no_reactor_warnings("Reconciler_Mount_ButtonSubtle_NoWarnings", &stderr);
     })
 }
 
 pub fn mount_button_text_link(h: Harness) -> FixtureFuture {
     Box::pin(async move {
-        let capture = h.capture_stderr();
         h.mount(cc(|_| button("Link").text_link().into()));
         h.render().await;
-        let stderr = capture.finish();
         assert_present!(h, "Reconciler_Mount_ButtonTextLink", bindings::Button);
         h.check(
             "Reconciler_Mount_ButtonTextLink_HasLabel",
             h.find_button("Link").is_some(),
         );
-        h.check_no_reactor_warnings("Reconciler_Mount_ButtonTextLink_NoWarnings", &stderr);
     })
 }
 

--- a/crates/tests/libs/reactor_selftest/src/fixtures/interactions.rs
+++ b/crates/tests/libs/reactor_selftest/src/fixtures/interactions.rs
@@ -292,15 +292,13 @@ pub fn radio_buttons_change_selection(h: Harness) -> FixtureFuture {
             initial,
         );
 
-        if let Err(e) = h.set_radio_buttons_selected_index(2) {
-            h.diag(&format!(
-                "radio_buttons_change_selection: driver failed: {e}\nvisual tree:\n{}",
-                h.dump_tree()
-            ));
-        }
+        // Try programmatic selection — this is known to fail reliably
+        // because WinUI RadioButtons.SelectionChanged only fires for real
+        // input events. Silence errors and fall through to the SKIP path.
+        let _ = h.set_radio_buttons_selected_index(2);
         // RadioButtons doesn't reliably fire SelectionChanged for programmatic input.
         let arrived = h
-            .render_until("radio-idx=2 to appear", |h| {
+            .render_until_quiet("radio-idx=2 to appear", |h| {
                 h.find_text("radio-idx=2").is_some()
             })
             .await;
@@ -308,7 +306,7 @@ pub fn radio_buttons_change_selection(h: Harness) -> FixtureFuture {
         if !arrived {
             h.check_skip(
                 "Interaction_RadioButtons_AfterChange",
-                "WinUI RadioButtons.SelectionChanged does not fire reliably for in-process programmatic input; verifiable only via out-of-process UI automation",
+                "programmatic RadioButtons selection not supported in-process",
             );
             return;
         }

--- a/crates/tests/libs/reactor_selftest/src/harness.rs
+++ b/crates/tests/libs/reactor_selftest/src/harness.rs
@@ -941,7 +941,12 @@ impl StderrCapture {
             let mut write_end: RawHandle = core::ptr::null_mut();
             // Use a 1 MB buffer so panic backtraces (RUST_BACKTRACE=1 on CI)
             // don't fill the pipe and deadlock the write side.
-            CreatePipe(&mut read_end, &mut write_end, core::ptr::null(), 1024 * 1024);
+            CreatePipe(
+                &mut read_end,
+                &mut write_end,
+                core::ptr::null(),
+                1024 * 1024,
+            );
             SetStdHandle(STD_ERROR_HANDLE, write_end);
             Self {
                 original,

--- a/crates/tests/libs/reactor_selftest/src/harness.rs
+++ b/crates/tests/libs/reactor_selftest/src/harness.rs
@@ -425,16 +425,15 @@ impl Harness {
         F: FnOnce() -> String,
     {
         if ok {
-            println!("ok {name}");
-        } else {
-            let d = diag();
-            if d.is_empty() {
-                println!("not ok {name}");
-            } else {
-                println!("not ok {name} - {d}");
-            }
-            self.inner.failures.set(self.inner.failures.get() + 1);
+            return;
         }
+        let d = diag();
+        if d.is_empty() {
+            println!("not ok {name}");
+        } else {
+            println!("not ok {name} - {d}");
+        }
+        self.inner.failures.set(self.inner.failures.get() + 1);
         let _ = std::io::stdout().flush();
     }
 
@@ -461,6 +460,27 @@ impl Harness {
     pub fn check_skip(&self, name: &str, reason: &str) {
         println!("ok {name} # SKIP {reason}");
         let _ = std::io::stdout().flush();
+    }
+
+    /// Begin capturing stderr output. Returns a [`StderrCapture`] that,
+    /// when finished, yields the captured bytes as a string. Use this to
+    /// detect `windows-reactor:` diagnostic warnings emitted by the
+    /// backend's `eprintln!` calls.
+    #[allow(clippy::unused_self)]
+    pub fn capture_stderr(&self) -> StderrCapture {
+        StderrCapture::start()
+    }
+
+    /// Assert that the captured stderr contains no `windows-reactor:`
+    /// diagnostic lines.
+    pub fn check_no_reactor_warnings(&self, name: &str, captured: &str) {
+        let warnings: Vec<&str> = captured
+            .lines()
+            .filter(|l| l.contains("windows-reactor:"))
+            .collect();
+        self.check_with(name, warnings.is_empty(), || {
+            format!("{} warning(s): {}", warnings.len(), warnings.join("; "))
+        });
     }
 
     /// Emit a free-form TAP diagnostic comment. Useful from driver helpers
@@ -855,4 +875,104 @@ fn window_hwnd(window: &Window) -> Result<HWND> {
     let mut hwnd = HWND(std::ptr::null_mut());
     unsafe { native.WindowHandle(&mut hwnd as *mut HWND).ok()? };
     Ok(hwnd)
+}
+
+// ── Stderr capture ─────────────────────────────────────────────────────
+
+type RawHandle = *mut core::ffi::c_void;
+const STD_ERROR_HANDLE: u32 = 0xFFFF_FFF4; // (DWORD)-12
+
+unsafe extern "system" {
+    fn GetStdHandle(nStdHandle: u32) -> RawHandle;
+    fn SetStdHandle(nStdHandle: u32, hHandle: RawHandle) -> i32;
+    fn CreatePipe(
+        hReadPipe: *mut RawHandle,
+        hWritePipe: *mut RawHandle,
+        lpPipeAttributes: *const core::ffi::c_void,
+        nSize: u32,
+    ) -> i32;
+    fn PeekNamedPipe(
+        hNamedPipe: RawHandle,
+        lpBuffer: *mut core::ffi::c_void,
+        nBufferSize: u32,
+        lpBytesRead: *mut u32,
+        lpTotalBytesAvail: *mut u32,
+        lpBytesLeftThisMessage: *mut u32,
+    ) -> i32;
+    fn ReadFile(
+        hFile: RawHandle,
+        lpBuffer: *mut u8,
+        nNumberOfBytesToRead: u32,
+        lpNumberOfBytesRead: *mut u32,
+        lpOverlapped: *mut core::ffi::c_void,
+    ) -> i32;
+    fn CloseHandle(hObject: RawHandle) -> i32;
+}
+
+/// Captures stderr output by redirecting the Win32 standard error handle
+/// to an anonymous pipe. Rust's `eprintln!` calls `GetStdHandle` on each
+/// write, so `SetStdHandle` is the correct redirection mechanism.
+pub struct StderrCapture {
+    original: RawHandle,
+    write_end: RawHandle,
+    read_end: RawHandle,
+}
+
+impl StderrCapture {
+    pub fn start() -> Self {
+        unsafe {
+            let original = GetStdHandle(STD_ERROR_HANDLE);
+            let mut read_end: RawHandle = core::ptr::null_mut();
+            let mut write_end: RawHandle = core::ptr::null_mut();
+            CreatePipe(&mut read_end, &mut write_end, core::ptr::null(), 0);
+            SetStdHandle(STD_ERROR_HANDLE, write_end);
+            Self {
+                original,
+                write_end,
+                read_end,
+            }
+        }
+    }
+
+    pub fn finish(self) -> String {
+        unsafe {
+            let _ = std::io::stderr().flush();
+            SetStdHandle(STD_ERROR_HANDLE, self.original);
+            CloseHandle(self.write_end);
+
+            let mut buf = vec![0u8; 65536];
+            let mut total = 0usize;
+            loop {
+                let mut avail: u32 = 0;
+                if PeekNamedPipe(
+                    self.read_end,
+                    core::ptr::null_mut(),
+                    0,
+                    core::ptr::null_mut(),
+                    &mut avail,
+                    core::ptr::null_mut(),
+                ) == 0
+                    || avail == 0
+                {
+                    break;
+                }
+                let mut read: u32 = 0;
+                let to_read = avail.min((buf.len() - total) as u32);
+                ReadFile(
+                    self.read_end,
+                    buf.as_mut_ptr().add(total),
+                    to_read,
+                    &mut read,
+                    core::ptr::null_mut(),
+                );
+                total += read as usize;
+                if total >= buf.len() {
+                    break;
+                }
+            }
+            CloseHandle(self.read_end);
+            buf.truncate(total);
+            String::from_utf8_lossy(&buf).into_owned()
+        }
+    }
 }

--- a/crates/tests/libs/reactor_selftest/src/harness.rs
+++ b/crates/tests/libs/reactor_selftest/src/harness.rs
@@ -404,6 +404,25 @@ impl Harness {
         false
     }
 
+    /// Like [`render_until`](Self::render_until), but does not emit a
+    /// diagnostic tree dump on timeout. Use for conditions that are
+    /// expected to time out (e.g. known-flaky WinUI programmatic input).
+    pub async fn render_until_quiet<F>(&self, _label: &str, mut pred: F) -> bool
+    where
+        F: FnMut(&Harness) -> bool,
+    {
+        const MAX_ITERATIONS: u32 = 30;
+        self.render().await;
+        for _ in 0..MAX_ITERATIONS {
+            if pred(self) {
+                return true;
+            }
+            YieldLow::new(self.inner.dispatcher.clone()).await;
+            self.render().await;
+        }
+        pred(self)
+    }
+
     fn is_idle(&self) -> bool {
         self.inner
             .host
@@ -718,22 +737,18 @@ impl Harness {
             return Err(Error::empty());
         };
         let btn = btn.clone();
-        self.report_hresult("set_radio_buttons_selected_index", move || {
-            let element: UIElement = btn.cast()?;
-            let peer = match crate::bindings::FrameworkElementAutomationPeer::FromElement(&element)
-            {
-                Ok(p) => p,
-                Err(_) => {
-                    crate::bindings::FrameworkElementAutomationPeer::CreatePeerForElement(&element)?
-                }
-            };
-            let pattern = peer
-                .cast::<crate::bindings::IAutomationPeer>()?
-                .GetPattern(crate::bindings::PatternInterface::Invoke)?;
-            let invoke: crate::bindings::IInvokeProvider = pattern.cast()?;
-            invoke.Invoke()?;
-            Ok(())
-        })
+        let element: UIElement = btn.cast()?;
+        let peer = match crate::bindings::FrameworkElementAutomationPeer::FromElement(&element) {
+            Ok(p) => p,
+            Err(_) => {
+                crate::bindings::FrameworkElementAutomationPeer::CreatePeerForElement(&element)?
+            }
+        };
+        let pattern = peer
+            .cast::<crate::bindings::IAutomationPeer>()?
+            .GetPattern(crate::bindings::PatternInterface::Invoke)?;
+        let invoke: crate::bindings::IInvokeProvider = pattern.cast()?;
+        invoke.Invoke()
     }
 
     /// Set the selected index on the first ComboBox in the tree.
@@ -924,7 +939,9 @@ impl StderrCapture {
             let original = GetStdHandle(STD_ERROR_HANDLE);
             let mut read_end: RawHandle = core::ptr::null_mut();
             let mut write_end: RawHandle = core::ptr::null_mut();
-            CreatePipe(&mut read_end, &mut write_end, core::ptr::null(), 0);
+            // Use a 1 MB buffer so panic backtraces (RUST_BACKTRACE=1 on CI)
+            // don't fill the pipe and deadlock the write side.
+            CreatePipe(&mut read_end, &mut write_end, core::ptr::null(), 1024 * 1024);
             SetStdHandle(STD_ERROR_HANDLE, write_end);
             Self {
                 original,

--- a/crates/tests/libs/reactor_selftest/src/main.rs
+++ b/crates/tests/libs/reactor_selftest/src/main.rs
@@ -95,7 +95,10 @@ async fn run_all(
         let _ = harness.update_progress(test_index, name);
         let failures_before = harness.failures();
 
+        let capture = harness.capture_stderr();
         f(harness.clone()).await;
+        let stderr = capture.finish();
+        harness.check_no_reactor_warnings(&format!("{name}_NoWarnings"), &stderr);
 
         let passed = harness.failures() == failures_before;
         if !passed {

--- a/crates/tests/libs/reactor_selftest/src/main.rs
+++ b/crates/tests/libs/reactor_selftest/src/main.rs
@@ -95,12 +95,13 @@ async fn run_all(
         let _ = harness.update_progress(test_index, name);
         let failures_before = harness.failures();
 
-        println!("# Running: {name}");
-        let _ = std::io::stdout().flush();
-
         f(harness.clone()).await;
 
         let passed = harness.failures() == failures_before;
+        if !passed {
+            println!("# FAILED: {name}");
+            let _ = std::io::stdout().flush();
+        }
         let _ = harness.mark_fixture_result(idx, passed);
 
         if slow {

--- a/crates/tests/libs/reactor_selftest/src/registry.rs
+++ b/crates/tests/libs/reactor_selftest/src/registry.rs
@@ -50,6 +50,18 @@ pub static FIXTURES: &[(&str, FixtureFn)] = &[
     ("Reconciler_Mount_ScrollView", controls::mount_scroll_view),
     ("Reconciler_Mount_Viewbox", controls::mount_viewbox),
     ("Reconciler_Mount_Button", controls::mount_button),
+    (
+        "Reconciler_Mount_ButtonAccent",
+        controls::mount_button_accent,
+    ),
+    (
+        "Reconciler_Mount_ButtonSubtle",
+        controls::mount_button_subtle,
+    ),
+    (
+        "Reconciler_Mount_ButtonTextLink",
+        controls::mount_button_text_link,
+    ),
     ("Reconciler_Mount_CheckBox", controls::mount_check_box),
     ("Reconciler_Mount_TextField", controls::mount_text_field),
     (


### PR DESCRIPTION
#4548 fixed a specific issue, but the test validation for `windows-reactor` should be able to catch this for all elements. This PR attempts to do just that. 

This then uncovered a remaining expander header bug also fixed in this PR.