### PR TITLE
More `unused_qualifications` libraries

### DIFF
--- a/crates/libs/bindgen/src/lib.rs
+++ b/crates/libs/bindgen/src/lib.rs
@@ -4,6 +4,7 @@
     clippy::enum_variant_names,
     clippy::upper_case_acronyms
 )]
+#![warn(unused_qualifications)]
 
 mod config;
 mod derive;
@@ -1091,7 +1092,7 @@ where
                 expand = false;
             }
             if expand {
-                for args in io::read_file_lines(&arg) {
+                for args in read_file_lines(&arg) {
                     if !args.starts_with("//") {
                         from_string(result, &args);
                     }

--- a/crates/libs/bindgen/src/winmd/mod.rs
+++ b/crates/libs/bindgen/src/winmd/mod.rs
@@ -54,7 +54,7 @@ pub trait GuidAttributeExt {
     fn guid_attribute(&self) -> Option<GUID>;
 }
 
-impl<T: windows_metadata::HasAttributes<'static>> GuidAttributeExt for T {
+impl<T: HasAttributes<'static>> GuidAttributeExt for T {
     fn guid_attribute(&self) -> Option<GUID> {
         self.find_attribute("GuidAttribute").map(|attribute| {
             fn unwrap_u32(value: &Value) -> u32 {

--- a/crates/libs/core/src/array.rs
+++ b/crates/libs/core/src/array.rs
@@ -25,7 +25,7 @@ impl<T: Type<T>> Array<T> {
     pub fn with_len(len: usize) -> Self {
         assert!(len < u32::MAX as usize);
         let bytes_amount = len
-            .checked_mul(core::mem::size_of::<T>())
+            .checked_mul(size_of::<T>())
             .expect("Attempted to allocate too large an Array");
 
         // WinRT arrays must be allocated with `CoTaskMemAlloc`.

--- a/crates/libs/core/src/com_object.rs
+++ b/crates/libs/core/src/com_object.rs
@@ -371,7 +371,7 @@ where
     }
 }
 
-impl<T> core::ops::Deref for StaticComObject<T>
+impl<T> Deref for StaticComObject<T>
 where
     T: ComObjectInner,
 {

--- a/crates/libs/core/src/imp/factory_cache.rs
+++ b/crates/libs/core/src/imp/factory_cache.rs
@@ -81,7 +81,7 @@ pub fn load_factory<C: crate::RuntimeName, I: Interface>() -> crate::Result<I> {
         // If combase hasn't been loaded yet, load it automatically so that this "just works"
         // for apartment-agnostic code, then retry.
         if code == CO_E_NOTINITIALIZED {
-            let mut cookie = core::ptr::null_mut();
+            let mut cookie = null_mut();
             CoIncrementMTAUsage(&mut cookie);
 
             code = get_com_factory();
@@ -148,7 +148,7 @@ unsafe fn delay_load<T>(library: crate::PCSTR, function: crate::PCSTR) -> Option
     unsafe {
         let library = LoadLibraryExA(
             library.0,
-            core::ptr::null_mut(),
+            null_mut(),
             LOAD_LIBRARY_SEARCH_DEFAULT_DIRS,
         );
 
@@ -159,7 +159,7 @@ unsafe fn delay_load<T>(library: crate::PCSTR, function: crate::PCSTR) -> Option
         let address = GetProcAddress(library, function.0);
 
         if address.is_some() {
-            return Some(core::mem::transmute_copy(&address));
+            return Some(transmute_copy(&address));
         }
 
         FreeLibrary(library);

--- a/crates/libs/core/src/lib.rs
+++ b/crates/libs/core/src/lib.rs
@@ -9,6 +9,7 @@
     clippy::missing_transmute_annotations,
     clippy::upper_case_acronyms
 )]
+#![warn(unused_qualifications)]
 
 #[cfg(windows)]
 include!("windows.rs");

--- a/crates/libs/metadata/src/lib.rs
+++ b/crates/libs/metadata/src/lib.rs
@@ -1,5 +1,6 @@
 #![doc = include_str!("../readme.md")]
 #![expect(non_snake_case, non_upper_case_globals, non_camel_case_types)]
+#![warn(unused_qualifications)]
 
 use std::cmp::Ordering;
 use std::collections::*;

--- a/crates/libs/metadata/src/merge/mod.rs
+++ b/crates/libs/metadata/src/merge/mod.rs
@@ -320,7 +320,7 @@ fn write_type(
     }
 }
 
-fn write_attributes<'a, R: reader::HasAttributes<'a>>(
+fn write_attributes<'a, R: HasAttributes<'a>>(
     file: &mut writer::File,
     parent: writer::HasAttribute,
     row: R,
@@ -335,7 +335,7 @@ fn write_attributes<'a, R: reader::HasAttributes<'a>>(
 ///   - If `arch_override` is `Some(bits)` with `bits != 0`, a new
 ///     `SupportedArchitectureAttribute(bits)` is written.
 ///   - If `arch_override` is `Some(0)`, no arch attribute is written (arch-neutral).
-fn write_attributes_with_arch<'a, R: reader::HasAttributes<'a>>(
+fn write_attributes_with_arch<'a, R: HasAttributes<'a>>(
     file: &mut writer::File,
     parent: writer::HasAttribute,
     row: R,

--- a/crates/libs/metadata/src/writer/codes.rs
+++ b/crates/libs/metadata/src/writer/codes.rs
@@ -36,7 +36,7 @@ code! { TypeDefOrRef(2)
 impl Default for TypeDefOrRef {
     fn default() -> Self {
         // This results in an encoded value of zero.
-        TypeDefOrRef::TypeDef(id::TypeDef(u32::MAX))
+        TypeDefOrRef::TypeDef(TypeDef(u32::MAX))
     }
 }
 

--- a/crates/libs/metadata/src/writer/file/blobs.rs
+++ b/crates/libs/metadata/src/writer/file/blobs.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 pub struct Blobs {
-    map: HashMap<Vec<u8>, id::BlobId>,
+    map: HashMap<Vec<u8>, BlobId>,
     stream: Vec<u8>,
 }
 
@@ -15,16 +15,16 @@ impl Default for Blobs {
 }
 
 impl Blobs {
-    pub fn insert(&mut self, value: &[u8]) -> id::BlobId {
+    pub fn insert(&mut self, value: &[u8]) -> BlobId {
         if value.is_empty() {
-            return id::BlobId(0);
+            return BlobId(0);
         }
 
         if let Some(pos) = self.map.get(value) {
             return *pos;
         }
 
-        let pos = id::BlobId(self.stream.len().try_into().unwrap());
+        let pos = BlobId(self.stream.len().try_into().unwrap());
         self.map.insert(value.to_vec(), pos);
         let len = value.len();
 

--- a/crates/libs/metadata/src/writer/file/helpers.rs
+++ b/crates/libs/metadata/src/writer/file/helpers.rs
@@ -32,7 +32,7 @@ impl Write for Vec<u8> {
         unsafe {
             self.extend_from_slice(std::slice::from_raw_parts(
                 value as *const _ as _,
-                core::mem::size_of::<T>(),
+                size_of::<T>(),
             ));
         }
     }

--- a/crates/libs/metadata/src/writer/file/into_stream.rs
+++ b/crates/libs/metadata/src/writer/file/into_stream.rs
@@ -107,14 +107,14 @@ impl File {
         let dos = IMAGE_DOS_HEADER {
             e_magic: IMAGE_DOS_SIGNATURE,
             e_lfarlc: 64,
-            e_lfanew: core::mem::size_of::<IMAGE_DOS_HEADER>() as i32,
+            e_lfanew: size_of::<IMAGE_DOS_HEADER>() as i32,
             ..Default::default()
         };
 
         let file = IMAGE_FILE_HEADER {
             Machine: IMAGE_FILE_MACHINE_I386,
             NumberOfSections: 1,
-            SizeOfOptionalHeader: core::mem::size_of::<IMAGE_OPTIONAL_HEADER32>() as u16,
+            SizeOfOptionalHeader: size_of::<IMAGE_OPTIONAL_HEADER32>() as u16,
             Characteristics: IMAGE_FILE_DLL
                 | IMAGE_FILE_32BIT_MACHINE
                 | IMAGE_FILE_EXECUTABLE_IMAGE,
@@ -152,7 +152,7 @@ impl File {
         };
 
         let mut clr = IMAGE_COR20_HEADER {
-            cb: core::mem::size_of::<IMAGE_COR20_HEADER>() as u32,
+            cb: size_of::<IMAGE_COR20_HEADER>() as u32,
             MajorRuntimeVersion: 2,
             MinorRuntimeVersion: 5,
             Flags: 1,
@@ -174,14 +174,14 @@ impl File {
         type GuidsHeader = STREAM_HEADER<8>;
         type BlobsHeader = STREAM_HEADER<8>;
 
-        let size_of_stream_headers = core::mem::size_of::<TablesHeader>()
-            + core::mem::size_of::<StringsHeader>()
-            + core::mem::size_of::<GuidsHeader>()
-            + core::mem::size_of::<BlobsHeader>();
+        let size_of_stream_headers = size_of::<TablesHeader>()
+            + size_of::<StringsHeader>()
+            + size_of::<GuidsHeader>()
+            + size_of::<BlobsHeader>();
 
         let size_of_image = optional.FileAlignment as usize
-            + core::mem::size_of::<IMAGE_COR20_HEADER>()
-            + core::mem::size_of::<METADATA_HEADER>()
+            + size_of::<IMAGE_COR20_HEADER>()
+            + size_of::<METADATA_HEADER>()
             + size_of_stream_headers
             + size_of_streams;
 
@@ -202,15 +202,14 @@ impl File {
         optional.DataDirectory[IMAGE_DIRECTORY_ENTRY_COM_DESCRIPTOR as usize] =
             IMAGE_DATA_DIRECTORY {
                 VirtualAddress: SECTION_ALIGNMENT,
-                Size: core::mem::size_of::<IMAGE_COR20_HEADER>() as u32,
+                Size: size_of::<IMAGE_COR20_HEADER>() as u32,
             };
 
         section.PointerToRawData = optional.FileAlignment;
 
-        clr.MetaData.VirtualAddress =
-            SECTION_ALIGNMENT + core::mem::size_of::<IMAGE_COR20_HEADER>() as u32;
+        clr.MetaData.VirtualAddress = SECTION_ALIGNMENT + size_of::<IMAGE_COR20_HEADER>() as u32;
 
-        clr.MetaData.Size = virtual_size - core::mem::size_of::<IMAGE_COR20_HEADER>() as u32;
+        clr.MetaData.Size = virtual_size - size_of::<IMAGE_COR20_HEADER>() as u32;
 
         let mut buffer = Vec::<u8>::new();
         buffer.write_header(&dos);

--- a/crates/libs/metadata/src/writer/file/mod.rs
+++ b/crates/libs/metadata/src/writer/file/mod.rs
@@ -18,14 +18,14 @@ pub struct File {
     strings: Strings,
     blobs: Blobs,
     records: rec::Records,
-    reference: Option<crate::reader::Index>,
+    reference: Option<reader::Index>,
 
     // Indexes for fast lookup of preexisting rows.
-    TypeRef: HashMap<String, HashMap<String, id::TypeRef>>,
-    TypeSpec: HashMap<id::BlobId, id::TypeSpec>,
-    AssemblyRef: HashMap<String, id::AssemblyRef>,
-    ModuleRef: HashMap<String, id::ModuleRef>,
-    MemberRef: HashMap<rec::MemberRef, id::MemberRef>,
+    TypeRef: HashMap<String, HashMap<String, TypeRef>>,
+    TypeSpec: HashMap<BlobId, TypeSpec>,
+    AssemblyRef: HashMap<String, AssemblyRef>,
+    ModuleRef: HashMap<String, ModuleRef>,
+    MemberRef: HashMap<rec::MemberRef, MemberRef>,
 
     // Staging for sorted rows before these records can be written. BTreeMap is used rather than HashMap to allow reproducible builds.
     Constant: BTreeMap<HasConstant, rec::Constant>,
@@ -68,21 +68,21 @@ impl File {
 
     /// Sets the reference `Index` used to resolve whether a `TypeRef` refers to a type
     /// defined locally in this file or in an external assembly.
-    pub fn set_reference(&mut self, reference: crate::reader::Index) {
+    pub fn set_reference(&mut self, reference: reader::Index) {
         self.reference = Some(reference);
     }
 
     /// Returns the reference `Index`, if one has been set via [`Self::set_reference`].
-    pub fn reference(&self) -> Option<&crate::reader::Index> {
+    pub fn reference(&self) -> Option<&reader::Index> {
         self.reference.as_ref()
     }
 
-    fn ModuleRef(&mut self, name: &str) -> id::ModuleRef {
+    fn ModuleRef(&mut self, name: &str) -> ModuleRef {
         if let Some(pos) = self.ModuleRef.get(name) {
             return *pos;
         }
 
-        let pos = id::ModuleRef(self.records.ModuleRef.push_pos(rec::ModuleRef {
+        let pos = ModuleRef(self.records.ModuleRef.push_pos(rec::ModuleRef {
             Name: self.strings.insert(name),
         }));
 
@@ -92,7 +92,7 @@ impl File {
 
     pub fn ImplMap(
         &mut self,
-        method: id::MethodDef,
+        method: MethodDef,
         flags: PInvokeAttributes,
         import_name: &str,
         import_scope: &str,
@@ -108,12 +108,12 @@ impl File {
     }
 
     /// Adds an `AssemblyRef` row for the given assembly name, returning the row offset.
-    fn AssemblyRef(&mut self, assembly_name: &str) -> id::AssemblyRef {
+    fn AssemblyRef(&mut self, assembly_name: &str) -> AssemblyRef {
         if let Some(pos) = self.AssemblyRef.get(assembly_name) {
             return *pos;
         }
 
-        let pos = id::AssemblyRef(if assembly_name == "System" {
+        let pos = AssemblyRef(if assembly_name == "System" {
             self.records.AssemblyRef.push_pos(rec::AssemblyRef {
                 Name: self.strings.insert("mscorlib"),
                 MajorVersion: 4,
@@ -145,8 +145,8 @@ impl File {
         name: &str,
         extends: TypeDefOrRef,
         flags: TypeAttributes,
-    ) -> id::TypeDef {
-        id::TypeDef(self.records.TypeDef.push_pos(rec::TypeDef {
+    ) -> TypeDef {
+        TypeDef(self.records.TypeDef.push_pos(rec::TypeDef {
             TypeName: self.strings.insert(name),
             TypeNamespace: self.strings.insert(namespace),
             Flags: flags,
@@ -157,7 +157,7 @@ impl File {
     }
 
     /// Adds a `TypeRef` row to the file, returning the row offset.
-    pub fn TypeRef(&mut self, namespace: &str, name: &str) -> id::TypeRef {
+    pub fn TypeRef(&mut self, namespace: &str, name: &str) -> TypeRef {
         if let Some(key) = self.TypeRef.get(namespace) {
             if let Some(pos) = key.get(name) {
                 return *pos;
@@ -166,7 +166,7 @@ impl File {
 
         let pos = if let Some((parent, leaf)) = name.rsplit_once('/') {
             let enclosing = self.TypeRef(namespace, parent);
-            id::TypeRef(self.records.TypeRef.push_pos(rec::TypeRef {
+            TypeRef(self.records.TypeRef.push_pos(rec::TypeRef {
                 TypeName: self.strings.insert(leaf),
                 TypeNamespace: self.strings.insert(""),
                 ResolutionScope: ResolutionScope::TypeRef(enclosing),
@@ -183,10 +183,10 @@ impl File {
             } else if namespace == "System" {
                 ResolutionScope::AssemblyRef(self.AssemblyRef("System"))
             } else {
-                ResolutionScope::Module(id::Module(0))
+                ResolutionScope::Module(Module(0))
             };
 
-            id::TypeRef(self.records.TypeRef.push_pos(rec::TypeRef {
+            TypeRef(self.records.TypeRef.push_pos(rec::TypeRef {
                 TypeName: self.strings.insert(name),
                 TypeNamespace: self.strings.insert(namespace),
                 ResolutionScope: scope,
@@ -201,7 +201,7 @@ impl File {
         pos
     }
 
-    pub fn TypeSpec(&mut self, namespace: &str, name: &str, generics: &[Type]) -> id::TypeSpec {
+    pub fn TypeSpec(&mut self, namespace: &str, name: &str, generics: &[Type]) -> TypeSpec {
         debug_assert!(!generics.is_empty());
         // Generic type references use the backtick-suffix convention per ECMA-335 §II.10.7.2.
         let name = format!("{name}`{}", generics.len());
@@ -223,7 +223,7 @@ impl File {
             return *pos;
         }
 
-        let pos = id::TypeSpec(self.records.TypeSpec.push_pos(rec::TypeSpec {
+        let pos = TypeSpec(self.records.TypeSpec.push_pos(rec::TypeSpec {
             Signature: signature,
         }));
         self.TypeSpec.insert(signature, pos);
@@ -231,10 +231,10 @@ impl File {
     }
 
     /// Adds a `Field` row to the file, returning the row offset.
-    pub fn Field(&mut self, name: &str, ty: &Type, flags: FieldAttributes) -> id::Field {
+    pub fn Field(&mut self, name: &str, ty: &Type, flags: FieldAttributes) -> Field {
         let signature = self.FieldSig(ty);
 
-        id::Field(self.records.Field.push_pos(rec::Field {
+        Field(self.records.Field.push_pos(rec::Field {
             Name: self.strings.insert(name),
             Flags: flags,
             Signature: signature,
@@ -248,10 +248,10 @@ impl File {
         signature: &Signature,
         flags: MethodAttributes,
         impl_flags: MethodImplAttributes,
-    ) -> id::MethodDef {
+    ) -> MethodDef {
         let signature = self.MethodDefSig(signature);
 
-        id::MethodDef(self.records.MethodDef.push_pos(rec::MethodDef {
+        MethodDef(self.records.MethodDef.push_pos(rec::MethodDef {
             RVA: 0,
             ImplFlags: impl_flags,
             Flags: flags,
@@ -266,7 +266,7 @@ impl File {
         name: &str,
         signature: &Signature,
         parent: MemberRefParent,
-    ) -> id::MemberRef {
+    ) -> MemberRef {
         let signature = self.MethodDefSig(signature);
 
         let record = rec::MemberRef {
@@ -279,14 +279,14 @@ impl File {
             return *pos;
         }
 
-        let pos = id::MemberRef(self.records.MemberRef.push_pos(record));
+        let pos = MemberRef(self.records.MemberRef.push_pos(record));
         self.MemberRef.insert(record, pos);
         pos
     }
 
     /// Adds a `Param` row to the file, returning the row offset.
-    pub fn Param(&mut self, name: &str, sequence: u16, flags: ParamAttributes) -> id::Param {
-        id::Param(self.records.Param.push_pos(rec::Param {
+    pub fn Param(&mut self, name: &str, sequence: u16, flags: ParamAttributes) -> Param {
+        Param(self.records.Param.push_pos(rec::Param {
             Flags: flags,
             Sequence: sequence,
             Name: self.strings.insert(name),
@@ -344,7 +344,7 @@ impl File {
             });
     }
 
-    pub fn ClassLayout(&mut self, parent: id::TypeDef, packing_size: u16, class_size: u32) {
+    pub fn ClassLayout(&mut self, parent: TypeDef, packing_size: u16, class_size: u32) {
         self.records.ClassLayout.push(rec::ClassLayout {
             PackingSize: packing_size,
             ClassSize: class_size,
@@ -352,14 +352,14 @@ impl File {
         });
     }
 
-    pub fn FieldLayout(&mut self, field: id::Field, offset: u32) {
+    pub fn FieldLayout(&mut self, field: Field, offset: u32) {
         self.records.FieldLayout.push(rec::FieldLayout {
             Offset: offset,
             Field: field.0,
         });
     }
 
-    pub fn NestedClass(&mut self, inner: id::TypeDef, outer: id::TypeDef) {
+    pub fn NestedClass(&mut self, inner: TypeDef, outer: TypeDef) {
         debug_assert!(inner.0 > outer.0);
 
         self.records.NestedClass.push(rec::NestedClass {
@@ -368,7 +368,7 @@ impl File {
         });
     }
 
-    pub fn InterfaceImpl(&mut self, class: id::TypeDef, interface: &Type) -> id::InterfaceImpl {
+    pub fn InterfaceImpl(&mut self, class: TypeDef, interface: &Type) -> InterfaceImpl {
         let Type::ClassName(interface) = interface else {
             panic!("invalid interface type");
         };
@@ -383,7 +383,7 @@ impl File {
             ))
         };
 
-        id::InterfaceImpl(self.records.InterfaceImpl.push_pos(rec::InterfaceImpl {
+        InterfaceImpl(self.records.InterfaceImpl.push_pos(rec::InterfaceImpl {
             Class: class,
             Interface: interface,
         }))
@@ -505,14 +505,14 @@ impl File {
     }
 
     /// Writes the `Type` into a `FileSig` buffer and stores it in the file, returning the blob offset.
-    fn FieldSig(&mut self, ty: &Type) -> id::BlobId {
+    fn FieldSig(&mut self, ty: &Type) -> BlobId {
         let mut buffer = vec![0x6]; // FIELD
         self.Type(ty, &mut buffer);
         self.blobs.insert(&buffer)
     }
 
     /// Writes the method signature into a `MethodDefSig` buffer and stores it in the file, returning the blob offset.
-    fn MethodDefSig(&mut self, signature: &Signature) -> id::BlobId {
+    fn MethodDefSig(&mut self, signature: &Signature) -> BlobId {
         let mut buffer = vec![signature.flags.0];
         buffer.write_compressed(signature.types.len());
         self.Type(&signature.return_type, &mut buffer);
@@ -524,13 +524,13 @@ impl File {
         self.blobs.insert(&buffer)
     }
 
-    fn ConstantValue(&mut self, value: &Value) -> id::BlobId {
+    fn ConstantValue(&mut self, value: &Value) -> BlobId {
         let mut buffer = vec![];
         buffer.write_value(value);
         self.blobs.insert(&buffer)
     }
 
-    fn AttributeValue(&mut self, values: &[(String, Value)]) -> id::BlobId {
+    fn AttributeValue(&mut self, values: &[(String, Value)]) -> BlobId {
         let mut buffer = vec![];
         buffer.write_u16(1); // prolog
 

--- a/crates/libs/metadata/src/writer/file/rec.rs
+++ b/crates/libs/metadata/src/writer/file/rec.rs
@@ -24,7 +24,7 @@ pub struct Records {
 }
 
 pub struct TypeSpec {
-    pub Signature: id::BlobId,
+    pub Signature: BlobId,
 }
 
 pub struct NestedClass {
@@ -33,7 +33,7 @@ pub struct NestedClass {
 }
 
 pub struct ModuleRef {
-    pub Name: id::StringId,
+    pub Name: StringId,
 }
 
 #[derive(Default)]
@@ -45,7 +45,7 @@ pub struct Assembly {
     pub RevisionNumber: u16,
     pub Flags: AssemblyFlags,
     pub PublicKey: u32,
-    pub Name: id::StringId,
+    pub Name: StringId,
     pub Culture: u32,
 }
 
@@ -58,7 +58,7 @@ pub struct InterfaceImpl {
 pub struct ImplMap {
     pub MappingFlags: PInvokeAttributes,
     pub MemberForwarded: MemberForwarded,
-    pub ImportName: id::StringId,
+    pub ImportName: StringId,
     pub ImportScope: id::ModuleRef,
 }
 
@@ -69,8 +69,8 @@ pub struct AssemblyRef {
     pub BuildNumber: u16,
     pub RevisionNumber: u16,
     pub Flags: AssemblyFlags,
-    pub PublicKeyOrToken: id::BlobId,
-    pub Name: id::StringId,
+    pub PublicKeyOrToken: BlobId,
+    pub Name: StringId,
     pub Culture: u32,
     pub HashValue: u32,
 }
@@ -85,13 +85,13 @@ pub struct ClassLayout {
 pub struct Constant {
     pub Type: u8,
     pub Parent: HasConstant,
-    pub Value: id::BlobId,
+    pub Value: BlobId,
 }
 
 pub struct Field {
     pub Flags: FieldAttributes,
-    pub Name: id::StringId,
-    pub Signature: id::BlobId,
+    pub Name: StringId,
+    pub Signature: BlobId,
 }
 
 pub struct FieldLayout {
@@ -103,15 +103,15 @@ pub struct MethodDef {
     pub RVA: u32,
     pub ImplFlags: MethodImplAttributes,
     pub Flags: MethodAttributes,
-    pub Name: id::StringId,
-    pub Signature: id::BlobId,
+    pub Name: StringId,
+    pub Signature: BlobId,
     pub ParamList: u32,
 }
 
 #[derive(Default)]
 pub struct Module {
     pub Generation: u16,
-    pub Name: id::StringId,
+    pub Name: StringId,
     pub Mvid: u32,
     pub EncId: u32,
     pub EncBaseId: u32,
@@ -122,19 +122,19 @@ pub struct GenericParam {
     pub Number: u16,
     pub Flags: GenericParamAttributes,
     pub Owner: TypeOrMethodDef,
-    pub Name: id::StringId,
+    pub Name: StringId,
 }
 
 pub struct Param {
     pub Flags: ParamAttributes,
     pub Sequence: u16,
-    pub Name: id::StringId,
+    pub Name: StringId,
 }
 
 pub struct TypeDef {
     pub Flags: TypeAttributes,
-    pub TypeName: id::StringId,
-    pub TypeNamespace: id::StringId,
+    pub TypeName: StringId,
+    pub TypeNamespace: StringId,
     pub Extends: TypeDefOrRef,
     pub FieldList: u32,
     pub MethodList: u32,
@@ -142,22 +142,22 @@ pub struct TypeDef {
 
 pub struct TypeRef {
     pub ResolutionScope: ResolutionScope,
-    pub TypeName: id::StringId,
-    pub TypeNamespace: id::StringId,
+    pub TypeName: StringId,
+    pub TypeNamespace: StringId,
 }
 
 #[derive(Copy, Clone)]
 pub struct Attribute {
     pub Parent: HasAttribute,
     pub Type: AttributeType,
-    pub Value: id::BlobId,
+    pub Value: BlobId,
 }
 
 #[derive(Hash, PartialEq, Eq, Copy, Clone)]
 pub struct MemberRef {
     pub Parent: MemberRefParent,
-    pub Name: id::StringId,
-    pub Signature: id::BlobId,
+    pub Name: StringId,
+    pub Signature: BlobId,
 }
 
 impl Records {

--- a/crates/libs/metadata/src/writer/file/strings.rs
+++ b/crates/libs/metadata/src/writer/file/strings.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 pub struct Strings {
-    map: HashMap<String, id::StringId>,
+    map: HashMap<String, StringId>,
     stream: Vec<u8>,
 }
 
@@ -15,16 +15,16 @@ impl Default for Strings {
 }
 
 impl Strings {
-    pub fn insert(&mut self, value: &str) -> id::StringId {
+    pub fn insert(&mut self, value: &str) -> StringId {
         if value.is_empty() {
-            return id::StringId(0);
+            return StringId(0);
         }
 
         if let Some(pos) = self.map.get(value) {
             return *pos;
         }
 
-        let pos = id::StringId(self.stream.len().try_into().unwrap());
+        let pos = StringId(self.stream.len().try_into().unwrap());
         self.map.insert(value.to_string(), pos);
         self.stream.extend_from_slice(value.as_bytes());
         self.stream.push(0);

--- a/crates/libs/rdl/src/clang/cx.rs
+++ b/crates/libs/rdl/src/clang/cx.rs
@@ -6,8 +6,7 @@ pub struct Library;
 
 impl Library {
     pub fn new() -> Result<Self, Error> {
-        clang_sys::load()
-            .map_err(|e| Error::new(&format!("failed to load libclang: {e}"), "", 0, 0))?;
+        load().map_err(|e| Error::new(&format!("failed to load libclang: {e}"), "", 0, 0))?;
         Ok(Self)
     }
 
@@ -19,7 +18,7 @@ impl Library {
 
 impl Drop for Library {
     fn drop(&mut self) {
-        _ = clang_sys::unload();
+        _ = unload();
     }
 }
 

--- a/crates/libs/rdl/src/clang/mod.rs
+++ b/crates/libs/rdl/src/clang/mod.rs
@@ -751,7 +751,7 @@ fn matches_filter(file: &str, filter: &str) -> bool {
 ///
 /// Handles `const GUID`, `const IID`, `const struct _GUID`, elaborated types,
 /// and typedef aliases for `GUID`/`IID`.
-fn is_guid_type(ty: &cx::Type) -> bool {
+fn is_guid_type(ty: &Type) -> bool {
     // Peel off any top-level const qualifier by looking at the canonical type.
     let name = match ty.kind() {
         CXType_Elaborated => ty.underlying_type().ty().name(),

--- a/crates/libs/rdl/src/clang/struct.rs
+++ b/crates/libs/rdl/src/clang/struct.rs
@@ -85,7 +85,7 @@ impl Struct {
         };
 
         let packed_attr = if let Some(packing) = self.packing {
-            let size = proc_macro2::Literal::u16_unsuffixed(packing);
+            let size = Literal::u16_unsuffixed(packing);
             quote! { #[packed(#size)] }
         } else {
             quote! {}

--- a/crates/libs/rdl/src/lib.rs
+++ b/crates/libs/rdl/src/lib.rs
@@ -1,4 +1,5 @@
 #![doc = include_str!("../readme.md")]
+#![warn(unused_qualifications)]
 
 mod clang;
 mod error;

--- a/crates/libs/rdl/src/reader/mod.rs
+++ b/crates/libs/rdl/src/reader/mod.rs
@@ -277,7 +277,7 @@ fn resolve_winrt(item: &mut Item, source_file: &str, parent: Option<bool>) -> Re
     Ok(())
 }
 
-fn read_winrt_expected<S: syn::spanned::Spanned>(
+fn read_winrt_expected<S: Spanned>(
     source_file: &str,
     span: &S,
     attrs: &[syn::Attribute],
@@ -297,7 +297,7 @@ fn read_winrt_expected<S: syn::spanned::Spanned>(
     }
 }
 
-fn read_winrt<S: syn::spanned::Spanned>(
+fn read_winrt<S: Spanned>(
     source_file: &str,
     span: &S,
     attrs: &[syn::Attribute],
@@ -391,13 +391,13 @@ struct Encoder<'a> {
 }
 
 impl Encoder<'_> {
-    fn error<S: syn::spanned::Spanned>(&self, spanned: S, message: &str) -> Error {
+    fn error<S: Spanned>(&self, spanned: S, message: &str) -> Error {
         let start = spanned.span().start();
 
         Error::new(message, &self.file.source, start.line, start.column)
     }
 
-    fn err<T, S: syn::spanned::Spanned>(&self, spanned: S, message: &str) -> Result<T, Error> {
+    fn err<T, S: Spanned>(&self, spanned: S, message: &str) -> Result<T, Error> {
         Err(self.error(spanned, message))
     }
 
@@ -867,7 +867,7 @@ impl Encoder<'_> {
     /// or anywhere else.  Primitive types and generic type parameters are always valid.
     /// Named types (structs, enums, interfaces, …) are checked against the local index
     /// first, then against any loaded reference metadata.
-    fn validate_type_is_winrt<S: syn::spanned::Spanned + quote::ToTokens>(
+    fn validate_type_is_winrt<S: Spanned + quote::ToTokens>(
         &self,
         span: &S,
         ty: &metadata::Type,

--- a/crates/libs/rdl/src/reader/struct.rs
+++ b/crates/libs/rdl/src/reader/struct.rs
@@ -3,7 +3,7 @@ use super::*;
 #[derive(Debug, Clone)]
 pub struct Struct {
     pub attrs: Vec<syn::Attribute>,
-    pub span: proc_macro2::Span,
+    pub span: Span,
     pub name: syn::Ident,
     pub fields: Vec<Field>,
     pub winrt: bool,

--- a/crates/libs/rdl/src/writer/interface.rs
+++ b/crates/libs/rdl/src/writer/interface.rs
@@ -63,7 +63,7 @@ fn write_members(
     let count = methods.len();
     let mut consumed = vec![false; count];
     let mut tokens = Vec::with_capacity(count);
-    let event_kw = proc_macro2::Ident::new("event", proc_macro2::Span::call_site());
+    let event_kw = proc_macro2::Ident::new("event", Span::call_site());
 
     for i in 0..count {
         if consumed[i] {

--- a/crates/libs/rdl/src/writer/mod.rs
+++ b/crates/libs/rdl/src/writer/mod.rs
@@ -797,12 +797,12 @@ fn guid_output(
         return Ok(GuidOutput::None);
     };
     let stored = extract_guid_from_attribute(attr)?;
-    let s = crate::reader::guid::build_interface_string(
+    let s = reader::guid::build_interface_string(
         item.namespace(),
         metadata::trim_tick(item.name()),
         methods,
     );
-    let derived = crate::reader::guid::guid_from_interface_string(&s);
+    let derived = reader::guid::guid_from_interface_string(&s);
     if stored == derived {
         Ok(GuidOutput::Omit)
     } else {

--- a/crates/libs/rdl/src/writer/struct.rs
+++ b/crates/libs/rdl/src/writer/struct.rs
@@ -226,7 +226,7 @@ fn write_packed_attr(item: &metadata::reader::TypeDef) -> TokenStream {
 /// token stream when `packing` is `None`.
 fn write_packed_attr_value(packing: Option<u16>) -> TokenStream {
     if let Some(size) = packing {
-        let size_literal = proc_macro2::Literal::u16_unsuffixed(size);
+        let size_literal = Literal::u16_unsuffixed(size);
         return quote! { #[packed(#size_literal)] };
     }
     quote! {}

--- a/crates/libs/reactor-setup/src/lib.rs
+++ b/crates/libs/reactor-setup/src/lib.rs
@@ -1,3 +1,4 @@
+#![warn(unused_qualifications)]
 use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};


### PR DESCRIPTION
Following #4551 this update adds the lint to `windows-rdl`, `windows-bindgen`, and `windows-metadata`. 