### PR TITLE
`windows-canvas` non-WinRT factory caching 

### DIFF
--- a/crates/libs/canvas/src/bitmap.rs
+++ b/crates/libs/canvas/src/bitmap.rs
@@ -20,18 +20,7 @@ impl Bitmap {
         path: &Path,
     ) -> windows_core::Result<Self> {
         unsafe {
-            let wic_factory: IWICImagingFactory = {
-                let mut ptr = core::ptr::null_mut();
-                CoCreateInstance(
-                    &CLSID_WICImagingFactory,
-                    core::ptr::null_mut(),
-                    CLSCTX_INPROC_SERVER,
-                    &<IWICImagingFactory as windows_core::Interface>::IID,
-                    &mut ptr,
-                )
-                .ok()?;
-                windows_core::Type::from_abi(ptr)?
-            };
+            let wic_factory = wic_factory()?;
 
             let wide_path: Vec<u16> = path
                 .as_os_str()
@@ -74,4 +63,30 @@ impl Bitmap {
         let size = unsafe { self.0.GetSize() };
         size.height
     }
+}
+
+fn wic_factory() -> windows_core::Result<IWICImagingFactory> {
+    thread_local! {
+        static SHARED: std::cell::OnceCell<IWICImagingFactory> = const { std::cell::OnceCell::new() };
+    }
+
+    SHARED.with(|cell| {
+        if let Some(factory) = cell.get() {
+            return Ok(factory.clone());
+        }
+
+        let factory: IWICImagingFactory = unsafe {
+            let mut ptr = core::ptr::null_mut();
+            CoCreateInstance(
+                &CLSID_WICImagingFactory,
+                core::ptr::null_mut(),
+                CLSCTX_INPROC_SERVER,
+                &<IWICImagingFactory as windows_core::Interface>::IID,
+                &mut ptr,
+            )
+            .ok()?;
+            windows_core::Type::from_abi(ptr)?
+        };
+        Ok(cell.get_or_init(|| factory).clone())
+    })
 }

--- a/crates/libs/canvas/src/device.rs
+++ b/crates/libs/canvas/src/device.rs
@@ -69,16 +69,7 @@ impl GpuDevice {
         let dxgi_adapter: IDXGIAdapter = unsafe { dxgi_device.GetAdapter()? };
         let dxgi_factory: IDXGIFactory2 = unsafe { dxgi_adapter.GetParent()? };
 
-        let mut dwrite_factory: Option<IDWriteFactory> = None;
-        unsafe {
-            DWriteCreateFactory(
-                DWRITE_FACTORY_TYPE_SHARED,
-                &IDWriteFactory::IID,
-                &mut dwrite_factory as *mut _ as *mut _,
-            )
-            .ok()?;
-        }
-        let dwrite_factory = dwrite_factory.unwrap();
+        let dwrite_factory = crate::text::dwrite_factory()?;
 
         Ok(Self {
             d3d_device,

--- a/crates/libs/canvas/src/text.rs
+++ b/crates/libs/canvas/src/text.rs
@@ -67,16 +67,7 @@ impl TextFormat {
 
     /// Create a text format with a specific weight.
     pub fn with_weight(family: &str, size: f32, weight: FontWeight) -> crate::Result<Self> {
-        let mut factory: Option<IDWriteFactory> = None;
-        unsafe {
-            DWriteCreateFactory(
-                DWRITE_FACTORY_TYPE_SHARED,
-                &IDWriteFactory::IID,
-                &mut factory as *mut _ as *mut _,
-            )
-            .ok()?;
-        }
-        let factory = factory.unwrap();
+        let factory = dwrite_factory()?;
 
         let family_wide: Vec<u16> = family.encode_utf16().chain(std::iter::once(0)).collect();
         let locale_wide: Vec<u16> = "en-us\0".encode_utf16().collect();
@@ -122,4 +113,24 @@ impl TextFormat {
     pub fn raw(&self) -> &IDWriteTextFormat {
         &self.raw
     }
+}
+
+pub(crate) fn dwrite_factory() -> crate::Result<IDWriteFactory> {
+    static SHARED: std::sync::OnceLock<IDWriteFactory> = std::sync::OnceLock::new();
+
+    if let Some(factory) = SHARED.get() {
+        return Ok(factory.clone());
+    }
+
+    let mut factory: Option<IDWriteFactory> = None;
+    unsafe {
+        DWriteCreateFactory(
+            DWRITE_FACTORY_TYPE_SHARED,
+            &IDWriteFactory::IID,
+            &mut factory as *mut _ as *mut _,
+        )
+        .ok()?;
+    }
+    let factory = factory.ok_or_else(windows_core::Error::empty)?;
+    Ok(SHARED.get_or_init(|| factory).clone())
 }


### PR DESCRIPTION
`windows-reactor` benefits from highly-efficient WinRT factory caching that is not available to COM factories. This update just adds manual factory caching for some factories to avoid reloading these factories during rendering. 