### PR TITLE
`windows-reactor` simpler backend and test coverage

### DIFF
--- a/crates/libs/reactor/src/winui/backend/convert.rs
+++ b/crates/libs/reactor/src/winui/backend/convert.rs
@@ -2,8 +2,7 @@
 //! the underlying `Microsoft.UI.Xaml` types. These are free functions
 //! that touch neither `WinUIBackend` state nor the `Handle` enum — see
 //! `winui/backend/mod.rs` for the dispatch tables and `Handle`-aware
-//! helpers (`apply_theme_brush`, `panel_children_vec`,
-//! `content_control_for`).
+//! helpers.
 
 use windows_core::Interface;
 
@@ -143,15 +142,6 @@ pub(super) fn string_as_textblock(s: &str) -> windows_core::Result<Xaml::TextBlo
     let tb = Xaml::TextBlock::new()?;
     tb.put_Text(s)?;
     Ok(tb)
-}
-
-pub(super) fn ui_element_collection_move(coll: &Xaml::UIElementCollection, from: usize, to: usize) {
-    let v = coll
-        .cast::<windows_collections::IVector<Xaml::UIElement>>()
-        .unwrap();
-    let item = v.GetAt(from as u32).unwrap();
-    v.RemoveAt(from as u32).unwrap();
-    v.InsertAt(to as u32, &item).unwrap();
 }
 
 pub(super) fn build_nav_view_item(

--- a/crates/libs/reactor/src/winui/backend/mod.rs
+++ b/crates/libs/reactor/src/winui/backend/mod.rs
@@ -306,46 +306,10 @@ impl WinUIBackend {
             .get(&child)
             .unwrap_or_else(|| panic!("WinUIBackend::visual_insert_at: unknown child {child}"));
         let child_ui = child_h.as_ui_element();
-        match parent_h {
-            Handle::StackPanel(_) | Handle::Grid(_) | Handle::Canvas(_) => {
-                let vec = panel_children_vec(parent_h).unwrap();
-                vec.InsertAt(v_index as u32, &child_ui).unwrap();
-            }
-            Handle::Border(b) => {
-                b.put_Child(&child_ui).unwrap();
-            }
-            Handle::Viewbox(v) => {
-                v.put_Child(&child_ui).unwrap();
-            }
-            Handle::ScrollViewer(_)
-            | Handle::Expander(_)
-            | Handle::TabViewItem(_)
-            | Handle::NavigationView(_)
-            | Handle::PivotItem(_) => {
-                let cc = content_control_for(parent_h).unwrap();
-                cc.put_Content(&child_ui).unwrap();
-            }
-            Handle::ScrollView(sv) => {
-                sv.put_Content(&child_ui).unwrap();
-            }
-            Handle::TabView(tv) => {
-                let items = tv.get_TabItems().unwrap();
-                let insp: windows_core::IInspectable = child_ui.cast().unwrap();
-                items.InsertAt(v_index as u32, &insp).unwrap();
-            }
-            Handle::Pivot(p) => {
-                let items = p
-                    .cast::<Xaml::IItemsControl>()
-                    .unwrap()
-                    .get_Items()
-                    .unwrap()
-                    .cast::<windows_collections::IVector<windows_core::IInspectable>>()
-                    .unwrap();
-                let insp: windows_core::IInspectable = child_ui.cast().unwrap();
-                items.InsertAt(v_index as u32, &insp).unwrap();
-            }
-            _ => panic!("WinUIBackend::visual_insert_at: {parent} is not a container"),
-        }
+        let cc = classify_container(parent_h).unwrap_or_else(|| {
+            panic!("WinUIBackend::visual_insert_at: {parent} is not a container")
+        });
+        container_insert(&cc, v_index, &child_ui);
     }
     /// Remove the child at visual index `v_index`. Logical mirror is NOT touched.
     fn visual_remove_at(&self, parent: ControlId, v_index: usize) {
@@ -353,50 +317,10 @@ impl WinUIBackend {
         let parent_h = map
             .get(&parent)
             .unwrap_or_else(|| panic!("WinUIBackend::visual_remove_at: unknown parent {parent}"));
-        match parent_h {
-            Handle::StackPanel(_) | Handle::Grid(_) | Handle::Canvas(_) => {
-                if let Some(vec) = panel_children_vec(parent_h) {
-                    vec.RemoveAt(v_index as u32).unwrap();
-                }
-            }
-            Handle::Border(b) => {
-                debug_assert_eq!(v_index, 0);
-                b.put_Child(None).unwrap();
-            }
-            Handle::Viewbox(v) => {
-                debug_assert_eq!(v_index, 0);
-                v.put_Child(None).unwrap();
-            }
-            Handle::ScrollViewer(_)
-            | Handle::Expander(_)
-            | Handle::TabViewItem(_)
-            | Handle::NavigationView(_)
-            | Handle::PivotItem(_) => {
-                debug_assert_eq!(v_index, 0);
-                if let Some(cc) = content_control_for(parent_h) {
-                    cc.put_Content(None).unwrap();
-                }
-            }
-            Handle::ScrollView(sv) => {
-                debug_assert_eq!(v_index, 0);
-                sv.put_Content(None).unwrap();
-            }
-            Handle::TabView(tv) => {
-                let items = tv.get_TabItems().unwrap();
-                items.RemoveAt(v_index as u32).unwrap();
-            }
-            Handle::Pivot(p) => {
-                let items = p
-                    .cast::<Xaml::IItemsControl>()
-                    .unwrap()
-                    .get_Items()
-                    .unwrap()
-                    .cast::<windows_collections::IVector<windows_core::IInspectable>>()
-                    .unwrap();
-                items.RemoveAt(v_index as u32).unwrap();
-            }
-            _ => panic!("WinUIBackend::visual_remove_at: {parent} is not a container"),
-        }
+        let cc = classify_container(parent_h).unwrap_or_else(|| {
+            panic!("WinUIBackend::visual_remove_at: {parent} is not a container")
+        });
+        container_remove(&cc, v_index);
     }
     /// In-place replace the child at visual index `v_index`. Caller
     /// must ensure `new` is non-phantom; logical mirror is NOT touched.
@@ -409,72 +333,184 @@ impl WinUIBackend {
             .get(&new)
             .unwrap_or_else(|| panic!("WinUIBackend::visual_set_at: unknown new {new}"));
         let new_ui = new_h.as_ui_element();
-        match parent_h {
-            Handle::StackPanel(_) | Handle::Grid(_) | Handle::Canvas(_) => {
-                let vec = panel_children_vec(parent_h).unwrap();
-                vec.SetAt(v_index as u32, &new_ui).unwrap();
-            }
-            Handle::Border(b) => {
-                b.put_Child(&new_ui).unwrap();
-            }
-            Handle::Viewbox(v) => {
-                v.put_Child(&new_ui).unwrap();
-            }
-            Handle::ScrollViewer(_)
-            | Handle::Expander(_)
-            | Handle::TabViewItem(_)
-            | Handle::NavigationView(_)
-            | Handle::PivotItem(_) => {
-                let cc = content_control_for(parent_h).unwrap();
-                cc.put_Content(&new_ui).unwrap();
-            }
-            Handle::ScrollView(sv) => {
-                sv.put_Content(&new_ui).unwrap();
-            }
-            Handle::TabView(tv) => {
-                let items = tv.get_TabItems().unwrap();
-                let insp: windows_core::IInspectable = new_ui.cast().unwrap();
-                items.SetAt(v_index as u32, &insp).unwrap();
-            }
-            Handle::Pivot(p) => {
-                let items = p
-                    .cast::<Xaml::IItemsControl>()
-                    .unwrap()
-                    .get_Items()
-                    .unwrap()
-                    .cast::<windows_collections::IVector<windows_core::IInspectable>>()
-                    .unwrap();
-                let insp: windows_core::IInspectable = new_ui.cast().unwrap();
-                items.SetAt(v_index as u32, &insp).unwrap();
-            }
-            _ => panic!("WinUIBackend::visual_set_at: {parent} is not a container"),
+        let cc = classify_container(parent_h)
+            .unwrap_or_else(|| panic!("WinUIBackend::visual_set_at: {parent} is not a container"));
+        container_set(&cc, v_index, &new_ui);
+    }
+}
+
+/// Classification of container handles for child-tree operations.
+/// Every container variant falls into one of these shapes, which
+/// determines how children are appended, removed, moved, etc.
+enum ContainerChildren<'a> {
+    /// Multi-child panel (StackPanel, Grid, Canvas, RelativePanel) backed
+    /// by `IPanel::Children` — a `UIElementCollection` (IVector<UIElement>).
+    Panel(windows_collections::IVector<Xaml::UIElement>),
+    /// Single-child container (Border, Viewbox) that uses `put_Child`.
+    SingleChild(&'a Handle),
+    /// Single-child `IContentControl` (ScrollViewer, Expander,
+    /// TabViewItem, NavigationView, PivotItem).
+    ContentControl(Xaml::IContentControl),
+    /// Single-child container that has a direct `put_Content` method but
+    /// does not implement `IContentControl` (ScrollView, SplitView).
+    DirectContent(&'a Handle),
+    /// IVector<IInspectable>-backed multi-child (TabView, Pivot).
+    InspectableVector(windows_collections::IVector<windows_core::IInspectable>),
+}
+
+/// Classify a `Handle` into its container shape. Returns `None` when the
+/// handle does not support children.
+fn classify_container(h: &Handle) -> Option<ContainerChildren<'_>> {
+    match h {
+        Handle::StackPanel(s) => Some(ContainerChildren::Panel(
+            s.cast::<Xaml::IPanel>()
+                .ok()?
+                .get_Children()
+                .ok()?
+                .cast()
+                .ok()?,
+        )),
+        Handle::Grid(g) => Some(ContainerChildren::Panel(
+            g.cast::<Xaml::IPanel>()
+                .ok()?
+                .get_Children()
+                .ok()?
+                .cast()
+                .ok()?,
+        )),
+        Handle::Canvas(c) => Some(ContainerChildren::Panel(
+            c.cast::<Xaml::IPanel>()
+                .ok()?
+                .get_Children()
+                .ok()?
+                .cast()
+                .ok()?,
+        )),
+        Handle::RelativePanel(r) => Some(ContainerChildren::Panel(
+            r.cast::<Xaml::IPanel>()
+                .ok()?
+                .get_Children()
+                .ok()?
+                .cast()
+                .ok()?,
+        )),
+        Handle::Border(_) | Handle::Viewbox(_) => Some(ContainerChildren::SingleChild(h)),
+        Handle::ScrollViewer(s) => Some(ContainerChildren::ContentControl(s.cast().ok()?)),
+        Handle::Expander(e) => Some(ContainerChildren::ContentControl(e.cast().ok()?)),
+        Handle::TabViewItem(ti) => Some(ContainerChildren::ContentControl(ti.cast().ok()?)),
+        Handle::NavigationView(nv) => Some(ContainerChildren::ContentControl(nv.cast().ok()?)),
+        Handle::PivotItem(pi) => Some(ContainerChildren::ContentControl(pi.cast().ok()?)),
+        Handle::ScrollView(_) | Handle::SplitView(_) => Some(ContainerChildren::DirectContent(h)),
+        Handle::TabView(tv) => Some(ContainerChildren::InspectableVector(
+            tv.get_TabItems().ok()?,
+        )),
+        Handle::Pivot(p) => Some(ContainerChildren::InspectableVector(
+            p.cast::<Xaml::IItemsControl>()
+                .ok()?
+                .get_Items()
+                .ok()?
+                .cast()
+                .ok()?,
+        )),
+        _ => None,
+    }
+}
+
+/// Append a child UIElement to a container.
+fn container_append(cc: &ContainerChildren<'_>, child: &Xaml::UIElement) {
+    match cc {
+        ContainerChildren::Panel(vec) => vec.Append(child).unwrap(),
+        ContainerChildren::SingleChild(h) => put_single_child(h, Some(child)),
+        ContainerChildren::ContentControl(c) => c.put_Content(child).unwrap(),
+        ContainerChildren::DirectContent(h) => put_direct_content(h, Some(child)),
+        ContainerChildren::InspectableVector(vec) => {
+            let insp: windows_core::IInspectable = child.cast().unwrap();
+            vec.Append(&insp).unwrap();
         }
     }
 }
 
-fn panel_children_vec(parent: &Handle) -> Option<windows_collections::IVector<Xaml::UIElement>> {
-    let panel = match parent {
-        Handle::StackPanel(s) => s.cast::<Xaml::IPanel>().ok()?,
-        Handle::Grid(g) => g.cast::<Xaml::IPanel>().ok()?,
-        Handle::Canvas(c) => c.cast::<Xaml::IPanel>().ok()?,
-        Handle::RelativePanel(r) => r.cast::<Xaml::IPanel>().ok()?,
-        _ => return None,
-    };
-    panel
-        .get_Children()
-        .ok()?
-        .cast::<windows_collections::IVector<Xaml::UIElement>>()
-        .ok()
+/// Insert a child UIElement at `index`.
+fn container_insert(cc: &ContainerChildren<'_>, index: usize, child: &Xaml::UIElement) {
+    match cc {
+        ContainerChildren::Panel(vec) => vec.InsertAt(index as u32, child).unwrap(),
+        ContainerChildren::SingleChild(h) => put_single_child(h, Some(child)),
+        ContainerChildren::ContentControl(c) => c.put_Content(child).unwrap(),
+        ContainerChildren::DirectContent(h) => put_direct_content(h, Some(child)),
+        ContainerChildren::InspectableVector(vec) => {
+            let insp: windows_core::IInspectable = child.cast().unwrap();
+            vec.InsertAt(index as u32, &insp).unwrap();
+        }
+    }
 }
 
-fn content_control_for(parent: &Handle) -> Option<Xaml::IContentControl> {
-    match parent {
-        Handle::ScrollViewer(s) => s.cast().ok(),
-        Handle::Expander(e) => e.cast().ok(),
-        Handle::TabViewItem(ti) => ti.cast().ok(),
-        Handle::NavigationView(nv) => nv.cast().ok(),
-        Handle::PivotItem(pi) => pi.cast().ok(),
-        _ => None,
+/// Replace the child at `index`.
+fn container_set(cc: &ContainerChildren<'_>, index: usize, child: &Xaml::UIElement) {
+    match cc {
+        ContainerChildren::Panel(vec) => vec.SetAt(index as u32, child).unwrap(),
+        ContainerChildren::SingleChild(h) => put_single_child(h, Some(child)),
+        ContainerChildren::ContentControl(c) => c.put_Content(child).unwrap(),
+        ContainerChildren::DirectContent(h) => put_direct_content(h, Some(child)),
+        ContainerChildren::InspectableVector(vec) => {
+            let insp: windows_core::IInspectable = child.cast().unwrap();
+            vec.SetAt(index as u32, &insp).unwrap();
+        }
+    }
+}
+
+/// Remove the child at `index`.
+fn container_remove(cc: &ContainerChildren<'_>, index: usize) {
+    match cc {
+        ContainerChildren::Panel(vec) => vec.RemoveAt(index as u32).unwrap(),
+        ContainerChildren::SingleChild(h) => {
+            debug_assert_eq!(index, 0);
+            put_single_child(h, None);
+        }
+        ContainerChildren::ContentControl(c) => {
+            debug_assert_eq!(index, 0);
+            c.put_Content(None::<&windows_core::IInspectable>).unwrap();
+        }
+        ContainerChildren::DirectContent(h) => {
+            debug_assert_eq!(index, 0);
+            put_direct_content(h, None);
+        }
+        ContainerChildren::InspectableVector(vec) => vec.RemoveAt(index as u32).unwrap(),
+    }
+}
+
+/// Move a child from `from` to `to` within a container. Single-child
+/// containers are no-ops.
+fn container_move(cc: &ContainerChildren<'_>, from: usize, to: usize) {
+    match cc {
+        ContainerChildren::Panel(vec) => {
+            let item = vec.GetAt(from as u32).unwrap();
+            vec.RemoveAt(from as u32).unwrap();
+            vec.InsertAt(to as u32, &item).unwrap();
+        }
+        ContainerChildren::SingleChild(_)
+        | ContainerChildren::ContentControl(_)
+        | ContainerChildren::DirectContent(_) => {}
+        ContainerChildren::InspectableVector(vec) => {
+            let item = vec.GetAt(from as u32).unwrap();
+            vec.RemoveAt(from as u32).unwrap();
+            vec.InsertAt(to as u32, &item).unwrap();
+        }
+    }
+}
+
+fn put_single_child(h: &Handle, child: Option<&Xaml::UIElement>) {
+    match h {
+        Handle::Border(b) => b.put_Child(child).unwrap(),
+        Handle::Viewbox(v) => v.put_Child(child).unwrap(),
+        _ => unreachable!(),
+    }
+}
+
+fn put_direct_content(h: &Handle, child: Option<&Xaml::UIElement>) {
+    match h {
+        Handle::ScrollView(sv) => sv.put_Content(child).unwrap(),
+        Handle::SplitView(sv) => sv.put_Content(child).unwrap(),
+        _ => unreachable!(),
     }
 }
 
@@ -704,6 +740,337 @@ fn run_property_animation_inner(
     Ok(())
 }
 
+/// Handle props that apply to any control via base-class interfaces
+/// (`IFrameworkElement`, `IUIElement`, `IControl`, `IPanel`, `IShape`, etc.).
+/// Each prop is dispatched by trying interface casts in priority order.
+/// Returns `Ok(true)` when handled, `Ok(false)` to fall through.
+fn try_universal_prop(
+    handle: &Handle,
+    prop: Prop,
+    value: &PropValue,
+) -> windows_core::Result<bool> {
+    match (prop, value) {
+        (Prop::FontSize, PropValue::F64(v)) => set_font_f64(handle, *v),
+        (Prop::FontSize, PropValue::Unset) => set_font_f64(handle, 14.0),
+        (Prop::FontWeight, PropValue::U16(w)) => {
+            set_font_weight(handle, WinFontWeight { Weight: *w })
+        }
+        (Prop::FontWeight, PropValue::Unset) => {
+            set_font_weight(handle, WinFontWeight { Weight: 400 })
+        }
+        (Prop::FontFamily, PropValue::Str(s)) => {
+            set_font_family(handle, &Xaml::FontFamily::CreateInstanceWithName(s)?)
+        }
+        (Prop::FontFamily, PropValue::Unset) => set_font_family(
+            handle,
+            &Xaml::FontFamily::CreateInstanceWithName("Segoe UI")?,
+        ),
+        (Prop::Margin, PropValue::Thickness(t)) => {
+            handle
+                .as_framework_element()
+                .put_Margin(to_xaml_thickness(*t))?;
+            Ok(true)
+        }
+        (Prop::Margin, PropValue::Unset) => {
+            handle
+                .as_framework_element()
+                .put_Margin(to_xaml_thickness(Thickness::default()))?;
+            Ok(true)
+        }
+        (Prop::Width, PropValue::F64(v)) => {
+            handle.as_framework_element().put_Width(*v)?;
+            Ok(true)
+        }
+        (Prop::Width, PropValue::Unset) => {
+            handle.as_framework_element().put_Width(f64::NAN)?;
+            Ok(true)
+        }
+        (Prop::Height, PropValue::F64(v)) => {
+            handle.as_framework_element().put_Height(*v)?;
+            Ok(true)
+        }
+        (Prop::Height, PropValue::Unset) => {
+            handle.as_framework_element().put_Height(f64::NAN)?;
+            Ok(true)
+        }
+        (Prop::MinWidth, PropValue::F64(v)) => {
+            handle.as_framework_element().put_MinWidth(*v)?;
+            Ok(true)
+        }
+        (Prop::MinWidth, PropValue::Unset) => {
+            handle.as_framework_element().put_MinWidth(0.0)?;
+            Ok(true)
+        }
+        (Prop::MaxWidth, PropValue::F64(v)) => {
+            handle.as_framework_element().put_MaxWidth(*v)?;
+            Ok(true)
+        }
+        (Prop::MaxWidth, PropValue::Unset) => {
+            handle.as_framework_element().put_MaxWidth(f64::INFINITY)?;
+            Ok(true)
+        }
+        (Prop::MinHeight, PropValue::F64(v)) => {
+            handle.as_framework_element().put_MinHeight(*v)?;
+            Ok(true)
+        }
+        (Prop::MinHeight, PropValue::Unset) => {
+            handle.as_framework_element().put_MinHeight(0.0)?;
+            Ok(true)
+        }
+        (Prop::MaxHeight, PropValue::F64(v)) => {
+            handle.as_framework_element().put_MaxHeight(*v)?;
+            Ok(true)
+        }
+        (Prop::MaxHeight, PropValue::Unset) => {
+            handle.as_framework_element().put_MaxHeight(f64::INFINITY)?;
+            Ok(true)
+        }
+        (Prop::HorizontalAlignment, PropValue::I32(v)) => {
+            handle
+                .as_framework_element()
+                .put_HorizontalAlignment(Xaml::HorizontalAlignment(*v))?;
+            Ok(true)
+        }
+        (Prop::HorizontalAlignment, PropValue::Unset) => {
+            handle
+                .as_framework_element()
+                .put_HorizontalAlignment(Xaml::HorizontalAlignment::Stretch)?;
+            Ok(true)
+        }
+        (Prop::VerticalAlignment, PropValue::I32(v)) => {
+            handle
+                .as_framework_element()
+                .put_VerticalAlignment(Xaml::VerticalAlignment(*v))?;
+            Ok(true)
+        }
+        (Prop::VerticalAlignment, PropValue::Unset) => {
+            handle
+                .as_framework_element()
+                .put_VerticalAlignment(Xaml::VerticalAlignment::Stretch)?;
+            Ok(true)
+        }
+        (Prop::Opacity, PropValue::F64(v)) => {
+            handle.as_ui_element().put_Opacity(*v)?;
+            Ok(true)
+        }
+        (Prop::Opacity, PropValue::Unset) => {
+            handle.as_ui_element().put_Opacity(1.0)?;
+            Ok(true)
+        }
+        (Prop::IsEnabled, PropValue::Unset) => {
+            handle
+                .as_ui_element()
+                .cast::<Xaml::IControl>()?
+                .put_IsEnabled(true)?;
+            Ok(true)
+        }
+        (Prop::Resources, PropValue::Resources(map)) => {
+            let rd = handle.as_framework_element().get_Resources()?;
+            let imap =
+                rd.cast::<windows_collections::IMap<
+                    windows_core::IInspectable,
+                    windows_core::IInspectable,
+                >>()?;
+            for (k, v) in map {
+                let key = windows_reference::IReference::from(k.as_str());
+                let val = windows_reference::IReference::from(v.as_str());
+                imap.Insert(&key, &val)?;
+            }
+            Ok(true)
+        }
+        (Prop::AttachedGridRow, PropValue::I32(v)) => {
+            Xaml::Grid::SetRow(&handle.as_framework_element(), *v)?;
+            Ok(true)
+        }
+        (Prop::AttachedGridColumn, PropValue::I32(v)) => {
+            Xaml::Grid::SetColumn(&handle.as_framework_element(), *v)?;
+            Ok(true)
+        }
+        (Prop::AttachedGridRowSpan, PropValue::I32(v)) => {
+            Xaml::Grid::SetRowSpan(&handle.as_framework_element(), *v)?;
+            Ok(true)
+        }
+        (Prop::AttachedGridColumnSpan, PropValue::I32(v)) => {
+            Xaml::Grid::SetColumnSpan(&handle.as_framework_element(), *v)?;
+            Ok(true)
+        }
+        (Prop::AttachedCanvasLeft, PropValue::F64(v)) => {
+            Xaml::Canvas::SetLeft(&handle.as_ui_element(), *v)?;
+            Ok(true)
+        }
+        (Prop::AttachedCanvasTop, PropValue::F64(v)) => {
+            Xaml::Canvas::SetTop(&handle.as_ui_element(), *v)?;
+            Ok(true)
+        }
+        (Prop::AttachedCanvasZIndex, PropValue::I32(v)) => {
+            Xaml::Canvas::SetZIndex(&handle.as_ui_element(), *v)?;
+            Ok(true)
+        }
+        (Prop::AlignLeftWithPanel, PropValue::Bool(v)) => {
+            Xaml::RelativePanel::SetAlignLeftWithPanel(&handle.as_ui_element(), *v)?;
+            Ok(true)
+        }
+        (Prop::AlignRightWithPanel, PropValue::Bool(v)) => {
+            Xaml::RelativePanel::SetAlignRightWithPanel(&handle.as_ui_element(), *v)?;
+            Ok(true)
+        }
+        (Prop::AlignTopWithPanel, PropValue::Bool(v)) => {
+            Xaml::RelativePanel::SetAlignTopWithPanel(&handle.as_ui_element(), *v)?;
+            Ok(true)
+        }
+        (Prop::AlignBottomWithPanel, PropValue::Bool(v)) => {
+            Xaml::RelativePanel::SetAlignBottomWithPanel(&handle.as_ui_element(), *v)?;
+            Ok(true)
+        }
+        (Prop::AlignHCenterWithPanel, PropValue::Bool(v)) => {
+            Xaml::RelativePanel::SetAlignHorizontalCenterWithPanel(&handle.as_ui_element(), *v)?;
+            Ok(true)
+        }
+        (Prop::AlignVCenterWithPanel, PropValue::Bool(v)) => {
+            Xaml::RelativePanel::SetAlignVerticalCenterWithPanel(&handle.as_ui_element(), *v)?;
+            Ok(true)
+        }
+        (Prop::Padding, PropValue::Thickness(t)) => set_padding(handle, to_xaml_thickness(*t)),
+        (Prop::Padding, PropValue::Unset) => {
+            set_padding(handle, to_xaml_thickness(Thickness::default()))
+        }
+        (Prop::Background, PropValue::Brush(br)) => set_background(handle, &brush_of(br)?),
+        (Prop::Background, PropValue::Unset) => set_background(handle, None::<&Xaml::Brush>),
+        (Prop::Foreground, PropValue::Brush(br)) => set_foreground(handle, &brush_of(br)?),
+        (Prop::Foreground, PropValue::Unset) => set_foreground(handle, None::<&Xaml::Brush>),
+        (Prop::Fill, PropValue::Brush(b)) => {
+            handle
+                .cast_inner::<Xaml::IShape>()?
+                .put_Fill(&brush_of(b)?)?;
+            Ok(true)
+        }
+        (Prop::Fill, PropValue::Unset) => {
+            handle.cast_inner::<Xaml::IShape>()?.put_Fill(None)?;
+            Ok(true)
+        }
+        (Prop::Stroke, PropValue::Brush(b)) => {
+            handle
+                .cast_inner::<Xaml::IShape>()?
+                .put_Stroke(&brush_of(b)?)?;
+            Ok(true)
+        }
+        (Prop::Stroke, PropValue::Unset) => {
+            handle.cast_inner::<Xaml::IShape>()?.put_Stroke(None)?;
+            Ok(true)
+        }
+        (Prop::StrokeThickness, PropValue::F64(v)) => {
+            handle
+                .cast_inner::<Xaml::IShape>()?
+                .put_StrokeThickness(*v)?;
+            Ok(true)
+        }
+        (Prop::StrokeThickness, PropValue::Unset) => {
+            handle
+                .cast_inner::<Xaml::IShape>()?
+                .put_StrokeThickness(0.0)?;
+            Ok(true)
+        }
+        _ => Ok(false),
+    }
+}
+
+fn set_padding(handle: &Handle, thickness: Xaml::Thickness) -> windows_core::Result<bool> {
+    if let Ok(border) = handle.cast_inner::<Xaml::IBorder>() {
+        border.put_Padding(thickness)?;
+    } else if let Ok(ctl) = handle.cast_inner::<Xaml::IControl>() {
+        ctl.put_Padding(thickness)?;
+    } else {
+        diag::unhandled_modifier("set_prop", Prop::Padding, handle);
+    }
+    Ok(true)
+}
+
+fn set_background(
+    handle: &Handle,
+    brush: impl windows_core::Param<Xaml::Brush>,
+) -> windows_core::Result<bool> {
+    if let Ok(panel) = handle.cast_inner::<Xaml::IPanel>() {
+        panel.put_Background(brush)?;
+    } else if let Ok(ctl) = handle.cast_inner::<Xaml::IControl>() {
+        ctl.put_Background(brush)?;
+    } else if let Ok(border) = handle.cast_inner::<Xaml::IBorder>() {
+        border.put_Background(brush)?;
+    }
+    // TextBlock/RichTextBlock: no background property — silently ignored.
+    Ok(true)
+}
+
+fn set_foreground(
+    handle: &Handle,
+    brush: impl windows_core::Param<Xaml::Brush>,
+) -> windows_core::Result<bool> {
+    if let Ok(ctl) = handle.cast_inner::<Xaml::IControl>() {
+        ctl.put_Foreground(brush)?;
+    } else if let Ok(tb) = handle.cast_inner::<Xaml::ITextBlock>() {
+        tb.put_Foreground(brush)?;
+    } else if let Ok(rtb) = handle.cast_inner::<Xaml::IRichTextBlock>() {
+        rtb.put_Foreground(brush)?;
+    } else {
+        diag::unhandled_modifier("set_prop", Prop::Foreground, handle);
+    }
+    Ok(true)
+}
+
+fn set_font_f64(handle: &Handle, v: f64) -> windows_core::Result<bool> {
+    if let Ok(ctrl) = handle.cast_inner::<Xaml::IControl>() {
+        ctrl.put_FontSize(v)?;
+    } else if let Ok(tb) = handle.cast_inner::<Xaml::ITextBlock>() {
+        tb.put_FontSize(v)?;
+    } else if let Ok(rtb) = handle.cast_inner::<Xaml::IRichTextBlock>() {
+        rtb.put_FontSize(v)?;
+    }
+    Ok(true)
+}
+
+fn set_font_weight(handle: &Handle, fw: WinFontWeight) -> windows_core::Result<bool> {
+    if let Ok(ctrl) = handle.cast_inner::<Xaml::IControl>() {
+        ctrl.put_FontWeight(fw)?;
+    } else if let Ok(tb) = handle.cast_inner::<Xaml::ITextBlock>() {
+        tb.put_FontWeight(fw)?;
+    }
+    Ok(true)
+}
+
+fn set_font_family(handle: &Handle, ff: &Xaml::FontFamily) -> windows_core::Result<bool> {
+    if let Ok(ctrl) = handle.cast_inner::<Xaml::IControl>() {
+        ctrl.put_FontFamily(ff)?;
+    } else if let Ok(tb) = handle.cast_inner::<Xaml::ITextBlock>() {
+        tb.put_FontFamily(ff)?;
+    } else if let Ok(rtb) = handle.cast_inner::<Xaml::IRichTextBlock>() {
+        rtb.put_FontFamily(ff)?;
+    }
+    Ok(true)
+}
+
+/// Populate an existing `IVector<IInspectable>` with string items (clear + append).
+fn set_str_items(
+    vec: &windows_collections::IVector<windows_core::IInspectable>,
+    items: &[String],
+) -> windows_core::Result<()> {
+    vec.Clear()?;
+    for s in items {
+        let insp = windows_reference::IReference::from(s.as_str());
+        vec.Append(&insp)?;
+    }
+    Ok(())
+}
+
+/// Build an `IVector<IInspectable>` from a string list (for `put_ItemsSource`).
+fn str_list_as_ivector(
+    items: &[String],
+) -> windows_collections::IVector<windows_core::IInspectable> {
+    let vec: Vec<Option<windows_core::IInspectable>> = items
+        .iter()
+        .map(|s| Some(windows_reference::IReference::from(s.as_str()).into()))
+        .collect();
+    vec.into()
+}
+
 impl Backend for WinUIBackend {
     fn create(&mut self, kind: ControlKind) -> ControlId {
         let id = self.alloc_id();
@@ -718,77 +1085,13 @@ impl Backend for WinUIBackend {
             .get(&id)
             .unwrap_or_else(|| panic!("WinUIBackend::set_prop: unknown control {id}"));
         let result: windows_core::Result<()> = (|| -> windows_core::Result<()> {
-            // Try generated dispatch first (handles method-based props automatically)
             if generated_set_prop::dispatch(handle, prop, value)? {
                 return Ok(());
             }
+            if try_universal_prop(handle, prop, value)? {
+                return Ok(());
+            }
             match (prop, value, handle) {
-                (Prop::FontSize, PropValue::F64(v), h) => {
-                    if let Ok(ctrl) = h.cast_inner::<Xaml::IControl>() {
-                        ctrl.put_FontSize(*v)
-                    } else if let Ok(tb) = h.cast_inner::<Xaml::ITextBlock>() {
-                        tb.put_FontSize(*v)
-                    } else if let Ok(rtb) = h.cast_inner::<Xaml::IRichTextBlock>() {
-                        rtb.put_FontSize(*v)
-                    } else {
-                        Ok(())
-                    }
-                }
-                (Prop::FontSize, PropValue::Unset, h) => {
-                    if let Ok(ctrl) = h.cast_inner::<Xaml::IControl>() {
-                        ctrl.put_FontSize(14.0)
-                    } else if let Ok(tb) = h.cast_inner::<Xaml::ITextBlock>() {
-                        tb.put_FontSize(14.0)
-                    } else if let Ok(rtb) = h.cast_inner::<Xaml::IRichTextBlock>() {
-                        rtb.put_FontSize(14.0)
-                    } else {
-                        Ok(())
-                    }
-                }
-                (Prop::FontWeight, PropValue::U16(w), h) => {
-                    let fw = WinFontWeight { Weight: *w };
-                    if let Ok(ctrl) = h.cast_inner::<Xaml::IControl>() {
-                        ctrl.put_FontWeight(fw)
-                    } else if let Ok(tb) = h.cast_inner::<Xaml::ITextBlock>() {
-                        tb.put_FontWeight(fw)
-                    } else {
-                        Ok(())
-                    }
-                }
-                (Prop::FontWeight, PropValue::Unset, h) => {
-                    let fw = WinFontWeight { Weight: 400 };
-                    if let Ok(ctrl) = h.cast_inner::<Xaml::IControl>() {
-                        ctrl.put_FontWeight(fw)
-                    } else if let Ok(tb) = h.cast_inner::<Xaml::ITextBlock>() {
-                        tb.put_FontWeight(fw)
-                    } else {
-                        Ok(())
-                    }
-                }
-                (Prop::FontFamily, PropValue::Str(s), h) => {
-                    let ff = Xaml::FontFamily::CreateInstanceWithName(s)?;
-                    if let Ok(ctrl) = h.cast_inner::<Xaml::IControl>() {
-                        ctrl.put_FontFamily(&ff)
-                    } else if let Ok(tb) = h.cast_inner::<Xaml::ITextBlock>() {
-                        tb.put_FontFamily(&ff)
-                    } else if let Ok(rtb) = h.cast_inner::<Xaml::IRichTextBlock>() {
-                        rtb.put_FontFamily(&ff)
-                    } else {
-                        Ok(())
-                    }
-                }
-                (Prop::FontFamily, PropValue::Unset, h) => {
-                    let ff = Xaml::FontFamily::CreateInstanceWithName("Segoe UI")?;
-                    if let Ok(ctrl) = h.cast_inner::<Xaml::IControl>() {
-                        ctrl.put_FontFamily(&ff)
-                    } else if let Ok(tb) = h.cast_inner::<Xaml::ITextBlock>() {
-                        tb.put_FontFamily(&ff)
-                    } else if let Ok(rtb) = h.cast_inner::<Xaml::IRichTextBlock>() {
-                        rtb.put_FontFamily(&ff)
-                    } else {
-                        Ok(())
-                    }
-                }
                 (Prop::IsTextSelectionEnabled, PropValue::Bool(v), Handle::RichTextBlock(tb)) => {
                     tb.put_IsTextSelectionEnabled(*v)
                 }
@@ -885,10 +1188,6 @@ impl Backend for WinUIBackend {
                     }
                     Ok(())
                 }
-                (Prop::IsEnabled, PropValue::Unset, _) => handle
-                    .as_ui_element()
-                    .cast::<Xaml::IControl>()?
-                    .put_IsEnabled(true),
                 (Prop::Value, PropValue::Str(s), Handle::TextBox(t)) => {
                     if t.get_Text().ok().as_deref() == Some(s.as_str()) {
                         return Ok(());
@@ -921,198 +1220,6 @@ impl Backend for WinUIBackend {
                     }
                     Ok(())
                 }
-                (Prop::AttachedGridRow, PropValue::I32(v), _) => {
-                    Xaml::Grid::SetRow(&handle.as_framework_element(), *v)
-                }
-                (Prop::AttachedGridColumn, PropValue::I32(v), _) => {
-                    Xaml::Grid::SetColumn(&handle.as_framework_element(), *v)
-                }
-                (Prop::AttachedGridRowSpan, PropValue::I32(v), _) => {
-                    Xaml::Grid::SetRowSpan(&handle.as_framework_element(), *v)
-                }
-                (Prop::AttachedGridColumnSpan, PropValue::I32(v), _) => {
-                    Xaml::Grid::SetColumnSpan(&handle.as_framework_element(), *v)
-                }
-                (Prop::Margin, PropValue::Thickness(t), _) => handle
-                    .as_framework_element()
-                    .cast::<Xaml::IFrameworkElement>()?
-                    .put_Margin(to_xaml_thickness(*t)),
-                (Prop::Margin, PropValue::Unset, _) => handle
-                    .as_framework_element()
-                    .cast::<Xaml::IFrameworkElement>()?
-                    .put_Margin(to_xaml_thickness(Thickness::default())),
-                (Prop::Width, PropValue::F64(v), _) => handle
-                    .as_framework_element()
-                    .cast::<Xaml::IFrameworkElement>()?
-                    .put_Width(*v),
-                (Prop::Width, PropValue::Unset, _) => handle
-                    .as_framework_element()
-                    .cast::<Xaml::IFrameworkElement>()?
-                    .put_Width(f64::NAN),
-                (Prop::Height, PropValue::F64(v), _) => handle
-                    .as_framework_element()
-                    .cast::<Xaml::IFrameworkElement>()?
-                    .put_Height(*v),
-                (Prop::Height, PropValue::Unset, _) => handle
-                    .as_framework_element()
-                    .cast::<Xaml::IFrameworkElement>()?
-                    .put_Height(f64::NAN),
-                (Prop::MinWidth, PropValue::F64(v), _) => handle
-                    .as_framework_element()
-                    .cast::<Xaml::IFrameworkElement>()?
-                    .put_MinWidth(*v),
-                (Prop::MinWidth, PropValue::Unset, _) => handle
-                    .as_framework_element()
-                    .cast::<Xaml::IFrameworkElement>()?
-                    .put_MinWidth(0.0),
-                (Prop::MaxWidth, PropValue::F64(v), _) => handle
-                    .as_framework_element()
-                    .cast::<Xaml::IFrameworkElement>()?
-                    .put_MaxWidth(*v),
-                (Prop::MaxWidth, PropValue::Unset, _) => handle
-                    .as_framework_element()
-                    .cast::<Xaml::IFrameworkElement>()?
-                    .put_MaxWidth(f64::INFINITY),
-                (Prop::MinHeight, PropValue::F64(v), _) => handle
-                    .as_framework_element()
-                    .cast::<Xaml::IFrameworkElement>()?
-                    .put_MinHeight(*v),
-                (Prop::MinHeight, PropValue::Unset, _) => handle
-                    .as_framework_element()
-                    .cast::<Xaml::IFrameworkElement>()?
-                    .put_MinHeight(0.0),
-                (Prop::MaxHeight, PropValue::F64(v), _) => handle
-                    .as_framework_element()
-                    .cast::<Xaml::IFrameworkElement>()?
-                    .put_MaxHeight(*v),
-                (Prop::MaxHeight, PropValue::Unset, _) => handle
-                    .as_framework_element()
-                    .cast::<Xaml::IFrameworkElement>()?
-                    .put_MaxHeight(f64::INFINITY),
-                (Prop::HorizontalAlignment, PropValue::I32(v), _) => handle
-                    .as_framework_element()
-                    .cast::<Xaml::IFrameworkElement>()?
-                    .put_HorizontalAlignment(Xaml::HorizontalAlignment(*v)),
-                (Prop::HorizontalAlignment, PropValue::Unset, _) => handle
-                    .as_framework_element()
-                    .cast::<Xaml::IFrameworkElement>()?
-                    .put_HorizontalAlignment(Xaml::HorizontalAlignment::Stretch),
-                (Prop::VerticalAlignment, PropValue::I32(v), _) => handle
-                    .as_framework_element()
-                    .cast::<Xaml::IFrameworkElement>()?
-                    .put_VerticalAlignment(Xaml::VerticalAlignment(*v)),
-                (Prop::VerticalAlignment, PropValue::Unset, _) => handle
-                    .as_framework_element()
-                    .cast::<Xaml::IFrameworkElement>()?
-                    .put_VerticalAlignment(Xaml::VerticalAlignment::Stretch),
-                (Prop::Opacity, PropValue::F64(v), _) => handle
-                    .as_ui_element()
-                    .cast::<Xaml::IUIElement>()?
-                    .put_Opacity(*v),
-                (Prop::Opacity, PropValue::Unset, _) => handle
-                    .as_ui_element()
-                    .cast::<Xaml::IUIElement>()?
-                    .put_Opacity(1.0),
-                (Prop::Resources, PropValue::Resources(map), _) => {
-                    let rd = handle
-                        .as_framework_element()
-                        .cast::<Xaml::IFrameworkElement>()?
-                        .get_Resources()?;
-                    let imap = rd.cast::<windows_collections::IMap<
-                        windows_core::IInspectable,
-                        windows_core::IInspectable,
-                    >>()?;
-                    for (k, v) in map {
-                        let key = windows_reference::IReference::from(k.as_str());
-                        let val = windows_reference::IReference::from(v.as_str());
-                        imap.Insert(&key, &val)?;
-                    }
-                    Ok(())
-                }
-                (Prop::Padding, PropValue::Thickness(t), Handle::Button(b)) => b
-                    .cast::<Xaml::IControl>()?
-                    .put_Padding(to_xaml_thickness(*t)),
-                (Prop::Padding, PropValue::Unset, Handle::Button(b)) => b
-                    .cast::<Xaml::IControl>()?
-                    .put_Padding(to_xaml_thickness(Thickness::default())),
-                (Prop::Padding, PropValue::Thickness(t), Handle::Border(br)) => {
-                    br.put_Padding(to_xaml_thickness(*t))
-                }
-                (Prop::Padding, PropValue::Unset, Handle::Border(br)) => {
-                    br.put_Padding(to_xaml_thickness(Thickness::default()))
-                }
-                (Prop::Padding, PropValue::Thickness(t), h) => {
-                    if let Ok(ctl) = h.as_framework_element().cast::<Xaml::Control>() {
-                        ctl.cast::<Xaml::IControl>()?
-                            .put_Padding(to_xaml_thickness(*t))
-                    } else {
-                        diag::unhandled_modifier("set_prop", Prop::Padding, h);
-                        Ok(())
-                    }
-                }
-                (Prop::Padding, PropValue::Unset, _) => {
-                    if let Ok(ctl) = handle.as_framework_element().cast::<Xaml::Control>() {
-                        ctl.cast::<Xaml::IControl>()?
-                            .put_Padding(to_xaml_thickness(Thickness::default()))
-                    } else {
-                        Ok(())
-                    }
-                }
-                (Prop::Background, PropValue::Brush(br), Handle::StackPanel(s)) => {
-                    s.cast::<Xaml::IPanel>()?.put_Background(&brush_of(br)?)
-                }
-                (Prop::Background, PropValue::Brush(br), Handle::Grid(g)) => {
-                    g.cast::<Xaml::IPanel>()?.put_Background(&brush_of(br)?)
-                }
-                (Prop::Background, PropValue::Brush(br), Handle::Canvas(c)) => {
-                    c.cast::<Xaml::IPanel>()?.put_Background(&brush_of(br)?)
-                }
-                (Prop::Background, PropValue::Brush(br), Handle::Border(b)) => {
-                    b.put_Background(&brush_of(br)?)
-                }
-                (Prop::Background, PropValue::Brush(br), Handle::Button(b)) => {
-                    b.cast::<Xaml::IControl>()?.put_Background(&brush_of(br)?)
-                }
-                (
-                    Prop::Background,
-                    PropValue::Brush(_),
-                    Handle::TextBlock(_) | Handle::RichTextBlock(_),
-                ) => Ok(()),
-                (Prop::Background, PropValue::Unset, Handle::StackPanel(s)) => {
-                    s.cast::<Xaml::IPanel>()?.put_Background(None)
-                }
-                (Prop::Background, PropValue::Unset, Handle::Grid(g)) => {
-                    g.cast::<Xaml::IPanel>()?.put_Background(None)
-                }
-                (Prop::Background, PropValue::Unset, Handle::Canvas(c)) => {
-                    c.cast::<Xaml::IPanel>()?.put_Background(None)
-                }
-                (Prop::Background, PropValue::Unset, Handle::Border(b)) => b.put_Background(None),
-                (Prop::Background, PropValue::Unset, Handle::Button(b)) => {
-                    b.cast::<Xaml::IControl>()?.put_Background(None)
-                }
-                (Prop::Foreground, PropValue::Brush(br), Handle::TextBlock(tb)) => {
-                    tb.put_Foreground(&brush_of(br)?)
-                }
-                (Prop::Foreground, PropValue::Brush(br), Handle::RichTextBlock(tb)) => {
-                    tb.put_Foreground(&brush_of(br)?)
-                }
-                (Prop::Foreground, PropValue::Brush(br), Handle::Button(b)) => {
-                    b.cast::<Xaml::IControl>()?.put_Foreground(&brush_of(br)?)
-                }
-                (Prop::Foreground, PropValue::Brush(_), h) => {
-                    diag::unhandled_modifier("set_prop", Prop::Foreground, h);
-                    Ok(())
-                }
-                (Prop::Foreground, PropValue::Unset, Handle::TextBlock(tb)) => {
-                    tb.put_Foreground(None)
-                }
-                (Prop::Foreground, PropValue::Unset, Handle::RichTextBlock(tb)) => {
-                    tb.put_Foreground(None)
-                }
-                (Prop::Foreground, PropValue::Unset, Handle::Button(b)) => {
-                    b.cast::<Xaml::IControl>()?.put_Foreground(None)
-                }
                 (Prop::Step, PropValue::F64(v), Handle::Slider(s)) => {
                     s.put_StepFrequency(*v)?;
                     s.cast::<Xaml::IRangeBase>()?.put_SmallChange(*v)
@@ -1131,7 +1238,7 @@ impl Backend for WinUIBackend {
                 (Prop::IsClosable, PropValue::Bool(v), Handle::TabViewItem(ti)) => {
                     ti.put_IsClosable(*v)
                 }
-                // ContentDialog (W6 — modal popup hosted via ShowAsync).
+                // ContentDialog — modal popup hosted via ShowAsync.
                 (Prop::IsOpen, PropValue::Bool(v), Handle::ContentDialog(d)) => {
                     if *v {
                         // ContentDialog needs a XamlRoot before ShowAsync; reuse
@@ -1190,30 +1297,6 @@ impl Backend for WinUIBackend {
                     p.put_DisplayName("")
                 }
                 (Prop::Initials, PropValue::Unset, Handle::PersonPicture(p)) => p.put_Initials(""),
-                (Prop::Fill, PropValue::Brush(b), Handle::Rectangle(r)) => {
-                    r.cast::<Xaml::IShape>()?.put_Fill(&brush_of(b)?)
-                }
-                (Prop::Fill, PropValue::Brush(b), Handle::Ellipse(e)) => {
-                    e.cast::<Xaml::IShape>()?.put_Fill(&brush_of(b)?)
-                }
-                (Prop::Stroke, PropValue::Brush(b), Handle::Rectangle(r)) => {
-                    r.cast::<Xaml::IShape>()?.put_Stroke(&brush_of(b)?)
-                }
-                (Prop::Stroke, PropValue::Brush(b), Handle::Ellipse(e)) => {
-                    e.cast::<Xaml::IShape>()?.put_Stroke(&brush_of(b)?)
-                }
-                (Prop::Stroke, PropValue::Brush(b), Handle::Line(l)) => {
-                    l.cast::<Xaml::IShape>()?.put_Stroke(&brush_of(b)?)
-                }
-                (Prop::StrokeThickness, PropValue::F64(v), Handle::Rectangle(r)) => {
-                    r.cast::<Xaml::IShape>()?.put_StrokeThickness(*v)
-                }
-                (Prop::StrokeThickness, PropValue::F64(v), Handle::Ellipse(e)) => {
-                    e.cast::<Xaml::IShape>()?.put_StrokeThickness(*v)
-                }
-                (Prop::StrokeThickness, PropValue::F64(v), Handle::Line(l)) => {
-                    l.cast::<Xaml::IShape>()?.put_StrokeThickness(*v)
-                }
                 (Prop::CornerRadius, PropValue::F64(v), Handle::Rectangle(r)) => {
                     r.put_RadiusX(*v).and_then(|_| r.put_RadiusY(*v))
                 }
@@ -1293,7 +1376,6 @@ impl Backend for WinUIBackend {
                     nv.put_SelectedItem(None)
                 }
                 (Prop::AutoSuggestBox, PropValue::Bool(true), Handle::NavigationView(nv)) => {
-                    // Create an AutoSuggestBox if one isn't already set.
                     let asb = Xaml::AutoSuggestBox::new()?;
                     nv.put_AutoSuggestBox(&asb)
                 }
@@ -1308,16 +1390,8 @@ impl Backend for WinUIBackend {
                 }
                 (Prop::AutoSuggestItems, PropValue::StrList(items), Handle::NavigationView(nv)) => {
                     if let Ok(asb) = nv.get_AutoSuggestBox() {
-                        let vec: Vec<Option<windows_core::IInspectable>> = items
-                            .iter()
-                            .map(|s| {
-                                let r = windows_reference::IReference::from(s.as_str());
-                                Some(r.into())
-                            })
-                            .collect();
-                        let ivec: windows_collections::IVector<windows_core::IInspectable> =
-                            vec.into();
-                        asb.cast::<Xaml::IItemsControl>()?.put_ItemsSource(&ivec)?;
+                        asb.cast::<Xaml::IItemsControl>()?
+                            .put_ItemsSource(&str_list_as_ivector(items))?;
                     }
                     Ok(())
                 }
@@ -1339,17 +1413,8 @@ impl Backend for WinUIBackend {
                     pi.put_Header(&tb)
                 }
                 (Prop::Items, PropValue::StrList(items), Handle::BreadcrumbBar(bc)) => {
-                    let vec: Vec<Option<windows_core::IInspectable>> = items
-                        .iter()
-                        .map(|s| {
-                            let r = windows_reference::IReference::from(s.as_str());
-                            Some(r.into())
-                        })
-                        .collect();
-                    let ivec: windows_collections::IVector<windows_core::IInspectable> = vec.into();
-                    bc.put_ItemsSource(&ivec)
+                    bc.put_ItemsSource(&str_list_as_ivector(items))
                 }
-                // ── W2: PasswordBox ───────────────────────────────────────────
                 (Prop::Value, PropValue::Str(s), Handle::PasswordBox(p)) => {
                     if p.get_Password().ok().as_deref() == Some(s.as_str()) {
                         return Ok(());
@@ -1357,42 +1422,13 @@ impl Backend for WinUIBackend {
                     p.put_Password(s.as_str())
                 }
                 (Prop::Value, PropValue::Unset, Handle::PasswordBox(p)) => p.put_Password(""),
-                // ── W3: RadioButtons ──────────────────────────────────────────
                 (Prop::Items, PropValue::StrList(items), Handle::RadioButtons(r)) => {
-                    let vec = r.get_Items()?;
-                    vec.Clear()?;
-                    for s in items {
-                        let insp = windows_reference::IReference::from(s.as_str());
-                        vec.Append(&insp)?;
-                    }
-                    Ok(())
+                    set_str_items(&r.get_Items()?.cast()?, items)
                 }
-                // ── W4: ComboBox ──────────────────────────────────────────────
-                (Prop::Items, PropValue::StrList(items), Handle::ComboBox(c)) => {
-                    let coll =
-                        c.cast::<Xaml::IItemsControl>()?
-                            .get_Items()?
-                            .cast::<windows_collections::IVector<windows_core::IInspectable>>()?;
-                    coll.Clear()?;
-                    for s in items {
-                        let insp = windows_reference::IReference::from(s.as_str());
-                        coll.Append(&insp)?;
-                    }
-                    Ok(())
-                }
-                // ── W5: Canvas attached props ─────────────────────────────────
-                (Prop::AttachedCanvasLeft, PropValue::F64(v), _) => {
-                    Xaml::Canvas::SetLeft(&handle.as_ui_element(), *v)
-                }
-                (Prop::AttachedCanvasTop, PropValue::F64(v), _) => {
-                    Xaml::Canvas::SetTop(&handle.as_ui_element(), *v)
-                }
-                (Prop::AttachedCanvasZIndex, PropValue::I32(v), _) => {
-                    Xaml::Canvas::SetZIndex(&handle.as_ui_element(), *v)
-                }
-                // ── W6: RepeatButton ──────────────────────────────────────────
-                // ── W7: RatingControl ─────────────────────────────────────────
-                // ── W8: ColorPicker ───────────────────────────────────────────
+                (Prop::Items, PropValue::StrList(items), Handle::ComboBox(c)) => set_str_items(
+                    &c.cast::<Xaml::IItemsControl>()?.get_Items()?.cast()?,
+                    items,
+                ),
                 (Prop::ColorValue, PropValue::Color { a, r, g, b }, Handle::ColorPicker(cp)) => cp
                     .put_Color(Xaml::Color {
                         A: *a,
@@ -1400,26 +1436,10 @@ impl Backend for WinUIBackend {
                         G: *g,
                         B: *b,
                     }),
-                // ── W9: DatePicker ────────────────────────────────────────────
-                // ── W10: TimePicker ───────────────────────────────────────────
-                // ── W11: CalendarDatePicker ───────────────────────────────────
-                // ── W12: CalendarView ─────────────────────────────────────────
-                // ── W13: ListBox ──────────────────────────────────────────────
-                (Prop::Items, PropValue::StrList(items), Handle::ListBox(lb)) => {
-                    let coll =
-                        lb.cast::<Xaml::IItemsControl>()?
-                            .get_Items()?
-                            .cast::<windows_collections::IVector<windows_core::IInspectable>>()?;
-                    coll.Clear()?;
-                    for s in items {
-                        let insp = windows_reference::IReference::from(s.as_str());
-                        coll.Append(&insp)?;
-                    }
-                    Ok(())
-                }
-                // ── W14: DropDownButton ───────────────────────────────────────
-                // ── W15: SplitButton ──────────────────────────────────────────
-                // ── W16: AutoSuggestBox ───────────────────────────────────────
+                (Prop::Items, PropValue::StrList(items), Handle::ListBox(lb)) => set_str_items(
+                    &lb.cast::<Xaml::IItemsControl>()?.get_Items()?.cast()?,
+                    items,
+                ),
                 (Prop::Text, PropValue::Str(s), Handle::AutoSuggestBox(asb)) => {
                     // Skip SetText when the control already has this value —
                     // calling SetText during a user-initiated TextChanged
@@ -1429,24 +1449,12 @@ impl Backend for WinUIBackend {
                     }
                     asb.put_Text(s)
                 }
-                (Prop::Items, PropValue::StrList(items), Handle::AutoSuggestBox(asb)) => {
-                    // Build a Rust Vec, wrap into IVector via the stock
-                    // implementation, then assign as ItemsSource.
-                    let vec: Vec<Option<windows_core::IInspectable>> = items
-                        .iter()
-                        .map(|s| {
-                            let r = windows_reference::IReference::from(s.as_str());
-                            Some(r.into())
-                        })
-                        .collect();
-                    let ivec: windows_collections::IVector<windows_core::IInspectable> = vec.into();
-                    asb.cast::<Xaml::IItemsControl>()?.put_ItemsSource(&ivec)
-                }
-                // ── W17: SplitView ───────────────────────────────────────
+                (Prop::Items, PropValue::StrList(items), Handle::AutoSuggestBox(asb)) => asb
+                    .cast::<Xaml::IItemsControl>()?
+                    .put_ItemsSource(&str_list_as_ivector(items)),
                 (Prop::DisplayMode, PropValue::I32(m), Handle::SplitView(sv)) => {
                     sv.put_DisplayMode(Xaml::SplitViewDisplayMode(*m))
                 }
-                // ── W18: MenuBar ─────────────────────────────────────────
                 (Prop::Items, PropValue::MenuBarItems(items), Handle::MenuBar(mb)) => {
                     let winui_items = mb.get_Items()?;
                     winui_items.Clear()?;
@@ -1460,7 +1468,6 @@ impl Backend for WinUIBackend {
                         }
                         winui_items.Append(&mbi)?;
                     }
-                    // Re-wire click handlers if a handler is already stored.
                     let handlers = self.menu_click_handlers.borrow();
                     if let Some(handler) = handlers.get(&id) {
                         let revs = Self::wire_menu_bar_clicks(mb, handler);
@@ -1472,7 +1479,6 @@ impl Backend for WinUIBackend {
                     }
                     Ok(())
                 }
-                // MenuFlyout on Button/DropDownButton
                 (
                     Prop::MenuFlyoutItems,
                     PropValue::MenuFlyoutItems(items),
@@ -1485,7 +1491,6 @@ impl Backend for WinUIBackend {
                         flyout_items.Append(&fi)?;
                     }
                     btn.cast::<Xaml::IButton>()?.put_Flyout(&flyout)?;
-                    // Wire click handlers if stored.
                     let handlers = self.menu_click_handlers.borrow();
                     if let Some(handler) = handlers.get(&id) {
                         let revs = Self::wire_flyout_clicks(&flyout, handler);
@@ -1505,7 +1510,6 @@ impl Backend for WinUIBackend {
                         flyout_items.Append(&fi)?;
                     }
                     btn.put_Flyout(&flyout)?;
-                    // Wire click handlers if stored.
                     let handlers = self.menu_click_handlers.borrow();
                     if let Some(handler) = handlers.get(&id) {
                         let revs = Self::wire_flyout_clicks(&flyout, handler);
@@ -1517,7 +1521,6 @@ impl Backend for WinUIBackend {
                     }
                     Ok(())
                 }
-                // CommandBarFlyout on Button
                 (
                     Prop::CommandBarFlyoutCommands,
                     PropValue::CommandBarFlyoutDef { primary, secondary },
@@ -1535,7 +1538,6 @@ impl Backend for WinUIBackend {
                         secondary_cmds.Append(&el)?;
                     }
                     btn.put_Flyout(&flyout)?;
-                    // Wire click handlers if stored.
                     let handlers = self.command_bar_flyout_handlers.borrow();
                     if let Some(handler) = handlers.get(&id) {
                         let mut revs = Self::wire_command_bar_clicks(&primary_cmds, handler);
@@ -1548,8 +1550,6 @@ impl Backend for WinUIBackend {
                     }
                     Ok(())
                 }
-                // ── W19: ScrollView ──────────────────────────────────────
-                // ── W20: TreeView ────────────────────────────────────────
                 (Prop::Nodes, PropValue::TreeViewNodes(nodes), Handle::TreeView(tv)) => {
                     let root = tv.get_RootNodes()?;
                     root.Clear()?;
@@ -1559,7 +1559,6 @@ impl Backend for WinUIBackend {
                     }
                     Ok(())
                 }
-                // ── W21: CommandBar ──────────────────────────────────────
                 (
                     Prop::PrimaryCommands,
                     PropValue::CommandBarCommands(cmds),
@@ -1571,7 +1570,6 @@ impl Backend for WinUIBackend {
                         let el = build_command_bar_element(def)?;
                         primary.Append(&el)?;
                     }
-                    // Wire click handlers.
                     let handlers = self.menu_click_handlers.borrow();
                     if let Some(handler) = handlers.get(&id) {
                         let revs = Self::wire_command_bar_clicks(&primary, handler);
@@ -1594,7 +1592,6 @@ impl Backend for WinUIBackend {
                         let el = build_command_bar_element(def)?;
                         secondary.Append(&el)?;
                     }
-                    // Wire click handlers for secondary too.
                     let handlers = self.menu_click_handlers.borrow();
                     if let Some(handler) = handlers.get(&id) {
                         let revs = Self::wire_command_bar_clicks(&secondary, handler);
@@ -1605,7 +1602,6 @@ impl Backend for WinUIBackend {
                     }
                     Ok(())
                 }
-                // ── W22: TeachingTip ────────────────────────────────────
                 (Prop::ActionButton, PropValue::Str(s), Handle::TeachingTip(tt)) => {
                     let boxed: windows_core::IInspectable =
                         windows_reference::IReference::<windows_core::HSTRING>::from(
@@ -1622,7 +1618,6 @@ impl Backend for WinUIBackend {
                         .cast()?;
                     tt.put_CloseButtonContent(&boxed)
                 }
-                // ── W23: SelectorBar ────────────────────────────────────
                 (Prop::Items, PropValue::SelectorBarItems(items), Handle::SelectorBar(sb)) => {
                     let vec = sb.get_Items()?;
                     vec.Clear()?;
@@ -1651,7 +1646,6 @@ impl Backend for WinUIBackend {
                     reb.put_Header(&tb)
                 }
                 (Prop::Header, PropValue::Unset, Handle::RichEditBox(reb)) => reb.put_Header(None),
-                // ── Flyout on Button ──────────────────────────────────────────
                 (Prop::FlyoutContent, PropValue::Str(s), Handle::Button(b)) => {
                     let flyout = Xaml::Flyout::new()?;
                     let tb = string_as_textblock(s)?;
@@ -1667,31 +1661,6 @@ impl Backend for WinUIBackend {
                             .put_Placement(Xaml::FlyoutPlacementMode(*v));
                     }
                     Ok(())
-                }
-                // ── RelativePanel attached props ──────────────────────────────
-                (Prop::AlignLeftWithPanel, PropValue::Bool(v), _) => {
-                    Xaml::RelativePanel::SetAlignLeftWithPanel(&handle.as_ui_element(), *v)
-                }
-                (Prop::AlignRightWithPanel, PropValue::Bool(v), _) => {
-                    Xaml::RelativePanel::SetAlignRightWithPanel(&handle.as_ui_element(), *v)
-                }
-                (Prop::AlignTopWithPanel, PropValue::Bool(v), _) => {
-                    Xaml::RelativePanel::SetAlignTopWithPanel(&handle.as_ui_element(), *v)
-                }
-                (Prop::AlignBottomWithPanel, PropValue::Bool(v), _) => {
-                    Xaml::RelativePanel::SetAlignBottomWithPanel(&handle.as_ui_element(), *v)
-                }
-                (Prop::AlignHCenterWithPanel, PropValue::Bool(v), _) => {
-                    Xaml::RelativePanel::SetAlignHorizontalCenterWithPanel(
-                        &handle.as_ui_element(),
-                        *v,
-                    )
-                }
-                (Prop::AlignVCenterWithPanel, PropValue::Bool(v), _) => {
-                    Xaml::RelativePanel::SetAlignVerticalCenterWithPanel(
-                        &handle.as_ui_element(),
-                        *v,
-                    )
                 }
                 (_, PropValue::Unset, _) => Ok(()),
                 (p, v, h) => {
@@ -1721,55 +1690,13 @@ impl Backend for WinUIBackend {
             .get(&child)
             .unwrap_or_else(|| panic!("WinUIBackend::append_child: unknown child {child}"));
         let child_ui = child_h.as_ui_element();
-        match parent_h {
-            Handle::StackPanel(_)
-            | Handle::Grid(_)
-            | Handle::Canvas(_)
-            | Handle::RelativePanel(_) => {
-                let vec = panel_children_vec(parent_h).unwrap();
-                vec.Append(&child_ui).unwrap();
-            }
-            Handle::Border(b) => {
-                b.put_Child(&child_ui).unwrap();
-            }
-            Handle::Viewbox(v) => {
-                v.put_Child(&child_ui).unwrap();
-            }
-            Handle::ScrollViewer(_)
-            | Handle::Expander(_)
-            | Handle::TabViewItem(_)
-            | Handle::NavigationView(_)
-            | Handle::PivotItem(_) => {
-                let cc = content_control_for(parent_h).unwrap();
-                cc.put_Content(&child_ui).unwrap();
-            }
-            Handle::SplitView(sv) => {
-                sv.put_Content(&child_ui).unwrap();
-            }
-            Handle::ScrollView(sv) => {
-                sv.put_Content(&child_ui).unwrap();
-            }
-            Handle::TabView(tv) => {
-                let items = tv.get_TabItems().unwrap();
-                let insp: windows_core::IInspectable = child_ui.cast().unwrap();
-                items.Append(&insp).unwrap();
-            }
-            Handle::Pivot(p) => {
-                let items = p
-                    .cast::<Xaml::IItemsControl>()
-                    .unwrap()
-                    .get_Items()
-                    .unwrap()
-                    .cast::<windows_collections::IVector<windows_core::IInspectable>>()
-                    .unwrap();
-                let insp: windows_core::IInspectable = child_ui.cast().unwrap();
-                items.Append(&insp).unwrap();
-            }
-            other => {
-                let kind = describe_kind(other);
-                panic!("WinUIBackend::append_child: {kind} ({parent}) is not a container");
-            }
-        }
+        let cc = classify_container(parent_h).unwrap_or_else(|| {
+            panic!(
+                "WinUIBackend::append_child: {} ({parent}) is not a container",
+                parent_h.kind_name()
+            )
+        });
+        container_append(&cc, &child_ui);
     }
     fn remove_child(&mut self, parent: ControlId, index: usize) {
         // Phantom children (e.g. ContentDialog) are never in the parent's
@@ -1793,46 +1720,9 @@ impl Backend for WinUIBackend {
         let parent_h = map
             .get(&parent)
             .unwrap_or_else(|| panic!("WinUIBackend::remove_child: unknown parent {parent}"));
-        match parent_h {
-            Handle::StackPanel(_) | Handle::Grid(_) | Handle::Canvas(_) => {
-                if let Some(vec) = panel_children_vec(parent_h) {
-                    vec.RemoveAt(v_index as u32).unwrap();
-                }
-            }
-            Handle::Border(b) => {
-                debug_assert_eq!(v_index, 0);
-                b.put_Child(None).unwrap();
-            }
-            Handle::Viewbox(v) => {
-                debug_assert_eq!(v_index, 0);
-                v.put_Child(None).unwrap();
-            }
-            Handle::ScrollViewer(_)
-            | Handle::Expander(_)
-            | Handle::TabViewItem(_)
-            | Handle::NavigationView(_)
-            | Handle::PivotItem(_) => {
-                debug_assert_eq!(v_index, 0);
-                if let Some(cc) = content_control_for(parent_h) {
-                    cc.put_Content(None).unwrap();
-                }
-            }
-            Handle::TabView(tv) => {
-                let items = tv.get_TabItems().unwrap();
-                items.RemoveAt(v_index as u32).unwrap();
-            }
-            Handle::Pivot(p) => {
-                let items = p
-                    .cast::<Xaml::IItemsControl>()
-                    .unwrap()
-                    .get_Items()
-                    .unwrap()
-                    .cast::<windows_collections::IVector<windows_core::IInspectable>>()
-                    .unwrap();
-                items.RemoveAt(v_index as u32).unwrap();
-            }
-            _ => panic!("WinUIBackend::remove_child: {parent} is not a container"),
-        }
+        let cc = classify_container(parent_h)
+            .unwrap_or_else(|| panic!("WinUIBackend::remove_child: {parent} is not a container"));
+        container_remove(&cc, v_index);
     }
     fn replace_child(&mut self, parent: ControlId, index: usize, new: ControlId) {
         let old = self
@@ -1888,55 +1778,9 @@ impl Backend for WinUIBackend {
         let parent_h = map
             .get(&parent)
             .unwrap_or_else(|| panic!("WinUIBackend::move_child: unknown parent {parent}"));
-        match parent_h {
-            Handle::StackPanel(s) => {
-                ui_element_collection_move(
-                    &s.cast::<Xaml::IPanel>().unwrap().get_Children().unwrap(),
-                    v_from,
-                    v_to,
-                );
-            }
-            Handle::Grid(g) => {
-                ui_element_collection_move(
-                    &g.cast::<Xaml::IPanel>().unwrap().get_Children().unwrap(),
-                    v_from,
-                    v_to,
-                );
-            }
-            Handle::Canvas(c) => {
-                ui_element_collection_move(
-                    &c.cast::<Xaml::IPanel>().unwrap().get_Children().unwrap(),
-                    v_from,
-                    v_to,
-                );
-            }
-            Handle::Border(_)
-            | Handle::Viewbox(_)
-            | Handle::ScrollViewer(_)
-            | Handle::Expander(_)
-            | Handle::TabViewItem(_)
-            | Handle::NavigationView(_)
-            | Handle::PivotItem(_) => {}
-            Handle::Pivot(p) => {
-                let items = p
-                    .cast::<Xaml::IItemsControl>()
-                    .unwrap()
-                    .get_Items()
-                    .unwrap()
-                    .cast::<windows_collections::IVector<windows_core::IInspectable>>()
-                    .unwrap();
-                let item = items.GetAt(v_from as u32).unwrap();
-                items.RemoveAt(v_from as u32).unwrap();
-                items.InsertAt(v_to as u32, &item).unwrap();
-            }
-            Handle::TabView(tv) => {
-                let items = tv.get_TabItems().unwrap();
-                let item = items.GetAt(v_from as u32).unwrap();
-                items.RemoveAt(v_from as u32).unwrap();
-                items.InsertAt(v_to as u32, &item).unwrap();
-            }
-            _ => panic!("WinUIBackend::move_child: {parent} is not a container"),
-        }
+        let cc = classify_container(parent_h)
+            .unwrap_or_else(|| panic!("WinUIBackend::move_child: {parent} is not a container"));
+        container_move(&cc, v_from, v_to);
     }
     fn insert_child(&mut self, parent: ControlId, index: usize, child: ControlId) {
         let v_index = self.visual_index(parent, index);
@@ -1957,43 +1801,9 @@ impl Backend for WinUIBackend {
             .get(&child)
             .unwrap_or_else(|| panic!("WinUIBackend::insert_child: unknown child {child}"));
         let child_ui = child_h.as_ui_element();
-        match parent_h {
-            Handle::StackPanel(_) | Handle::Grid(_) | Handle::Canvas(_) => {
-                let vec = panel_children_vec(parent_h).unwrap();
-                vec.InsertAt(v_index as u32, &child_ui).unwrap();
-            }
-            Handle::Border(b) => {
-                b.put_Child(&child_ui).unwrap();
-            }
-            Handle::Viewbox(v) => {
-                v.put_Child(&child_ui).unwrap();
-            }
-            Handle::ScrollViewer(_)
-            | Handle::Expander(_)
-            | Handle::TabViewItem(_)
-            | Handle::NavigationView(_)
-            | Handle::PivotItem(_) => {
-                let cc = content_control_for(parent_h).unwrap();
-                cc.put_Content(&child_ui).unwrap();
-            }
-            Handle::TabView(tv) => {
-                let items = tv.get_TabItems().unwrap();
-                let insp: windows_core::IInspectable = child_ui.cast().unwrap();
-                items.InsertAt(v_index as u32, &insp).unwrap();
-            }
-            Handle::Pivot(p) => {
-                let items = p
-                    .cast::<Xaml::IItemsControl>()
-                    .unwrap()
-                    .get_Items()
-                    .unwrap()
-                    .cast::<windows_collections::IVector<windows_core::IInspectable>>()
-                    .unwrap();
-                let insp: windows_core::IInspectable = child_ui.cast().unwrap();
-                items.InsertAt(v_index as u32, &insp).unwrap();
-            }
-            _ => panic!("WinUIBackend::insert_child: {parent} is not a container"),
-        }
+        let cc = classify_container(parent_h)
+            .unwrap_or_else(|| panic!("WinUIBackend::insert_child: {parent} is not a container"));
+        container_insert(&cc, v_index, &child_ui);
     }
     fn set_templated_item_count(&mut self, _id: ControlId, _count: usize) {}
     fn set_templated_row_content(
@@ -2236,7 +2046,6 @@ impl Backend for WinUIBackend {
             .get(&id)
             .unwrap_or_else(|| panic!("WinUIBackend::attach_event: unknown control {id}"));
 
-        // Try generated dispatch first
         if let Some(revs) = generated_attach_event::dispatch(handle, event, &handler) {
             if !revs.is_empty() {
                 self.event_revokers.borrow_mut().insert((id, event), revs);
@@ -2419,7 +2228,6 @@ impl Backend for WinUIBackend {
                         .unwrap(),
                 );
             }
-            // ── ColorPicker ColorChanged ──────────────────────────────────
             (Event::ColorChanged, Handle::ColorPicker(cp)) => {
                 revokers.push(
                     cp.add_ColorChanged(move |_sender, args| {
@@ -2436,7 +2244,6 @@ impl Backend for WinUIBackend {
                     .unwrap(),
                 );
             }
-            // ── W9: DatePicker ────────────────────────────────────────────
             (Event::SelectedDateChanged, Handle::DatePicker(dp)) => {
                 revokers.push(
                     dp.add_SelectedDateChanged(move |_sender, args| {
@@ -2449,7 +2256,6 @@ impl Backend for WinUIBackend {
                     .unwrap(),
                 );
             }
-            // ── W10: TimePicker ───────────────────────────────────────────
             (Event::SelectedTimeChanged, Handle::TimePicker(tp)) => {
                 revokers.push(
                     tp.add_SelectedTimeChanged(move |_sender, args| {
@@ -2463,7 +2269,6 @@ impl Backend for WinUIBackend {
                     .unwrap(),
                 );
             }
-            // ── W11: CalendarDatePicker ───────────────────────────────────
             (Event::CalendarDateSelected, Handle::CalendarDatePicker(cdp)) => {
                 revokers.push(
                     cdp.add_DateChanged(move |_sender, args| {
@@ -2476,7 +2281,6 @@ impl Backend for WinUIBackend {
                     .unwrap(),
                 );
             }
-            // ── W13: ListBox ──────────────────────────────────────────────
             (Event::SelectionChanged, Handle::ListBox(lb)) => {
                 revokers.push(
                     lb.cast::<Xaml::ISelector>()
@@ -2493,7 +2297,6 @@ impl Backend for WinUIBackend {
                         .unwrap(),
                 );
             }
-            // ── W16: AutoSuggestBox ───────────────────────────────────────
             (Event::TextChanged, Handle::AutoSuggestBox(asb)) => {
                 revokers.push(
                     asb.add_TextChanged(move |sender, args| {
@@ -2545,13 +2348,11 @@ impl Backend for WinUIBackend {
                     .unwrap(),
                 );
             }
-            // ── W18: MenuBar ─────────────────────────────────────────
             (Event::ItemClicked, Handle::MenuBar(mb)) => {
                 // Store the handler so set_prop can re-wire on item rebuild.
                 self.menu_click_handlers
                     .borrow_mut()
                     .insert(id, handler.clone());
-                // Wire click on all existing items.
                 let revs = Self::wire_menu_bar_clicks(mb, &handler);
                 revokers.extend(revs);
             }
@@ -2565,7 +2366,6 @@ impl Backend for WinUIBackend {
                     .borrow_mut()
                     .insert(id, handler);
             }
-            // ── W20: TreeView ─────────────────────────────────────────
             (Event::ItemInvoked, Handle::TreeView(tv)) => {
                 revokers.push(
                     tv.add_ItemInvoked(move |_sender, args| {
@@ -2590,13 +2390,11 @@ impl Backend for WinUIBackend {
                     .unwrap(),
                 );
             }
-            // ── W21: CommandBar ─────────────────────────────────────────
             (Event::Click, Handle::CommandBar(cb)) => {
                 // Store the handler so set_prop can re-wire on rebuild.
                 self.menu_click_handlers
                     .borrow_mut()
                     .insert(id, handler.clone());
-                // Wire click on all existing primary + secondary commands.
                 if let Ok(primary) = cb.get_PrimaryCommands() {
                     let revs = Self::wire_command_bar_clicks(&primary, &handler);
                     revokers.extend(revs);
@@ -2606,7 +2404,6 @@ impl Backend for WinUIBackend {
                     revokers.extend(revs);
                 }
             }
-            // ── W23: SelectorBar ─────────────────────────────────────────
             (Event::SelectionChanged, Handle::SelectorBar(sb)) => {
                 let sb2 = sb.clone();
                 revokers.push(

--- a/crates/libs/reactor/src/winui/backend/mod.rs
+++ b/crates/libs/reactor/src/winui/backend/mod.rs
@@ -995,8 +995,9 @@ fn set_background(
         ctl.put_Background(brush)?;
     } else if let Ok(border) = handle.cast_inner::<Xaml::IBorder>() {
         border.put_Background(brush)?;
+    } else {
+        diag::unhandled_modifier("set_prop", Prop::Background, handle);
     }
-    // TextBlock/RichTextBlock: no background property — silently ignored.
     Ok(true)
 }
 

--- a/crates/libs/reactor/src/winui/backend/mod.rs
+++ b/crates/libs/reactor/src/winui/backend/mod.rs
@@ -1024,6 +1024,8 @@ fn set_font_f64(handle: &Handle, v: f64) -> windows_core::Result<bool> {
         tb.put_FontSize(v)?;
     } else if let Ok(rtb) = handle.cast_inner::<Xaml::IRichTextBlock>() {
         rtb.put_FontSize(v)?;
+    } else {
+        diag::unhandled_modifier("set_prop", Prop::FontSize, handle);
     }
     Ok(true)
 }
@@ -1033,6 +1035,8 @@ fn set_font_weight(handle: &Handle, fw: WinFontWeight) -> windows_core::Result<b
         ctrl.put_FontWeight(fw)?;
     } else if let Ok(tb) = handle.cast_inner::<Xaml::ITextBlock>() {
         tb.put_FontWeight(fw)?;
+    } else {
+        diag::unhandled_modifier("set_prop", Prop::FontWeight, handle);
     }
     Ok(true)
 }
@@ -1044,6 +1048,8 @@ fn set_font_family(handle: &Handle, ff: &Xaml::FontFamily) -> windows_core::Resu
         tb.put_FontFamily(ff)?;
     } else if let Ok(rtb) = handle.cast_inner::<Xaml::IRichTextBlock>() {
         rtb.put_FontFamily(ff)?;
+    } else {
+        diag::unhandled_modifier("set_prop", Prop::FontFamily, handle);
     }
     Ok(true)
 }

--- a/crates/tests/libs/reactor/tests/universal_props.rs
+++ b/crates/tests/libs/reactor/tests/universal_props.rs
@@ -1,0 +1,241 @@
+//! Tests for the `try_universal_prop` dispatch and related helpers that were
+//! extracted from per-control match arms during the backend consolidation.
+//! Covers: min/max sizing, canvas z_index, relative panel attached props,
+//! and is_enabled unset.
+
+use std::rc::Rc;
+
+use windows_reactor::core::backend::{Op, Prop, PropValue, RecordingBackend};
+use windows_reactor::core::element::{Button, Element, Modifiers, StackPanel, TextBlock};
+use windows_reactor::core::reconciler::Reconciler;
+
+fn rr() -> Rc<dyn Fn()> {
+    Rc::new(|| {})
+}
+
+fn mount(el: &Element) -> Reconciler<RecordingBackend> {
+    let mut r = Reconciler::new(RecordingBackend::new());
+    r.reconcile(None, el, None, rr());
+    r
+}
+
+fn props_for(r: &Reconciler<RecordingBackend>, prop: Prop) -> Vec<PropValue> {
+    r.backend
+        .ops
+        .iter()
+        .filter_map(|o| match o {
+            Op::SetProp { prop: p, value, .. } if *p == prop => Some(value.clone()),
+            _ => None,
+        })
+        .collect()
+}
+
+// ── Min/Max sizing ──────────────────────────────────────────────────────
+
+#[test]
+fn min_width_emits_set_prop() {
+    let el = Element::TextBlock(TextBlock {
+        text: "x".into(),
+        modifiers: Modifiers {
+            min_width: Some(100.0),
+            ..Modifiers::default()
+        },
+        ..TextBlock::default()
+    });
+    let r = mount(&el);
+    let vals = props_for(&r, Prop::MinWidth);
+    assert_eq!(vals, vec![PropValue::F64(100.0)]);
+}
+
+#[test]
+fn max_width_emits_set_prop() {
+    let el = Element::TextBlock(TextBlock {
+        text: "x".into(),
+        modifiers: Modifiers {
+            max_width: Some(500.0),
+            ..Modifiers::default()
+        },
+        ..TextBlock::default()
+    });
+    let r = mount(&el);
+    let vals = props_for(&r, Prop::MaxWidth);
+    assert_eq!(vals, vec![PropValue::F64(500.0)]);
+}
+
+#[test]
+fn min_height_emits_set_prop() {
+    let el = Element::TextBlock(TextBlock {
+        text: "x".into(),
+        modifiers: Modifiers {
+            min_height: Some(50.0),
+            ..Modifiers::default()
+        },
+        ..TextBlock::default()
+    });
+    let r = mount(&el);
+    let vals = props_for(&r, Prop::MinHeight);
+    assert_eq!(vals, vec![PropValue::F64(50.0)]);
+}
+
+#[test]
+fn max_height_emits_set_prop() {
+    let el = Element::TextBlock(TextBlock {
+        text: "x".into(),
+        modifiers: Modifiers {
+            max_height: Some(800.0),
+            ..Modifiers::default()
+        },
+        ..TextBlock::default()
+    });
+    let r = mount(&el);
+    let vals = props_for(&r, Prop::MaxHeight);
+    assert_eq!(vals, vec![PropValue::F64(800.0)]);
+}
+
+#[test]
+fn min_max_unset_on_diff() {
+    let el1 = Element::TextBlock(TextBlock {
+        text: "x".into(),
+        modifiers: Modifiers {
+            min_width: Some(100.0),
+            max_height: Some(800.0),
+            ..Modifiers::default()
+        },
+        ..TextBlock::default()
+    });
+    let el2 = Element::TextBlock(TextBlock {
+        text: "x".into(),
+        modifiers: Modifiers::default(),
+        ..TextBlock::default()
+    });
+    let mut r = Reconciler::new(RecordingBackend::new());
+    let id = r.reconcile(None, &el1, None, rr()).unwrap();
+    r.backend.clear_ops();
+    r.reconcile(Some(&el1), &el2, Some(id), rr());
+
+    let min_w = props_for(&r, Prop::MinWidth);
+    let max_h = props_for(&r, Prop::MaxHeight);
+    assert_eq!(min_w, vec![PropValue::Unset]);
+    assert_eq!(max_h, vec![PropValue::Unset]);
+}
+
+// ── Canvas ZIndex ───────────────────────────────────────────────────────
+
+#[test]
+fn canvas_z_index_emits_set_prop() {
+    use windows_reactor::core::element::Canvas;
+
+    let child: Element = TextBlock::new("hi").into();
+    let child = child.canvas_z_index(5);
+    let el: Element = Canvas::new([child]).into();
+    let r = mount(&el);
+    let vals = props_for(&r, Prop::AttachedCanvasZIndex);
+    assert_eq!(vals, vec![PropValue::I32(5)]);
+}
+
+// ── RelativePanel attached props ────────────────────────────────────────
+// The relative_align_* methods store RelativePanelAlignment in the element's
+// attached props. The reconciler dispatches them regardless of parent type.
+
+#[test]
+fn relative_panel_align_left_emits_set_prop() {
+    let child: Element = TextBlock::new("hi").into();
+    let child = child.relative_align_left();
+    let el: Element = StackPanel {
+        children: vec![child],
+        ..StackPanel::vertical()
+    }
+    .into();
+    let r = mount(&el);
+    let vals = props_for(&r, Prop::AlignLeftWithPanel);
+    assert_eq!(vals, vec![PropValue::Bool(true)]);
+}
+
+#[test]
+fn relative_panel_align_right_emits_set_prop() {
+    let child: Element = TextBlock::new("hi").into();
+    let child = child.relative_align_right();
+    let el: Element = StackPanel {
+        children: vec![child],
+        ..StackPanel::vertical()
+    }
+    .into();
+    let r = mount(&el);
+    let vals = props_for(&r, Prop::AlignRightWithPanel);
+    assert_eq!(vals, vec![PropValue::Bool(true)]);
+}
+
+#[test]
+fn relative_panel_align_top_emits_set_prop() {
+    let child: Element = TextBlock::new("hi").into();
+    let child = child.relative_align_top();
+    let el: Element = StackPanel {
+        children: vec![child],
+        ..StackPanel::vertical()
+    }
+    .into();
+    let r = mount(&el);
+    let vals = props_for(&r, Prop::AlignTopWithPanel);
+    assert_eq!(vals, vec![PropValue::Bool(true)]);
+}
+
+#[test]
+fn relative_panel_align_bottom_emits_set_prop() {
+    let child: Element = TextBlock::new("hi").into();
+    let child = child.relative_align_bottom();
+    let el: Element = StackPanel {
+        children: vec![child],
+        ..StackPanel::vertical()
+    }
+    .into();
+    let r = mount(&el);
+    let vals = props_for(&r, Prop::AlignBottomWithPanel);
+    assert_eq!(vals, vec![PropValue::Bool(true)]);
+}
+
+#[test]
+fn relative_panel_align_h_center_emits_set_prop() {
+    let child: Element = TextBlock::new("hi").into();
+    let child = child.relative_align_h_center();
+    let el: Element = StackPanel {
+        children: vec![child],
+        ..StackPanel::vertical()
+    }
+    .into();
+    let r = mount(&el);
+    let vals = props_for(&r, Prop::AlignHCenterWithPanel);
+    assert_eq!(vals, vec![PropValue::Bool(true)]);
+}
+
+#[test]
+fn relative_panel_align_v_center_emits_set_prop() {
+    let child: Element = TextBlock::new("hi").into();
+    let child = child.relative_align_v_center();
+    let el: Element = StackPanel {
+        children: vec![child],
+        ..StackPanel::vertical()
+    }
+    .into();
+    let r = mount(&el);
+    let vals = props_for(&r, Prop::AlignVCenterWithPanel);
+    assert_eq!(vals, vec![PropValue::Bool(true)]);
+}
+
+// ── IsEnabled transition ─────────────────────────────────────────────────
+
+#[test]
+fn is_enabled_false_to_true_emits_set_prop() {
+    let el1: Element = Button {
+        is_enabled: false,
+        ..Button::new("x")
+    }
+    .into();
+    let el2: Element = Button::new("x").into();
+    let mut r = Reconciler::new(RecordingBackend::new());
+    let id = r.reconcile(None, &el1, None, rr()).unwrap();
+    r.backend.clear_ops();
+    r.reconcile(Some(&el1), &el2, Some(id), rr());
+
+    let vals = props_for(&r, Prop::IsEnabled);
+    assert_eq!(vals, vec![PropValue::Bool(true)]);
+}

--- a/crates/tests/libs/reactor_selftest/src/fixtures/mod.rs
+++ b/crates/tests/libs/reactor_selftest/src/fixtures/mod.rs
@@ -13,3 +13,4 @@ pub mod prop_updates;
 pub mod reconciler;
 pub mod reconciler_stress;
 pub mod tooltip;
+pub mod universal_props;

--- a/crates/tests/libs/reactor_selftest/src/fixtures/universal_props.rs
+++ b/crates/tests/libs/reactor_selftest/src/fixtures/universal_props.rs
@@ -20,6 +20,7 @@ use windows_reactor::vstack;
 /// on. Verifies the COM calls succeed on a real FrameworkElement.
 pub fn min_max_sizing(h: Harness) -> FixtureFuture {
     Box::pin(async move {
+        let cap = h.capture_stderr();
         h.mount(cc(|cx| {
             let (constrained, set) = cx.use_state(true);
             let tb = if constrained {
@@ -39,7 +40,6 @@ pub fn min_max_sizing(h: Harness) -> FixtureFuture {
         }));
         h.render().await;
 
-        let cap = h.capture_stderr();
         h.check(
             "UniversalProp_MinMax_MountConstrained",
             h.find_text("constrained").is_some(),
@@ -67,6 +67,7 @@ pub fn min_max_sizing(h: Harness) -> FixtureFuture {
 /// Canvas.SetZIndex COM call succeeds.
 pub fn canvas_z_index(h: Harness) -> FixtureFuture {
     Box::pin(async move {
+        let cap = h.capture_stderr();
         h.mount(cc(|_| {
             Canvas::new([
                 text_block("back").canvas_z_index(0),
@@ -76,7 +77,6 @@ pub fn canvas_z_index(h: Harness) -> FixtureFuture {
         }));
         h.render().await;
 
-        let cap = h.capture_stderr();
         h.check(
             "UniversalProp_CanvasZIndex_BackPresent",
             h.find_text("back").is_some(),
@@ -93,6 +93,7 @@ pub fn canvas_z_index(h: Harness) -> FixtureFuture {
 /// Verifies the static RelativePanel.SetAlign*WithPanel COM calls succeed.
 pub fn relative_panel_alignment(h: Harness) -> FixtureFuture {
     Box::pin(async move {
+        let cap = h.capture_stderr();
         h.mount(cc(|_| {
             let left: Element = text_block("L").into();
             let right: Element = text_block("R").into();
@@ -112,7 +113,6 @@ pub fn relative_panel_alignment(h: Harness) -> FixtureFuture {
         }));
         h.render().await;
 
-        let cap = h.capture_stderr();
         h.check(
             "UniversalProp_RelativeAlign_ChildrenPresent",
             h.find_text("L").is_some() && h.find_text("R").is_some(),
@@ -127,6 +127,7 @@ pub fn relative_panel_alignment(h: Harness) -> FixtureFuture {
 /// Background, Foreground, and Padding).
 pub fn background_foreground_padding_transition(h: Harness) -> FixtureFuture {
     Box::pin(async move {
+        let cap = h.capture_stderr();
         h.mount(cc(|cx| {
             let (styled, set) = cx.use_state(true);
             let btn = if styled {
@@ -151,7 +152,6 @@ pub fn background_foreground_padding_transition(h: Harness) -> FixtureFuture {
         }));
         h.render().await;
 
-        let cap = h.capture_stderr();
         h.check(
             "UniversalProp_BgFgPad_MountStyled",
             h.find_button("styled").is_some(),
@@ -179,6 +179,7 @@ pub fn background_foreground_padding_transition(h: Harness) -> FixtureFuture {
 /// call succeeds in both directions.
 pub fn opacity_transition(h: Harness) -> FixtureFuture {
     Box::pin(async move {
+        let cap = h.capture_stderr();
         h.mount(cc(|cx| {
             let (faded, set) = cx.use_state(true);
             let tb = if faded {
@@ -190,7 +191,6 @@ pub fn opacity_transition(h: Harness) -> FixtureFuture {
         }));
         h.render().await;
 
-        let cap = h.capture_stderr();
         h.check(
             "UniversalProp_Opacity_MountFaded",
             h.find_text("faded").is_some(),

--- a/crates/tests/libs/reactor_selftest/src/fixtures/universal_props.rs
+++ b/crates/tests/libs/reactor_selftest/src/fixtures/universal_props.rs
@@ -1,0 +1,208 @@
+//! Live WinUI coverage for refactored `try_universal_prop` paths and related
+//! helpers: min/max sizing, canvas z_index, relative-panel alignment, and
+//! background/foreground/padding set+clear transitions.
+//!
+//! Most of these cannot read back values from WinUI (the selftest bindings
+//! are minimal), so the tests verify:
+//! 1. Mount with the prop set succeeds (COM call doesn't fail/panic).
+//! 2. Prop transitions (set → clear → set) succeed without errors.
+//! 3. No `windows-reactor:` diagnostic warnings are emitted.
+
+use windows_reactor::core::element::{Canvas, Color, Element, RelativePanel};
+use windows_reactor::dsl::{ElementExt, button, text_block};
+
+use crate::fixtures::reconciler::{FixtureFuture, cc};
+use crate::harness::Harness;
+
+use windows_reactor::vstack;
+
+/// Mount a TextBlock with min/max constraints, then toggle them off and back
+/// on. Verifies the COM calls succeed on a real FrameworkElement.
+pub fn min_max_sizing(h: Harness) -> FixtureFuture {
+    Box::pin(async move {
+        h.mount(cc(|cx| {
+            let (constrained, set) = cx.use_state(true);
+            let tb = if constrained {
+                text_block("constrained")
+                    .min_width(50.0)
+                    .max_width(400.0)
+                    .min_height(20.0)
+                    .max_height(200.0)
+            } else {
+                text_block("unconstrained")
+            };
+            vstack((
+                tb,
+                button("Toggle").on_click(move || set.call(!constrained)),
+            ))
+            .into()
+        }));
+        h.render().await;
+
+        let cap = h.capture_stderr();
+        h.check(
+            "UniversalProp_MinMax_MountConstrained",
+            h.find_text("constrained").is_some(),
+        );
+
+        let _ = h.click_button("Toggle");
+        h.render().await;
+        h.check(
+            "UniversalProp_MinMax_ClearConstraints",
+            h.find_text("unconstrained").is_some(),
+        );
+
+        let _ = h.click_button("Toggle");
+        h.render().await;
+        h.check(
+            "UniversalProp_MinMax_RestoreConstraints",
+            h.find_text("constrained").is_some(),
+        );
+
+        h.check_no_reactor_warnings("UniversalProp_MinMax_NoWarnings", &cap.finish());
+    })
+}
+
+/// Mount a Canvas child with canvas_z_index set. Verifies the static
+/// Canvas.SetZIndex COM call succeeds.
+pub fn canvas_z_index(h: Harness) -> FixtureFuture {
+    Box::pin(async move {
+        h.mount(cc(|_| {
+            Canvas::new([
+                text_block("back").canvas_z_index(0),
+                text_block("front").canvas_z_index(10),
+            ])
+            .into()
+        }));
+        h.render().await;
+
+        let cap = h.capture_stderr();
+        h.check(
+            "UniversalProp_CanvasZIndex_BackPresent",
+            h.find_text("back").is_some(),
+        );
+        h.check(
+            "UniversalProp_CanvasZIndex_FrontPresent",
+            h.find_text("front").is_some(),
+        );
+        h.check_no_reactor_warnings("UniversalProp_CanvasZIndex_NoWarnings", &cap.finish());
+    })
+}
+
+/// Mount a RelativePanel with children using alignment attached props.
+/// Verifies the static RelativePanel.SetAlign*WithPanel COM calls succeed.
+pub fn relative_panel_alignment(h: Harness) -> FixtureFuture {
+    Box::pin(async move {
+        h.mount(cc(|_| {
+            let left: Element = text_block("L").into();
+            let right: Element = text_block("R").into();
+            let top: Element = text_block("T").into();
+            let bottom: Element = text_block("B").into();
+            let hc: Element = text_block("HC").into();
+            let vc: Element = text_block("VC").into();
+            RelativePanel::new([
+                left.relative_align_left(),
+                right.relative_align_right(),
+                top.relative_align_top(),
+                bottom.relative_align_bottom(),
+                hc.relative_align_h_center(),
+                vc.relative_align_v_center(),
+            ])
+            .into()
+        }));
+        h.render().await;
+
+        let cap = h.capture_stderr();
+        h.check(
+            "UniversalProp_RelativeAlign_ChildrenPresent",
+            h.find_text("L").is_some() && h.find_text("R").is_some(),
+        );
+        h.check_no_reactor_warnings("UniversalProp_RelativeAlign_NoWarnings", &cap.finish());
+    })
+}
+
+/// Mount with background/foreground/padding set, then clear them, then
+/// restore them. Verifies the set/unset COM calls on IControl/IPanel/IBorder
+/// don't fail. Uses a Button since it implements IControl (which supports
+/// Background, Foreground, and Padding).
+pub fn background_foreground_padding_transition(h: Harness) -> FixtureFuture {
+    Box::pin(async move {
+        h.mount(cc(|cx| {
+            let (styled, set) = cx.use_state(true);
+            let btn = if styled {
+                button("styled")
+                    .background(Color {
+                        a: 255,
+                        r: 200,
+                        g: 0,
+                        b: 0,
+                    })
+                    .foreground(Color {
+                        a: 255,
+                        r: 255,
+                        g: 255,
+                        b: 255,
+                    })
+                    .padding(10.0)
+            } else {
+                button("plain")
+            };
+            vstack((btn, button("Toggle").on_click(move || set.call(!styled)))).into()
+        }));
+        h.render().await;
+
+        let cap = h.capture_stderr();
+        h.check(
+            "UniversalProp_BgFgPad_MountStyled",
+            h.find_button("styled").is_some(),
+        );
+
+        let _ = h.click_button("Toggle");
+        h.render().await;
+        h.check(
+            "UniversalProp_BgFgPad_ClearStyle",
+            h.find_button("plain").is_some(),
+        );
+
+        let _ = h.click_button("Toggle");
+        h.render().await;
+        h.check(
+            "UniversalProp_BgFgPad_RestoreStyle",
+            h.find_button("styled").is_some(),
+        );
+
+        h.check_no_reactor_warnings("UniversalProp_BgFgPad_NoWarnings", &cap.finish());
+    })
+}
+
+/// Mount with opacity set, then clear it. Verifies the UIElement.Opacity COM
+/// call succeeds in both directions.
+pub fn opacity_transition(h: Harness) -> FixtureFuture {
+    Box::pin(async move {
+        h.mount(cc(|cx| {
+            let (faded, set) = cx.use_state(true);
+            let tb = if faded {
+                text_block("faded").opacity(0.5)
+            } else {
+                text_block("full")
+            };
+            vstack((tb, button("Toggle").on_click(move || set.call(!faded)))).into()
+        }));
+        h.render().await;
+
+        let cap = h.capture_stderr();
+        h.check(
+            "UniversalProp_Opacity_MountFaded",
+            h.find_text("faded").is_some(),
+        );
+
+        let _ = h.click_button("Toggle");
+        h.render().await;
+        h.check(
+            "UniversalProp_Opacity_ClearOpacity",
+            h.find_text("full").is_some(),
+        );
+
+        h.check_no_reactor_warnings("UniversalProp_Opacity_NoWarnings", &cap.finish());
+    })
+}

--- a/crates/tests/libs/reactor_selftest/src/registry.rs
+++ b/crates/tests/libs/reactor_selftest/src/registry.rs
@@ -2,7 +2,7 @@ use crate::fixtures::reconciler::FixtureFuture;
 use crate::fixtures::{
     all_layouts, backdrop, controls, controls_extended, dynamic, error_boundary, event_detachment,
     grid_attached, hooks, interactions, layout, prop_updates, reconciler, reconciler_stress,
-    tooltip,
+    tooltip, universal_props,
 };
 use crate::harness::Harness;
 
@@ -334,5 +334,26 @@ pub static FIXTURES: &[(&str, FixtureFn)] = &[
     (
         "KeyedStress_TypeMismatch",
         reconciler_stress::positional_type_mismatch,
+    ),
+    // ── Universal prop fixtures (try_universal_prop live coverage) ──────
+    (
+        "UniversalProp_MinMaxSizing",
+        universal_props::min_max_sizing,
+    ),
+    (
+        "UniversalProp_CanvasZIndex",
+        universal_props::canvas_z_index,
+    ),
+    (
+        "UniversalProp_RelativePanelAlignment",
+        universal_props::relative_panel_alignment,
+    ),
+    (
+        "UniversalProp_BgFgPadTransition",
+        universal_props::background_foreground_padding_transition,
+    ),
+    (
+        "UniversalProp_OpacityTransition",
+        universal_props::opacity_transition,
     ),
 ];


### PR DESCRIPTION
This a targeted refactor of the backend to consolidate repeated patterns in container and property dispatch not specific to any one control/element. 

I also beefed up the test coverage this backend. 