### PR TITLE
Reduce reliance on `allow` to hide (generated) dead code

### DIFF
--- a/crates/libs/bindgen/src/guid.rs
+++ b/crates/libs/bindgen/src/guid.rs
@@ -1,3 +1,4 @@
+#[expect(clippy::upper_case_acronyms)]
 pub struct GUID(
     pub u32,
     pub u16,

--- a/crates/libs/bindgen/src/lib.rs
+++ b/crates/libs/bindgen/src/lib.rs
@@ -1,9 +1,4 @@
 #![doc = include_str!("../readme.md")]
-#![expect(
-    non_upper_case_globals,
-    clippy::enum_variant_names,
-    clippy::upper_case_acronyms
-)]
 #![warn(unused_qualifications)]
 
 mod config;

--- a/crates/libs/bindgen/src/type_name.rs
+++ b/crates/libs/bindgen/src/type_name.rs
@@ -17,6 +17,7 @@ impl PartialOrd for TypeName {
     }
 }
 
+#[expect(non_upper_case_globals)]
 impl TypeName {
     pub const Object: Self = Self("System", "Object");
 

--- a/crates/libs/bindgen/src/types/mod.rs
+++ b/crates/libs/bindgen/src/types/mod.rs
@@ -29,6 +29,7 @@ pub use interface::*;
 pub use method::*;
 pub use r#struct::*;
 
+#[expect(clippy::upper_case_acronyms, clippy::enum_variant_names)]
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum Type {
     CppFn(CppFn),

--- a/crates/libs/canvas/src/lib.rs
+++ b/crates/libs/canvas/src/lib.rs
@@ -1,12 +1,11 @@
 #![warn(unused_qualifications)]
 
-#[allow(
+#[expect(
     non_snake_case,
     non_upper_case_globals,
     non_camel_case_types,
     clippy::upper_case_acronyms,
     clippy::missing_transmute_annotations,
-    clippy::missing_safety_doc,
     clippy::too_many_arguments
 )]
 mod bindings;

--- a/crates/libs/collections/src/lib.rs
+++ b/crates/libs/collections/src/lib.rs
@@ -1,16 +1,14 @@
 #![warn(unused_qualifications)]
 #![doc = include_str!("../readme.md")]
 #![cfg_attr(all(not(feature = "std")), no_std)]
-#![expect(
-    missing_docs,
+
+#[expect(
+    unused_qualifications,
     non_snake_case,
     non_camel_case_types,
     non_upper_case_globals,
-    clippy::missing_transmute_annotations,
-    clippy::type_complexity
+    clippy::missing_transmute_annotations
 )]
-
-#[allow(unused_qualifications)]
 mod bindings;
 pub use bindings::*;
 

--- a/crates/libs/collections/src/lib.rs
+++ b/crates/libs/collections/src/lib.rs
@@ -1,9 +1,7 @@
-#![warn(unused_qualifications)]
 #![doc = include_str!("../readme.md")]
 #![cfg_attr(all(not(feature = "std")), no_std)]
 
 #[expect(
-    unused_qualifications,
     non_snake_case,
     non_camel_case_types,
     non_upper_case_globals,

--- a/crates/libs/future/src/lib.rs
+++ b/crates/libs/future/src/lib.rs
@@ -1,9 +1,7 @@
-#![warn(unused_qualifications)]
 #![doc = include_str!("../readme.md")]
 #![cfg_attr(all(not(feature = "std")), no_std)]
 
 mod r#async;
-#[allow(unused_qualifications)]
 #[expect(non_snake_case, non_camel_case_types, non_upper_case_globals)]
 mod bindings;
 #[cfg(windows)]

--- a/crates/libs/future/src/lib.rs
+++ b/crates/libs/future/src/lib.rs
@@ -1,18 +1,12 @@
 #![warn(unused_qualifications)]
-#![expect(
-    missing_docs,
-    non_snake_case,
-    non_camel_case_types,
-    non_upper_case_globals,
-    clippy::all
-)]
 #![doc = include_str!("../readme.md")]
 #![cfg_attr(all(not(feature = "std")), no_std)]
 
 mod r#async;
-#[allow(unused_qualifications)]
+#[expect(unused_qualifications, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 mod bindings;
 #[cfg(windows)]
+#[expect(non_snake_case, non_camel_case_types, clippy::upper_case_acronyms)]
 mod bindings_impl;
 mod join;
 mod waiter;

--- a/crates/libs/future/src/lib.rs
+++ b/crates/libs/future/src/lib.rs
@@ -3,7 +3,8 @@
 #![cfg_attr(all(not(feature = "std")), no_std)]
 
 mod r#async;
-#[expect(unused_qualifications, non_snake_case, non_camel_case_types, non_upper_case_globals)]
+#[allow(unused_qualifications)]
+#[expect(non_snake_case, non_camel_case_types, non_upper_case_globals)]
 mod bindings;
 #[cfg(windows)]
 #[expect(non_snake_case, non_camel_case_types, clippy::upper_case_acronyms)]

--- a/crates/libs/numerics/src/lib.rs
+++ b/crates/libs/numerics/src/lib.rs
@@ -1,9 +1,9 @@
 #![warn(unused_qualifications)]
-#![expect(missing_docs, non_snake_case)]
 #![doc = include_str!("../readme.md")]
 #![cfg_attr(all(not(feature = "std")), no_std)]
 #![forbid(unsafe_code)]
 
+#[expect(non_snake_case)]
 mod bindings;
 pub use bindings::*;
 

--- a/crates/libs/numerics/src/vector2.rs
+++ b/crates/libs/numerics/src/vector2.rs
@@ -1,8 +1,8 @@
 use super::*;
 
 impl Vector2 {
-    pub fn new(X: f32, Y: f32) -> Self {
-        Self { X, Y }
+    pub fn new(x: f32, y: f32) -> Self {
+        Self { X: x, Y: y }
     }
     pub fn zero() -> Self {
         Self { X: 0f32, Y: 0f32 }

--- a/crates/libs/numerics/src/vector3.rs
+++ b/crates/libs/numerics/src/vector3.rs
@@ -1,8 +1,8 @@
 use super::*;
 
 impl Vector3 {
-    pub fn new(X: f32, Y: f32, Z: f32) -> Self {
-        Self { X, Y, Z }
+    pub fn new(x: f32, y: f32, z: f32) -> Self {
+        Self { X: x, Y: y, Z: z }
     }
     pub fn zero() -> Self {
         Self {

--- a/crates/libs/numerics/src/vector4.rs
+++ b/crates/libs/numerics/src/vector4.rs
@@ -1,8 +1,13 @@
 use super::*;
 
 impl Vector4 {
-    pub fn new(X: f32, Y: f32, Z: f32, W: f32) -> Self {
-        Self { X, Y, Z, W }
+    pub fn new(x: f32, y: f32, z: f32, w: f32) -> Self {
+        Self {
+            X: x,
+            Y: y,
+            Z: z,
+            W: w,
+        }
     }
     pub fn zero() -> Self {
         Self {

--- a/crates/libs/reference/src/bindings.rs
+++ b/crates/libs/reference/src/bindings.rs
@@ -1036,18 +1036,6 @@ impl<T: windows_core::RuntimeType + 'static> windows_core::imp::CanInto<IPropert
 {
     const QUERY: bool = true;
 }
-impl<T: windows_core::RuntimeType + 'static> IReference<T> {
-    pub fn Value(&self) -> windows_core::Result<T> {
-        unsafe {
-            let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).Value)(
-                windows_core::Interface::as_raw(self),
-                &mut result__,
-            )
-            .and_then(|| windows_core::Type::from_abi(result__))
-        }
-    }
-}
 impl<T: windows_core::RuntimeType + 'static> windows_core::RuntimeName for IReference<T> {
     const NAME: &'static str = "Windows.Foundation.IReference";
     const RUNTIME_CLASS_NAME: windows_core::imp::ConstBuffer =

--- a/crates/libs/reference/src/lib.rs
+++ b/crates/libs/reference/src/lib.rs
@@ -1,19 +1,13 @@
 #![warn(unused_qualifications)]
 #![doc = include_str!("../readme.md")]
 #![cfg_attr(all(not(feature = "std")), no_std)]
-#![allow(
-    missing_docs,
-    non_snake_case,
-    non_camel_case_types,
-    non_upper_case_globals,
-    clippy::missing_transmute_annotations
-)]
 
 #[cfg(windows)]
-#[allow(dead_code)]
+#[expect(non_snake_case, non_camel_case_types, non_upper_case_globals)]
 mod bindings;
 
 #[cfg(all(windows, feature = "std"))]
 mod reference;
+
 #[cfg(all(windows, feature = "std"))]
 pub use reference::IReference;

--- a/crates/libs/reference/src/reference.rs
+++ b/crates/libs/reference/src/reference.rs
@@ -57,6 +57,7 @@ impl<T: RuntimeType + 'static> RuntimeName for IReference<T> {
 
 impl<T: RuntimeType + 'static> IReference<T> {
     /// Retrieves the boxed value.
+    #[allow(non_snake_case)]
     pub fn Value(&self) -> Result<T> {
         unsafe {
             let mut result__ = core::mem::zeroed();

--- a/crates/libs/registry/src/lib.rs
+++ b/crates/libs/registry/src/lib.rs
@@ -2,12 +2,6 @@
 #![doc = include_str!("../readme.md")]
 #![cfg(windows)]
 #![no_std]
-#![expect(
-    dead_code,
-    non_snake_case,
-    non_camel_case_types,
-    clippy::upper_case_acronyms
-)]
 
 #[macro_use]
 extern crate alloc;
@@ -16,6 +10,12 @@ use alloc::{string::String, vec::Vec};
 use core::ops::Deref;
 use core::ptr::{null, null_mut};
 
+#[expect(
+    dead_code,
+    non_snake_case,
+    non_camel_case_types,
+    clippy::upper_case_acronyms
+)]
 mod bindings;
 use bindings::*;
 

--- a/crates/libs/services/src/lib.rs
+++ b/crates/libs/services/src/lib.rs
@@ -1,13 +1,8 @@
 #![warn(unused_qualifications)]
 #![doc = include_str!("../readme.md")]
 #![cfg(windows)]
-#![expect(
-    non_camel_case_types,
-    non_snake_case,
-    clippy::upper_case_acronyms,
-    clippy::type_complexity
-)]
 
+#[expect(non_camel_case_types, non_snake_case, clippy::upper_case_acronyms)]
 mod bindings;
 use bindings::*;
 use std::boxed::Box;

--- a/crates/libs/strings/src/lib.rs
+++ b/crates/libs/strings/src/lib.rs
@@ -33,13 +33,7 @@ mod hstring_header;
 use hstring_header::*;
 
 #[cfg(windows)]
-#[allow(
-    non_snake_case,
-    non_upper_case_globals,
-    non_camel_case_types,
-    dead_code,
-    clippy::all
-)]
+#[expect(non_camel_case_types, clippy::upper_case_acronyms)]
 mod bindings;
 
 mod decode;

--- a/crates/libs/time/src/lib.rs
+++ b/crates/libs/time/src/lib.rs
@@ -2,6 +2,7 @@
 #![doc = include_str!("../readme.md")]
 #![cfg_attr(all(not(feature = "std")), no_std)]
 
+#[allow(dead_code)]
 #[expect(non_snake_case, clippy::upper_case_acronyms)]
 mod bindings;
 mod datetime;

--- a/crates/libs/time/src/lib.rs
+++ b/crates/libs/time/src/lib.rs
@@ -2,8 +2,7 @@
 #![doc = include_str!("../readme.md")]
 #![cfg_attr(all(not(feature = "std")), no_std)]
 
-#[allow(dead_code)]
-#[expect(missing_docs, non_snake_case, clippy::upper_case_acronyms)]
+#[expect(non_snake_case, clippy::upper_case_acronyms)]
 mod bindings;
 mod datetime;
 mod timespan;

--- a/crates/libs/version/src/lib.rs
+++ b/crates/libs/version/src/lib.rs
@@ -2,8 +2,8 @@
 #![doc = include_str!("../readme.md")]
 #![cfg(windows)]
 #![cfg_attr(not(test), no_std)]
-#![allow(non_snake_case, non_camel_case_types, clippy::upper_case_acronyms)]
 
+#[expect(non_snake_case, non_camel_case_types, clippy::upper_case_acronyms)]
 mod bindings;
 use bindings::*;
 


### PR DESCRIPTION
This helps to highlight optimizations in generated code. 