### PR TITLE
Add boxing helpers

### DIFF
--- a/crates/libs/bindgen/src/types/cpp_interface.rs
+++ b/crates/libs/bindgen/src/types/cpp_interface.rs
@@ -435,7 +435,7 @@ impl CppInterface {
                     impl #name {
                         pub fn new<'a, T: #impl_name>(this: &'a T) -> windows_core::ScopedInterface<'a, Self> {
                             let this = windows_core::ScopedHeap { vtable: &#implvtbl_ident::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
-                            let this = core::mem::ManuallyDrop::new(windows_core::imp::Box::new(this));
+                            let this = core::mem::ManuallyDrop::new(windows_core::imp::box_new(this));
                             unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
                         }
                     }

--- a/crates/libs/bindgen/src/types/delegate.rs
+++ b/crates/libs/bindgen/src/types/delegate.rs
@@ -119,7 +119,7 @@ impl Delegate {
                 pub fn new<#fn_constraint>(invoke: F) -> Self {
                     let com = windows_core::imp::DelegateBox::<#name, F>::new(&#boxed::<#generic_names F>::VTABLE, invoke);
                     unsafe {
-                        core::mem::transmute(windows_core::imp::Box::new(com))
+                        core::mem::transmute(windows_core::imp::box_new(com))
                     }
                 }
             }

--- a/crates/libs/bindgen/src/types/method.rs
+++ b/crates/libs/bindgen/src/types/method.rs
@@ -906,7 +906,7 @@ impl Method {
                             #prelude
                             let #pname: #delegate_name = {
                                 let com = windows_core::imp::DelegateBox::<#delegate_name, F>::new(&#boxed_name::<#generic_names F>::VTABLE, #pname);
-                                unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+                                unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
                             };
                         }
                     } else {

--- a/crates/libs/collections/src/bindings.rs
+++ b/crates/libs/collections/src/bindings.rs
@@ -2894,7 +2894,7 @@ impl<K: windows_core::RuntimeType + 'static, V: windows_core::RuntimeType + 'sta
             &MapChangedEventHandlerBox::<K, V, F>::VTABLE,
             invoke,
         );
-        unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+        unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
     }
     pub fn Invoke<P0, P1>(&self, sender: P0, event: P1) -> windows_core::Result<()>
     where
@@ -3014,7 +3014,7 @@ impl<T: windows_core::RuntimeType + 'static> VectorChangedEventHandler<T> {
             &VectorChangedEventHandlerBox::<T, F>::VTABLE,
             invoke,
         );
-        unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+        unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
     }
     pub fn Invoke<P0, P1>(&self, sender: P0, event: P1) -> windows_core::Result<()>
     where

--- a/crates/libs/collections/src/lib.rs
+++ b/crates/libs/collections/src/lib.rs
@@ -1,3 +1,4 @@
+#![warn(unused_qualifications)]
 #![doc = include_str!("../readme.md")]
 #![cfg_attr(all(not(feature = "std")), no_std)]
 

--- a/crates/libs/core/src/com_object.rs
+++ b/crates/libs/core/src/com_object.rs
@@ -1,4 +1,5 @@
 use crate::{IUnknown, IUnknownImpl, Interface, InterfaceRef};
+use alloc::boxed::Box;
 use core::any::Any;
 use core::borrow::Borrow;
 use core::ops::Deref;

--- a/crates/libs/core/src/com_object.rs
+++ b/crates/libs/core/src/com_object.rs
@@ -1,4 +1,3 @@
-use crate::imp::Box;
 use crate::{IUnknown, IUnknownImpl, Interface, InterfaceRef};
 use core::any::Any;
 use core::borrow::Borrow;

--- a/crates/libs/core/src/imp/mod.rs
+++ b/crates/libs/core/src/imp/mod.rs
@@ -1,6 +1,8 @@
 #[cfg(windows)]
 include!("windows.rs");
 
+use alloc::boxed::Box;
+
 mod agile;
 mod bindings;
 mod can_into;
@@ -121,20 +123,23 @@ pub use define_interface;
 // Box is not in the prelude for no_std crates. These helpers let generated code
 // avoid `windows_core::imp::Box` which triggers the unused_qualifications lint.
 
+#[allow(unused_qualifications)]
 #[inline(always)]
 #[doc(hidden)]
-pub fn box_new<T>(value: T) -> Box<T> {
-    Box::new(value)
+pub fn box_new<T>(value: T) -> alloc::boxed::Box<T> {
+    alloc::boxed::Box::new(value)
 }
 
+#[allow(unused_qualifications)]
 #[inline(always)]
 #[doc(hidden)]
-pub unsafe fn box_from_raw<T>(raw: *mut T) -> Box<T> {
-    unsafe { Box::from_raw(raw) }
+pub unsafe fn box_from_raw<T>(raw: *mut T) -> alloc::boxed::Box<T> {
+    unsafe { alloc::boxed::Box::from_raw(raw) }
 }
 
+#[allow(unused_qualifications)]
 #[inline(always)]
 #[doc(hidden)]
-pub fn box_into_raw<T>(b: Box<T>) -> *mut T {
-    Box::into_raw(b)
+pub fn box_into_raw<T>(b: alloc::boxed::Box<T>) -> *mut T {
+    alloc::boxed::Box::into_raw(b)
 }

--- a/crates/libs/core/src/imp/mod.rs
+++ b/crates/libs/core/src/imp/mod.rs
@@ -118,5 +118,20 @@ macro_rules! define_interface {
 #[doc(hidden)]
 pub use define_interface;
 
+#[inline(always)]
 #[doc(hidden)]
-pub use alloc::boxed::Box;
+pub fn box_new<T>(value: T) -> Box<T> {
+    Box::new(value)
+}
+
+#[inline(always)]
+#[doc(hidden)]
+pub unsafe fn box_from_raw<T>(raw: *mut T) -> Box<T> {
+    unsafe { Box::from_raw(raw) }
+}
+
+#[inline(always)]
+#[doc(hidden)]
+pub fn box_into_raw<T>(b: Box<T>) -> *mut T {
+    Box::into_raw(b)
+}

--- a/crates/libs/core/src/imp/mod.rs
+++ b/crates/libs/core/src/imp/mod.rs
@@ -118,6 +118,9 @@ macro_rules! define_interface {
 #[doc(hidden)]
 pub use define_interface;
 
+// Box is not in the prelude for no_std crates. These helpers let generated code
+// avoid `windows_core::imp::Box` which triggers the unused_qualifications lint.
+
 #[inline(always)]
 #[doc(hidden)]
 pub fn box_new<T>(value: T) -> Box<T> {

--- a/crates/libs/core/src/implement_macro.rs
+++ b/crates/libs/core/src/implement_macro.rs
@@ -351,7 +351,7 @@ macro_rules! __implement_decl_struct {
                 unsafe {
                     let remaining = (*self_).count.release();
                     if remaining == 0 {
-                        _ = $crate::imp::Box::from_raw(self_);
+                        _ = $crate::imp::box_from_raw(self_);
                     }
                     remaining
                 }
@@ -445,9 +445,9 @@ macro_rules! __implement_decl_struct {
             type Outer = $impl_name;
 
             fn into_object(self) -> $crate::ComObject<Self> {
-                let boxed = $crate::imp::Box::<$impl_name>::new(self.into_outer());
+                let boxed = $crate::imp::box_new(self.into_outer());
                 unsafe {
-                    let ptr = $crate::imp::Box::into_raw(boxed);
+                    let ptr = $crate::imp::box_into_raw(boxed);
                     $crate::ComObject::from_raw(::core::ptr::NonNull::new_unchecked(ptr))
                 }
             }
@@ -956,7 +956,7 @@ macro_rules! __implement_decl_g_struct {
                 unsafe {
                     let remaining = (*self_).count.release();
                     if remaining == 0 {
-                        _ = $crate::imp::Box::from_raw(self_);
+                        _ = $crate::imp::box_from_raw(self_);
                     }
                     remaining
                 }
@@ -1050,9 +1050,9 @@ macro_rules! __implement_decl_g_struct {
             type Outer = $impl_name < $($gp),+ >;
 
             fn into_object(self) -> $crate::ComObject<Self> {
-                let boxed = $crate::imp::Box::<$impl_name < $($gp),+ >>::new(self.into_outer());
+                let boxed = $crate::imp::box_new(self.into_outer());
                 unsafe {
-                    let ptr = $crate::imp::Box::into_raw(boxed);
+                    let ptr = $crate::imp::box_into_raw(boxed);
                     $crate::ComObject::from_raw(::core::ptr::NonNull::new_unchecked(ptr))
                 }
             }

--- a/crates/libs/future/src/bindings.rs
+++ b/crates/libs/future/src/bindings.rs
@@ -19,7 +19,7 @@ impl AsyncActionCompletedHandler {
             &AsyncActionCompletedHandlerBox::<F>::VTABLE,
             invoke,
         );
-        unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+        unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
     }
     pub fn Invoke<P0>(&self, asyncinfo: P0, asyncstatus: AsyncStatus) -> windows_core::Result<()>
     where
@@ -112,7 +112,7 @@ impl<TProgress: windows_core::RuntimeType + 'static> AsyncActionProgressHandler<
             &AsyncActionProgressHandlerBox::<TProgress, F>::VTABLE,
             invoke,
         );
-        unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+        unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
     }
     pub fn Invoke<P0, P1>(&self, asyncinfo: P0, progressinfo: P1) -> windows_core::Result<()>
     where
@@ -240,7 +240,7 @@ impl<TProgress: windows_core::RuntimeType + 'static>
             &AsyncActionWithProgressCompletedHandlerBox::<TProgress, F>::VTABLE,
             invoke,
         );
-        unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+        unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
     }
     pub fn Invoke<P0>(&self, asyncinfo: P0, asyncstatus: AsyncStatus) -> windows_core::Result<()>
     where
@@ -361,7 +361,7 @@ impl<TResult: windows_core::RuntimeType + 'static> AsyncOperationCompletedHandle
             &AsyncOperationCompletedHandlerBox::<TResult, F>::VTABLE,
             invoke,
         );
-        unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+        unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
     }
     pub fn Invoke<P0>(&self, asyncinfo: P0, asyncstatus: AsyncStatus) -> windows_core::Result<()>
     where
@@ -488,7 +488,7 @@ impl<TResult: windows_core::RuntimeType + 'static, TProgress: windows_core::Runt
             &AsyncOperationProgressHandlerBox::<TResult, TProgress, F>::VTABLE,
             invoke,
         );
-        unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+        unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
     }
     pub fn Invoke<P0, P1>(&self, asyncinfo: P0, progressinfo: P1) -> windows_core::Result<()>
     where
@@ -634,7 +634,7 @@ impl<TResult: windows_core::RuntimeType + 'static, TProgress: windows_core::Runt
             &AsyncOperationWithProgressCompletedHandlerBox::<TResult, TProgress, F>::VTABLE,
             invoke,
         );
-        unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+        unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
     }
     pub fn Invoke<P0>(&self, asyncinfo: P0, asyncstatus: AsyncStatus) -> windows_core::Result<()>
     where

--- a/crates/libs/future/src/lib.rs
+++ b/crates/libs/future/src/lib.rs
@@ -1,3 +1,4 @@
+#![warn(unused_qualifications)]
 #![doc = include_str!("../readme.md")]
 #![cfg_attr(all(not(feature = "std")), no_std)]
 

--- a/crates/libs/implement/src/gen.rs
+++ b/crates/libs/implement/src/gen.rs
@@ -210,7 +210,7 @@ fn gen_iunknown_impl(inputs: &ImplementInputs) -> syn::Item {
             unsafe fn Release(self_: *mut Self) -> u32 {
                 let remaining = (*self_).count.release();
                 if remaining == 0 {
-                    _ = ::windows_core::imp::Box::from_raw(self_);
+                    _ = ::windows_core::imp::box_from_raw(self_);
                 }
                 remaining
             }
@@ -263,9 +263,9 @@ fn gen_impl_com_object_inner(inputs: &ImplementInputs) -> syn::Item {
             // adjustments it performs.
 
             fn into_object(self) -> ::windows_core::ComObject<Self> {
-                let boxed = ::windows_core::imp::Box::<#impl_ident::#generics_idents>::new(self.into_outer());
+                let boxed = ::windows_core::imp::box_new(self.into_outer());
                 unsafe {
-                    let ptr = ::windows_core::imp::Box::into_raw(boxed);
+                    let ptr = ::windows_core::imp::box_into_raw(boxed);
                     ::windows_core::ComObject::from_raw(
                         ::core::ptr::NonNull::new_unchecked(ptr)
                     )

--- a/crates/libs/interface/src/generation.rs
+++ b/crates/libs/interface/src/generation.rs
@@ -285,7 +285,7 @@ impl Interface {
                 impl #name {
                     fn new<'a, T: #trait_name>(this: &'a T) -> ::windows_core::ScopedInterface<'a, #name> {
                         let this = ::windows_core::ScopedHeap { vtable: &#implvtbl_name::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
-                        let this = ::core::mem::ManuallyDrop::new(::windows_core::imp::Box::new(this));
+                        let this = ::core::mem::ManuallyDrop::new(::windows_core::imp::box_new(this));
                         unsafe { ::windows_core::ScopedInterface::new(::core::mem::transmute(&this.vtable)) }
                     }
                 }

--- a/crates/libs/reactor/src/bindings.rs
+++ b/crates/libs/reactor/src/bindings.rs
@@ -484,7 +484,7 @@ impl ApplicationInitializationCallback {
             &ApplicationInitializationCallbackBox::<F>::VTABLE,
             invoke,
         );
-        unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+        unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
     }
 }
 #[repr(C)]
@@ -2306,7 +2306,7 @@ impl CompositionTarget {
                     &EventHandlerBox::<windows_core::IInspectable, F>::VTABLE,
                     handler,
                 );
-            unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+            unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
         };
         Self::ICompositionTargetStatics(|this| unsafe {
             let mut result__ = core::mem::zeroed();
@@ -2976,7 +2976,7 @@ impl DispatcherQueueHandler {
             &DispatcherQueueHandlerBox::<F>::VTABLE,
             invoke,
         );
-        unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+        unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
     }
 }
 #[repr(C)]
@@ -4868,7 +4868,7 @@ impl IAutoSuggestBox {
                     >::VTABLE,
                     handler,
                 );
-            unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+            unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
@@ -4894,7 +4894,7 @@ impl IAutoSuggestBox {
     {
         let handler: TypedEventHandler<AutoSuggestBox, AutoSuggestBoxTextChangedEventArgs> = {
             let com = windows_core::imp::DelegateBox::< TypedEventHandler < AutoSuggestBox , AutoSuggestBoxTextChangedEventArgs > , F >::new (& TypedEventHandlerBox::< AutoSuggestBox , AutoSuggestBoxTextChangedEventArgs , F >::VTABLE , handler) ;
-            unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+            unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
@@ -4923,7 +4923,7 @@ impl IAutoSuggestBox {
     {
         let handler: TypedEventHandler<AutoSuggestBox, AutoSuggestBoxQuerySubmittedEventArgs> = {
             let com = windows_core::imp::DelegateBox::< TypedEventHandler < AutoSuggestBox , AutoSuggestBoxQuerySubmittedEventArgs > , F >::new (& TypedEventHandlerBox::< AutoSuggestBox , AutoSuggestBoxQuerySubmittedEventArgs , F >::VTABLE , handler) ;
-            unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+            unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
@@ -5431,7 +5431,7 @@ impl IBreadcrumbBar {
     {
         let handler: TypedEventHandler<BreadcrumbBar, BreadcrumbBarItemClickedEventArgs> = {
             let com = windows_core::imp::DelegateBox::< TypedEventHandler < BreadcrumbBar , BreadcrumbBarItemClickedEventArgs > , F >::new (& TypedEventHandlerBox::< BreadcrumbBar , BreadcrumbBarItemClickedEventArgs , F >::VTABLE , handler) ;
-            unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+            unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
@@ -5587,7 +5587,7 @@ impl IButtonBase {
                 &RoutedEventHandlerBox::<F>::VTABLE,
                 handler,
             );
-            unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+            unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
@@ -5711,7 +5711,7 @@ impl ICalendarDatePicker {
                 >::VTABLE,
                 handler,
             );
-            unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+            unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
@@ -5886,7 +5886,7 @@ impl ICalendarView {
                     >::VTABLE,
                     handler,
                 );
-            unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+            unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
@@ -6337,7 +6337,7 @@ impl IColorPicker {
                 &TypedEventHandlerBox::<ColorPicker, ColorChangedEventArgs, F>::VTABLE,
                 handler,
             );
-            unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+            unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
@@ -7158,7 +7158,7 @@ impl IContentDialog {
                 &TypedEventHandlerBox::<ContentDialog, ContentDialogClosedEventArgs, F>::VTABLE,
                 handler,
             );
-            unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+            unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
@@ -7589,7 +7589,7 @@ impl IDatePicker {
     {
         let handler: TypedEventHandler<DatePicker, DatePickerSelectedValueChangedEventArgs> = {
             let com = windows_core::imp::DelegateBox::< TypedEventHandler < DatePicker , DatePickerSelectedValueChangedEventArgs > , F >::new (& TypedEventHandlerBox::< DatePicker , DatePickerSelectedValueChangedEventArgs , F >::VTABLE , handler) ;
-            unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+            unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
@@ -7889,7 +7889,7 @@ impl IDispatcherQueueTimer {
     {
         let handler: TypedEventHandler<DispatcherQueueTimer, windows_core::IInspectable> = {
             let com = windows_core::imp::DelegateBox::< TypedEventHandler < DispatcherQueueTimer , windows_core::IInspectable > , F >::new (& TypedEventHandlerBox::< DispatcherQueueTimer , windows_core::IInspectable , F >::VTABLE , handler) ;
-            unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+            unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
@@ -8048,7 +8048,7 @@ impl IExpander {
                 &TypedEventHandlerBox::<Expander, ExpanderExpandingEventArgs, F>::VTABLE,
                 handler,
             );
-            unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+            unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
@@ -8077,7 +8077,7 @@ impl IExpander {
                 &TypedEventHandlerBox::<Expander, ExpanderCollapsedEventArgs, F>::VTABLE,
                 handler,
             );
-            unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+            unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
@@ -8503,7 +8503,7 @@ impl IFrameworkElement {
                 &SizeChangedEventHandlerBox::<F>::VTABLE,
                 handler,
             );
-            unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+            unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
@@ -8536,7 +8536,7 @@ impl IFrameworkElement {
                 &TypedEventHandlerBox::<FrameworkElement, windows_core::IInspectable, F>::VTABLE,
                 handler,
             );
-            unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+            unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
@@ -9153,7 +9153,7 @@ impl IInfoBar {
                 &TypedEventHandlerBox::<InfoBar, InfoBarClosedEventArgs, F>::VTABLE,
                 handler,
             );
-            unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+            unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
@@ -9457,7 +9457,7 @@ impl IKeyboardAccelerator {
                     >::VTABLE,
                     handler,
                 );
-            unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+            unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
@@ -10026,7 +10026,7 @@ impl IMenuFlyoutItem {
                 &RoutedEventHandlerBox::<F>::VTABLE,
                 handler,
             );
-            unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+            unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
@@ -10355,7 +10355,7 @@ impl INavigationView {
                     >::VTABLE,
                     handler,
                 );
-            unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+            unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
@@ -10503,7 +10503,7 @@ impl INavigationView2 {
     {
         let handler: TypedEventHandler<NavigationView, NavigationViewBackRequestedEventArgs> = {
             let com = windows_core::imp::DelegateBox::< TypedEventHandler < NavigationView , NavigationViewBackRequestedEventArgs > , F >::new (& TypedEventHandlerBox::< NavigationView , NavigationViewBackRequestedEventArgs , F >::VTABLE , handler) ;
-            unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+            unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
@@ -10831,7 +10831,7 @@ impl INumberBox {
                 &TypedEventHandlerBox::<NumberBox, NumberBoxValueChangedEventArgs, F>::VTABLE,
                 handler,
             );
-            unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+            unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
@@ -11184,7 +11184,7 @@ impl IPasswordBox {
                 &RoutedEventHandlerBox::<F>::VTABLE,
                 handler,
             );
-            unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+            unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
@@ -11374,7 +11374,7 @@ impl IPivot {
                 &SelectionChangedEventHandlerBox::<F>::VTABLE,
                 handler,
             );
-            unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+            unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
@@ -11877,7 +11877,7 @@ impl IRadioButtons {
                 &SelectionChangedEventHandlerBox::<F>::VTABLE,
                 handler,
             );
-            unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+            unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
@@ -12040,7 +12040,7 @@ impl IRangeBase {
                 &RangeBaseValueChangedEventHandlerBox::<F>::VTABLE,
                 handler,
             );
-            unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+            unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
@@ -12192,7 +12192,7 @@ impl IRatingControl {
                 &TypedEventHandlerBox::<RatingControl, windows_core::IInspectable, F>::VTABLE,
                 handler,
             );
-            unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+            unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
@@ -12570,7 +12570,7 @@ impl IRichEditBox {
                 &RoutedEventHandlerBox::<F>::VTABLE,
                 handler,
             );
-            unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+            unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
@@ -13138,7 +13138,7 @@ impl ISelector {
                 &SelectionChangedEventHandlerBox::<F>::VTABLE,
                 handler,
             );
-            unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+            unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
@@ -13224,7 +13224,7 @@ impl ISelectorBar {
     {
         let handler: TypedEventHandler<SelectorBar, SelectorBarSelectionChangedEventArgs> = {
             let com = windows_core::imp::DelegateBox::< TypedEventHandler < SelectorBar , SelectorBarSelectionChangedEventArgs > , F >::new (& TypedEventHandlerBox::< SelectorBar , SelectorBarSelectionChangedEventArgs , F >::VTABLE , handler) ;
-            unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+            unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
@@ -13627,7 +13627,7 @@ impl ISplitButton {
                 &TypedEventHandlerBox::<SplitButton, SplitButtonClickEventArgs, F>::VTABLE,
                 handler,
             );
-            unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+            unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
@@ -13777,7 +13777,7 @@ impl ISplitView {
                 &TypedEventHandlerBox::<SplitView, windows_core::IInspectable, F>::VTABLE,
                 handler,
             );
-            unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+            unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
@@ -14092,7 +14092,7 @@ impl ISwapChainPanel {
                 &TypedEventHandlerBox::<SwapChainPanel, windows_core::IInspectable, F>::VTABLE,
                 handler,
             );
-            unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+            unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
@@ -14265,7 +14265,7 @@ impl ITabView {
                 &TypedEventHandlerBox::<TabView, TabViewTabCloseRequestedEventArgs, F>::VTABLE,
                 handler,
             );
-            unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+            unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
@@ -14297,7 +14297,7 @@ impl ITabView {
                 &TypedEventHandlerBox::<TabView, windows_core::IInspectable, F>::VTABLE,
                 handler,
             );
-            unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+            unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
@@ -14369,7 +14369,7 @@ impl ITabView {
                 &SelectionChangedEventHandlerBox::<F>::VTABLE,
                 handler,
             );
-            unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+            unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
@@ -14687,7 +14687,7 @@ impl ITeachingTip {
                 &TypedEventHandlerBox::<TeachingTip, windows_core::IInspectable, F>::VTABLE,
                 handler,
             );
-            unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+            unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
@@ -14717,7 +14717,7 @@ impl ITeachingTip {
                 &TypedEventHandlerBox::<TeachingTip, TeachingTipClosedEventArgs, F>::VTABLE,
                 handler,
             );
-            unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+            unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
@@ -15074,7 +15074,7 @@ impl ITextBox {
                 &TextChangedEventHandlerBox::<F>::VTABLE,
                 handler,
             );
-            unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+            unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
@@ -15373,7 +15373,7 @@ impl ITimePicker {
     {
         let handler: TypedEventHandler<TimePicker, TimePickerSelectedValueChangedEventArgs> = {
             let com = windows_core::imp::DelegateBox::< TypedEventHandler < TimePicker , TimePickerSelectedValueChangedEventArgs > , F >::new (& TypedEventHandlerBox::< TimePicker , TimePickerSelectedValueChangedEventArgs , F >::VTABLE , handler) ;
-            unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+            unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
@@ -15569,7 +15569,7 @@ impl ITitleBar {
                 &TypedEventHandlerBox::<TitleBar, windows_core::IInspectable, F>::VTABLE,
                 handler,
             );
-            unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+            unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
@@ -15601,7 +15601,7 @@ impl ITitleBar {
                 &TypedEventHandlerBox::<TitleBar, windows_core::IInspectable, F>::VTABLE,
                 handler,
             );
-            unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+            unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
@@ -15732,7 +15732,7 @@ impl IToggleButton {
                 &RoutedEventHandlerBox::<F>::VTABLE,
                 handler,
             );
-            unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+            unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
@@ -15759,7 +15759,7 @@ impl IToggleButton {
                 &RoutedEventHandlerBox::<F>::VTABLE,
                 handler,
             );
-            unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+            unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
@@ -15899,7 +15899,7 @@ impl IToggleSwitch {
                 &RoutedEventHandlerBox::<F>::VTABLE,
                 handler,
             );
-            unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+            unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
@@ -16080,7 +16080,7 @@ impl ITreeView {
                 &TypedEventHandlerBox::<TreeView, TreeViewItemInvokedEventArgs, F>::VTABLE,
                 handler,
             );
-            unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+            unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
@@ -16367,7 +16367,7 @@ impl IUIElement {
                 &PointerEventHandlerBox::<F>::VTABLE,
                 handler,
             );
-            unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+            unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
@@ -16399,7 +16399,7 @@ impl IUIElement {
                 &PointerEventHandlerBox::<F>::VTABLE,
                 handler,
             );
-            unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+            unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
@@ -16431,7 +16431,7 @@ impl IUIElement {
                 &PointerEventHandlerBox::<F>::VTABLE,
                 handler,
             );
-            unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+            unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
@@ -16460,7 +16460,7 @@ impl IUIElement {
                 &TappedEventHandlerBox::<F>::VTABLE,
                 handler,
             );
-            unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+            unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
@@ -16489,7 +16489,7 @@ impl IUIElement {
                 &RightTappedEventHandlerBox::<F>::VTABLE,
                 handler,
             );
-            unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+            unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
@@ -17080,7 +17080,7 @@ impl IWindow {
                 &TypedEventHandlerBox::<windows_core::IInspectable, WindowEventArgs, F>::VTABLE,
                 handler,
             );
-            unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+            unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
         };
         unsafe {
             let mut result__ = core::mem::zeroed();

--- a/crates/libs/windows/src/Windows/ApplicationModel/Background/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Background/mod.rs
@@ -560,7 +560,7 @@ impl windows_core::RuntimeType for BackgroundTaskCanceledEventHandler {
 impl BackgroundTaskCanceledEventHandler {
     pub fn new<F: Fn(windows_core::Ref<IBackgroundTaskInstance>, BackgroundTaskCancellationReason) -> windows_core::Result<()> + Send + 'static>(invoke: F) -> Self {
         let com = windows_core::imp::DelegateBox::<BackgroundTaskCanceledEventHandler, F>::new(&BackgroundTaskCanceledEventHandlerBox::<F>::VTABLE, invoke);
-        unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+        unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
     }
     pub fn Invoke<P0>(&self, sender: P0, reason: BackgroundTaskCancellationReason) -> windows_core::Result<()>
     where
@@ -650,7 +650,7 @@ impl windows_core::RuntimeType for BackgroundTaskCompletedEventHandler {
 impl BackgroundTaskCompletedEventHandler {
     pub fn new<F: Fn(windows_core::Ref<BackgroundTaskRegistration>, windows_core::Ref<BackgroundTaskCompletedEventArgs>) -> windows_core::Result<()> + Send + 'static>(invoke: F) -> Self {
         let com = windows_core::imp::DelegateBox::<BackgroundTaskCompletedEventHandler, F>::new(&BackgroundTaskCompletedEventHandlerBox::<F>::VTABLE, invoke);
-        unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+        unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
     }
     pub fn Invoke<P0, P1>(&self, sender: P0, args: P1) -> windows_core::Result<()>
     where
@@ -741,7 +741,7 @@ impl windows_core::RuntimeType for BackgroundTaskProgressEventHandler {
 impl BackgroundTaskProgressEventHandler {
     pub fn new<F: Fn(windows_core::Ref<BackgroundTaskRegistration>, windows_core::Ref<BackgroundTaskProgressEventArgs>) -> windows_core::Result<()> + Send + 'static>(invoke: F) -> Self {
         let com = windows_core::imp::DelegateBox::<BackgroundTaskProgressEventHandler, F>::new(&BackgroundTaskProgressEventHandlerBox::<F>::VTABLE, invoke);
-        unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+        unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
     }
     pub fn Invoke<P0, P1>(&self, sender: P0, args: P1) -> windows_core::Result<()>
     where

--- a/crates/libs/windows/src/Windows/ApplicationModel/DataTransfer/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/DataTransfer/mod.rs
@@ -1069,7 +1069,7 @@ impl windows_core::RuntimeType for DataProviderHandler {
 impl DataProviderHandler {
     pub fn new<F: Fn(windows_core::Ref<DataProviderRequest>) -> windows_core::Result<()> + Send + 'static>(invoke: F) -> Self {
         let com = windows_core::imp::DelegateBox::<DataProviderHandler, F>::new(&DataProviderHandlerBox::<F>::VTABLE, invoke);
-        unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+        unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
     }
     pub fn Invoke<P0>(&self, request: P0) -> windows_core::Result<()>
     where
@@ -2321,7 +2321,7 @@ impl windows_core::RuntimeType for ShareProviderHandler {
 impl ShareProviderHandler {
     pub fn new<F: Fn(windows_core::Ref<ShareProviderOperation>) -> windows_core::Result<()> + Send + 'static>(invoke: F) -> Self {
         let com = windows_core::imp::DelegateBox::<ShareProviderHandler, F>::new(&ShareProviderHandlerBox::<F>::VTABLE, invoke);
-        unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+        unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
     }
     pub fn Invoke<P0>(&self, operation: P0) -> windows_core::Result<()>
     where

--- a/crates/libs/windows/src/Windows/ApplicationModel/Payments/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Payments/mod.rs
@@ -1331,7 +1331,7 @@ impl windows_core::RuntimeType for PaymentRequestChangedHandler {
 impl PaymentRequestChangedHandler {
     pub fn new<F: Fn(windows_core::Ref<PaymentRequest>, windows_core::Ref<PaymentRequestChangedArgs>) -> windows_core::Result<()> + Send + 'static>(invoke: F) -> Self {
         let com = windows_core::imp::DelegateBox::<PaymentRequestChangedHandler, F>::new(&PaymentRequestChangedHandlerBox::<F>::VTABLE, invoke);
-        unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+        unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
     }
     pub fn Invoke<P0, P1>(&self, paymentrequest: P0, args: P1) -> windows_core::Result<()>
     where

--- a/crates/libs/windows/src/Windows/Data/Text/mod.rs
+++ b/crates/libs/windows/src/Windows/Data/Text/mod.rs
@@ -344,7 +344,7 @@ impl windows_core::RuntimeType for SelectableWordSegmentsTokenizingHandler {
 impl SelectableWordSegmentsTokenizingHandler {
     pub fn new<F: Fn(windows_core::Ref<windows_collections::IIterable<SelectableWordSegment>>, windows_core::Ref<windows_collections::IIterable<SelectableWordSegment>>) -> windows_core::Result<()> + Send + 'static>(invoke: F) -> Self {
         let com = windows_core::imp::DelegateBox::<SelectableWordSegmentsTokenizingHandler, F>::new(&SelectableWordSegmentsTokenizingHandlerBox::<F>::VTABLE, invoke);
-        unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+        unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
     }
     pub fn Invoke<P0, P1>(&self, precedingwords: P0, words: P1) -> windows_core::Result<()>
     where
@@ -966,7 +966,7 @@ impl windows_core::RuntimeType for WordSegmentsTokenizingHandler {
 impl WordSegmentsTokenizingHandler {
     pub fn new<F: Fn(windows_core::Ref<windows_collections::IIterable<WordSegment>>, windows_core::Ref<windows_collections::IIterable<WordSegment>>) -> windows_core::Result<()> + Send + 'static>(invoke: F) -> Self {
         let com = windows_core::imp::DelegateBox::<WordSegmentsTokenizingHandler, F>::new(&WordSegmentsTokenizingHandlerBox::<F>::VTABLE, invoke);
-        unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+        unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
     }
     pub fn Invoke<P0, P1>(&self, precedingwords: P0, words: P1) -> windows_core::Result<()>
     where

--- a/crates/libs/windows/src/Windows/Devices/SmartCards/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/SmartCards/mod.rs
@@ -2845,7 +2845,7 @@ impl windows_core::RuntimeType for SmartCardPinResetHandler {
 impl SmartCardPinResetHandler {
     pub fn new<F: Fn(windows_core::Ref<SmartCardProvisioning>, windows_core::Ref<SmartCardPinResetRequest>) -> windows_core::Result<()> + Send + 'static>(invoke: F) -> Self {
         let com = windows_core::imp::DelegateBox::<SmartCardPinResetHandler, F>::new(&SmartCardPinResetHandlerBox::<F>::VTABLE, invoke);
-        unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+        unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
     }
     pub fn Invoke<P0, P1>(&self, sender: P0, request: P1) -> windows_core::Result<()>
     where

--- a/crates/libs/windows/src/Windows/Devices/Sms/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Sms/mod.rs
@@ -1915,7 +1915,7 @@ impl windows_core::RuntimeType for SmsDeviceStatusChangedEventHandler {
 impl SmsDeviceStatusChangedEventHandler {
     pub fn new<F: Fn(windows_core::Ref<SmsDevice>) -> windows_core::Result<()> + Send + 'static>(invoke: F) -> Self {
         let com = windows_core::imp::DelegateBox::<SmsDeviceStatusChangedEventHandler, F>::new(&SmsDeviceStatusChangedEventHandlerBox::<F>::VTABLE, invoke);
-        unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+        unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
     }
     pub fn Invoke<P0>(&self, sender: P0) -> windows_core::Result<()>
     where
@@ -2237,7 +2237,7 @@ impl windows_core::RuntimeType for SmsMessageReceivedEventHandler {
 impl SmsMessageReceivedEventHandler {
     pub fn new<F: Fn(windows_core::Ref<SmsDevice>, windows_core::Ref<SmsMessageReceivedEventArgs>) -> windows_core::Result<()> + Send + 'static>(invoke: F) -> Self {
         let com = windows_core::imp::DelegateBox::<SmsMessageReceivedEventHandler, F>::new(&SmsMessageReceivedEventHandlerBox::<F>::VTABLE, invoke);
-        unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+        unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
     }
     pub fn Invoke<P0, P1>(&self, sender: P0, e: P1) -> windows_core::Result<()>
     where

--- a/crates/libs/windows/src/Windows/Foundation/mod.rs
+++ b/crates/libs/windows/src/Windows/Foundation/mod.rs
@@ -52,7 +52,7 @@ impl windows_core::RuntimeType for DeferralCompletedHandler {
 impl DeferralCompletedHandler {
     pub fn new<F: Fn() -> windows_core::Result<()> + Send + 'static>(invoke: F) -> Self {
         let com = windows_core::imp::DelegateBox::<DeferralCompletedHandler, F>::new(&DeferralCompletedHandlerBox::<F>::VTABLE, invoke);
-        unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+        unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
     }
     pub fn Invoke(&self) -> windows_core::Result<()> {
         unsafe { (windows_core::Interface::vtable(self).Invoke)(windows_core::Interface::as_raw(self)).ok() }
@@ -96,7 +96,7 @@ impl<T: windows_core::RuntimeType + 'static> windows_core::RuntimeType for Event
 impl<T: windows_core::RuntimeType + 'static> EventHandler<T> {
     pub fn new<F: Fn(windows_core::Ref<windows_core::IInspectable>, windows_core::Ref<T>) -> windows_core::Result<()> + Send + 'static>(invoke: F) -> Self {
         let com = windows_core::imp::DelegateBox::<EventHandler<T>, F>::new(&EventHandlerBox::<T, F>::VTABLE, invoke);
-        unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+        unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
     }
     pub fn Invoke<P0, P1>(&self, sender: P0, args: P1) -> windows_core::Result<()>
     where
@@ -2053,7 +2053,7 @@ impl<TSender: windows_core::RuntimeType + 'static, TResult: windows_core::Runtim
 impl<TSender: windows_core::RuntimeType + 'static, TResult: windows_core::RuntimeType + 'static> TypedEventHandler<TSender, TResult> {
     pub fn new<F: Fn(windows_core::Ref<TSender>, windows_core::Ref<TResult>) -> windows_core::Result<()> + Send + 'static>(invoke: F) -> Self {
         let com = windows_core::imp::DelegateBox::<TypedEventHandler<TSender, TResult>, F>::new(&TypedEventHandlerBox::<TSender, TResult, F>::VTABLE, invoke);
-        unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+        unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
     }
     pub fn Invoke<P0, P1>(&self, sender: P0, args: P1) -> windows_core::Result<()>
     where

--- a/crates/libs/windows/src/Windows/Gaming/Preview/GamesEnumeration/mod.rs
+++ b/crates/libs/windows/src/Windows/Gaming/Preview/GamesEnumeration/mod.rs
@@ -101,7 +101,7 @@ impl windows_core::RuntimeType for GameListChangedEventHandler {
 impl GameListChangedEventHandler {
     pub fn new<F: Fn(windows_core::Ref<GameListEntry>) -> windows_core::Result<()> + Send + 'static>(invoke: F) -> Self {
         let com = windows_core::imp::DelegateBox::<GameListChangedEventHandler, F>::new(&GameListChangedEventHandlerBox::<F>::VTABLE, invoke);
-        unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+        unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
     }
     pub fn Invoke<P0>(&self, game: P0) -> windows_core::Result<()>
     where
@@ -270,7 +270,7 @@ impl windows_core::RuntimeType for GameListRemovedEventHandler {
 impl GameListRemovedEventHandler {
     pub fn new<F: Fn(&windows_core::HSTRING) -> windows_core::Result<()> + Send + 'static>(invoke: F) -> Self {
         let com = windows_core::imp::DelegateBox::<GameListRemovedEventHandler, F>::new(&GameListRemovedEventHandlerBox::<F>::VTABLE, invoke);
-        unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+        unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
     }
     pub fn Invoke(&self, identifier: &windows_core::HSTRING) -> windows_core::Result<()> {
         unsafe { (windows_core::Interface::vtable(self).Invoke)(windows_core::Interface::as_raw(self), core::mem::transmute_copy(identifier)).ok() }

--- a/crates/libs/windows/src/Windows/Graphics/Display/mod.rs
+++ b/crates/libs/windows/src/Windows/Graphics/Display/mod.rs
@@ -931,7 +931,7 @@ impl windows_core::RuntimeType for DisplayPropertiesEventHandler {
 impl DisplayPropertiesEventHandler {
     pub fn new<F: Fn(windows_core::Ref<windows_core::IInspectable>) -> windows_core::Result<()> + Send + 'static>(invoke: F) -> Self {
         let com = windows_core::imp::DelegateBox::<DisplayPropertiesEventHandler, F>::new(&DisplayPropertiesEventHandlerBox::<F>::VTABLE, invoke);
-        unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+        unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
     }
     pub fn Invoke<P0>(&self, sender: P0) -> windows_core::Result<()>
     where

--- a/crates/libs/windows/src/Windows/Graphics/Printing/mod.rs
+++ b/crates/libs/windows/src/Windows/Graphics/Printing/mod.rs
@@ -2042,7 +2042,7 @@ impl windows_core::RuntimeType for PrintTaskSourceRequestedHandler {
 impl PrintTaskSourceRequestedHandler {
     pub fn new<F: Fn(windows_core::Ref<PrintTaskSourceRequestedArgs>) -> windows_core::Result<()> + Send + 'static>(invoke: F) -> Self {
         let com = windows_core::imp::DelegateBox::<PrintTaskSourceRequestedHandler, F>::new(&PrintTaskSourceRequestedHandlerBox::<F>::VTABLE, invoke);
-        unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+        unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
     }
     pub fn Invoke<P0>(&self, args: P0) -> windows_core::Result<()>
     where

--- a/crates/libs/windows/src/Windows/Graphics/Printing3D/mod.rs
+++ b/crates/libs/windows/src/Windows/Graphics/Printing3D/mod.rs
@@ -879,7 +879,7 @@ impl windows_core::RuntimeType for Print3DTaskSourceRequestedHandler {
 impl Print3DTaskSourceRequestedHandler {
     pub fn new<F: Fn(windows_core::Ref<Print3DTaskSourceRequestedArgs>) -> windows_core::Result<()> + Send + 'static>(invoke: F) -> Self {
         let com = windows_core::imp::DelegateBox::<Print3DTaskSourceRequestedHandler, F>::new(&Print3DTaskSourceRequestedHandlerBox::<F>::VTABLE, invoke);
-        unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+        unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
     }
     pub fn Invoke<P0>(&self, args: P0) -> windows_core::Result<()>
     where

--- a/crates/libs/windows/src/Windows/Management/Setup/mod.rs
+++ b/crates/libs/windows/src/Windows/Management/Setup/mod.rs
@@ -154,7 +154,7 @@ impl windows_core::RuntimeType for DeploymentSessionHeartbeatRequested {
 impl DeploymentSessionHeartbeatRequested {
     pub fn new<F: Fn(windows_core::Ref<DeploymentSessionHeartbeatRequestedEventArgs>) -> windows_core::Result<()> + Send + 'static>(invoke: F) -> Self {
         let com = windows_core::imp::DelegateBox::<DeploymentSessionHeartbeatRequested, F>::new(&DeploymentSessionHeartbeatRequestedBox::<F>::VTABLE, invoke);
-        unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+        unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
     }
     pub fn Invoke<P0>(&self, eventargs: P0) -> windows_core::Result<()>
     where

--- a/crates/libs/windows/src/Windows/Media/Capture/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/Capture/mod.rs
@@ -6802,7 +6802,7 @@ impl windows_core::RuntimeType for MediaCaptureFailedEventHandler {
 impl MediaCaptureFailedEventHandler {
     pub fn new<F: Fn(windows_core::Ref<MediaCapture>, windows_core::Ref<MediaCaptureFailedEventArgs>) -> windows_core::Result<()> + Send + 'static>(invoke: F) -> Self {
         let com = windows_core::imp::DelegateBox::<MediaCaptureFailedEventHandler, F>::new(&MediaCaptureFailedEventHandlerBox::<F>::VTABLE, invoke);
-        unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+        unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
     }
     pub fn Invoke<P0, P1>(&self, sender: P0, erroreventargs: P1) -> windows_core::Result<()>
     where
@@ -7682,7 +7682,7 @@ impl windows_core::RuntimeType for RecordLimitationExceededEventHandler {
 impl RecordLimitationExceededEventHandler {
     pub fn new<F: Fn(windows_core::Ref<MediaCapture>) -> windows_core::Result<()> + Send + 'static>(invoke: F) -> Self {
         let com = windows_core::imp::DelegateBox::<RecordLimitationExceededEventHandler, F>::new(&RecordLimitationExceededEventHandlerBox::<F>::VTABLE, invoke);
-        unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+        unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
     }
     pub fn Invoke<P0>(&self, sender: P0) -> windows_core::Result<()>
     where

--- a/crates/libs/windows/src/Windows/Media/Devices/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/Devices/mod.rs
@@ -467,7 +467,7 @@ impl windows_core::RuntimeType for CallControlEventHandler {
 impl CallControlEventHandler {
     pub fn new<F: Fn(windows_core::Ref<CallControl>) -> windows_core::Result<()> + Send + 'static>(invoke: F) -> Self {
         let com = windows_core::imp::DelegateBox::<CallControlEventHandler, F>::new(&CallControlEventHandlerBox::<F>::VTABLE, invoke);
-        unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+        unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
     }
     pub fn Invoke<P0>(&self, sender: P0) -> windows_core::Result<()>
     where
@@ -779,7 +779,7 @@ impl windows_core::RuntimeType for DialRequestedEventHandler {
 impl DialRequestedEventHandler {
     pub fn new<F: Fn(windows_core::Ref<CallControl>, windows_core::Ref<DialRequestedEventArgs>) -> windows_core::Result<()> + Send + 'static>(invoke: F) -> Self {
         let com = windows_core::imp::DelegateBox::<DialRequestedEventHandler, F>::new(&DialRequestedEventHandlerBox::<F>::VTABLE, invoke);
-        unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+        unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
     }
     pub fn Invoke<P0, P1>(&self, sender: P0, e: P1) -> windows_core::Result<()>
     where
@@ -2978,7 +2978,7 @@ impl windows_core::RuntimeType for KeypadPressedEventHandler {
 impl KeypadPressedEventHandler {
     pub fn new<F: Fn(windows_core::Ref<CallControl>, windows_core::Ref<KeypadPressedEventArgs>) -> windows_core::Result<()> + Send + 'static>(invoke: F) -> Self {
         let com = windows_core::imp::DelegateBox::<KeypadPressedEventHandler, F>::new(&KeypadPressedEventHandlerBox::<F>::VTABLE, invoke);
-        unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+        unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
     }
     pub fn Invoke<P0, P1>(&self, sender: P0, e: P1) -> windows_core::Result<()>
     where
@@ -3598,7 +3598,7 @@ impl windows_core::RuntimeType for RedialRequestedEventHandler {
 impl RedialRequestedEventHandler {
     pub fn new<F: Fn(windows_core::Ref<CallControl>, windows_core::Ref<RedialRequestedEventArgs>) -> windows_core::Result<()> + Send + 'static>(invoke: F) -> Self {
         let com = windows_core::imp::DelegateBox::<RedialRequestedEventHandler, F>::new(&RedialRequestedEventHandlerBox::<F>::VTABLE, invoke);
-        unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+        unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
     }
     pub fn Invoke<P0, P1>(&self, sender: P0, e: P1) -> windows_core::Result<()>
     where

--- a/crates/libs/windows/src/Windows/Media/Protection/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/Protection/mod.rs
@@ -37,7 +37,7 @@ impl windows_core::RuntimeType for ComponentLoadFailedEventHandler {
 impl ComponentLoadFailedEventHandler {
     pub fn new<F: Fn(windows_core::Ref<MediaProtectionManager>, windows_core::Ref<ComponentLoadFailedEventArgs>) -> windows_core::Result<()> + Send + 'static>(invoke: F) -> Self {
         let com = windows_core::imp::DelegateBox::<ComponentLoadFailedEventHandler, F>::new(&ComponentLoadFailedEventHandlerBox::<F>::VTABLE, invoke);
-        unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+        unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
     }
     pub fn Invoke<P0, P1>(&self, sender: P0, e: P1) -> windows_core::Result<()>
     where
@@ -609,7 +609,7 @@ impl windows_core::RuntimeType for RebootNeededEventHandler {
 impl RebootNeededEventHandler {
     pub fn new<F: Fn(windows_core::Ref<MediaProtectionManager>) -> windows_core::Result<()> + Send + 'static>(invoke: F) -> Self {
         let com = windows_core::imp::DelegateBox::<RebootNeededEventHandler, F>::new(&RebootNeededEventHandlerBox::<F>::VTABLE, invoke);
-        unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+        unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
     }
     pub fn Invoke<P0>(&self, sender: P0) -> windows_core::Result<()>
     where
@@ -835,7 +835,7 @@ impl windows_core::RuntimeType for ServiceRequestedEventHandler {
 impl ServiceRequestedEventHandler {
     pub fn new<F: Fn(windows_core::Ref<MediaProtectionManager>, windows_core::Ref<ServiceRequestedEventArgs>) -> windows_core::Result<()> + Send + 'static>(invoke: F) -> Self {
         let com = windows_core::imp::DelegateBox::<ServiceRequestedEventHandler, F>::new(&ServiceRequestedEventHandlerBox::<F>::VTABLE, invoke);
-        unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+        unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
     }
     pub fn Invoke<P0, P1>(&self, sender: P0, e: P1) -> windows_core::Result<()>
     where

--- a/crates/libs/windows/src/Windows/Networking/Connectivity/mod.rs
+++ b/crates/libs/windows/src/Windows/Networking/Connectivity/mod.rs
@@ -1731,7 +1731,7 @@ impl windows_core::RuntimeType for NetworkStatusChangedEventHandler {
 impl NetworkStatusChangedEventHandler {
     pub fn new<F: Fn(windows_core::Ref<windows_core::IInspectable>) -> windows_core::Result<()> + Send + 'static>(invoke: F) -> Self {
         let com = windows_core::imp::DelegateBox::<NetworkStatusChangedEventHandler, F>::new(&NetworkStatusChangedEventHandlerBox::<F>::VTABLE, invoke);
-        unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+        unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
     }
     pub fn Invoke<P0>(&self, sender: P0) -> windows_core::Result<()>
     where

--- a/crates/libs/windows/src/Windows/Networking/Proximity/mod.rs
+++ b/crates/libs/windows/src/Windows/Networking/Proximity/mod.rs
@@ -29,7 +29,7 @@ impl windows_core::RuntimeType for DeviceArrivedEventHandler {
 impl DeviceArrivedEventHandler {
     pub fn new<F: Fn(windows_core::Ref<ProximityDevice>) -> windows_core::Result<()> + Send + 'static>(invoke: F) -> Self {
         let com = windows_core::imp::DelegateBox::<DeviceArrivedEventHandler, F>::new(&DeviceArrivedEventHandlerBox::<F>::VTABLE, invoke);
-        unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+        unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
     }
     pub fn Invoke<P0>(&self, sender: P0) -> windows_core::Result<()>
     where
@@ -68,7 +68,7 @@ impl windows_core::RuntimeType for DeviceDepartedEventHandler {
 impl DeviceDepartedEventHandler {
     pub fn new<F: Fn(windows_core::Ref<ProximityDevice>) -> windows_core::Result<()> + Send + 'static>(invoke: F) -> Self {
         let com = windows_core::imp::DelegateBox::<DeviceDepartedEventHandler, F>::new(&DeviceDepartedEventHandlerBox::<F>::VTABLE, invoke);
-        unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+        unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
     }
     pub fn Invoke<P0>(&self, sender: P0) -> windows_core::Result<()>
     where
@@ -310,7 +310,7 @@ impl windows_core::RuntimeType for MessageReceivedHandler {
 impl MessageReceivedHandler {
     pub fn new<F: Fn(windows_core::Ref<ProximityDevice>, windows_core::Ref<ProximityMessage>) -> windows_core::Result<()> + Send + 'static>(invoke: F) -> Self {
         let com = windows_core::imp::DelegateBox::<MessageReceivedHandler, F>::new(&MessageReceivedHandlerBox::<F>::VTABLE, invoke);
-        unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+        unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
     }
     pub fn Invoke<P0, P1>(&self, sender: P0, message: P1) -> windows_core::Result<()>
     where
@@ -350,7 +350,7 @@ impl windows_core::RuntimeType for MessageTransmittedHandler {
 impl MessageTransmittedHandler {
     pub fn new<F: Fn(windows_core::Ref<ProximityDevice>, i64) -> windows_core::Result<()> + Send + 'static>(invoke: F) -> Self {
         let com = windows_core::imp::DelegateBox::<MessageTransmittedHandler, F>::new(&MessageTransmittedHandlerBox::<F>::VTABLE, invoke);
-        unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+        unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
     }
     pub fn Invoke<P0>(&self, sender: P0, messageid: i64) -> windows_core::Result<()>
     where

--- a/crates/libs/windows/src/Windows/Security/Credentials/mod.rs
+++ b/crates/libs/windows/src/Windows/Security/Credentials/mod.rs
@@ -10,7 +10,7 @@ impl windows_core::RuntimeType for AttestationChallengeHandler {
 impl AttestationChallengeHandler {
     pub fn new<F: Fn(windows_core::Ref<super::super::Storage::Streams::IBuffer>) -> windows_core::Result<super::super::Storage::Streams::IBuffer> + Send + 'static>(invoke: F) -> Self {
         let com = windows_core::imp::DelegateBox::<AttestationChallengeHandler, F>::new(&AttestationChallengeHandlerBox::<F>::VTABLE, invoke);
-        unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+        unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
     }
     pub fn Invoke<P0>(&self, challenge: P0) -> windows_core::Result<super::super::Storage::Streams::IBuffer>
     where

--- a/crates/libs/windows/src/Windows/Security/Isolation/mod.rs
+++ b/crates/libs/windows/src/Windows/Security/Isolation/mod.rs
@@ -5,7 +5,7 @@ impl windows_core::RuntimeType for HostMessageReceivedCallback {
 impl HostMessageReceivedCallback {
     pub fn new<F: Fn(&windows_core::GUID, windows_core::Ref<windows_collections::IVectorView<windows_core::IInspectable>>) -> windows_core::Result<()> + Send + 'static>(invoke: F) -> Self {
         let com = windows_core::imp::DelegateBox::<HostMessageReceivedCallback, F>::new(&HostMessageReceivedCallbackBox::<F>::VTABLE, invoke);
-        unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+        unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
     }
     pub fn Invoke<P1>(&self, receiverid: windows_core::GUID, message: P1) -> windows_core::Result<()>
     where
@@ -1737,7 +1737,7 @@ impl windows_core::RuntimeType for MessageReceivedCallback {
 impl MessageReceivedCallback {
     pub fn new<F: Fn(&windows_core::GUID, windows_core::Ref<windows_collections::IVectorView<windows_core::IInspectable>>) -> windows_core::Result<()> + Send + 'static>(invoke: F) -> Self {
         let com = windows_core::imp::DelegateBox::<MessageReceivedCallback, F>::new(&MessageReceivedCallbackBox::<F>::VTABLE, invoke);
-        unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+        unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
     }
     pub fn Invoke<P1>(&self, receiverid: windows_core::GUID, message: P1) -> windows_core::Result<()>
     where

--- a/crates/libs/windows/src/Windows/Storage/Provider/mod.rs
+++ b/crates/libs/windows/src/Windows/Storage/Provider/mod.rs
@@ -2444,7 +2444,7 @@ impl windows_core::RuntimeType for StorageProviderKnownFolderSyncRequestedHandle
 impl StorageProviderKnownFolderSyncRequestedHandler {
     pub fn new<F: Fn(windows_core::Ref<StorageProviderKnownFolderSyncRequestArgs>) -> windows_core::Result<()> + Send + 'static>(invoke: F) -> Self {
         let com = windows_core::imp::DelegateBox::<StorageProviderKnownFolderSyncRequestedHandler, F>::new(&StorageProviderKnownFolderSyncRequestedHandlerBox::<F>::VTABLE, invoke);
-        unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+        unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
     }
     pub fn Invoke<P0>(&self, args: P0) -> windows_core::Result<()>
     where

--- a/crates/libs/windows/src/Windows/Storage/mod.rs
+++ b/crates/libs/windows/src/Windows/Storage/mod.rs
@@ -589,7 +589,7 @@ impl windows_core::RuntimeType for ApplicationDataSetVersionHandler {
 impl ApplicationDataSetVersionHandler {
     pub fn new<F: Fn(windows_core::Ref<SetVersionRequest>) -> windows_core::Result<()> + Send + 'static>(invoke: F) -> Self {
         let com = windows_core::imp::DelegateBox::<ApplicationDataSetVersionHandler, F>::new(&ApplicationDataSetVersionHandlerBox::<F>::VTABLE, invoke);
-        unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+        unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
     }
     pub fn Invoke<P0>(&self, setversionrequest: P0) -> windows_core::Result<()>
     where
@@ -5610,7 +5610,7 @@ impl windows_core::RuntimeType for StreamedFileDataRequestedHandler {
 impl StreamedFileDataRequestedHandler {
     pub fn new<F: Fn(windows_core::Ref<StreamedFileDataRequest>) -> windows_core::Result<()> + Send + 'static>(invoke: F) -> Self {
         let com = windows_core::imp::DelegateBox::<StreamedFileDataRequestedHandler, F>::new(&StreamedFileDataRequestedHandlerBox::<F>::VTABLE, invoke);
-        unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+        unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
     }
     pub fn Invoke<P0>(&self, stream: P0) -> windows_core::Result<()>
     where

--- a/crates/libs/windows/src/Windows/System/RemoteDesktop/Input/mod.rs
+++ b/crates/libs/windows/src/Windows/System/RemoteDesktop/Input/mod.rs
@@ -174,7 +174,7 @@ impl windows_core::RuntimeType for RemoteTextConnectionDataHandler {
 impl RemoteTextConnectionDataHandler {
     pub fn new<F: Fn(&[u8]) -> windows_core::Result<bool> + Send + 'static>(invoke: F) -> Self {
         let com = windows_core::imp::DelegateBox::<RemoteTextConnectionDataHandler, F>::new(&RemoteTextConnectionDataHandlerBox::<F>::VTABLE, invoke);
-        unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+        unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
     }
     pub fn Invoke(&self, pdudata: &[u8]) -> windows_core::Result<bool> {
         unsafe {

--- a/crates/libs/windows/src/Windows/System/Threading/Core/mod.rs
+++ b/crates/libs/windows/src/Windows/System/Threading/Core/mod.rs
@@ -110,7 +110,7 @@ impl windows_core::RuntimeType for SignalHandler {
 impl SignalHandler {
     pub fn new<F: Fn(windows_core::Ref<SignalNotifier>, bool) -> windows_core::Result<()> + Send + 'static>(invoke: F) -> Self {
         let com = windows_core::imp::DelegateBox::<SignalHandler, F>::new(&SignalHandlerBox::<F>::VTABLE, invoke);
-        unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+        unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
     }
     pub fn Invoke<P0>(&self, signalnotifier: P0, timedout: bool) -> windows_core::Result<()>
     where

--- a/crates/libs/windows/src/Windows/System/Threading/mod.rs
+++ b/crates/libs/windows/src/Windows/System/Threading/mod.rs
@@ -159,7 +159,7 @@ impl windows_core::RuntimeType for TimerDestroyedHandler {
 impl TimerDestroyedHandler {
     pub fn new<F: Fn(windows_core::Ref<ThreadPoolTimer>) -> windows_core::Result<()> + Send + 'static>(invoke: F) -> Self {
         let com = windows_core::imp::DelegateBox::<TimerDestroyedHandler, F>::new(&TimerDestroyedHandlerBox::<F>::VTABLE, invoke);
-        unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+        unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
     }
     pub fn Invoke<P0>(&self, timer: P0) -> windows_core::Result<()>
     where
@@ -198,7 +198,7 @@ impl windows_core::RuntimeType for TimerElapsedHandler {
 impl TimerElapsedHandler {
     pub fn new<F: Fn(windows_core::Ref<ThreadPoolTimer>) -> windows_core::Result<()> + Send + 'static>(invoke: F) -> Self {
         let com = windows_core::imp::DelegateBox::<TimerElapsedHandler, F>::new(&TimerElapsedHandlerBox::<F>::VTABLE, invoke);
-        unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+        unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
     }
     pub fn Invoke<P0>(&self, timer: P0) -> windows_core::Result<()>
     where
@@ -237,7 +237,7 @@ impl windows_core::RuntimeType for WorkItemHandler {
 impl WorkItemHandler {
     pub fn new<F: Fn(windows_core::Ref<windows_future::IAsyncAction>) -> windows_core::Result<()> + Send + 'static>(invoke: F) -> Self {
         let com = windows_core::imp::DelegateBox::<WorkItemHandler, F>::new(&WorkItemHandlerBox::<F>::VTABLE, invoke);
-        unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+        unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
     }
     pub fn Invoke<P0>(&self, operation: P0) -> windows_core::Result<()>
     where

--- a/crates/libs/windows/src/Windows/System/mod.rs
+++ b/crates/libs/windows/src/Windows/System/mod.rs
@@ -1139,7 +1139,7 @@ impl windows_core::RuntimeType for DispatcherQueueHandler {
 impl DispatcherQueueHandler {
     pub fn new<F: Fn() -> windows_core::Result<()> + Send + 'static>(invoke: F) -> Self {
         let com = windows_core::imp::DelegateBox::<DispatcherQueueHandler, F>::new(&DispatcherQueueHandlerBox::<F>::VTABLE, invoke);
-        unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+        unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
     }
     pub fn Invoke(&self) -> windows_core::Result<()> {
         unsafe { (windows_core::Interface::vtable(self).Invoke)(windows_core::Interface::as_raw(self)).ok() }

--- a/crates/libs/windows/src/Windows/UI/ApplicationSettings/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/ApplicationSettings/mod.rs
@@ -223,7 +223,7 @@ impl windows_core::RuntimeType for CredentialCommandCredentialDeletedHandler {
 impl CredentialCommandCredentialDeletedHandler {
     pub fn new<F: Fn(windows_core::Ref<CredentialCommand>) -> windows_core::Result<()> + Send + 'static>(invoke: F) -> Self {
         let com = windows_core::imp::DelegateBox::<CredentialCommandCredentialDeletedHandler, F>::new(&CredentialCommandCredentialDeletedHandlerBox::<F>::VTABLE, invoke);
-        unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+        unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
     }
     pub fn Invoke<P0>(&self, command: P0) -> windows_core::Result<()>
     where
@@ -845,7 +845,7 @@ impl windows_core::RuntimeType for WebAccountCommandInvokedHandler {
 impl WebAccountCommandInvokedHandler {
     pub fn new<F: Fn(windows_core::Ref<WebAccountCommand>, windows_core::Ref<WebAccountInvokedArgs>) -> windows_core::Result<()> + Send + 'static>(invoke: F) -> Self {
         let com = windows_core::imp::DelegateBox::<WebAccountCommandInvokedHandler, F>::new(&WebAccountCommandInvokedHandlerBox::<F>::VTABLE, invoke);
-        unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+        unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
     }
     pub fn Invoke<P0, P1>(&self, command: P0, args: P1) -> windows_core::Result<()>
     where
@@ -951,7 +951,7 @@ impl windows_core::RuntimeType for WebAccountProviderCommandInvokedHandler {
 impl WebAccountProviderCommandInvokedHandler {
     pub fn new<F: Fn(windows_core::Ref<WebAccountProviderCommand>) -> windows_core::Result<()> + Send + 'static>(invoke: F) -> Self {
         let com = windows_core::imp::DelegateBox::<WebAccountProviderCommandInvokedHandler, F>::new(&WebAccountProviderCommandInvokedHandlerBox::<F>::VTABLE, invoke);
-        unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+        unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
     }
     pub fn Invoke<P0>(&self, command: P0) -> windows_core::Result<()>
     where

--- a/crates/libs/windows/src/Windows/UI/Core/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Core/mod.rs
@@ -2095,7 +2095,7 @@ impl windows_core::RuntimeType for DispatchedHandler {
 impl DispatchedHandler {
     pub fn new<F: Fn() -> windows_core::Result<()> + Send + 'static>(invoke: F) -> Self {
         let com = windows_core::imp::DelegateBox::<DispatchedHandler, F>::new(&DispatchedHandlerBox::<F>::VTABLE, invoke);
-        unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+        unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
     }
     pub fn Invoke(&self) -> windows_core::Result<()> {
         unsafe { (windows_core::Interface::vtable(self).Invoke)(windows_core::Interface::as_raw(self)).ok() }
@@ -4720,7 +4720,7 @@ impl windows_core::RuntimeType for IdleDispatchedHandler {
 impl IdleDispatchedHandler {
     pub fn new<F: Fn(windows_core::Ref<IdleDispatchedHandlerArgs>) -> windows_core::Result<()> + Send + 'static>(invoke: F) -> Self {
         let com = windows_core::imp::DelegateBox::<IdleDispatchedHandler, F>::new(&IdleDispatchedHandlerBox::<F>::VTABLE, invoke);
-        unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+        unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
     }
     pub fn Invoke<P0>(&self, e: P0) -> windows_core::Result<()>
     where

--- a/crates/libs/windows/src/Windows/UI/Popups/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Popups/mod.rs
@@ -489,7 +489,7 @@ impl windows_core::RuntimeType for UICommandInvokedHandler {
 impl UICommandInvokedHandler {
     pub fn new<F: Fn(windows_core::Ref<IUICommand>) -> windows_core::Result<()> + Send + 'static>(invoke: F) -> Self {
         let com = windows_core::imp::DelegateBox::<UICommandInvokedHandler, F>::new(&UICommandInvokedHandlerBox::<F>::VTABLE, invoke);
-        unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+        unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
     }
     pub fn Invoke<P0>(&self, command: P0) -> windows_core::Result<()>
     where

--- a/crates/libs/windows/src/Windows/UI/WebUI/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/WebUI/mod.rs
@@ -27,7 +27,7 @@ impl windows_core::RuntimeType for ActivatedEventHandler {
 impl ActivatedEventHandler {
     pub fn new<F: Fn(windows_core::Ref<windows_core::IInspectable>, windows_core::Ref<super::super::ApplicationModel::Activation::IActivatedEventArgs>) -> windows_core::Result<()> + Send + 'static>(invoke: F) -> Self {
         let com = windows_core::imp::DelegateBox::<ActivatedEventHandler, F>::new(&ActivatedEventHandlerBox::<F>::VTABLE, invoke);
-        unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+        unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
     }
     pub fn Invoke<P0, P1>(&self, sender: P0, eventargs: P1) -> windows_core::Result<()>
     where
@@ -128,7 +128,7 @@ impl windows_core::RuntimeType for BackgroundActivatedEventHandler {
 impl BackgroundActivatedEventHandler {
     pub fn new<F: Fn(windows_core::Ref<windows_core::IInspectable>, windows_core::Ref<super::super::ApplicationModel::Activation::IBackgroundActivatedEventArgs>) -> windows_core::Result<()> + Send + 'static>(invoke: F) -> Self {
         let com = windows_core::imp::DelegateBox::<BackgroundActivatedEventHandler, F>::new(&BackgroundActivatedEventHandlerBox::<F>::VTABLE, invoke);
-        unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+        unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
     }
     pub fn Invoke<P0, P1>(&self, sender: P0, eventargs: P1) -> windows_core::Result<()>
     where
@@ -206,7 +206,7 @@ impl windows_core::RuntimeType for EnteredBackgroundEventHandler {
 impl EnteredBackgroundEventHandler {
     pub fn new<F: Fn(windows_core::Ref<windows_core::IInspectable>, windows_core::Ref<super::super::ApplicationModel::IEnteredBackgroundEventArgs>) -> windows_core::Result<()> + Send + 'static>(invoke: F) -> Self {
         let com = windows_core::imp::DelegateBox::<EnteredBackgroundEventHandler, F>::new(&EnteredBackgroundEventHandlerBox::<F>::VTABLE, invoke);
-        unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+        unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
     }
     pub fn Invoke<P0, P1>(&self, sender: P0, e: P1) -> windows_core::Result<()>
     where
@@ -788,7 +788,7 @@ impl windows_core::RuntimeType for LeavingBackgroundEventHandler {
 impl LeavingBackgroundEventHandler {
     pub fn new<F: Fn(windows_core::Ref<windows_core::IInspectable>, windows_core::Ref<super::super::ApplicationModel::ILeavingBackgroundEventArgs>) -> windows_core::Result<()> + Send + 'static>(invoke: F) -> Self {
         let com = windows_core::imp::DelegateBox::<LeavingBackgroundEventHandler, F>::new(&LeavingBackgroundEventHandlerBox::<F>::VTABLE, invoke);
-        unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+        unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
     }
     pub fn Invoke<P0, P1>(&self, sender: P0, e: P1) -> windows_core::Result<()>
     where
@@ -831,7 +831,7 @@ impl windows_core::RuntimeType for NavigatedEventHandler {
 impl NavigatedEventHandler {
     pub fn new<F: Fn(windows_core::Ref<windows_core::IInspectable>, windows_core::Ref<IWebUINavigatedEventArgs>) -> windows_core::Result<()> + Send + 'static>(invoke: F) -> Self {
         let com = windows_core::imp::DelegateBox::<NavigatedEventHandler, F>::new(&NavigatedEventHandlerBox::<F>::VTABLE, invoke);
-        unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+        unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
     }
     pub fn Invoke<P0, P1>(&self, sender: P0, e: P1) -> windows_core::Result<()>
     where
@@ -929,7 +929,7 @@ impl windows_core::RuntimeType for ResumingEventHandler {
 impl ResumingEventHandler {
     pub fn new<F: Fn(windows_core::Ref<windows_core::IInspectable>) -> windows_core::Result<()> + Send + 'static>(invoke: F) -> Self {
         let com = windows_core::imp::DelegateBox::<ResumingEventHandler, F>::new(&ResumingEventHandlerBox::<F>::VTABLE, invoke);
-        unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+        unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
     }
     pub fn Invoke<P0>(&self, sender: P0) -> windows_core::Result<()>
     where
@@ -1024,7 +1024,7 @@ impl windows_core::RuntimeType for SuspendingEventHandler {
 impl SuspendingEventHandler {
     pub fn new<F: Fn(windows_core::Ref<windows_core::IInspectable>, windows_core::Ref<super::super::ApplicationModel::ISuspendingEventArgs>) -> windows_core::Result<()> + Send + 'static>(invoke: F) -> Self {
         let com = windows_core::imp::DelegateBox::<SuspendingEventHandler, F>::new(&SuspendingEventHandlerBox::<F>::VTABLE, invoke);
-        unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+        unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
     }
     pub fn Invoke<P0, P1>(&self, sender: P0, e: P1) -> windows_core::Result<()>
     where

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D/mod.rs
@@ -984,7 +984,7 @@ impl<T: ID3DInclude_Impl> ID3DInclude_ImplVtbl<T> {
 impl ID3DInclude {
     pub fn new<'a, T: ID3DInclude_Impl>(this: &'a T) -> windows_core::ScopedInterface<'a, Self> {
         let this = windows_core::ScopedHeap { vtable: &ID3DInclude_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
-        let this = core::mem::ManuallyDrop::new(windows_core::imp::Box::new(this));
+        let this = core::mem::ManuallyDrop::new(windows_core::imp::box_new(this));
         unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
     }
 }
@@ -1539,7 +1539,7 @@ impl<T: ID3DShaderCacheInstallerClient_Impl> ID3DShaderCacheInstallerClient_Impl
 impl ID3DShaderCacheInstallerClient {
     pub fn new<'a, T: ID3DShaderCacheInstallerClient_Impl>(this: &'a T) -> windows_core::ScopedInterface<'a, Self> {
         let this = windows_core::ScopedHeap { vtable: &ID3DShaderCacheInstallerClient_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
-        let this = core::mem::ManuallyDrop::new(windows_core::imp::Box::new(this));
+        let this = core::mem::ManuallyDrop::new(windows_core::imp::box_new(this));
         unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
     }
 }

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D10/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D10/mod.rs
@@ -4818,7 +4818,7 @@ impl<T: ID3D10EffectBlendVariable_Impl> ID3D10EffectBlendVariable_ImplVtbl<T> {
 impl ID3D10EffectBlendVariable {
     pub fn new<'a, T: ID3D10EffectBlendVariable_Impl>(this: &'a T) -> windows_core::ScopedInterface<'a, Self> {
         let this = windows_core::ScopedHeap { vtable: &ID3D10EffectBlendVariable_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
-        let this = core::mem::ManuallyDrop::new(windows_core::imp::Box::new(this));
+        let this = core::mem::ManuallyDrop::new(windows_core::imp::box_new(this));
         unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
     }
 }
@@ -4931,7 +4931,7 @@ impl<T: ID3D10EffectConstantBuffer_Impl> ID3D10EffectConstantBuffer_ImplVtbl<T> 
 impl ID3D10EffectConstantBuffer {
     pub fn new<'a, T: ID3D10EffectConstantBuffer_Impl>(this: &'a T) -> windows_core::ScopedInterface<'a, Self> {
         let this = windows_core::ScopedHeap { vtable: &ID3D10EffectConstantBuffer_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
-        let this = core::mem::ManuallyDrop::new(windows_core::imp::Box::new(this));
+        let this = core::mem::ManuallyDrop::new(windows_core::imp::box_new(this));
         unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
     }
 }
@@ -5003,7 +5003,7 @@ impl<T: ID3D10EffectDepthStencilVariable_Impl> ID3D10EffectDepthStencilVariable_
 impl ID3D10EffectDepthStencilVariable {
     pub fn new<'a, T: ID3D10EffectDepthStencilVariable_Impl>(this: &'a T) -> windows_core::ScopedInterface<'a, Self> {
         let this = windows_core::ScopedHeap { vtable: &ID3D10EffectDepthStencilVariable_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
-        let this = core::mem::ManuallyDrop::new(windows_core::imp::Box::new(this));
+        let this = core::mem::ManuallyDrop::new(windows_core::imp::box_new(this));
         unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
     }
 }
@@ -5104,7 +5104,7 @@ impl<T: ID3D10EffectDepthStencilViewVariable_Impl> ID3D10EffectDepthStencilViewV
 impl ID3D10EffectDepthStencilViewVariable {
     pub fn new<'a, T: ID3D10EffectDepthStencilViewVariable_Impl>(this: &'a T) -> windows_core::ScopedInterface<'a, Self> {
         let this = windows_core::ScopedHeap { vtable: &ID3D10EffectDepthStencilViewVariable_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
-        let this = core::mem::ManuallyDrop::new(windows_core::imp::Box::new(this));
+        let this = core::mem::ManuallyDrop::new(windows_core::imp::box_new(this));
         unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
     }
 }
@@ -5245,7 +5245,7 @@ impl<T: ID3D10EffectMatrixVariable_Impl> ID3D10EffectMatrixVariable_ImplVtbl<T> 
 impl ID3D10EffectMatrixVariable {
     pub fn new<'a, T: ID3D10EffectMatrixVariable_Impl>(this: &'a T) -> windows_core::ScopedInterface<'a, Self> {
         let this = windows_core::ScopedHeap { vtable: &ID3D10EffectMatrixVariable_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
-        let this = core::mem::ManuallyDrop::new(windows_core::imp::Box::new(this));
+        let this = core::mem::ManuallyDrop::new(windows_core::imp::box_new(this));
         unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
     }
 }
@@ -5393,7 +5393,7 @@ impl<T: ID3D10EffectPass_Impl> ID3D10EffectPass_ImplVtbl<T> {
 impl ID3D10EffectPass {
     pub fn new<'a, T: ID3D10EffectPass_Impl>(this: &'a T) -> windows_core::ScopedInterface<'a, Self> {
         let this = windows_core::ScopedHeap { vtable: &ID3D10EffectPass_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
-        let this = core::mem::ManuallyDrop::new(windows_core::imp::Box::new(this));
+        let this = core::mem::ManuallyDrop::new(windows_core::imp::box_new(this));
         unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
     }
 }
@@ -5498,7 +5498,7 @@ impl<T: ID3D10EffectRasterizerVariable_Impl> ID3D10EffectRasterizerVariable_Impl
 impl ID3D10EffectRasterizerVariable {
     pub fn new<'a, T: ID3D10EffectRasterizerVariable_Impl>(this: &'a T) -> windows_core::ScopedInterface<'a, Self> {
         let this = windows_core::ScopedHeap { vtable: &ID3D10EffectRasterizerVariable_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
-        let this = core::mem::ManuallyDrop::new(windows_core::imp::Box::new(this));
+        let this = core::mem::ManuallyDrop::new(windows_core::imp::box_new(this));
         unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
     }
 }
@@ -5599,7 +5599,7 @@ impl<T: ID3D10EffectRenderTargetViewVariable_Impl> ID3D10EffectRenderTargetViewV
 impl ID3D10EffectRenderTargetViewVariable {
     pub fn new<'a, T: ID3D10EffectRenderTargetViewVariable_Impl>(this: &'a T) -> windows_core::ScopedInterface<'a, Self> {
         let this = windows_core::ScopedHeap { vtable: &ID3D10EffectRenderTargetViewVariable_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
-        let this = core::mem::ManuallyDrop::new(windows_core::imp::Box::new(this));
+        let this = core::mem::ManuallyDrop::new(windows_core::imp::box_new(this));
         unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
     }
 }
@@ -5667,7 +5667,7 @@ impl<T: ID3D10EffectSamplerVariable_Impl> ID3D10EffectSamplerVariable_ImplVtbl<T
 impl ID3D10EffectSamplerVariable {
     pub fn new<'a, T: ID3D10EffectSamplerVariable_Impl>(this: &'a T) -> windows_core::ScopedInterface<'a, Self> {
         let this = windows_core::ScopedHeap { vtable: &ID3D10EffectSamplerVariable_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
-        let this = core::mem::ManuallyDrop::new(windows_core::imp::Box::new(this));
+        let this = core::mem::ManuallyDrop::new(windows_core::imp::box_new(this));
         unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
     }
 }
@@ -5887,7 +5887,7 @@ impl<T: ID3D10EffectScalarVariable_Impl> ID3D10EffectScalarVariable_ImplVtbl<T> 
 impl ID3D10EffectScalarVariable {
     pub fn new<'a, T: ID3D10EffectScalarVariable_Impl>(this: &'a T) -> windows_core::ScopedInterface<'a, Self> {
         let this = windows_core::ScopedHeap { vtable: &ID3D10EffectScalarVariable_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
-        let this = core::mem::ManuallyDrop::new(windows_core::imp::Box::new(this));
+        let this = core::mem::ManuallyDrop::new(windows_core::imp::box_new(this));
         unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
     }
 }
@@ -5988,7 +5988,7 @@ impl<T: ID3D10EffectShaderResourceVariable_Impl> ID3D10EffectShaderResourceVaria
 impl ID3D10EffectShaderResourceVariable {
     pub fn new<'a, T: ID3D10EffectShaderResourceVariable_Impl>(this: &'a T) -> windows_core::ScopedInterface<'a, Self> {
         let this = windows_core::ScopedHeap { vtable: &ID3D10EffectShaderResourceVariable_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
-        let this = core::mem::ManuallyDrop::new(windows_core::imp::Box::new(this));
+        let this = core::mem::ManuallyDrop::new(windows_core::imp::box_new(this));
         unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
     }
 }
@@ -6143,7 +6143,7 @@ impl<T: ID3D10EffectShaderVariable_Impl> ID3D10EffectShaderVariable_ImplVtbl<T> 
 impl ID3D10EffectShaderVariable {
     pub fn new<'a, T: ID3D10EffectShaderVariable_Impl>(this: &'a T) -> windows_core::ScopedInterface<'a, Self> {
         let this = windows_core::ScopedHeap { vtable: &ID3D10EffectShaderVariable_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
-        let this = core::mem::ManuallyDrop::new(windows_core::imp::Box::new(this));
+        let this = core::mem::ManuallyDrop::new(windows_core::imp::box_new(this));
         unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
     }
 }
@@ -6211,7 +6211,7 @@ impl<T: ID3D10EffectStringVariable_Impl> ID3D10EffectStringVariable_ImplVtbl<T> 
 impl ID3D10EffectStringVariable {
     pub fn new<'a, T: ID3D10EffectStringVariable_Impl>(this: &'a T) -> windows_core::ScopedInterface<'a, Self> {
         let this = windows_core::ScopedHeap { vtable: &ID3D10EffectStringVariable_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
-        let this = core::mem::ManuallyDrop::new(windows_core::imp::Box::new(this));
+        let this = core::mem::ManuallyDrop::new(windows_core::imp::box_new(this));
         unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
     }
 }
@@ -6336,7 +6336,7 @@ impl<T: ID3D10EffectTechnique_Impl> ID3D10EffectTechnique_ImplVtbl<T> {
 impl ID3D10EffectTechnique {
     pub fn new<'a, T: ID3D10EffectTechnique_Impl>(this: &'a T) -> windows_core::ScopedInterface<'a, Self> {
         let this = windows_core::ScopedHeap { vtable: &ID3D10EffectTechnique_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
-        let this = core::mem::ManuallyDrop::new(windows_core::imp::Box::new(this));
+        let this = core::mem::ManuallyDrop::new(windows_core::imp::box_new(this));
         unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
     }
 }
@@ -6470,7 +6470,7 @@ impl<T: ID3D10EffectType_Impl> ID3D10EffectType_ImplVtbl<T> {
 impl ID3D10EffectType {
     pub fn new<'a, T: ID3D10EffectType_Impl>(this: &'a T) -> windows_core::ScopedInterface<'a, Self> {
         let this = windows_core::ScopedHeap { vtable: &ID3D10EffectType_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
-        let this = core::mem::ManuallyDrop::new(windows_core::imp::Box::new(this));
+        let this = core::mem::ManuallyDrop::new(windows_core::imp::box_new(this));
         unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
     }
 }
@@ -6832,7 +6832,7 @@ impl<T: ID3D10EffectVariable_Impl> ID3D10EffectVariable_ImplVtbl<T> {
 impl ID3D10EffectVariable {
     pub fn new<'a, T: ID3D10EffectVariable_Impl>(this: &'a T) -> windows_core::ScopedInterface<'a, Self> {
         let this = windows_core::ScopedHeap { vtable: &ID3D10EffectVariable_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
-        let this = core::mem::ManuallyDrop::new(windows_core::imp::Box::new(this));
+        let this = core::mem::ManuallyDrop::new(windows_core::imp::box_new(this));
         unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
     }
 }
@@ -7025,7 +7025,7 @@ impl<T: ID3D10EffectVectorVariable_Impl> ID3D10EffectVectorVariable_ImplVtbl<T> 
 impl ID3D10EffectVectorVariable {
     pub fn new<'a, T: ID3D10EffectVectorVariable_Impl>(this: &'a T) -> windows_core::ScopedInterface<'a, Self> {
         let this = windows_core::ScopedHeap { vtable: &ID3D10EffectVectorVariable_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
-        let this = core::mem::ManuallyDrop::new(windows_core::imp::Box::new(this));
+        let this = core::mem::ManuallyDrop::new(windows_core::imp::box_new(this));
         unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
     }
 }
@@ -8404,7 +8404,7 @@ impl<T: ID3D10ShaderReflectionConstantBuffer_Impl> ID3D10ShaderReflectionConstan
 impl ID3D10ShaderReflectionConstantBuffer {
     pub fn new<'a, T: ID3D10ShaderReflectionConstantBuffer_Impl>(this: &'a T) -> windows_core::ScopedInterface<'a, Self> {
         let this = windows_core::ScopedHeap { vtable: &ID3D10ShaderReflectionConstantBuffer_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
-        let this = core::mem::ManuallyDrop::new(windows_core::imp::Box::new(this));
+        let this = core::mem::ManuallyDrop::new(windows_core::imp::box_new(this));
         unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
     }
 }
@@ -8496,7 +8496,7 @@ impl<T: ID3D10ShaderReflectionType_Impl> ID3D10ShaderReflectionType_ImplVtbl<T> 
 impl ID3D10ShaderReflectionType {
     pub fn new<'a, T: ID3D10ShaderReflectionType_Impl>(this: &'a T) -> windows_core::ScopedInterface<'a, Self> {
         let this = windows_core::ScopedHeap { vtable: &ID3D10ShaderReflectionType_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
-        let this = core::mem::ManuallyDrop::new(windows_core::imp::Box::new(this));
+        let this = core::mem::ManuallyDrop::new(windows_core::imp::box_new(this));
         unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
     }
 }
@@ -8547,7 +8547,7 @@ impl<T: ID3D10ShaderReflectionVariable_Impl> ID3D10ShaderReflectionVariable_Impl
 impl ID3D10ShaderReflectionVariable {
     pub fn new<'a, T: ID3D10ShaderReflectionVariable_Impl>(this: &'a T) -> windows_core::ScopedInterface<'a, Self> {
         let this = windows_core::ScopedHeap { vtable: &ID3D10ShaderReflectionVariable_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
-        let this = core::mem::ManuallyDrop::new(windows_core::imp::Box::new(this));
+        let this = core::mem::ManuallyDrop::new(windows_core::imp::box_new(this));
         unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
     }
 }

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D11/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D11/mod.rs
@@ -10154,7 +10154,7 @@ impl<T: ID3D11FunctionParameterReflection_Impl> ID3D11FunctionParameterReflectio
 impl ID3D11FunctionParameterReflection {
     pub fn new<'a, T: ID3D11FunctionParameterReflection_Impl>(this: &'a T) -> windows_core::ScopedInterface<'a, Self> {
         let this = windows_core::ScopedHeap { vtable: &ID3D11FunctionParameterReflection_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
-        let this = core::mem::ManuallyDrop::new(windows_core::imp::Box::new(this));
+        let this = core::mem::ManuallyDrop::new(windows_core::imp::box_new(this));
         unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
     }
 }
@@ -10299,7 +10299,7 @@ impl<T: ID3D11FunctionReflection_Impl> ID3D11FunctionReflection_ImplVtbl<T> {
 impl ID3D11FunctionReflection {
     pub fn new<'a, T: ID3D11FunctionReflection_Impl>(this: &'a T) -> windows_core::ScopedInterface<'a, Self> {
         let this = windows_core::ScopedHeap { vtable: &ID3D11FunctionReflection_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
-        let this = core::mem::ManuallyDrop::new(windows_core::imp::Box::new(this));
+        let this = core::mem::ManuallyDrop::new(windows_core::imp::box_new(this));
         unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
     }
 }
@@ -12181,7 +12181,7 @@ impl<T: ID3D11ShaderReflectionConstantBuffer_Impl> ID3D11ShaderReflectionConstan
 impl ID3D11ShaderReflectionConstantBuffer {
     pub fn new<'a, T: ID3D11ShaderReflectionConstantBuffer_Impl>(this: &'a T) -> windows_core::ScopedInterface<'a, Self> {
         let this = windows_core::ScopedHeap { vtable: &ID3D11ShaderReflectionConstantBuffer_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
-        let this = core::mem::ManuallyDrop::new(windows_core::imp::Box::new(this));
+        let this = core::mem::ManuallyDrop::new(windows_core::imp::box_new(this));
         unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
     }
 }
@@ -12373,7 +12373,7 @@ impl<T: ID3D11ShaderReflectionType_Impl> ID3D11ShaderReflectionType_ImplVtbl<T> 
 impl ID3D11ShaderReflectionType {
     pub fn new<'a, T: ID3D11ShaderReflectionType_Impl>(this: &'a T) -> windows_core::ScopedInterface<'a, Self> {
         let this = windows_core::ScopedHeap { vtable: &ID3D11ShaderReflectionType_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
-        let this = core::mem::ManuallyDrop::new(windows_core::imp::Box::new(this));
+        let this = core::mem::ManuallyDrop::new(windows_core::imp::box_new(this));
         unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
     }
 }
@@ -12448,7 +12448,7 @@ impl<T: ID3D11ShaderReflectionVariable_Impl> ID3D11ShaderReflectionVariable_Impl
 impl ID3D11ShaderReflectionVariable {
     pub fn new<'a, T: ID3D11ShaderReflectionVariable_Impl>(this: &'a T) -> windows_core::ScopedInterface<'a, Self> {
         let this = windows_core::ScopedHeap { vtable: &ID3D11ShaderReflectionVariable_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
-        let this = core::mem::ManuallyDrop::new(windows_core::imp::Box::new(this));
+        let this = core::mem::ManuallyDrop::new(windows_core::imp::box_new(this));
         unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
     }
 }

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D12/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D12/mod.rs
@@ -13146,7 +13146,7 @@ impl<T: ID3D12FunctionParameterReflection_Impl> ID3D12FunctionParameterReflectio
 impl ID3D12FunctionParameterReflection {
     pub fn new<'a, T: ID3D12FunctionParameterReflection_Impl>(this: &'a T) -> windows_core::ScopedInterface<'a, Self> {
         let this = windows_core::ScopedHeap { vtable: &ID3D12FunctionParameterReflection_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
-        let this = core::mem::ManuallyDrop::new(windows_core::imp::Box::new(this));
+        let this = core::mem::ManuallyDrop::new(windows_core::imp::box_new(this));
         unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
     }
 }
@@ -13291,7 +13291,7 @@ impl<T: ID3D12FunctionReflection_Impl> ID3D12FunctionReflection_ImplVtbl<T> {
 impl ID3D12FunctionReflection {
     pub fn new<'a, T: ID3D12FunctionReflection_Impl>(this: &'a T) -> windows_core::ScopedInterface<'a, Self> {
         let this = windows_core::ScopedHeap { vtable: &ID3D12FunctionReflection_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
-        let this = core::mem::ManuallyDrop::new(windows_core::imp::Box::new(this));
+        let this = core::mem::ManuallyDrop::new(windows_core::imp::box_new(this));
         unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
     }
 }
@@ -17225,7 +17225,7 @@ impl<T: ID3D12ShaderReflectionConstantBuffer_Impl> ID3D12ShaderReflectionConstan
 impl ID3D12ShaderReflectionConstantBuffer {
     pub fn new<'a, T: ID3D12ShaderReflectionConstantBuffer_Impl>(this: &'a T) -> windows_core::ScopedInterface<'a, Self> {
         let this = windows_core::ScopedHeap { vtable: &ID3D12ShaderReflectionConstantBuffer_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
-        let this = core::mem::ManuallyDrop::new(windows_core::imp::Box::new(this));
+        let this = core::mem::ManuallyDrop::new(windows_core::imp::box_new(this));
         unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
     }
 }
@@ -17417,7 +17417,7 @@ impl<T: ID3D12ShaderReflectionType_Impl> ID3D12ShaderReflectionType_ImplVtbl<T> 
 impl ID3D12ShaderReflectionType {
     pub fn new<'a, T: ID3D12ShaderReflectionType_Impl>(this: &'a T) -> windows_core::ScopedInterface<'a, Self> {
         let this = windows_core::ScopedHeap { vtable: &ID3D12ShaderReflectionType_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
-        let this = core::mem::ManuallyDrop::new(windows_core::imp::Box::new(this));
+        let this = core::mem::ManuallyDrop::new(windows_core::imp::box_new(this));
         unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
     }
 }
@@ -17492,7 +17492,7 @@ impl<T: ID3D12ShaderReflectionVariable_Impl> ID3D12ShaderReflectionVariable_Impl
 impl ID3D12ShaderReflectionVariable {
     pub fn new<'a, T: ID3D12ShaderReflectionVariable_Impl>(this: &'a T) -> windows_core::ScopedInterface<'a, Self> {
         let this = windows_core::ScopedHeap { vtable: &ID3D12ShaderReflectionVariable_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
-        let this = core::mem::ManuallyDrop::new(windows_core::imp::Box::new(this));
+        let this = core::mem::ManuallyDrop::new(windows_core::imp::box_new(this));
         unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
     }
 }

--- a/crates/libs/windows/src/Windows/Win32/Graphics/GdiPlus/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/GdiPlus/mod.rs
@@ -4126,7 +4126,7 @@ impl<T: GdiplusAbort_Impl> GdiplusAbort_ImplVtbl<T> {
 impl GdiplusAbort {
     pub fn new<'a, T: GdiplusAbort_Impl>(this: &'a T) -> windows_core::ScopedInterface<'a, Self> {
         let this = windows_core::ScopedHeap { vtable: &GdiplusAbort_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
-        let this = core::mem::ManuallyDrop::new(windows_core::imp::Box::new(this));
+        let this = core::mem::ManuallyDrop::new(windows_core::imp::box_new(this));
         unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
     }
 }

--- a/crates/libs/windows/src/Windows/Win32/Media/Audio/XAudio2/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/Audio/XAudio2/mod.rs
@@ -698,7 +698,7 @@ impl<T: IXAudio2EngineCallback_Impl> IXAudio2EngineCallback_ImplVtbl<T> {
 impl IXAudio2EngineCallback {
     pub fn new<'a, T: IXAudio2EngineCallback_Impl>(this: &'a T) -> windows_core::ScopedInterface<'a, Self> {
         let this = windows_core::ScopedHeap { vtable: &IXAudio2EngineCallback_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
-        let this = core::mem::ManuallyDrop::new(windows_core::imp::Box::new(this));
+        let this = core::mem::ManuallyDrop::new(windows_core::imp::box_new(this));
         unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
     }
 }
@@ -802,7 +802,7 @@ impl<T: IXAudio2MasteringVoice_Impl> IXAudio2MasteringVoice_ImplVtbl<T> {
 impl IXAudio2MasteringVoice {
     pub fn new<'a, T: IXAudio2MasteringVoice_Impl>(this: &'a T) -> windows_core::ScopedInterface<'a, Self> {
         let this = windows_core::ScopedHeap { vtable: &IXAudio2MasteringVoice_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
-        let this = core::mem::ManuallyDrop::new(windows_core::imp::Box::new(this));
+        let this = core::mem::ManuallyDrop::new(windows_core::imp::box_new(this));
         unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
     }
 }
@@ -973,7 +973,7 @@ impl<T: IXAudio2SourceVoice_Impl> IXAudio2SourceVoice_ImplVtbl<T> {
 impl IXAudio2SourceVoice {
     pub fn new<'a, T: IXAudio2SourceVoice_Impl>(this: &'a T) -> windows_core::ScopedInterface<'a, Self> {
         let this = windows_core::ScopedHeap { vtable: &IXAudio2SourceVoice_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
-        let this = core::mem::ManuallyDrop::new(windows_core::imp::Box::new(this));
+        let this = core::mem::ManuallyDrop::new(windows_core::imp::box_new(this));
         unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
     }
 }
@@ -1003,7 +1003,7 @@ impl<T: IXAudio2SubmixVoice_Impl> IXAudio2SubmixVoice_ImplVtbl<T> {
 impl IXAudio2SubmixVoice {
     pub fn new<'a, T: IXAudio2SubmixVoice_Impl>(this: &'a T) -> windows_core::ScopedInterface<'a, Self> {
         let this = windows_core::ScopedHeap { vtable: &IXAudio2SubmixVoice_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
-        let this = core::mem::ManuallyDrop::new(windows_core::imp::Box::new(this));
+        let this = core::mem::ManuallyDrop::new(windows_core::imp::box_new(this));
         unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
     }
 }
@@ -1316,7 +1316,7 @@ impl<T: IXAudio2Voice_Impl> IXAudio2Voice_ImplVtbl<T> {
 impl IXAudio2Voice {
     pub fn new<'a, T: IXAudio2Voice_Impl>(this: &'a T) -> windows_core::ScopedInterface<'a, Self> {
         let this = windows_core::ScopedHeap { vtable: &IXAudio2Voice_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
-        let this = core::mem::ManuallyDrop::new(windows_core::imp::Box::new(this));
+        let this = core::mem::ManuallyDrop::new(windows_core::imp::box_new(this));
         unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
     }
 }
@@ -1447,7 +1447,7 @@ impl<T: IXAudio2VoiceCallback_Impl> IXAudio2VoiceCallback_ImplVtbl<T> {
 impl IXAudio2VoiceCallback {
     pub fn new<'a, T: IXAudio2VoiceCallback_Impl>(this: &'a T) -> windows_core::ScopedInterface<'a, Self> {
         let this = windows_core::ScopedHeap { vtable: &IXAudio2VoiceCallback_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
-        let this = core::mem::ManuallyDrop::new(windows_core::imp::Box::new(this));
+        let this = core::mem::ManuallyDrop::new(windows_core::imp::box_new(this));
         unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
     }
 }

--- a/crates/libs/windows/src/Windows/Win32/Media/Speech/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/Speech/mod.rs
@@ -2058,7 +2058,7 @@ impl<T: ISpNotifyCallback_Impl> ISpNotifyCallback_ImplVtbl<T> {
 impl ISpNotifyCallback {
     pub fn new<'a, T: ISpNotifyCallback_Impl>(this: &'a T) -> windows_core::ScopedInterface<'a, Self> {
         let this = windows_core::ScopedHeap { vtable: &ISpNotifyCallback_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
-        let this = core::mem::ManuallyDrop::new(windows_core::imp::Box::new(this));
+        let this = core::mem::ManuallyDrop::new(windows_core::imp::box_new(this));
         unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
     }
 }
@@ -6856,7 +6856,7 @@ impl<T: ISpTask_Impl> ISpTask_ImplVtbl<T> {
 impl ISpTask {
     pub fn new<'a, T: ISpTask_Impl>(this: &'a T) -> windows_core::ScopedInterface<'a, Self> {
         let this = windows_core::ScopedHeap { vtable: &ISpTask_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
-        let this = core::mem::ManuallyDrop::new(windows_core::imp::Box::new(this));
+        let this = core::mem::ManuallyDrop::new(windows_core::imp::box_new(this));
         unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
     }
 }
@@ -7204,7 +7204,7 @@ impl<T: ISpThreadTask_Impl> ISpThreadTask_ImplVtbl<T> {
 impl ISpThreadTask {
     pub fn new<'a, T: ISpThreadTask_Impl>(this: &'a T) -> windows_core::ScopedInterface<'a, Self> {
         let this = windows_core::ScopedHeap { vtable: &ISpThreadTask_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
-        let this = core::mem::ManuallyDrop::new(windows_core::imp::Box::new(this));
+        let this = core::mem::ManuallyDrop::new(windows_core::imp::box_new(this));
         unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
     }
 }

--- a/crates/libs/windows/src/Windows/Win32/Storage/Vss/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/Vss/mod.rs
@@ -1348,7 +1348,7 @@ impl<T: IVssCreateWriterMetadata_Impl> IVssCreateWriterMetadata_ImplVtbl<T> {
 impl IVssCreateWriterMetadata {
     pub fn new<'a, T: IVssCreateWriterMetadata_Impl>(this: &'a T) -> windows_core::ScopedInterface<'a, Self> {
         let this = windows_core::ScopedHeap { vtable: &IVssCreateWriterMetadata_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
-        let this = core::mem::ManuallyDrop::new(windows_core::imp::Box::new(this));
+        let this = core::mem::ManuallyDrop::new(windows_core::imp::box_new(this));
         unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
     }
 }
@@ -2956,7 +2956,7 @@ impl<T: IVssWriterComponents_Impl> IVssWriterComponents_ImplVtbl<T> {
 impl IVssWriterComponents {
     pub fn new<'a, T: IVssWriterComponents_Impl>(this: &'a T) -> windows_core::ScopedInterface<'a, Self> {
         let this = windows_core::ScopedHeap { vtable: &IVssWriterComponents_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
-        let this = core::mem::ManuallyDrop::new(windows_core::imp::Box::new(this));
+        let this = core::mem::ManuallyDrop::new(windows_core::imp::box_new(this));
         unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
     }
 }

--- a/crates/libs/windows/src/Windows/Win32/System/Com/StructuredStorage/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Com/StructuredStorage/mod.rs
@@ -1920,7 +1920,7 @@ impl<T: IMemoryAllocator_Impl> IMemoryAllocator_ImplVtbl<T> {
 impl IMemoryAllocator {
     pub fn new<'a, T: IMemoryAllocator_Impl>(this: &'a T) -> windows_core::ScopedInterface<'a, Self> {
         let this = windows_core::ScopedHeap { vtable: &IMemoryAllocator_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
-        let this = core::mem::ManuallyDrop::new(windows_core::imp::Box::new(this));
+        let this = core::mem::ManuallyDrop::new(windows_core::imp::box_new(this));
         unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
     }
 }

--- a/crates/libs/windows/src/Windows/Win32/System/Search/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Search/mod.rs
@@ -17372,7 +17372,7 @@ impl<T: IUMS_Impl> IUMS_ImplVtbl<T> {
 impl IUMS {
     pub fn new<'a, T: IUMS_Impl>(this: &'a T) -> windows_core::ScopedInterface<'a, Self> {
         let this = windows_core::ScopedHeap { vtable: &IUMS_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
-        let this = core::mem::ManuallyDrop::new(windows_core::imp::Box::new(this));
+        let this = core::mem::ManuallyDrop::new(windows_core::imp::box_new(this));
         unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
     }
 }

--- a/crates/libs/windows/src/Windows/Win32/System/WinRT/Metadata/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WinRT/Metadata/mod.rs
@@ -3929,7 +3929,7 @@ impl<T: IRoMetaDataLocator_Impl> IRoMetaDataLocator_ImplVtbl<T> {
 impl IRoMetaDataLocator {
     pub fn new<'a, T: IRoMetaDataLocator_Impl>(this: &'a T) -> windows_core::ScopedInterface<'a, Self> {
         let this = windows_core::ScopedHeap { vtable: &IRoMetaDataLocator_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
-        let this = core::mem::ManuallyDrop::new(windows_core::imp::Box::new(this));
+        let this = core::mem::ManuallyDrop::new(windows_core::imp::box_new(this));
         unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
     }
 }
@@ -4106,7 +4106,7 @@ impl<T: IRoSimpleMetaDataBuilder_Impl> IRoSimpleMetaDataBuilder_ImplVtbl<T> {
 impl IRoSimpleMetaDataBuilder {
     pub fn new<'a, T: IRoSimpleMetaDataBuilder_Impl>(this: &'a T) -> windows_core::ScopedInterface<'a, Self> {
         let this = windows_core::ScopedHeap { vtable: &IRoSimpleMetaDataBuilder_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
-        let this = core::mem::ManuallyDrop::new(windows_core::imp::Box::new(this));
+        let this = core::mem::ManuallyDrop::new(windows_core::imp::box_new(this));
         unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
     }
 }

--- a/crates/samples/windows/xaml_app/src/bindings.rs
+++ b/crates/samples/windows/xaml_app/src/bindings.rs
@@ -328,7 +328,7 @@ impl ApplicationInitializationCallback {
             &ApplicationInitializationCallbackBox::<F>::VTABLE,
             invoke,
         );
-        unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+        unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
     }
     pub fn Invoke<P0>(&self, p: P0) -> windows_core::Result<()>
     where

--- a/crates/tests/libs/bindgen/data/bindgen/auto_events/expected.rs
+++ b/crates/tests/libs/bindgen/data/bindgen/auto_events/expected.rs
@@ -14,7 +14,7 @@ pub mod Test {
                 &CompletedCallbackBox::<F>::VTABLE,
                 invoke,
             );
-            unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+            unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
         }
     }
     #[repr(C)]
@@ -121,7 +121,7 @@ pub mod Test {
                     &HandlerBox::<F>::VTABLE,
                     handler,
                 );
-                unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+                unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
             };
             unsafe {
                 let mut result__ = core::mem::zeroed();

--- a/crates/tests/libs/bindgen/data/bindgen/class_with_handler/expected.rs
+++ b/crates/tests/libs/bindgen/data/bindgen/class_with_handler/expected.rs
@@ -71,7 +71,7 @@ impl DeferralCompletedHandler {
             &DeferralCompletedHandlerBox::<F>::VTABLE,
             invoke,
         );
-        unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+        unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
     }
     pub fn Invoke(&self) -> windows_core::Result<()> {
         unsafe {

--- a/crates/tests/libs/bindgen/data/bindgen/delegate/expected.rs
+++ b/crates/tests/libs/bindgen/data/bindgen/delegate/expected.rs
@@ -13,7 +13,7 @@ impl DeferralCompletedHandler {
             &DeferralCompletedHandlerBox::<F>::VTABLE,
             invoke,
         );
-        unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+        unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
     }
     pub fn Invoke(&self) -> windows_core::Result<()> {
         unsafe {

--- a/crates/tests/libs/bindgen/data/bindgen/delegate_generic/expected.rs
+++ b/crates/tests/libs/bindgen/data/bindgen/delegate_generic/expected.rs
@@ -30,7 +30,7 @@ impl<T: windows_core::RuntimeType + 'static> EventHandler<T> {
             &EventHandlerBox::<T, F>::VTABLE,
             invoke,
         );
-        unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+        unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
     }
     pub fn Invoke<P0, P1>(&self, sender: P0, args: P1) -> windows_core::Result<()>
     where

--- a/crates/tests/libs/bindgen/data/bindgen/implements/expected.rs
+++ b/crates/tests/libs/bindgen/data/bindgen/implements/expected.rs
@@ -55,7 +55,7 @@ pub mod Test {
                 vtable: &IFoo_ImplVtbl::<T>::VTABLE as *const _ as *const _,
                 this: this as *const _ as *const _,
             };
-            let this = core::mem::ManuallyDrop::new(windows_core::imp::Box::new(this));
+            let this = core::mem::ManuallyDrop::new(windows_core::imp::box_new(this));
             unsafe { windows_core::ScopedInterface::new(core::mem::transmute(&this.vtable)) }
         }
     }

--- a/crates/tests/libs/bindgen/data/bindgen/method_filter_property/expected.rs
+++ b/crates/tests/libs/bindgen/data/bindgen/method_filter_property/expected.rs
@@ -18,7 +18,7 @@ pub mod Test {
         ) -> Self {
             let com =
                 windows_core::imp::DelegateBox::<Handler, F>::new(&HandlerBox::<F>::VTABLE, invoke);
-            unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+            unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
         }
         pub fn Invoke<P0>(&self, sender: P0) -> windows_result::Result<()>
         where

--- a/crates/tests/libs/reactor_selftest/src/bindings.rs
+++ b/crates/tests/libs/reactor_selftest/src/bindings.rs
@@ -484,7 +484,7 @@ impl ApplicationInitializationCallback {
             &ApplicationInitializationCallbackBox::<F>::VTABLE,
             invoke,
         );
-        unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+        unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
     }
 }
 #[repr(C)]
@@ -2722,7 +2722,7 @@ impl CompositionTarget {
                     &EventHandlerBox::<windows_core::IInspectable, F>::VTABLE,
                     handler,
                 );
-            unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+            unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
         };
         Self::ICompositionTargetStatics(|this| unsafe {
             let mut result__ = core::mem::zeroed();
@@ -3329,7 +3329,7 @@ impl DependencyPropertyChangedCallback {
             &DependencyPropertyChangedCallbackBox::<F>::VTABLE,
             invoke,
         );
-        unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+        unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
     }
 }
 #[repr(C)]
@@ -3513,7 +3513,7 @@ impl DispatcherQueueHandler {
             &DispatcherQueueHandlerBox::<F>::VTABLE,
             invoke,
         );
-        unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+        unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
     }
 }
 #[repr(C)]
@@ -5368,7 +5368,7 @@ impl IAutoSuggestBox {
                     >::VTABLE,
                     handler,
                 );
-            unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+            unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
@@ -5394,7 +5394,7 @@ impl IAutoSuggestBox {
     {
         let handler: TypedEventHandler<AutoSuggestBox, AutoSuggestBoxTextChangedEventArgs> = {
             let com = windows_core::imp::DelegateBox::< TypedEventHandler < AutoSuggestBox , AutoSuggestBoxTextChangedEventArgs > , F >::new (& TypedEventHandlerBox::< AutoSuggestBox , AutoSuggestBoxTextChangedEventArgs , F >::VTABLE , handler) ;
-            unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+            unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
@@ -5423,7 +5423,7 @@ impl IAutoSuggestBox {
     {
         let handler: TypedEventHandler<AutoSuggestBox, AutoSuggestBoxQuerySubmittedEventArgs> = {
             let com = windows_core::imp::DelegateBox::< TypedEventHandler < AutoSuggestBox , AutoSuggestBoxQuerySubmittedEventArgs > , F >::new (& TypedEventHandlerBox::< AutoSuggestBox , AutoSuggestBoxQuerySubmittedEventArgs , F >::VTABLE , handler) ;
-            unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+            unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
@@ -7508,7 +7508,7 @@ impl IBreadcrumbBar {
     {
         let handler: TypedEventHandler<BreadcrumbBar, BreadcrumbBarItemClickedEventArgs> = {
             let com = windows_core::imp::DelegateBox::< TypedEventHandler < BreadcrumbBar , BreadcrumbBarItemClickedEventArgs > , F >::new (& TypedEventHandlerBox::< BreadcrumbBar , BreadcrumbBarItemClickedEventArgs , F >::VTABLE , handler) ;
-            unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+            unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
@@ -7697,7 +7697,7 @@ impl IButtonBase {
                 &RoutedEventHandlerBox::<F>::VTABLE,
                 handler,
             );
-            unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+            unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
@@ -7834,7 +7834,7 @@ impl ICalendarDatePicker {
                 >::VTABLE,
                 handler,
             );
-            unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+            unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
@@ -8009,7 +8009,7 @@ impl ICalendarView {
                     >::VTABLE,
                     handler,
                 );
-            unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+            unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
@@ -8460,7 +8460,7 @@ impl IColorPicker {
                 &TypedEventHandlerBox::<ColorPicker, ColorChangedEventArgs, F>::VTABLE,
                 handler,
             );
-            unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+            unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
@@ -9302,7 +9302,7 @@ impl IContentDialog {
                 &TypedEventHandlerBox::<ContentDialog, ContentDialogClosedEventArgs, F>::VTABLE,
                 handler,
             );
-            unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+            unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
@@ -9746,7 +9746,7 @@ impl IDatePicker {
     {
         let handler: TypedEventHandler<DatePicker, DatePickerSelectedValueChangedEventArgs> = {
             let com = windows_core::imp::DelegateBox::< TypedEventHandler < DatePicker , DatePickerSelectedValueChangedEventArgs > , F >::new (& TypedEventHandlerBox::< DatePicker , DatePickerSelectedValueChangedEventArgs , F >::VTABLE , handler) ;
-            unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+            unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
@@ -10232,7 +10232,7 @@ impl IDispatcherQueueTimer {
     {
         let handler: TypedEventHandler<DispatcherQueueTimer, windows_core::IInspectable> = {
             let com = windows_core::imp::DelegateBox::< TypedEventHandler < DispatcherQueueTimer , windows_core::IInspectable > , F >::new (& TypedEventHandlerBox::< DispatcherQueueTimer , windows_core::IInspectable , F >::VTABLE , handler) ;
-            unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+            unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
@@ -10391,7 +10391,7 @@ impl IExpander {
                 &TypedEventHandlerBox::<Expander, ExpanderExpandingEventArgs, F>::VTABLE,
                 handler,
             );
-            unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+            unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
@@ -10420,7 +10420,7 @@ impl IExpander {
                 &TypedEventHandlerBox::<Expander, ExpanderCollapsedEventArgs, F>::VTABLE,
                 handler,
             );
-            unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+            unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
@@ -10846,7 +10846,7 @@ impl IFrameworkElement {
                 &SizeChangedEventHandlerBox::<F>::VTABLE,
                 handler,
             );
-            unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+            unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
@@ -10879,7 +10879,7 @@ impl IFrameworkElement {
                 &TypedEventHandlerBox::<FrameworkElement, windows_core::IInspectable, F>::VTABLE,
                 handler,
             );
-            unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+            unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
@@ -11525,7 +11525,7 @@ impl IInfoBar {
                 &TypedEventHandlerBox::<InfoBar, InfoBarClosedEventArgs, F>::VTABLE,
                 handler,
             );
-            unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+            unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
@@ -11882,7 +11882,7 @@ impl IKeyboardAccelerator {
                     >::VTABLE,
                     handler,
                 );
-            unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+            unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
@@ -12451,7 +12451,7 @@ impl IMenuFlyoutItem {
                 &RoutedEventHandlerBox::<F>::VTABLE,
                 handler,
             );
-            unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+            unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
@@ -12780,7 +12780,7 @@ impl INavigationView {
                     >::VTABLE,
                     handler,
                 );
-            unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+            unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
@@ -12928,7 +12928,7 @@ impl INavigationView2 {
     {
         let handler: TypedEventHandler<NavigationView, NavigationViewBackRequestedEventArgs> = {
             let com = windows_core::imp::DelegateBox::< TypedEventHandler < NavigationView , NavigationViewBackRequestedEventArgs > , F >::new (& TypedEventHandlerBox::< NavigationView , NavigationViewBackRequestedEventArgs , F >::VTABLE , handler) ;
-            unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+            unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
@@ -13256,7 +13256,7 @@ impl INumberBox {
                 &TypedEventHandlerBox::<NumberBox, NumberBoxValueChangedEventArgs, F>::VTABLE,
                 handler,
             );
-            unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+            unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
@@ -13609,7 +13609,7 @@ impl IPasswordBox {
                 &RoutedEventHandlerBox::<F>::VTABLE,
                 handler,
             );
-            unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+            unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
@@ -13799,7 +13799,7 @@ impl IPivot {
                 &SelectionChangedEventHandlerBox::<F>::VTABLE,
                 handler,
             );
-            unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+            unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
@@ -14302,7 +14302,7 @@ impl IRadioButtons {
                 &SelectionChangedEventHandlerBox::<F>::VTABLE,
                 handler,
             );
-            unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+            unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
@@ -14465,7 +14465,7 @@ impl IRangeBase {
                 &RangeBaseValueChangedEventHandlerBox::<F>::VTABLE,
                 handler,
             );
-            unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+            unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
@@ -14617,7 +14617,7 @@ impl IRatingControl {
                 &TypedEventHandlerBox::<RatingControl, windows_core::IInspectable, F>::VTABLE,
                 handler,
             );
-            unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+            unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
@@ -15023,7 +15023,7 @@ impl IRichEditBox {
                 &RoutedEventHandlerBox::<F>::VTABLE,
                 handler,
             );
-            unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+            unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
@@ -15591,7 +15591,7 @@ impl ISelector {
                 &SelectionChangedEventHandlerBox::<F>::VTABLE,
                 handler,
             );
-            unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+            unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
@@ -15677,7 +15677,7 @@ impl ISelectorBar {
     {
         let handler: TypedEventHandler<SelectorBar, SelectorBarSelectionChangedEventArgs> = {
             let com = windows_core::imp::DelegateBox::< TypedEventHandler < SelectorBar , SelectorBarSelectionChangedEventArgs > , F >::new (& TypedEventHandlerBox::< SelectorBar , SelectorBarSelectionChangedEventArgs , F >::VTABLE , handler) ;
-            unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+            unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
@@ -16080,7 +16080,7 @@ impl ISplitButton {
                 &TypedEventHandlerBox::<SplitButton, SplitButtonClickEventArgs, F>::VTABLE,
                 handler,
             );
-            unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+            unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
@@ -16230,7 +16230,7 @@ impl ISplitView {
                 &TypedEventHandlerBox::<SplitView, windows_core::IInspectable, F>::VTABLE,
                 handler,
             );
-            unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+            unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
@@ -16651,7 +16651,7 @@ impl ISwapChainPanel {
                 &TypedEventHandlerBox::<SwapChainPanel, windows_core::IInspectable, F>::VTABLE,
                 handler,
             );
-            unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+            unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
@@ -16856,7 +16856,7 @@ impl ITabView {
                 &TypedEventHandlerBox::<TabView, TabViewTabCloseRequestedEventArgs, F>::VTABLE,
                 handler,
             );
-            unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+            unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
@@ -16888,7 +16888,7 @@ impl ITabView {
                 &TypedEventHandlerBox::<TabView, windows_core::IInspectable, F>::VTABLE,
                 handler,
             );
-            unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+            unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
@@ -16960,7 +16960,7 @@ impl ITabView {
                 &SelectionChangedEventHandlerBox::<F>::VTABLE,
                 handler,
             );
-            unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+            unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
@@ -17278,7 +17278,7 @@ impl ITeachingTip {
                 &TypedEventHandlerBox::<TeachingTip, windows_core::IInspectable, F>::VTABLE,
                 handler,
             );
-            unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+            unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
@@ -17308,7 +17308,7 @@ impl ITeachingTip {
                 &TypedEventHandlerBox::<TeachingTip, TeachingTipClosedEventArgs, F>::VTABLE,
                 handler,
             );
-            unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+            unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
@@ -17665,7 +17665,7 @@ impl ITextBox {
                 &TextChangedEventHandlerBox::<F>::VTABLE,
                 handler,
             );
-            unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+            unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
@@ -17964,7 +17964,7 @@ impl ITimePicker {
     {
         let handler: TypedEventHandler<TimePicker, TimePickerSelectedValueChangedEventArgs> = {
             let com = windows_core::imp::DelegateBox::< TypedEventHandler < TimePicker , TimePickerSelectedValueChangedEventArgs > , F >::new (& TypedEventHandlerBox::< TimePicker , TimePickerSelectedValueChangedEventArgs , F >::VTABLE , handler) ;
-            unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+            unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
@@ -18160,7 +18160,7 @@ impl ITitleBar {
                 &TypedEventHandlerBox::<TitleBar, windows_core::IInspectable, F>::VTABLE,
                 handler,
             );
-            unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+            unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
@@ -18192,7 +18192,7 @@ impl ITitleBar {
                 &TypedEventHandlerBox::<TitleBar, windows_core::IInspectable, F>::VTABLE,
                 handler,
             );
-            unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+            unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
@@ -18323,7 +18323,7 @@ impl IToggleButton {
                 &RoutedEventHandlerBox::<F>::VTABLE,
                 handler,
             );
-            unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+            unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
@@ -18350,7 +18350,7 @@ impl IToggleButton {
                 &RoutedEventHandlerBox::<F>::VTABLE,
                 handler,
             );
-            unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+            unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
@@ -18490,7 +18490,7 @@ impl IToggleSwitch {
                 &RoutedEventHandlerBox::<F>::VTABLE,
                 handler,
             );
-            unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+            unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
@@ -18671,7 +18671,7 @@ impl ITreeView {
                 &TypedEventHandlerBox::<TreeView, TreeViewItemInvokedEventArgs, F>::VTABLE,
                 handler,
             );
-            unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+            unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
@@ -18958,7 +18958,7 @@ impl IUIElement {
                 &PointerEventHandlerBox::<F>::VTABLE,
                 handler,
             );
-            unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+            unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
@@ -18990,7 +18990,7 @@ impl IUIElement {
                 &PointerEventHandlerBox::<F>::VTABLE,
                 handler,
             );
-            unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+            unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
@@ -19022,7 +19022,7 @@ impl IUIElement {
                 &PointerEventHandlerBox::<F>::VTABLE,
                 handler,
             );
-            unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+            unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
@@ -19051,7 +19051,7 @@ impl IUIElement {
                 &TappedEventHandlerBox::<F>::VTABLE,
                 handler,
             );
-            unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+            unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
@@ -19080,7 +19080,7 @@ impl IUIElement {
                 &RightTappedEventHandlerBox::<F>::VTABLE,
                 handler,
             );
-            unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+            unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
@@ -19671,7 +19671,7 @@ impl IWindow {
                 &TypedEventHandlerBox::<windows_core::IInspectable, WindowEventArgs, F>::VTABLE,
                 handler,
             );
-            unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+            unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
         };
         unsafe {
             let mut result__ = core::mem::zeroed();

--- a/crates/tests/misc/component/src/bindings.rs
+++ b/crates/tests/misc/component/src/bindings.rs
@@ -11,7 +11,7 @@ impl Callback {
     pub fn new<F: Fn(i32) -> windows_core::Result<i32> + Send + 'static>(invoke: F) -> Self {
         let com =
             windows_core::imp::DelegateBox::<Callback, F>::new(&CallbackBox::<F>::VTABLE, invoke);
-        unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+        unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
     }
     pub fn Invoke(&self, a: i32) -> windows_core::Result<i32> {
         unsafe {

--- a/crates/tests/misc/component_client/src/bindings.rs
+++ b/crates/tests/misc/component_client/src/bindings.rs
@@ -11,7 +11,7 @@ impl Callback {
     pub fn new<F: Fn(i32) -> windows_core::Result<i32> + Send + 'static>(invoke: F) -> Self {
         let com =
             windows_core::imp::DelegateBox::<Callback, F>::new(&CallbackBox::<F>::VTABLE, invoke);
-        unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
+        unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
     }
     pub fn Invoke(&self, a: i32) -> windows_core::Result<i32> {
         unsafe {


### PR DESCRIPTION
Replace `windows_core::imp::Box` re-export with `box_new`, `box_from_raw`, and `box_into_raw` helper functions. `Box` is not in the prelude for `no_std` crates, so generated code used the fully-qualified `windows_core::imp::Box` path - which triggers the `unused_qualifications` lint in consuming crates. The new helpers avoid shadowing the prelude name entirely.