### PR TITLE
`windows-reactor` fix calculator sample accent button rendering

### DIFF
--- a/crates/samples/reactor/minimal/examples/calculator.rs
+++ b/crates/samples/reactor/minimal/examples/calculator.rs
@@ -208,7 +208,6 @@ fn app(cx: &mut RenderCx) -> Element {
             let h = equals_handler.clone();
             move || h()
         })
-        .foreground(Color::rgb(255, 255, 255))
         .horizontal_alignment(HorizontalAlignment::Stretch)
         .vertical_alignment(VerticalAlignment::Stretch)
         .accent()

--- a/crates/samples/reactor/minimal/examples/calculator.rs
+++ b/crates/samples/reactor/minimal/examples/calculator.rs
@@ -211,7 +211,7 @@ fn app(cx: &mut RenderCx) -> Element {
         .foreground(Color::rgb(255, 255, 255))
         .horizontal_alignment(HorizontalAlignment::Stretch)
         .vertical_alignment(VerticalAlignment::Stretch)
-        .background(ThemeRef::Accent)
+        .accent()
         .into();
 
     // Button grid matching Windows Calculator Standard layout:


### PR DESCRIPTION
This now uses the built-in accent support for buttons and looks much better.

<img width="194" height="285" alt="image" src="https://github.com/user-attachments/assets/5ade1b72-d472-4d2c-afaf-34fef7803a01" />

Tested with `cargo run -p reactor_minimal --example calculator`
