### PR TITLE
Consolidate device management and add device-lost recovery in reactor/direct2d sample

### DIFF
--- a/crates/samples/reactor/direct2d/src/device.rs
+++ b/crates/samples/reactor/direct2d/src/device.rs
@@ -1,36 +1,31 @@
 //! Consolidated GPU device shared by every Direct2D sample in this app.
 //!
-//! A single [`SharedDevice`] (D3D11 device + Direct2D factory/device) is created
-//! once and handed to the samples through the reactor [`DEVICE`] context, so they
-//! all render with the same device.
+//! A single [`SharedDevice`] is created once and shared via the [`Gpu`] context,
+//! so every sample renders with the same device.
 //!
-//! The D2D factory is created `MULTI_THREADED` because the swap-chain sample
-//! presents from a dedicated worker thread while the surface-image-source sample
-//! draws on the UI thread; a multithreaded factory serializes D2D's own calls so
-//! the one D2D device can be used from both.
-//!
-//! Note: a multithreaded factory only serializes D2D's *own* calls, not raw
-//! D3D/DXGI interop on the shared device. This sample does not yet add the
-//! explicit `ID2D1Multithread` locking that would be needed to fully harden that
-//! interop; the focus here is on consolidating the device.
+//! The D2D factory is `MULTI_THREADED` because the swap-chain sample presents
+//! from a worker thread while the surface-image-source sample draws on the UI
+//! thread. That only serializes D2D's own calls, not raw D3D/DXGI interop; the
+//! `ID2D1Multithread` locking needed to fully harden that interop is not added
+//! here.
 
 use std::ops::Deref;
 use std::rc::Rc;
 use std::sync::LazyLock;
 
+use windows::Win32::Foundation::D2DERR_RECREATE_TARGET;
 use windows::Win32::Graphics::Direct2D::*;
 use windows::Win32::Graphics::Direct3D::*;
 use windows::Win32::Graphics::Direct3D11::*;
 use windows::Win32::Graphics::Dxgi::*;
-use windows::core::{Interface, Result};
-use windows_reactor::Context;
+use windows::core::{HRESULT, Interface, Result};
+use windows_reactor::{Context, Updater};
 
-/// The app-wide shared GPU device. Owns the D3D11 device, the `MULTI_THREADED`
-/// Direct2D factory and device, and the DXGI factory.
+/// The app-wide shared GPU device: the D3D11 device, the `MULTI_THREADED` D2D
+/// factory and device, and the DXGI factory.
 ///
-/// Every interface held here is an agile (free-threaded) COM object, so a clone
-/// of this struct can be moved onto the swap-chain sample's render thread; see
-/// [`Device::to_send`].
+/// Every interface is an agile COM object, so a clone can be moved onto the
+/// swap-chain sample's render thread; see [`Device::to_send`].
 #[derive(Clone)]
 pub struct SharedDevice {
     d3d_device: ID3D11Device,
@@ -60,8 +55,8 @@ impl SharedDevice {
         }
         let d3d_device = d3d_device.unwrap();
 
-        // MULTI_THREADED so the single D2D device can be used from both the UI
-        // thread and the swap-chain sample's render thread.
+        // MULTI_THREADED so the one D2D device works from both the UI and render
+        // threads.
         let d2d_factory: ID2D1Factory1 =
             unsafe { D2D1CreateFactory(D2D1_FACTORY_TYPE_MULTI_THREADED, None)? };
 
@@ -94,13 +89,11 @@ impl SharedDevice {
     }
 }
 
-/// Reference-counted handle to a [`SharedDevice`], suitable for use as a reactor
-/// context value and as a `use_effect` dependency.
+/// Reference-counted handle to a [`SharedDevice`], usable as a context value and
+/// a `use_effect` dependency.
 ///
-/// Equality is by identity (`Rc::ptr_eq`), so recreating the device after a
-/// device-lost event yields a value that compares unequal to the old one. That
-/// difference is what drives dependents (keyed on the device) to rebuild their
-/// device-specific resources.
+/// Equality is by identity (`Rc::ptr_eq`), so a recreated device compares
+/// unequal to the old one, driving device-keyed dependents to rebuild.
 #[derive(Clone)]
 pub struct Device(Rc<SharedDevice>);
 
@@ -110,9 +103,8 @@ impl Device {
         Ok(Self(Rc::new(SharedDevice::new()?)))
     }
 
-    /// A `Send` snapshot of the device's agile COM interfaces, for moving onto a
-    /// render worker thread. The clone shares the same underlying COM objects as
-    /// this handle.
+    /// A `Send` snapshot of the agile COM interfaces, for moving onto the render
+    /// thread. Shares the same underlying COM objects as this handle.
     pub fn to_send(&self) -> SharedDevice {
         (*self.0).clone()
     }
@@ -131,16 +123,55 @@ impl PartialEq for Device {
     }
 }
 
-/// Stable key for the device context. Stored as a `Context<()>` so the `static`
-/// is `Sync` — the real context value holds an `Rc` (UI-thread only), so the
-/// typed [`Context`] is rebuilt on demand via [`device_context`] using this id.
-static DEVICE_KEY: LazyLock<Context<()>> = LazyLock::new(|| Context::new(()));
+/// What every sample needs from the root: the shared [`Device`] (`None` until
+/// created, and briefly during recreation) and a way to request recovery.
+#[derive(Clone, PartialEq)]
+pub struct Gpu {
+    device: Option<Device>,
+    recover: Updater<u32>,
+}
 
-/// The app-wide device context, carrying the shared [`Device`]. `None` until the
-/// root creates it (and, in the device-lost flow, while it is being recreated).
-pub fn device_context() -> Context<Option<Device>> {
+impl Gpu {
+    pub fn new(device: Option<Device>, recover: Updater<u32>) -> Self {
+        Self { device, recover }
+    }
+
+    /// The shared device, or `None` while it is being (re)created.
+    pub fn device(&self) -> Option<Device> {
+        self.device.clone()
+    }
+
+    /// Ask the root to recreate the shared device. Bumps a counter that re-runs
+    /// the root's create/recover effect; recreation is unconditional.
+    pub fn request_recovery(&self) {
+        self.recover.call(|g| g.wrapping_add(1));
+    }
+}
+
+/// Stable id for the GPU context. Held as a `Context<()>` so the `static` is
+/// `Sync`; the real value holds `Rc`s, so [`gpu_context`] rebuilds the typed
+/// [`Context`] on demand.
+static GPU_KEY: LazyLock<Context<()>> = LazyLock::new(|| Context::new(()));
+
+/// The app-wide GPU context. `None` until the root installs it.
+pub fn gpu_context() -> Context<Option<Gpu>> {
     Context {
         default: None,
-        id: DEVICE_KEY.id,
+        id: GPU_KEY.id,
     }
+}
+
+/// Whether an `HRESULT` means the GPU device was lost and must be recreated.
+/// Matches the set Win2D treats as device-lost in
+/// `DeviceLostException::IsDeviceLostHResult`.
+pub fn is_device_lost(hr: HRESULT) -> bool {
+    matches!(
+        hr,
+        DXGI_ERROR_DEVICE_HUNG
+            | DXGI_ERROR_DEVICE_REMOVED
+            | DXGI_ERROR_DEVICE_RESET
+            | DXGI_ERROR_DRIVER_INTERNAL_ERROR
+            | DXGI_ERROR_INVALID_CALL
+            | D2DERR_RECREATE_TARGET
+    )
 }

--- a/crates/samples/reactor/direct2d/src/device.rs
+++ b/crates/samples/reactor/direct2d/src/device.rs
@@ -1,0 +1,146 @@
+//! Consolidated GPU device shared by every Direct2D sample in this app.
+//!
+//! A single [`SharedDevice`] (D3D11 device + Direct2D factory/device) is created
+//! once and handed to the samples through the reactor [`DEVICE`] context, so they
+//! all render with the same device.
+//!
+//! The D2D factory is created `MULTI_THREADED` because the swap-chain sample
+//! presents from a dedicated worker thread while the surface-image-source sample
+//! draws on the UI thread; a multithreaded factory serializes D2D's own calls so
+//! the one D2D device can be used from both.
+//!
+//! Note: a multithreaded factory only serializes D2D's *own* calls, not raw
+//! D3D/DXGI interop on the shared device. This sample does not yet add the
+//! explicit `ID2D1Multithread` locking that would be needed to fully harden that
+//! interop; the focus here is on consolidating the device.
+
+use std::ops::Deref;
+use std::rc::Rc;
+use std::sync::LazyLock;
+
+use windows::Win32::Graphics::Direct2D::*;
+use windows::Win32::Graphics::Direct3D::*;
+use windows::Win32::Graphics::Direct3D11::*;
+use windows::Win32::Graphics::Dxgi::*;
+use windows::core::{Interface, Result};
+use windows_reactor::Context;
+
+/// The app-wide shared GPU device. Owns the D3D11 device, the `MULTI_THREADED`
+/// Direct2D factory and device, and the DXGI factory.
+///
+/// Every interface held here is an agile (free-threaded) COM object, so a clone
+/// of this struct can be moved onto the swap-chain sample's render thread; see
+/// [`Device::to_send`].
+#[derive(Clone)]
+pub struct SharedDevice {
+    d3d_device: ID3D11Device,
+    d2d_device: ID2D1Device,
+    dxgi_factory: IDXGIFactory2,
+}
+
+// SAFETY: every interface held here is an agile (free-threaded) COM object.
+unsafe impl Send for SharedDevice {}
+
+impl SharedDevice {
+    /// Create a hardware-backed shared device.
+    fn new() -> Result<Self> {
+        let mut d3d_device: Option<ID3D11Device> = None;
+        unsafe {
+            D3D11CreateDevice(
+                None,
+                D3D_DRIVER_TYPE_HARDWARE,
+                None,
+                D3D11_CREATE_DEVICE_BGRA_SUPPORT,
+                Some(&[D3D_FEATURE_LEVEL_11_0]),
+                D3D11_SDK_VERSION,
+                Some(&mut d3d_device),
+                None,
+                None,
+            )?;
+        }
+        let d3d_device = d3d_device.unwrap();
+
+        // MULTI_THREADED so the single D2D device can be used from both the UI
+        // thread and the swap-chain sample's render thread.
+        let d2d_factory: ID2D1Factory1 =
+            unsafe { D2D1CreateFactory(D2D1_FACTORY_TYPE_MULTI_THREADED, None)? };
+
+        let dxgi_device: IDXGIDevice = d3d_device.cast()?;
+        let d2d_device = unsafe { d2d_factory.CreateDevice(&dxgi_device)? };
+
+        let dxgi_adapter = unsafe { dxgi_device.GetAdapter()? };
+        let dxgi_factory: IDXGIFactory2 = unsafe { dxgi_adapter.GetParent()? };
+
+        Ok(Self {
+            d3d_device,
+            d2d_device,
+            dxgi_factory,
+        })
+    }
+
+    /// The shared D3D11 device.
+    pub fn d3d_device(&self) -> &ID3D11Device {
+        &self.d3d_device
+    }
+
+    /// The shared Direct2D device. Create a per-thread device context from this.
+    pub fn d2d_device(&self) -> &ID2D1Device {
+        &self.d2d_device
+    }
+
+    /// The DXGI factory, for creating the composition swap chain.
+    pub fn dxgi_factory(&self) -> &IDXGIFactory2 {
+        &self.dxgi_factory
+    }
+}
+
+/// Reference-counted handle to a [`SharedDevice`], suitable for use as a reactor
+/// context value and as a `use_effect` dependency.
+///
+/// Equality is by identity (`Rc::ptr_eq`), so recreating the device after a
+/// device-lost event yields a value that compares unequal to the old one. That
+/// difference is what drives dependents (keyed on the device) to rebuild their
+/// device-specific resources.
+#[derive(Clone)]
+pub struct Device(Rc<SharedDevice>);
+
+impl Device {
+    /// Create a new shared device.
+    pub fn new() -> Result<Self> {
+        Ok(Self(Rc::new(SharedDevice::new()?)))
+    }
+
+    /// A `Send` snapshot of the device's agile COM interfaces, for moving onto a
+    /// render worker thread. The clone shares the same underlying COM objects as
+    /// this handle.
+    pub fn to_send(&self) -> SharedDevice {
+        (*self.0).clone()
+    }
+}
+
+impl Deref for Device {
+    type Target = SharedDevice;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl PartialEq for Device {
+    fn eq(&self, other: &Self) -> bool {
+        Rc::ptr_eq(&self.0, &other.0)
+    }
+}
+
+/// Stable key for the device context. Stored as a `Context<()>` so the `static`
+/// is `Sync` — the real context value holds an `Rc` (UI-thread only), so the
+/// typed [`Context`] is rebuilt on demand via [`device_context`] using this id.
+static DEVICE_KEY: LazyLock<Context<()>> = LazyLock::new(|| Context::new(()));
+
+/// The app-wide device context, carrying the shared [`Device`]. `None` until the
+/// root creates it (and, in the device-lost flow, while it is being recreated).
+pub fn device_context() -> Context<Option<Device>> {
+    Context {
+        default: None,
+        id: DEVICE_KEY.id,
+    }
+}

--- a/crates/samples/reactor/direct2d/src/device.rs
+++ b/crates/samples/reactor/direct2d/src/device.rs
@@ -33,9 +33,6 @@ pub struct SharedDevice {
     dxgi_factory: IDXGIFactory2,
 }
 
-// SAFETY: every interface held here is an agile (free-threaded) COM object.
-unsafe impl Send for SharedDevice {}
-
 impl SharedDevice {
     /// Create a hardware-backed shared device.
     fn new() -> Result<Self> {
@@ -124,7 +121,7 @@ impl PartialEq for Device {
 }
 
 /// What every sample needs from the root: the shared [`Device`] (`None` until
-/// created, and briefly during recreation) and a way to request recovery.
+/// first created) and a way to request recovery.
 #[derive(Clone, PartialEq)]
 pub struct Gpu {
     device: Option<Device>,
@@ -136,7 +133,7 @@ impl Gpu {
         Self { device, recover }
     }
 
-    /// The shared device, or `None` while it is being (re)created.
+    /// The shared device, or `None` before the first successful creation.
     pub fn device(&self) -> Option<Device> {
         self.device.clone()
     }

--- a/crates/samples/reactor/direct2d/src/main.rs
+++ b/crates/samples/reactor/direct2d/src/main.rs
@@ -5,6 +5,7 @@
 
 use windows_reactor::*;
 
+mod device;
 mod shell;
 mod surface_image_source;
 mod swap_chain;

--- a/crates/samples/reactor/direct2d/src/shell.rs
+++ b/crates/samples/reactor/direct2d/src/shell.rs
@@ -1,13 +1,25 @@
 //! Hub shell hosting the Direct2D samples in a `NavigationView`. Each sample is
 //! a self-contained component, so its state (such as the render thread) is
 //! created and torn down as the user navigates between samples.
+//!
+//! The shell owns the app-wide shared GPU [`Device`] and publishes it through the
+//! [`DEVICE`] context, so every sample renders with the same device.
 
+use crate::device::{Device, device_context};
 use crate::surface_image_source::surface_image_source_sample;
 use crate::swap_chain::swap_chain_sample;
 use windows_reactor::*;
 
 pub fn shell(cx: &mut RenderCx) -> Element {
     let (selected_tag, set_selected_tag) = cx.use_state(String::from("swap-chain"));
+
+    // The single shared device for the whole app. Created once on mount; the
+    // samples below read it from the `DEVICE` context.
+    let (device, set_device) = cx.use_state::<Option<Device>>(None);
+    cx.use_effect((), move || match Device::new() {
+        Ok(d) => set_device.call(Some(d)),
+        Err(e) => eprintln!("failed to create shared device: {e}"),
+    });
 
     let nav_items = vec![
         NavViewItem::new("Swap Chain Panel")
@@ -33,5 +45,5 @@ pub fn shell(cx: &mut RenderCx) -> Element {
                 set_selected_tag.call(tag);
             }
         })
-        .into()
+        .provide(&device_context(), device)
 }

--- a/crates/samples/reactor/direct2d/src/shell.rs
+++ b/crates/samples/reactor/direct2d/src/shell.rs
@@ -24,7 +24,6 @@ pub fn shell(cx: &mut RenderCx) -> Element {
 
     // Create the device on mount and recreate it on every recovery request.
     cx.use_effect(recover_gen, {
-        let update_device = update_device.clone();
         move || {
             update_device.call(|current| match Device::new() {
                 Ok(d) => Some(d),
@@ -55,18 +54,10 @@ pub fn shell(cx: &mut RenderCx) -> Element {
         _ => component(swap_chain_sample, ()),
     };
 
-    // Test aid: recreate the shared device on demand, without a real GPU
-    // device-removal event.
+    // Test aid: exercise the same recovery path as a real device-lost event.
     let recreate_device = {
-        move || {
-            update_device.call(|current| match Device::new() {
-                Ok(d) => Some(d),
-                Err(e) => {
-                    eprintln!("failed to recreate shared device: {e}");
-                    current
-                }
-            });
-        }
+        let gpu = gpu.clone();
+        move || gpu.request_recovery()
     };
 
     let nav_view = NavigationView::new(nav_items, content)

--- a/crates/samples/reactor/direct2d/src/shell.rs
+++ b/crates/samples/reactor/direct2d/src/shell.rs
@@ -2,10 +2,11 @@
 //! a self-contained component, so its state (such as the render thread) is
 //! created and torn down as the user navigates between samples.
 //!
-//! The shell owns the app-wide shared GPU [`Device`] and publishes it through the
-//! [`DEVICE`] context, so every sample renders with the same device.
+//! The shell owns the app-wide shared GPU [`Device`] and publishes it (with the
+//! recovery signal) through the [`Gpu`](crate::device::Gpu) context, so every
+//! sample renders with the same device.
 
-use crate::device::{Device, device_context};
+use crate::device::{Device, Gpu, gpu_context};
 use crate::surface_image_source::surface_image_source_sample;
 use crate::swap_chain::swap_chain_sample;
 use windows_reactor::*;
@@ -13,13 +14,32 @@ use windows_reactor::*;
 pub fn shell(cx: &mut RenderCx) -> Element {
     let (selected_tag, set_selected_tag) = cx.use_state(String::from("swap-chain"));
 
-    // The single shared device for the whole app. Created once on mount; the
-    // samples below read it from the `DEVICE` context.
-    let (device, set_device) = cx.use_state::<Option<Device>>(None);
-    cx.use_effect((), move || match Device::new() {
-        Ok(d) => set_device.call(Some(d)),
-        Err(e) => eprintln!("failed to create shared device: {e}"),
+    // The single shared device for the whole app. `use_reducer` gives a
+    // functional updater whose closure sees the current device at apply time.
+    let (device, update_device) = cx.use_reducer::<Option<Device>>(None);
+
+    // Bumped on each `Gpu::request_recovery`; also seeds the create/recover
+    // effect, so the device is created once on mount.
+    let (recover_gen, bump_recover) = cx.use_reducer::<u32>(0);
+
+    // Create the device on mount and recreate it on every recovery request.
+    cx.use_effect(recover_gen, {
+        let update_device = update_device.clone();
+        move || {
+            update_device.call(|current| match Device::new() {
+                Ok(d) => Some(d),
+                Err(e) => {
+                    eprintln!("failed to create shared device: {e}");
+                    current
+                }
+            });
+        }
     });
+
+    // Memoize the recovery updater so the `Gpu` context value keeps a stable
+    // identity across renders (the raw updater is freshly allocated each render).
+    let bump_recover = cx.use_memo((), move || bump_recover);
+    let gpu = Gpu::new(device, bump_recover);
 
     let nav_items = vec![
         NavViewItem::new("Swap Chain Panel")
@@ -35,7 +55,21 @@ pub fn shell(cx: &mut RenderCx) -> Element {
         _ => component(swap_chain_sample, ()),
     };
 
-    NavigationView::new(nav_items, content)
+    // Test aid: recreate the shared device on demand, without a real GPU
+    // device-removal event.
+    let recreate_device = {
+        move || {
+            update_device.call(|current| match Device::new() {
+                Ok(d) => Some(d),
+                Err(e) => {
+                    eprintln!("failed to recreate shared device: {e}");
+                    current
+                }
+            });
+        }
+    };
+
+    let nav_view = NavigationView::new(nav_items, content)
         .selected_tag(&selected_tag)
         .settings_visible(false)
         .pane_title("Direct2D Samples")
@@ -45,5 +79,18 @@ pub fn shell(cx: &mut RenderCx) -> Element {
                 set_selected_tag.call(tag);
             }
         })
-        .provide(&device_context(), device)
+        .provide(&gpu_context(), Some(gpu));
+
+    // Stack a "Recreate Device" button beneath the navigation view.
+    grid((
+        nav_view.grid_row(0),
+        button("Recreate Device")
+            .icon(SymbolGlyph::Refresh)
+            .on_click(recreate_device)
+            .margin(Thickness::uniform(12.0))
+            .grid_row(1),
+    ))
+    .rows([GridLength::Star(1.0), GridLength::Auto])
+    .columns([GridLength::Star(1.0)])
+    .into()
 }

--- a/crates/samples/reactor/direct2d/src/shell.rs
+++ b/crates/samples/reactor/direct2d/src/shell.rs
@@ -85,7 +85,7 @@ pub fn shell(cx: &mut RenderCx) -> Element {
     grid((
         nav_view.grid_row(0),
         button("Recreate Device")
-            .icon(SymbolGlyph::Refresh)
+            .icon(Symbol::Refresh)
             .on_click(recreate_device)
             .margin(Thickness::uniform(12.0))
             .grid_row(1),

--- a/crates/samples/reactor/direct2d/src/surface_image_source.rs
+++ b/crates/samples/reactor/direct2d/src/surface_image_source.rs
@@ -14,7 +14,7 @@ const SIZE: i32 = 256;
 /// Create a `SurfaceImageSource`, attach the shared Direct2D device, and draw a
 /// single static frame into it. Runs on the UI thread, as required by
 /// `SurfaceImageSource`.
-fn build_surface(device: &Device) -> windows::core::Result<SurfaceImageSource> {
+fn build_surface(device: &Device) -> Result<SurfaceImageSource> {
     let surface = SurfaceImageSource::new(SIZE, SIZE)?;
     surface.set_device(device.d2d_device())?;
 

--- a/crates/samples/reactor/direct2d/src/surface_image_source.rs
+++ b/crates/samples/reactor/direct2d/src/surface_image_source.rs
@@ -1,7 +1,7 @@
 //! Demo of displaying a `SurfaceImageSource` with the reactor `Image` widget,
 //! drawing into it once with Direct2D using the app-wide shared device.
 
-use crate::device::{Device, device_context};
+use crate::device::{Device, Gpu, gpu_context, is_device_lost};
 use windows::Win32::Graphics::Direct2D::Common::*;
 use windows::Win32::Graphics::Direct2D::*;
 use windows_numerics::{Matrix3x2, Vector2};
@@ -64,29 +64,28 @@ fn build_surface(device: &Device) -> windows::core::Result<SurfaceImageSource> {
 /// Sample page: a static Direct2D drawing rendered into a `SurfaceImageSource`
 /// and displayed with the reactor `Image` widget.
 pub fn surface_image_source_sample(_: &(), cx: &mut RenderCx) -> Element {
-    let device = cx.use_context(&device_context());
-    let surface = cx.use_ref::<Option<SurfaceImageSource>>(None);
-    // The device the current surface was built with; rebuild when it changes
-    // (e.g. the shared device is recreated after a device-lost event).
-    let built_for = cx.use_ref::<Option<Device>>(None);
+    let gpu = cx.use_context(&gpu_context());
+    let device = gpu.as_ref().and_then(Gpu::device);
+    let (surface, set_surface) = cx.use_state::<Option<SurfaceImageSource>>(None);
 
-    let stale = built_for.borrow().as_ref() != device.as_ref();
-    if stale {
-        if let Some(dev) = device.as_ref() {
-            match build_surface(dev) {
-                Ok(sis) => {
-                    surface.set(Some(sis));
-                    built_for.set(Some(dev.clone()));
+    // (Re)build the surface whenever the shared device appears or changes (e.g.
+    // after recovery). On device loss, ask the root to recreate the device.
+    cx.use_effect(device.clone(), {
+        move || match device.as_ref() {
+            Some(dev) => match build_surface(dev) {
+                Ok(sis) => set_surface.call(Some(sis)),
+                Err(e) if is_device_lost(e.code()) => {
+                    if let Some(gpu) = gpu.as_ref() {
+                        gpu.request_recovery();
+                    }
                 }
                 Err(e) => eprintln!("failed to build surface: {e}"),
-            }
-        } else {
-            surface.set(None);
-            built_for.set(None);
+            },
+            None => set_surface.call(None),
         }
-    }
+    });
 
-    let image: Element = match surface.get_cloned() {
+    let image: Element = match surface {
         Some(sis) => Image::new(sis.into())
             .width(SIZE as f64)
             .height(SIZE as f64)

--- a/crates/samples/reactor/direct2d/src/surface_image_source.rs
+++ b/crates/samples/reactor/direct2d/src/surface_image_source.rs
@@ -1,12 +1,9 @@
 //! Demo of displaying a `SurfaceImageSource` with the reactor `Image` widget,
-//! drawing into it once with Direct2D.
+//! drawing into it once with Direct2D using the app-wide shared device.
 
+use crate::device::{Device, device_context};
 use windows::Win32::Graphics::Direct2D::Common::*;
 use windows::Win32::Graphics::Direct2D::*;
-use windows::Win32::Graphics::Direct3D::*;
-use windows::Win32::Graphics::Direct3D11::*;
-use windows::Win32::Graphics::Dxgi::*;
-use windows::core::{Interface, Result};
 use windows_numerics::{Matrix3x2, Vector2};
 use windows_reactor::*;
 
@@ -14,39 +11,12 @@ use windows_reactor::*;
 /// 1:1 mapping at 96 DPI.
 const SIZE: i32 = 256;
 
-/// Create a Direct2D device backed by a hardware D3D11 device, suitable for
-/// handing to a `SurfaceImageSource`.
-fn create_d2d_device() -> Result<ID2D1Device> {
-    let mut d3d_device: Option<ID3D11Device> = None;
-    unsafe {
-        D3D11CreateDevice(
-            None,
-            D3D_DRIVER_TYPE_HARDWARE,
-            None,
-            D3D11_CREATE_DEVICE_BGRA_SUPPORT,
-            Some(&[D3D_FEATURE_LEVEL_11_0]),
-            D3D11_SDK_VERSION,
-            Some(&mut d3d_device),
-            None,
-            None,
-        )?;
-    }
-    let d3d_device = d3d_device.unwrap();
-
-    let d2d_factory: ID2D1Factory1 =
-        unsafe { D2D1CreateFactory(D2D1_FACTORY_TYPE_SINGLE_THREADED, None)? };
-    let dxgi_device: IDXGIDevice = d3d_device.cast()?;
-    unsafe { d2d_factory.CreateDevice(&dxgi_device) }
-}
-
-/// Create a `SurfaceImageSource`, attach a Direct2D device, and draw a single
-/// static frame into it. Runs on the UI thread, as required by
+/// Create a `SurfaceImageSource`, attach the shared Direct2D device, and draw a
+/// single static frame into it. Runs on the UI thread, as required by
 /// `SurfaceImageSource`.
-fn build_surface() -> Result<SurfaceImageSource> {
+fn build_surface(device: &Device) -> windows::core::Result<SurfaceImageSource> {
     let surface = SurfaceImageSource::new(SIZE, SIZE)?;
-
-    let device = create_d2d_device()?;
-    surface.set_device(&device)?;
+    surface.set_device(device.d2d_device())?;
 
     let (context, (offset_x, offset_y)) =
         surface.begin_draw::<ID2D1DeviceContext>(0, 0, SIZE, SIZE)?;
@@ -94,22 +64,38 @@ fn build_surface() -> Result<SurfaceImageSource> {
 /// Sample page: a static Direct2D drawing rendered into a `SurfaceImageSource`
 /// and displayed with the reactor `Image` widget.
 pub fn surface_image_source_sample(_: &(), cx: &mut RenderCx) -> Element {
-    // Create and draw the surface once; it persists across re-renders.
+    let device = cx.use_context(&device_context());
     let surface = cx.use_ref::<Option<SurfaceImageSource>>(None);
-    if surface.borrow().is_none() {
-        match build_surface() {
-            Ok(sis) => surface.set(Some(sis)),
-            Err(e) => eprintln!("failed to build surface: {e}"),
+    // The device the current surface was built with; rebuild when it changes
+    // (e.g. the shared device is recreated after a device-lost event).
+    let built_for = cx.use_ref::<Option<Device>>(None);
+
+    let stale = built_for.borrow().as_ref() != device.as_ref();
+    if stale {
+        if let Some(dev) = device.as_ref() {
+            match build_surface(dev) {
+                Ok(sis) => {
+                    surface.set(Some(sis));
+                    built_for.set(Some(dev.clone()));
+                }
+                Err(e) => eprintln!("failed to build surface: {e}"),
+            }
+        } else {
+            surface.set(None);
+            built_for.set(None);
         }
     }
 
-    vstack((
-        text_block("Image backed by a SurfaceImageSource:"),
-        Image::new(surface.get_cloned().into())
+    let image: Element = match surface.get_cloned() {
+        Some(sis) => Image::new(sis.into())
             .width(SIZE as f64)
-            .height(SIZE as f64),
-    ))
-    .spacing(8.0)
-    .margin(Thickness::uniform(16.0))
-    .into()
+            .height(SIZE as f64)
+            .into(),
+        None => text_block("Creating shared device\u{2026}").into(),
+    };
+
+    vstack((text_block("Image backed by a SurfaceImageSource:"), image))
+        .spacing(8.0)
+        .margin(Thickness::uniform(16.0))
+        .into()
 }

--- a/crates/samples/reactor/direct2d/src/swap_chain.rs
+++ b/crates/samples/reactor/direct2d/src/swap_chain.rs
@@ -3,10 +3,10 @@
 //! dedicated worker thread that presents into a composition swap chain.
 //!
 //! The D3D/D2D device is not created here; it is the app-wide shared `Device`
-//! taken from the `DEVICE` context and handed to the worker thread as an owned
+//! taken from the `Gpu` context and handed to the worker thread as an owned
 //! `SharedDevice` snapshot.
 
-use crate::device::{Device, device_context};
+use crate::device::{Device, Gpu, gpu_context};
 use render::{RenderThread, SendSwap};
 use std::rc::Rc;
 use windows_reactor::*;
@@ -18,7 +18,7 @@ mod render {
     use std::thread::{self, JoinHandle};
     use std::time::Duration;
 
-    use crate::device::SharedDevice;
+    use crate::device::{SharedDevice, is_device_lost};
     use windows::Win32::Foundation::DXGI_STATUS_OCCLUDED;
     use windows::Win32::Graphics::Direct2D::Common::*;
     use windows::Win32::Graphics::Direct2D::*;
@@ -78,16 +78,21 @@ mod render {
         /// thread renders with. `initial_count` is the number of circles to draw
         /// before the first `set_circle_count`. `on_swap_chain` is invoked once,
         /// on the render thread, after the swap chain is created so the caller can
-        /// attach it to its presentation surface.
+        /// attach it to its presentation surface. `on_device_lost` is invoked, on
+        /// the render thread, if rendering fails because the GPU device was lost;
+        /// the worker then exits, leaving the caller to recreate the device.
         pub fn new(
             device: SharedDevice,
             initial_count: u32,
             on_swap_chain: impl FnOnce(SendSwap) + Send + 'static,
+            on_device_lost: impl FnOnce() + Send + 'static,
         ) -> Self {
             let (commands, rx) = channel();
             let worker = thread::spawn(move || {
-                if let Err(e) = render_loop(rx, device, initial_count, on_swap_chain) {
-                    eprintln!("render thread failed: {e}");
+                match render_loop(rx, device, initial_count, on_swap_chain) {
+                    Ok(()) => {}
+                    Err(e) if is_device_lost(e.code()) => on_device_lost(),
+                    Err(e) => eprintln!("render thread failed: {e}"),
                 }
             });
             Self {
@@ -342,17 +347,23 @@ mod render {
 /// with buttons to add or remove circles.
 pub fn swap_chain_sample(_: &(), cx: &mut RenderCx) -> Element {
     let (count, set_count) = cx.use_state(5_u32);
-    let device = cx.use_context(&device_context());
+    let gpu = cx.use_context(&gpu_context());
+    let device = gpu.as_ref().and_then(Gpu::device);
     let panel = cx.use_ref::<Option<SwapChainPanelHandle>>(None);
     let (swap_chain, set_swap_chain) = cx.use_async_state::<Option<SendSwap>>(None);
     let render_thread = cx.use_ref::<Option<RenderThread>>(None);
-    // Tracks which device the live render thread was started with, so the thread
-    // is (re)spawned when the shared device first appears or is later swapped.
+    // Which device the live render thread was started with, so it respawns when
+    // the shared device appears or is swapped.
     let started_for = cx.use_ref::<Option<Device>>(None);
+    // Token marshalled back from the worker on device loss. A fresh token per
+    // worker means a new loss always changes the value, firing the recovery
+    // effect below.
+    let (lost_token, set_lost_token) = cx.use_async_state::<u64>(0);
+    let next_token = cx.use_ref::<u64>(0);
 
-    // (Re)spawn the render thread once both the panel and the shared device are
-    // available, and whenever the device identity changes. Constructing the new
-    // thread and storing it drops any previous one (joining it).
+    // (Re)spawn the render thread once the panel and device are both available,
+    // and whenever the device changes. Storing the new thread drops (joins) any
+    // previous one.
     let try_start: Rc<dyn Fn()> = {
         let panel = panel.clone();
         let render_thread = render_thread.clone();
@@ -368,10 +379,19 @@ pub fn swap_chain_sample(_: &(), cx: &mut RenderCx) -> Element {
                 return;
             }
 
+            let token = {
+                let mut t = next_token.borrow_mut();
+                *t += 1;
+                *t
+            };
             let set_swap_chain = set_swap_chain.clone();
-            let thread = RenderThread::new(dev.to_send(), count, move |swap| {
-                set_swap_chain.call(Some(swap));
-            });
+            let set_lost_token = set_lost_token.clone();
+            let thread = RenderThread::new(
+                dev.to_send(),
+                count,
+                move |swap| set_swap_chain.call(Some(swap)),
+                move || set_lost_token.call(token),
+            );
             render_thread.set(Some(thread));
             started_for.set(Some(dev));
         })
@@ -394,6 +414,19 @@ pub fn swap_chain_sample(_: &(), cx: &mut RenderCx) -> Element {
     cx.use_effect(device, {
         let try_start = try_start.clone();
         move || try_start()
+    });
+
+    // The worker marshals a token here on device loss; ask the root to recreate
+    // the shared device. Token 0 means nothing was lost.
+    cx.use_effect(lost_token, {
+        move || {
+            if lost_token == 0 {
+                return;
+            }
+            if let Some(gpu) = gpu.as_ref() {
+                gpu.request_recovery();
+            }
+        }
     });
 
     // Push the current circle count to the render thread whenever it changes.

--- a/crates/samples/reactor/direct2d/src/swap_chain.rs
+++ b/crates/samples/reactor/direct2d/src/swap_chain.rs
@@ -76,12 +76,13 @@ mod render {
         pub fn new(
             device: SharedDevice,
             initial_count: u32,
+            initial_size: (u32, u32),
             on_swap_chain: impl FnOnce(SendSwap) + Send + 'static,
             on_device_lost: impl FnOnce() + Send + 'static,
         ) -> Self {
             let (commands, rx) = channel();
             let worker = thread::spawn(move || {
-                match render_loop(rx, device, initial_count, on_swap_chain) {
+                match render_loop(rx, device, initial_count, initial_size, on_swap_chain) {
                     Ok(()) => {}
                     Err(e) if is_device_lost(e.code()) => on_device_lost(),
                     Err(e) => eprintln!("render thread failed: {e}"),
@@ -292,9 +293,10 @@ mod render {
         rx: Receiver<RenderCommand>,
         device: SharedDevice,
         initial_count: u32,
+        initial_size: (u32, u32),
         on_swap_chain: impl FnOnce(SendSwap),
     ) -> Result<()> {
-        let mut size = (400_u32, 300_u32);
+        let mut size = initial_size;
         let mut count = initial_count;
         let mut state = create_d2d_state(&device, size.0, size.1)?;
 
@@ -333,6 +335,7 @@ mod render {
 #[derive(Clone)]
 struct RenderHost {
     panel: HookRef<Option<SwapChainPanelHandle>>,
+    panel_size: HookRef<(u32, u32)>,
     render_thread: HookRef<Option<RenderThread>>,
     try_start: Rc<dyn Fn()>,
 }
@@ -354,6 +357,7 @@ impl RenderHost {
     }
 
     fn resize(&self, width: u32, height: u32) {
+        self.panel_size.set((width, height));
         if let Some(r) = self.render_thread.borrow().as_ref() {
             r.resize(width, height);
         }
@@ -365,6 +369,7 @@ impl RenderHost {
 fn use_render_host(cx: &mut RenderCx, gpu: Option<Gpu>, count: u32) -> RenderHost {
     let device = gpu.as_ref().and_then(Gpu::device);
     let panel = cx.use_ref::<Option<SwapChainPanelHandle>>(None);
+    let panel_size = cx.use_ref::<(u32, u32)>((400, 300));
     let (swap_chain, set_swap_chain) = cx.use_async_state::<Option<SendSwap>>(None);
     let render_thread = cx.use_ref::<Option<RenderThread>>(None);
     // Which device the live worker was started with, to avoid respawning it for
@@ -378,6 +383,7 @@ fn use_render_host(cx: &mut RenderCx, gpu: Option<Gpu>, count: u32) -> RenderHos
 
     let try_start: Rc<dyn Fn()> = {
         let panel = panel.clone();
+        let panel_size = panel_size.clone();
         let render_thread = render_thread.clone();
         let device = device.clone();
         Rc::new(move || {
@@ -395,9 +401,11 @@ fn use_render_host(cx: &mut RenderCx, gpu: Option<Gpu>, count: u32) -> RenderHos
             };
             let set_swap_chain = set_swap_chain.clone();
             let set_lost_token = set_lost_token.clone();
+            let size = *panel_size.borrow();
             let thread = RenderThread::new(
                 dev.to_send(),
                 count,
+                size,
                 move |swap| set_swap_chain.call(Some(swap)),
                 move || set_lost_token.call(token),
             );
@@ -447,6 +455,7 @@ fn use_render_host(cx: &mut RenderCx, gpu: Option<Gpu>, count: u32) -> RenderHos
 
     RenderHost {
         panel,
+        panel_size,
         render_thread,
         try_start,
     }

--- a/crates/samples/reactor/direct2d/src/swap_chain.rs
+++ b/crates/samples/reactor/direct2d/src/swap_chain.rs
@@ -329,17 +329,48 @@ mod render {
     }
 }
 
-/// Sample page: animated Direct2D circles presented through a `SwapChainPanel`,
-/// with buttons to add or remove circles.
-pub fn swap_chain_sample(_: &(), cx: &mut RenderCx) -> Element {
-    let (count, set_count) = cx.use_state(5_u32);
-    let gpu = cx.use_context(&gpu_context());
+/// Hosts the Direct2D render worker behind a `SwapChainPanel`: (re)spawns it for
+/// the shared device, attaches the swap chain it produces, pushes circle-count
+/// changes, and routes device loss back to the root for recovery.
+#[derive(Clone)]
+struct RenderHost {
+    panel: HookRef<Option<SwapChainPanelHandle>>,
+    render_thread: HookRef<Option<RenderThread>>,
+    try_start: Rc<dyn Fn()>,
+}
+
+impl RenderHost {
+    /// Store the panel handle and start the worker once the panel mounts.
+    fn mount(&self, handle: SwapChainPanelHandle) {
+        self.panel.set(Some(handle));
+        (self.try_start)();
+    }
+
+    /// Stop and join the worker while the panel and its swap chain still exist,
+    /// so it never presents into a destroyed panel.
+    fn unmount(&self) {
+        // Release the borrow before the worker is dropped, so the join does not
+        // run while the ref is held.
+        let thread = self.render_thread.borrow_mut().take();
+        drop(thread);
+    }
+
+    fn resize(&self, width: u32, height: u32) {
+        if let Some(r) = self.render_thread.borrow().as_ref() {
+            r.resize(width, height);
+        }
+    }
+}
+
+/// Drive the render worker for the shared device, returning a [`RenderHost`] to
+/// wire into the `SwapChainPanel`'s lifecycle callbacks.
+fn use_render_host(cx: &mut RenderCx, gpu: Option<Gpu>, count: u32) -> RenderHost {
     let device = gpu.as_ref().and_then(Gpu::device);
     let panel = cx.use_ref::<Option<SwapChainPanelHandle>>(None);
     let (swap_chain, set_swap_chain) = cx.use_async_state::<Option<SendSwap>>(None);
     let render_thread = cx.use_ref::<Option<RenderThread>>(None);
-    // Which device the live render thread was started with, so it respawns when
-    // the shared device appears or is swapped.
+    // Which device the live worker was started with, to avoid respawning it for
+    // the same device.
     let started_for = cx.use_ref::<Option<Device>>(None);
     // Token marshalled back from the worker on device loss. A fresh token per
     // worker means a new loss always changes the value, firing the recovery
@@ -347,9 +378,6 @@ pub fn swap_chain_sample(_: &(), cx: &mut RenderCx) -> Element {
     let (lost_token, set_lost_token) = cx.use_async_state::<u64>(0);
     let next_token = cx.use_ref::<u64>(0);
 
-    // (Re)spawn the render thread once the panel and device are both available,
-    // and whenever the device changes. Storing the new thread drops (joins) any
-    // previous one.
     let try_start: Rc<dyn Fn()> = {
         let panel = panel.clone();
         let render_thread = render_thread.clone();
@@ -358,10 +386,7 @@ pub fn swap_chain_sample(_: &(), cx: &mut RenderCx) -> Element {
             let Some(dev) = device.clone() else {
                 return;
             };
-            if panel.borrow().is_none() {
-                return;
-            }
-            if started_for.borrow().as_ref() == Some(&dev) {
+            if panel.borrow().is_none() || started_for.borrow().as_ref() == Some(&dev) {
                 return;
             }
 
@@ -383,7 +408,7 @@ pub fn swap_chain_sample(_: &(), cx: &mut RenderCx) -> Element {
         })
     };
 
-    // Attach the swap chain to the panel once the worker thread reports it.
+    // Attach the swap chain to the panel once the worker reports it.
     cx.use_effect(swap_chain.clone(), {
         let panel = panel.clone();
         move || {
@@ -396,26 +421,23 @@ pub fn swap_chain_sample(_: &(), cx: &mut RenderCx) -> Element {
         }
     });
 
-    // (Re)start the render thread when the shared device appears or changes.
+    // (Re)start the worker when the shared device appears or changes.
     cx.use_effect(device, {
         let try_start = try_start.clone();
         move || try_start()
     });
 
-    // The worker marshals a token here on device loss; ask the root to recreate
-    // the shared device. Token 0 means nothing was lost.
-    cx.use_effect(lost_token, {
-        move || {
-            if lost_token == 0 {
-                return;
-            }
-            if let Some(gpu) = gpu.as_ref() {
-                gpu.request_recovery();
-            }
+    // On device loss the worker marshals a token here; ask the root to recreate
+    // the device. Token 0 means nothing was lost.
+    cx.use_effect(lost_token, move || {
+        if lost_token != 0
+            && let Some(gpu) = gpu.as_ref()
+        {
+            gpu.request_recovery();
         }
     });
 
-    // Push the current circle count to the render thread whenever it changes.
+    // Push circle-count changes to the worker.
     cx.use_effect(count, {
         let render_thread = render_thread.clone();
         move || {
@@ -425,15 +447,27 @@ pub fn swap_chain_sample(_: &(), cx: &mut RenderCx) -> Element {
         }
     });
 
+    RenderHost {
+        panel,
+        render_thread,
+        try_start,
+    }
+}
+
+/// Sample page: animated Direct2D circles presented through a `SwapChainPanel`,
+/// with buttons to add or remove circles.
+pub fn swap_chain_sample(_: &(), cx: &mut RenderCx) -> Element {
+    let (count, set_count) = cx.use_state(5_u32);
+    let gpu = cx.use_context(&gpu_context());
+    let host = use_render_host(cx, gpu, count);
+
     let add = {
         let set_count = set_count.clone();
         move || set_count.call(count + 1)
     };
-    let remove = {
-        move || {
-            if count > 0 {
-                set_count.call(count - 1);
-            }
+    let remove = move || {
+        if count > 0 {
+            set_count.call(count - 1);
         }
     };
 
@@ -442,27 +476,14 @@ pub fn swap_chain_sample(_: &(), cx: &mut RenderCx) -> Element {
         Element::from(
             swap_chain_panel()
                 .on_mounted({
-                    let try_start = try_start.clone();
-                    move |handle| {
-                        panel.set(Some(handle));
-                        try_start();
-                    }
+                    let host = host.clone();
+                    move |handle| host.mount(handle)
                 })
                 .on_unmounted({
-                    let render_thread = render_thread.clone();
-                    move |_handle| {
-                        // Stop and join the render worker while the panel and
-                        // its swap chain still exist, so the worker never
-                        // presents into a panel that has already been destroyed.
-                        let thread = render_thread.borrow_mut().take();
-                        drop(thread);
-                    }
+                    let host = host.clone();
+                    move |_handle| host.unmount()
                 })
-                .on_resize(move |w, h| {
-                    if let Some(r) = render_thread.borrow().as_ref() {
-                        r.resize(w as u32, h as u32);
-                    }
-                })
+                .on_resize(move |w, h| host.resize(w as u32, h as u32))
                 .margin(Thickness {
                     left: margin,
                     top: margin,

--- a/crates/samples/reactor/direct2d/src/swap_chain.rs
+++ b/crates/samples/reactor/direct2d/src/swap_chain.rs
@@ -54,8 +54,6 @@ mod render {
     #[derive(Clone, PartialEq)]
     pub struct SendSwap(IDXGISwapChain1);
 
-    unsafe impl Send for SendSwap {}
-
     impl SendSwap {
         /// The swap chain, for attaching to the UI-thread presentation surface.
         pub fn swap_chain(&self) -> &IDXGISwapChain1 {

--- a/crates/samples/reactor/direct2d/src/swap_chain.rs
+++ b/crates/samples/reactor/direct2d/src/swap_chain.rs
@@ -48,39 +48,33 @@ mod render {
         Idle,
     }
 
-    /// Wraps an `IDXGISwapChain1` so it can be handed back to the UI thread for
-    /// attachment via `SetSwapChain`. DXGI swap chains are agile (free-threaded),
-    /// and only the render thread ever presents/resizes this one, so moving the
-    /// reference across the thread boundary is sound.
+    /// Wraps `IDXGISwapChain1` so it can be handed back to the UI thread. Sound
+    /// because swap chains are agile and only the render thread presents/resizes
+    /// this one.
     #[derive(Clone, PartialEq)]
     pub struct SendSwap(IDXGISwapChain1);
 
     unsafe impl Send for SendSwap {}
 
     impl SendSwap {
-        /// The swap chain produced by the render thread, ready to be attached to a
-        /// presentation surface on the UI thread.
+        /// The swap chain, for attaching to the UI-thread presentation surface.
         pub fn swap_chain(&self) -> &IDXGISwapChain1 {
             &self.0
         }
     }
 
-    /// Owns the render thread and the channel used to talk to it. Created once the
-    /// panel is ready. Dropping it asks the thread to stop and waits for it to
-    /// finish, so a clean shutdown happens on any drop path.
+    /// Owns the render thread and the channel to it. Dropping it stops and joins
+    /// the thread.
     pub struct RenderThread {
         commands: Sender<RenderCommand>,
         worker: Option<JoinHandle<()>>,
     }
 
     impl RenderThread {
-        /// Spawn the render thread. `device` is the app-wide shared device the
-        /// thread renders with. `initial_count` is the number of circles to draw
-        /// before the first `set_circle_count`. `on_swap_chain` is invoked once,
-        /// on the render thread, after the swap chain is created so the caller can
-        /// attach it to its presentation surface. `on_device_lost` is invoked, on
-        /// the render thread, if rendering fails because the GPU device was lost;
-        /// the worker then exits, leaving the caller to recreate the device.
+        /// Spawn the render thread, rendering with the shared `device`.
+        /// `on_swap_chain` runs once the swap chain is created, so the caller can
+        /// attach it. `on_device_lost` runs if rendering fails from device loss,
+        /// after which the worker exits.
         pub fn new(
             device: SharedDevice,
             initial_count: u32,
@@ -118,15 +112,13 @@ mod render {
     }
 
     impl Drop for RenderThread {
-        /// Ask the render thread to stop and wait for it to finish, so the worker
-        /// has fully released its device and swap-chain references before we
-        /// return. Joining (rather than detaching) is what prevents an orphaned
-        /// worker from continuing to render on the shared device and racing a
-        /// newly spawned worker when the sample is switched away and back.
+        /// Stop and join the worker so it has released its device and swap-chain
+        /// references before we return. Joining prevents an orphaned worker from
+        /// racing a freshly spawned one when the sample is switched away and back.
         ///
-        /// This is safe to do on the UI thread: the worker only ever blocks in
-        /// `Present(1)`, which returns at the next vblank regardless of the UI
-        /// message pump, so it promptly observes `Shutdown` and exits.
+        /// Safe on the UI thread: the worker only blocks in `Present(1)`, which
+        /// returns at vblank regardless of the message pump, so it promptly sees
+        /// `Shutdown`.
         fn drop(&mut self) {
             self.send(RenderCommand::Shutdown);
             if let Some(worker) = self.worker.take() {
@@ -283,11 +275,8 @@ mod render {
 
             state.target.EndDraw(None, None)?;
 
-            // `Present(1)` blocks until vblank, pacing the loop at the display
-            // refresh rate.
-            //
-            // `DXGI_STATUS_OCCLUDED` is a success status, so it has to be
-            // inspected before `ok()` discards it. The caller throttles on it.
+            // `Present(1)` blocks until vblank to pace the loop. DXGI_STATUS_OCCLUDED
+            // is a success status, so check it before `ok()` discards it.
             let present = state.swap_chain.Present(1, DXGI_PRESENT(0));
             if present == DXGI_STATUS_OCCLUDED {
                 return Ok(FrameStatus::Idle);
@@ -298,12 +287,9 @@ mod render {
         Ok(FrameStatus::Presented)
     }
 
-    /// Entry point for the dedicated render thread. Drives the animation loop on
-    /// the shared `device`, draining commands from the caller. `Present(1)` paces
-    /// the loop at the display refresh rate while the surface is visible.
-    ///
-    /// `on_swap_chain` is invoked once, after the swap chain is created, so the
-    /// caller can attach it to its presentation surface.
+    /// Render-thread entry point: drives the animation loop on the shared
+    /// `device`, draining commands. `on_swap_chain` runs once after the swap
+    /// chain is created.
     fn render_loop(
         rx: Receiver<RenderCommand>,
         device: SharedDevice,

--- a/crates/samples/reactor/direct2d/src/swap_chain.rs
+++ b/crates/samples/reactor/direct2d/src/swap_chain.rs
@@ -1,8 +1,14 @@
 //! Hosts Direct2D content inside a reactor UI via `SwapChainPanel`, with WinUI
 //! buttons to add/remove animated circles. Direct2D rendering runs on a
 //! dedicated worker thread that presents into a composition swap chain.
+//!
+//! The D3D/D2D device is not created here; it is the app-wide shared `Device`
+//! taken from the `DEVICE` context and handed to the worker thread as an owned
+//! `SharedDevice` snapshot.
 
+use crate::device::{Device, device_context};
 use render::{RenderThread, SendSwap};
+use std::rc::Rc;
 use windows_reactor::*;
 
 /// Direct2D rendering, isolated on a dedicated worker thread. Only the handle
@@ -12,14 +18,13 @@ mod render {
     use std::thread::{self, JoinHandle};
     use std::time::Duration;
 
+    use crate::device::SharedDevice;
     use windows::Win32::Foundation::DXGI_STATUS_OCCLUDED;
     use windows::Win32::Graphics::Direct2D::Common::*;
     use windows::Win32::Graphics::Direct2D::*;
-    use windows::Win32::Graphics::Direct3D::*;
-    use windows::Win32::Graphics::Direct3D11::*;
     use windows::Win32::Graphics::Dxgi::Common::*;
     use windows::Win32::Graphics::Dxgi::*;
-    use windows::core::{Interface, Result};
+    use windows::core::Result;
     use windows_numerics::*;
 
     struct D2DState {
@@ -69,17 +74,19 @@ mod render {
     }
 
     impl RenderThread {
-        /// Spawn the render thread. `initial_count` is the number of circles to
-        /// draw before the first `set_circle_count`. `on_swap_chain` is invoked
-        /// once, on the render thread, after the swap chain is created so the
-        /// caller can attach it to its presentation surface.
+        /// Spawn the render thread. `device` is the app-wide shared device the
+        /// thread renders with. `initial_count` is the number of circles to draw
+        /// before the first `set_circle_count`. `on_swap_chain` is invoked once,
+        /// on the render thread, after the swap chain is created so the caller can
+        /// attach it to its presentation surface.
         pub fn new(
+            device: SharedDevice,
             initial_count: u32,
             on_swap_chain: impl FnOnce(SendSwap) + Send + 'static,
         ) -> Self {
             let (commands, rx) = channel();
             let worker = thread::spawn(move || {
-                if let Err(e) = render_loop(rx, initial_count, on_swap_chain) {
+                if let Err(e) = render_loop(rx, device, initial_count, on_swap_chain) {
                     eprintln!("render thread failed: {e}");
                 }
             });
@@ -106,7 +113,15 @@ mod render {
     }
 
     impl Drop for RenderThread {
-        /// Ask the render thread to stop and wait for it to finish.
+        /// Ask the render thread to stop and wait for it to finish, so the worker
+        /// has fully released its device and swap-chain references before we
+        /// return. Joining (rather than detaching) is what prevents an orphaned
+        /// worker from continuing to render on the shared device and racing a
+        /// newly spawned worker when the sample is switched away and back.
+        ///
+        /// This is safe to do on the UI thread: the worker only ever blocks in
+        /// `Present(1)`, which returns at the next vblank regardless of the UI
+        /// message pump, so it promptly observes `Shutdown` and exits.
         fn drop(&mut self) {
             self.send(RenderCommand::Shutdown);
             if let Some(worker) = self.worker.take() {
@@ -149,31 +164,13 @@ mod render {
         Ok(())
     }
 
-    fn create_d2d_state(width: u32, height: u32) -> Result<D2DState> {
-        let mut device: Option<ID3D11Device> = None;
-        unsafe {
-            D3D11CreateDevice(
-                None,
-                D3D_DRIVER_TYPE_HARDWARE,
-                None,
-                D3D11_CREATE_DEVICE_BGRA_SUPPORT,
-                Some(&[D3D_FEATURE_LEVEL_11_0]),
-                D3D11_SDK_VERSION,
-                Some(&mut device),
-                None,
-                None,
-            )?;
-        }
-        let device = device.unwrap();
-
-        let d2d_factory: ID2D1Factory1 =
-            unsafe { D2D1CreateFactory(D2D1_FACTORY_TYPE_SINGLE_THREADED, None)? };
-        let dxgi_device: IDXGIDevice = device.cast()?;
-        let d2d_device = unsafe { d2d_factory.CreateDevice(&dxgi_device)? };
-        let target = unsafe { d2d_device.CreateDeviceContext(D2D1_DEVICE_CONTEXT_OPTIONS_NONE)? };
-
-        let dxgi_adapter = unsafe { dxgi_device.GetAdapter()? };
-        let dxgi_factory: IDXGIFactory2 = unsafe { dxgi_adapter.GetParent()? };
+    fn create_d2d_state(device: &SharedDevice, width: u32, height: u32) -> Result<D2DState> {
+        // Per-thread device context from the shared D2D device.
+        let target = unsafe {
+            device
+                .d2d_device()
+                .CreateDeviceContext(D2D1_DEVICE_CONTEXT_OPTIONS_NONE)?
+        };
 
         let desc = DXGI_SWAP_CHAIN_DESC1 {
             Width: width,
@@ -190,8 +187,13 @@ mod render {
             ..Default::default()
         };
 
-        let swap_chain =
-            unsafe { dxgi_factory.CreateSwapChainForComposition(&device, &desc, None)? };
+        // Swap-chain creation and the initial bitmap binding are D3D/DXGI interop
+        // on the shared device.
+        let swap_chain = unsafe {
+            device
+                .dxgi_factory()
+                .CreateSwapChainForComposition(device.d3d_device(), &desc, None)?
+        };
 
         let surface: IDXGISurface = unsafe { swap_chain.GetBuffer(0)? };
         let bitmap_props = D2D1_BITMAP_PROPERTIES1 {
@@ -276,6 +278,9 @@ mod render {
 
             state.target.EndDraw(None, None)?;
 
+            // `Present(1)` blocks until vblank, pacing the loop at the display
+            // refresh rate.
+            //
             // `DXGI_STATUS_OCCLUDED` is a success status, so it has to be
             // inspected before `ok()` discards it. The caller throttles on it.
             let present = state.swap_chain.Present(1, DXGI_PRESENT(0));
@@ -288,20 +293,21 @@ mod render {
         Ok(FrameStatus::Presented)
     }
 
-    /// Entry point for the dedicated render thread. Owns all D3D/D2D state, drains
-    /// commands from the caller, and drives the animation loop. `Present(1)` paces
+    /// Entry point for the dedicated render thread. Drives the animation loop on
+    /// the shared `device`, draining commands from the caller. `Present(1)` paces
     /// the loop at the display refresh rate while the surface is visible.
     ///
     /// `on_swap_chain` is invoked once, after the swap chain is created, so the
     /// caller can attach it to its presentation surface.
     fn render_loop(
         rx: Receiver<RenderCommand>,
+        device: SharedDevice,
         initial_count: u32,
         on_swap_chain: impl FnOnce(SendSwap),
     ) -> Result<()> {
         let mut size = (400_u32, 300_u32);
         let mut count = initial_count;
-        let mut state = create_d2d_state(size.0, size.1)?;
+        let mut state = create_d2d_state(&device, size.0, size.1)?;
 
         // Hand the swap chain back to the caller to attach it to its surface.
         on_swap_chain(SendSwap(state.swap_chain.clone()));
@@ -336,9 +342,40 @@ mod render {
 /// with buttons to add or remove circles.
 pub fn swap_chain_sample(_: &(), cx: &mut RenderCx) -> Element {
     let (count, set_count) = cx.use_state(5_u32);
+    let device = cx.use_context(&device_context());
     let panel = cx.use_ref::<Option<SwapChainPanelHandle>>(None);
     let (swap_chain, set_swap_chain) = cx.use_async_state::<Option<SendSwap>>(None);
     let render_thread = cx.use_ref::<Option<RenderThread>>(None);
+    // Tracks which device the live render thread was started with, so the thread
+    // is (re)spawned when the shared device first appears or is later swapped.
+    let started_for = cx.use_ref::<Option<Device>>(None);
+
+    // (Re)spawn the render thread once both the panel and the shared device are
+    // available, and whenever the device identity changes. Constructing the new
+    // thread and storing it drops any previous one (joining it).
+    let try_start: Rc<dyn Fn()> = {
+        let panel = panel.clone();
+        let render_thread = render_thread.clone();
+        let device = device.clone();
+        Rc::new(move || {
+            let Some(dev) = device.clone() else {
+                return;
+            };
+            if panel.borrow().is_none() {
+                return;
+            }
+            if started_for.borrow().as_ref() == Some(&dev) {
+                return;
+            }
+
+            let set_swap_chain = set_swap_chain.clone();
+            let thread = RenderThread::new(dev.to_send(), count, move |swap| {
+                set_swap_chain.call(Some(swap));
+            });
+            render_thread.set(Some(thread));
+            started_for.set(Some(dev));
+        })
+    };
 
     // Attach the swap chain to the panel once the worker thread reports it.
     cx.use_effect(swap_chain.clone(), {
@@ -351,6 +388,12 @@ pub fn swap_chain_sample(_: &(), cx: &mut RenderCx) -> Element {
                 eprintln!("set_swap_chain failed: {e}");
             }
         }
+    });
+
+    // (Re)start the render thread when the shared device appears or changes.
+    cx.use_effect(device, {
+        let try_start = try_start.clone();
+        move || try_start()
     });
 
     // Push the current circle count to the render thread whenever it changes.
@@ -380,20 +423,25 @@ pub fn swap_chain_sample(_: &(), cx: &mut RenderCx) -> Element {
         Element::from(
             swap_chain_panel()
                 .on_mounted({
-                    let render_thread = render_thread.clone();
+                    let try_start = try_start.clone();
                     move |handle| {
                         panel.set(Some(handle));
-                        let set_swap_chain = set_swap_chain.clone();
-                        render_thread.set(Some(RenderThread::new(count, move |swap| {
-                            set_swap_chain.call(Some(swap));
-                        })));
+                        try_start();
                     }
                 })
-                .on_resize({
-                    move |w, h| {
-                        if let Some(r) = render_thread.borrow().as_ref() {
-                            r.resize(w as u32, h as u32);
-                        }
+                .on_unmounted({
+                    let render_thread = render_thread.clone();
+                    move |_handle| {
+                        // Stop and join the render worker while the panel and
+                        // its swap chain still exist, so the worker never
+                        // presents into a panel that has already been destroyed.
+                        let thread = render_thread.borrow_mut().take();
+                        drop(thread);
+                    }
+                })
+                .on_resize(move |w, h| {
+                    if let Some(r) = render_thread.borrow().as_ref() {
+                        r.resize(w as u32, h as u32);
                     }
                 })
                 .margin(Thickness {


### PR DESCRIPTION
Consolidates GPU device management in the reactor `direct2d` sample so a single shared D3D11 + Direct2D device is shared across all samples, and adds device-lost recovery.

## What changed

**Shared device (Part 1)**
- New `device` module: `SharedDevice` (agile COM, `MULTI_THREADED` D2D factory) and `Device` (`Rc`, ptr-eq identity), exposed through a reactor `Gpu` context via `gpu_context()`.
- Both samples (`swap_chain`, `surface_image_source`) now draw from the same device instead of each creating their own.

**Device-lost recovery (Part 2)**
- `Gpu` carries the device plus a recovery `Updater`. The app root (`shell`) owns the device and a `recover_gen` counter; a single effect keyed on `recover_gen` recreates the shared device on every `request_recovery()` (and on initial mount).
- `is_device_lost` matches Win2D's set of device-lost codes (the five DXGI removal codes plus `D2DERR_RECREATE_TARGET`). Samples call `gpu.request_recovery()` on any such error; recovery always recreates the device (no local-recreate / health-check gate).
- A "Recreate Device" test button under the NavigationView triggers the same path for manual testing.

**Worker plumbing**
- The `swap_chain` worker-thread plumbing (panel ref, swap-chain async state, render thread, spawn dedup, device-loss token marshalling, effects) is extracted into a `use_render_host` hook with `mount`/`unmount`/`resize`, leaving `swap_chain_sample` lean. Device loss detected on the worker is marshalled to the UI thread (the `Updater` is not `Send`) before triggering recovery.

## Testing
- `cargo build`/`clippy`/`fmt` clean for `reactor_direct2d`.
- Ran the sample: switching between samples, resizing, and the "Recreate Device" button all recover correctly.
