### PR TITLE
`windows-bindgen` universal event simplification

### DIFF
--- a/crates/libs/bindgen/src/types/method.rs
+++ b/crates/libs/bindgen/src/types/method.rs
@@ -749,14 +749,15 @@ impl Method {
 
         let vcall = build_vcall(&args);
 
-        // minimal: suppress remove_* methods and replace add_* methods
-        // with a combined wrapper returning EventRevoker.
+        // Suppress remove_* methods and replace add_* methods with a combined
+        // wrapper returning EventRevoker. Excluded from --package mode because
+        // the windows crate's public API preserves the raw add/remove pattern.
         let raw_method_name = self.def.name();
         let is_event_add = !noexcept
-            && config.bindgen.style.is_minimal()
+            && !config.bindgen.layout.is_package()
             && self.def.flags().contains(MethodAttributes::SpecialName)
             && raw_method_name.starts_with("add_");
-        let is_event_remove = config.bindgen.style.is_minimal()
+        let is_event_remove = !config.bindgen.layout.is_package()
             && self.def.flags().contains(MethodAttributes::SpecialName)
             && raw_method_name.starts_with("remove_");
         let suppress_event_remove = is_event_remove
@@ -819,11 +820,11 @@ impl Method {
                     // run under `--minimal`, its `new` accepts the void-
                     // returning closure directly and returns S_OK internally,
                     // so we can pass `handler` straight through. Otherwise
-                    // (the delegate comes from a referenced crate built
-                    // without `--minimal`), wrap the handler to satisfy its
+                    // (default mode or the delegate comes from a referenced
+                    // crate), wrap the handler to satisfy its
                     // `Fn(...) -> Result<()>` constraint.
-                    let delegate_is_local_minimal =
-                        config.references.contains(d.type_name()).is_none();
+                    let delegate_is_local_minimal = config.bindgen.style.is_minimal()
+                        && config.references.contains(d.type_name()).is_none();
 
                     // Rebuild typed_args, replacing the delegate slot with a raw
                     // interface pointer for the locally-constructed delegate.

--- a/crates/libs/collections/src/bindings.rs
+++ b/crates/libs/collections/src/bindings.rs
@@ -1381,27 +1381,29 @@ impl<K: windows_core::RuntimeType + 'static, V: windows_core::RuntimeType + 'sta
 impl<K: windows_core::RuntimeType + 'static, V: windows_core::RuntimeType + 'static>
     IObservableMap<K, V>
 {
-    pub fn MapChanged<P0>(&self, vhnd: P0) -> windows_core::Result<i64>
+    pub fn MapChanged<F>(&self, vhnd: F) -> windows_core::Result<windows_core::EventRevoker>
     where
-        P0: windows_core::Param<MapChangedEventHandler<K, V>>,
+        F: Fn(windows_core::Ref<IObservableMap<K, V>>, windows_core::Ref<IMapChangedEventArgs<K>>)
+            + Send
+            + 'static,
     {
+        let vhnd = <MapChangedEventHandler<K, V>>::new(move |a0, a1| {
+            vhnd(a0, a1);
+            Ok(())
+        });
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).MapChanged)(
+            let token__ = (windows_core::Interface::vtable(self).MapChanged)(
                 windows_core::Interface::as_raw(self),
-                vhnd.param().abi(),
+                windows_core::Interface::as_raw(&vhnd),
                 &mut result__,
             )
-            .map(|| result__)
-        }
-    }
-    pub fn RemoveMapChanged(&self, token: i64) -> windows_core::Result<()> {
-        unsafe {
-            (windows_core::Interface::vtable(self).RemoveMapChanged)(
-                windows_core::Interface::as_raw(self),
-                token,
-            )
-            .ok()
+            .map(|| result__)?;
+            Ok(windows_core::EventRevoker::new(
+                self.clone(),
+                token__,
+                windows_core::Interface::vtable(self).RemoveMapChanged,
+            ))
         }
     }
     pub fn First(&self) -> windows_core::Result<IIterator<IKeyValuePair<K, V>>> {
@@ -1654,27 +1656,29 @@ impl<T: windows_core::RuntimeType + 'static> windows_core::imp::CanInto<IVector<
     const QUERY: bool = true;
 }
 impl<T: windows_core::RuntimeType + 'static> IObservableVector<T> {
-    pub fn VectorChanged<P0>(&self, vhnd: P0) -> windows_core::Result<i64>
+    pub fn VectorChanged<F>(&self, vhnd: F) -> windows_core::Result<windows_core::EventRevoker>
     where
-        P0: windows_core::Param<VectorChangedEventHandler<T>>,
+        F: Fn(windows_core::Ref<IObservableVector<T>>, windows_core::Ref<IVectorChangedEventArgs>)
+            + Send
+            + 'static,
     {
+        let vhnd = <VectorChangedEventHandler<T>>::new(move |a0, a1| {
+            vhnd(a0, a1);
+            Ok(())
+        });
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).VectorChanged)(
+            let token__ = (windows_core::Interface::vtable(self).VectorChanged)(
                 windows_core::Interface::as_raw(self),
-                vhnd.param().abi(),
+                windows_core::Interface::as_raw(&vhnd),
                 &mut result__,
             )
-            .map(|| result__)
-        }
-    }
-    pub fn RemoveVectorChanged(&self, token: i64) -> windows_core::Result<()> {
-        unsafe {
-            (windows_core::Interface::vtable(self).RemoveVectorChanged)(
-                windows_core::Interface::as_raw(self),
-                token,
-            )
-            .ok()
+            .map(|| result__)?;
+            Ok(windows_core::EventRevoker::new(
+                self.clone(),
+                token__,
+                windows_core::Interface::vtable(self).RemoveVectorChanged,
+            ))
         }
     }
     pub fn First(&self) -> windows_core::Result<IIterator<T>> {

--- a/crates/libs/core/src/event_revoker.rs
+++ b/crates/libs/core/src/event_revoker.rs
@@ -3,14 +3,17 @@ use core::ffi::c_void;
 
 /// A handle that automatically revokes an event registration when dropped.
 ///
-/// Obtained by calling an event-registration method generated with the
-/// `--minimal` bindgen option. The registration is revoked when the
-/// `EventRevoker` is dropped.
+/// Obtained by calling an event-registration method (e.g. `Click`, `Closed`).
+/// The registration is revoked when the `EventRevoker` is dropped.
+///
+/// To keep the event handler alive indefinitely, call [`forget`] to prevent
+/// the automatic revocation.
 ///
 /// Call [`into_token`] to take back the raw token and prevent the automatic
 /// revocation, which is useful for interoperating with code that manages
 /// registration tokens directly.
 ///
+/// [`forget`]: EventRevoker::forget
 /// [`into_token`]: EventRevoker::into_token
 #[must_use = "event registrations are revoked when the EventRevoker is dropped"]
 pub struct EventRevoker {
@@ -46,6 +49,15 @@ impl EventRevoker {
         // Release the source interface reference without calling Remove*.
         unsafe { core::ptr::drop_in_place(&mut this.source) };
         token
+    }
+
+    /// Consumes the revoker without revoking the event handler, keeping the
+    /// handler alive indefinitely.
+    ///
+    /// This is useful for "fire and forget" event registrations where the
+    /// handler should outlive any particular scope.
+    pub fn forget(self) {
+        core::mem::forget(self);
     }
 }
 

--- a/crates/samples/windows/xaml_app/src/bindings.rs
+++ b/crates/samples/windows/xaml_app/src/bindings.rs
@@ -7,70 +7,37 @@ windows_core::imp::interface_hierarchy!(
     windows_core::IInspectable
 );
 impl Application {
-    pub fn RemoveUnhandledException(&self, token: i64) -> windows_core::Result<()> {
-        unsafe {
-            (windows_core::Interface::vtable(self).RemoveUnhandledException)(
-                windows_core::Interface::as_raw(self),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveSuspending(&self, token: i64) -> windows_core::Result<()> {
-        unsafe {
-            (windows_core::Interface::vtable(self).RemoveSuspending)(
-                windows_core::Interface::as_raw(self),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn Resuming<P0>(&self, handler: P0) -> windows_core::Result<i64>
+    pub fn Resuming<F>(&self, handler: F) -> windows_core::Result<windows_core::EventRevoker>
     where
-        P0: windows_core::Param<windows::Foundation::EventHandler<windows_core::IInspectable>>,
+        F: Fn(
+                windows_core::Ref<windows_core::IInspectable>,
+                windows_core::Ref<windows_core::IInspectable>,
+            ) + Send
+            + 'static,
     {
+        let handler =
+            <windows::Foundation::EventHandler<windows_core::IInspectable>>::new(move |a0, a1| {
+                handler(a0, a1);
+                Ok(())
+            });
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).Resuming)(
+            let token__ = (windows_core::Interface::vtable(self).Resuming)(
                 windows_core::Interface::as_raw(self),
-                handler.param().abi(),
+                windows_core::Interface::as_raw(&handler),
                 &mut result__,
             )
-            .map(|| result__)
-        }
-    }
-    pub fn RemoveResuming(&self, token: i64) -> windows_core::Result<()> {
-        unsafe {
-            (windows_core::Interface::vtable(self).RemoveResuming)(
-                windows_core::Interface::as_raw(self),
-                token,
-            )
-            .ok()
+            .map(|| result__)?;
+            Ok(windows_core::EventRevoker::new(
+                self.clone(),
+                token__,
+                windows_core::Interface::vtable(self).RemoveResuming,
+            ))
         }
     }
     pub fn Exit(&self) -> windows_core::Result<()> {
         unsafe {
             (windows_core::Interface::vtable(self).Exit)(windows_core::Interface::as_raw(self)).ok()
-        }
-    }
-    pub fn RemoveLeavingBackground(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IApplication2>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveLeavingBackground)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveEnteredBackground(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IApplication2>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveEnteredBackground)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
         }
     }
     pub fn new() -> windows_core::Result<Application> {
@@ -602,15 +569,6 @@ impl Control {
             .ok()
         }
     }
-    pub fn RemoveIsEnabledChanged(&self, token: i64) -> windows_core::Result<()> {
-        unsafe {
-            (windows_core::Interface::vtable(self).RemoveIsEnabledChanged)(
-                windows_core::Interface::as_raw(self),
-                token,
-            )
-            .ok()
-        }
-    }
     pub fn ApplyTemplate(&self) -> windows_core::Result<bool> {
         unsafe {
             let mut result__ = core::mem::zeroed();
@@ -797,26 +755,6 @@ impl Control {
             (windows_core::Interface::vtable(this).SetXYFocusDown)(
                 windows_core::Interface::as_raw(this),
                 value.param().abi(),
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveFocusEngaged(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IControl4>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveFocusEngaged)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveFocusDisengaged(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IControl4>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveFocusDisengaged)(
-                windows_core::Interface::as_raw(this),
-                token,
             )
             .ok()
         }
@@ -1248,59 +1186,33 @@ impl Control {
             .and_then(|| windows_core::Type::from_abi(result__))
         }
     }
-    pub fn RemoveLoaded(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IFrameworkElement>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveLoaded)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveUnloaded(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IFrameworkElement>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveUnloaded)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveSizeChanged(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IFrameworkElement>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveSizeChanged)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn LayoutUpdated<P0>(&self, handler: P0) -> windows_core::Result<i64>
+    pub fn LayoutUpdated<F>(&self, handler: F) -> windows_core::Result<windows_core::EventRevoker>
     where
-        P0: windows_core::Param<windows::Foundation::EventHandler<windows_core::IInspectable>>,
+        F: Fn(
+                windows_core::Ref<windows_core::IInspectable>,
+                windows_core::Ref<windows_core::IInspectable>,
+            ) + Send
+            + 'static,
     {
         let this = &windows_core::Interface::cast::<IFrameworkElement>(self)?;
+        let handler =
+            <windows::Foundation::EventHandler<windows_core::IInspectable>>::new(move |a0, a1| {
+                handler(a0, a1);
+                Ok(())
+            });
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(this).LayoutUpdated)(
+            let token__ = (windows_core::Interface::vtable(this).LayoutUpdated)(
                 windows_core::Interface::as_raw(this),
-                handler.param().abi(),
+                windows_core::Interface::as_raw(&handler),
                 &mut result__,
             )
-            .map(|| result__)
-        }
-    }
-    pub fn RemoveLayoutUpdated(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IFrameworkElement>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveLayoutUpdated)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
+            .map(|| result__)?;
+            Ok(windows_core::EventRevoker::new(
+                this.clone(),
+                token__,
+                windows_core::Interface::vtable(this).RemoveLayoutUpdated,
+            ))
         }
     }
     pub fn FindName(
@@ -1318,44 +1230,33 @@ impl Control {
             .and_then(|| windows_core::Type::from_abi(result__))
         }
     }
-    pub fn RemoveDataContextChanged(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IFrameworkElement2>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveDataContextChanged)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn Loading<P0>(&self, handler: P0) -> windows_core::Result<i64>
+    pub fn Loading<F>(&self, handler: F) -> windows_core::Result<windows_core::EventRevoker>
     where
-        P0: windows_core::Param<
-                windows::Foundation::TypedEventHandler<
-                    FrameworkElement,
-                    windows_core::IInspectable,
-                >,
-            >,
+        F: Fn(windows_core::Ref<FrameworkElement>, windows_core::Ref<windows_core::IInspectable>)
+            + Send
+            + 'static,
     {
         let this = &windows_core::Interface::cast::<IFrameworkElement3>(self)?;
+        let handler = <windows::Foundation::TypedEventHandler<
+            FrameworkElement,
+            windows_core::IInspectable,
+        >>::new(move |a0, a1| {
+            handler(a0, a1);
+            Ok(())
+        });
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(this).Loading)(
+            let token__ = (windows_core::Interface::vtable(this).Loading)(
                 windows_core::Interface::as_raw(this),
-                handler.param().abi(),
+                windows_core::Interface::as_raw(&handler),
                 &mut result__,
             )
-            .map(|| result__)
-        }
-    }
-    pub fn RemoveLoading(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IFrameworkElement3>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveLoading)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
+            .map(|| result__)?;
+            Ok(windows_core::EventRevoker::new(
+                this.clone(),
+                token__,
+                windows_core::Interface::vtable(this).RemoveLoading,
+            ))
         }
     }
     pub fn AllowFocusOnInteraction(&self) -> windows_core::Result<bool> {
@@ -1400,34 +1301,36 @@ impl Control {
             .ok()
         }
     }
-    pub fn ActualThemeChanged<P0>(&self, handler: P0) -> windows_core::Result<i64>
+    pub fn ActualThemeChanged<F>(
+        &self,
+        handler: F,
+    ) -> windows_core::Result<windows_core::EventRevoker>
     where
-        P0: windows_core::Param<
-                windows::Foundation::TypedEventHandler<
-                    FrameworkElement,
-                    windows_core::IInspectable,
-                >,
-            >,
+        F: Fn(windows_core::Ref<FrameworkElement>, windows_core::Ref<windows_core::IInspectable>)
+            + Send
+            + 'static,
     {
         let this = &windows_core::Interface::cast::<IFrameworkElement6>(self)?;
+        let handler = <windows::Foundation::TypedEventHandler<
+            FrameworkElement,
+            windows_core::IInspectable,
+        >>::new(move |a0, a1| {
+            handler(a0, a1);
+            Ok(())
+        });
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(this).ActualThemeChanged)(
+            let token__ = (windows_core::Interface::vtable(this).ActualThemeChanged)(
                 windows_core::Interface::as_raw(this),
-                handler.param().abi(),
+                windows_core::Interface::as_raw(&handler),
                 &mut result__,
             )
-            .map(|| result__)
-        }
-    }
-    pub fn RemoveActualThemeChanged(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IFrameworkElement6>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveActualThemeChanged)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
+            .map(|| result__)?;
+            Ok(windows_core::EventRevoker::new(
+                this.clone(),
+                token__,
+                windows_core::Interface::vtable(this).RemoveActualThemeChanged,
+            ))
         }
     }
     pub fn IsLoaded(&self) -> windows_core::Result<bool> {
@@ -1439,16 +1342,6 @@ impl Control {
                 &mut result__,
             )
             .map(|| result__)
-        }
-    }
-    pub fn RemoveEffectiveViewportChanged(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IFrameworkElement7>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveEffectiveViewportChanged)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
         }
     }
     pub fn MeasureOverride(
@@ -1730,256 +1623,6 @@ impl Control {
             .ok()
         }
     }
-    pub fn RemoveKeyUp(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveKeyUp)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveKeyDown(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveKeyDown)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveGotFocus(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveGotFocus)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveLostFocus(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveLostFocus)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveDragEnter(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveDragEnter)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveDragLeave(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveDragLeave)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveDragOver(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveDragOver)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveDrop(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveDrop)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemovePointerPressed(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemovePointerPressed)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemovePointerMoved(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemovePointerMoved)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemovePointerReleased(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemovePointerReleased)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemovePointerEntered(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemovePointerEntered)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemovePointerExited(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemovePointerExited)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemovePointerCaptureLost(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemovePointerCaptureLost)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemovePointerCanceled(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemovePointerCanceled)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemovePointerWheelChanged(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemovePointerWheelChanged)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveTapped(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveTapped)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveDoubleTapped(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveDoubleTapped)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveHolding(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveHolding)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveRightTapped(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveRightTapped)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveManipulationStarting(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveManipulationStarting)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveManipulationInertiaStarting(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveManipulationInertiaStarting)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveManipulationStarted(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveManipulationStarted)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveManipulationDelta(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveManipulationDelta)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveManipulationCompleted(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveManipulationCompleted)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
     pub fn Measure(&self, availablesize: windows::Foundation::Size) -> windows_core::Result<()> {
         let this = &windows_core::Interface::cast::<IUIElement>(self)?;
         unsafe {
@@ -2086,26 +1729,6 @@ impl Control {
             (windows_core::Interface::vtable(this).SetCanDrag)(
                 windows_core::Interface::as_raw(this),
                 value,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveDragStarting(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement3>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveDragStarting)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveDropCompleted(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement3>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveDropCompleted)(
-                windows_core::Interface::as_raw(this),
-                token,
             )
             .ok()
         }
@@ -2219,56 +1842,6 @@ impl Control {
             .ok()
         }
     }
-    pub fn RemoveContextRequested(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement4>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveContextRequested)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveContextCanceled(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement4>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveContextCanceled)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveAccessKeyDisplayRequested(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement4>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveAccessKeyDisplayRequested)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveAccessKeyDisplayDismissed(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement4>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveAccessKeyDisplayDismissed)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveAccessKeyInvoked(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement4>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveAccessKeyInvoked)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
     pub fn KeyTipHorizontalOffset(&self) -> windows_core::Result<f64> {
         let this = &windows_core::Interface::cast::<IUIElement5>(self)?;
         unsafe {
@@ -2311,81 +1884,11 @@ impl Control {
             .ok()
         }
     }
-    pub fn RemoveGettingFocus(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement5>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveGettingFocus)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveLosingFocus(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement5>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveLosingFocus)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveNoFocusCandidateFound(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement5>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveNoFocusCandidateFound)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
     pub fn StartBringIntoView(&self) -> windows_core::Result<()> {
         let this = &windows_core::Interface::cast::<IUIElement5>(self)?;
         unsafe {
             (windows_core::Interface::vtable(this).StartBringIntoView)(
                 windows_core::Interface::as_raw(this),
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveCharacterReceived(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement7>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveCharacterReceived)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveProcessKeyboardAccelerators(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement7>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveProcessKeyboardAccelerators)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemovePreviewKeyDown(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement7>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemovePreviewKeyDown)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemovePreviewKeyUp(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement7>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemovePreviewKeyUp)(
-                windows_core::Interface::as_raw(this),
-                token,
             )
             .ok()
         }
@@ -2434,16 +1937,6 @@ impl Control {
             (windows_core::Interface::vtable(this).SetKeyboardAcceleratorPlacementTarget)(
                 windows_core::Interface::as_raw(this),
                 value.param().abi(),
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveBringIntoViewRequested(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement8>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveBringIntoViewRequested)(
-                windows_core::Interface::as_raw(this),
-                token,
             )
             .ok()
         }
@@ -3101,54 +2594,32 @@ impl FrameworkElement {
             .and_then(|| windows_core::Type::from_abi(result__))
         }
     }
-    pub fn RemoveLoaded(&self, token: i64) -> windows_core::Result<()> {
-        unsafe {
-            (windows_core::Interface::vtable(self).RemoveLoaded)(
-                windows_core::Interface::as_raw(self),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveUnloaded(&self, token: i64) -> windows_core::Result<()> {
-        unsafe {
-            (windows_core::Interface::vtable(self).RemoveUnloaded)(
-                windows_core::Interface::as_raw(self),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveSizeChanged(&self, token: i64) -> windows_core::Result<()> {
-        unsafe {
-            (windows_core::Interface::vtable(self).RemoveSizeChanged)(
-                windows_core::Interface::as_raw(self),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn LayoutUpdated<P0>(&self, handler: P0) -> windows_core::Result<i64>
+    pub fn LayoutUpdated<F>(&self, handler: F) -> windows_core::Result<windows_core::EventRevoker>
     where
-        P0: windows_core::Param<windows::Foundation::EventHandler<windows_core::IInspectable>>,
+        F: Fn(
+                windows_core::Ref<windows_core::IInspectable>,
+                windows_core::Ref<windows_core::IInspectable>,
+            ) + Send
+            + 'static,
     {
+        let handler =
+            <windows::Foundation::EventHandler<windows_core::IInspectable>>::new(move |a0, a1| {
+                handler(a0, a1);
+                Ok(())
+            });
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).LayoutUpdated)(
+            let token__ = (windows_core::Interface::vtable(self).LayoutUpdated)(
                 windows_core::Interface::as_raw(self),
-                handler.param().abi(),
+                windows_core::Interface::as_raw(&handler),
                 &mut result__,
             )
-            .map(|| result__)
-        }
-    }
-    pub fn RemoveLayoutUpdated(&self, token: i64) -> windows_core::Result<()> {
-        unsafe {
-            (windows_core::Interface::vtable(self).RemoveLayoutUpdated)(
-                windows_core::Interface::as_raw(self),
-                token,
-            )
-            .ok()
+            .map(|| result__)?;
+            Ok(windows_core::EventRevoker::new(
+                self.clone(),
+                token__,
+                windows_core::Interface::vtable(self).RemoveLayoutUpdated,
+            ))
         }
     }
     pub fn FindName(
@@ -3165,44 +2636,33 @@ impl FrameworkElement {
             .and_then(|| windows_core::Type::from_abi(result__))
         }
     }
-    pub fn RemoveDataContextChanged(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IFrameworkElement2>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveDataContextChanged)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn Loading<P0>(&self, handler: P0) -> windows_core::Result<i64>
+    pub fn Loading<F>(&self, handler: F) -> windows_core::Result<windows_core::EventRevoker>
     where
-        P0: windows_core::Param<
-                windows::Foundation::TypedEventHandler<
-                    FrameworkElement,
-                    windows_core::IInspectable,
-                >,
-            >,
+        F: Fn(windows_core::Ref<FrameworkElement>, windows_core::Ref<windows_core::IInspectable>)
+            + Send
+            + 'static,
     {
         let this = &windows_core::Interface::cast::<IFrameworkElement3>(self)?;
+        let handler = <windows::Foundation::TypedEventHandler<
+            FrameworkElement,
+            windows_core::IInspectable,
+        >>::new(move |a0, a1| {
+            handler(a0, a1);
+            Ok(())
+        });
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(this).Loading)(
+            let token__ = (windows_core::Interface::vtable(this).Loading)(
                 windows_core::Interface::as_raw(this),
-                handler.param().abi(),
+                windows_core::Interface::as_raw(&handler),
                 &mut result__,
             )
-            .map(|| result__)
-        }
-    }
-    pub fn RemoveLoading(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IFrameworkElement3>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveLoading)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
+            .map(|| result__)?;
+            Ok(windows_core::EventRevoker::new(
+                this.clone(),
+                token__,
+                windows_core::Interface::vtable(this).RemoveLoading,
+            ))
         }
     }
     pub fn AllowFocusOnInteraction(&self) -> windows_core::Result<bool> {
@@ -3247,34 +2707,36 @@ impl FrameworkElement {
             .ok()
         }
     }
-    pub fn ActualThemeChanged<P0>(&self, handler: P0) -> windows_core::Result<i64>
+    pub fn ActualThemeChanged<F>(
+        &self,
+        handler: F,
+    ) -> windows_core::Result<windows_core::EventRevoker>
     where
-        P0: windows_core::Param<
-                windows::Foundation::TypedEventHandler<
-                    FrameworkElement,
-                    windows_core::IInspectable,
-                >,
-            >,
+        F: Fn(windows_core::Ref<FrameworkElement>, windows_core::Ref<windows_core::IInspectable>)
+            + Send
+            + 'static,
     {
         let this = &windows_core::Interface::cast::<IFrameworkElement6>(self)?;
+        let handler = <windows::Foundation::TypedEventHandler<
+            FrameworkElement,
+            windows_core::IInspectable,
+        >>::new(move |a0, a1| {
+            handler(a0, a1);
+            Ok(())
+        });
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(this).ActualThemeChanged)(
+            let token__ = (windows_core::Interface::vtable(this).ActualThemeChanged)(
                 windows_core::Interface::as_raw(this),
-                handler.param().abi(),
+                windows_core::Interface::as_raw(&handler),
                 &mut result__,
             )
-            .map(|| result__)
-        }
-    }
-    pub fn RemoveActualThemeChanged(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IFrameworkElement6>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveActualThemeChanged)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
+            .map(|| result__)?;
+            Ok(windows_core::EventRevoker::new(
+                this.clone(),
+                token__,
+                windows_core::Interface::vtable(this).RemoveActualThemeChanged,
+            ))
         }
     }
     pub fn IsLoaded(&self) -> windows_core::Result<bool> {
@@ -3286,16 +2748,6 @@ impl FrameworkElement {
                 &mut result__,
             )
             .map(|| result__)
-        }
-    }
-    pub fn RemoveEffectiveViewportChanged(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IFrameworkElement7>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveEffectiveViewportChanged)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
         }
     }
     pub fn new() -> windows_core::Result<FrameworkElement> {
@@ -3619,256 +3071,6 @@ impl FrameworkElement {
             .ok()
         }
     }
-    pub fn RemoveKeyUp(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveKeyUp)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveKeyDown(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveKeyDown)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveGotFocus(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveGotFocus)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveLostFocus(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveLostFocus)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveDragEnter(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveDragEnter)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveDragLeave(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveDragLeave)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveDragOver(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveDragOver)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveDrop(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveDrop)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemovePointerPressed(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemovePointerPressed)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemovePointerMoved(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemovePointerMoved)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemovePointerReleased(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemovePointerReleased)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemovePointerEntered(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemovePointerEntered)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemovePointerExited(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemovePointerExited)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemovePointerCaptureLost(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemovePointerCaptureLost)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemovePointerCanceled(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemovePointerCanceled)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemovePointerWheelChanged(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemovePointerWheelChanged)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveTapped(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveTapped)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveDoubleTapped(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveDoubleTapped)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveHolding(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveHolding)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveRightTapped(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveRightTapped)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveManipulationStarting(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveManipulationStarting)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveManipulationInertiaStarting(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveManipulationInertiaStarting)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveManipulationStarted(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveManipulationStarted)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveManipulationDelta(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveManipulationDelta)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveManipulationCompleted(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveManipulationCompleted)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
     pub fn Measure(&self, availablesize: windows::Foundation::Size) -> windows_core::Result<()> {
         let this = &windows_core::Interface::cast::<IUIElement>(self)?;
         unsafe {
@@ -3975,26 +3177,6 @@ impl FrameworkElement {
             (windows_core::Interface::vtable(this).SetCanDrag)(
                 windows_core::Interface::as_raw(this),
                 value,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveDragStarting(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement3>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveDragStarting)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveDropCompleted(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement3>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveDropCompleted)(
-                windows_core::Interface::as_raw(this),
-                token,
             )
             .ok()
         }
@@ -4108,56 +3290,6 @@ impl FrameworkElement {
             .ok()
         }
     }
-    pub fn RemoveContextRequested(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement4>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveContextRequested)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveContextCanceled(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement4>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveContextCanceled)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveAccessKeyDisplayRequested(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement4>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveAccessKeyDisplayRequested)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveAccessKeyDisplayDismissed(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement4>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveAccessKeyDisplayDismissed)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveAccessKeyInvoked(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement4>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveAccessKeyInvoked)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
     pub fn KeyTipHorizontalOffset(&self) -> windows_core::Result<f64> {
         let this = &windows_core::Interface::cast::<IUIElement5>(self)?;
         unsafe {
@@ -4200,81 +3332,11 @@ impl FrameworkElement {
             .ok()
         }
     }
-    pub fn RemoveGettingFocus(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement5>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveGettingFocus)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveLosingFocus(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement5>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveLosingFocus)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveNoFocusCandidateFound(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement5>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveNoFocusCandidateFound)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
     pub fn StartBringIntoView(&self) -> windows_core::Result<()> {
         let this = &windows_core::Interface::cast::<IUIElement5>(self)?;
         unsafe {
             (windows_core::Interface::vtable(this).StartBringIntoView)(
                 windows_core::Interface::as_raw(this),
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveCharacterReceived(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement7>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveCharacterReceived)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveProcessKeyboardAccelerators(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement7>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveProcessKeyboardAccelerators)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemovePreviewKeyDown(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement7>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemovePreviewKeyDown)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemovePreviewKeyUp(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement7>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemovePreviewKeyUp)(
-                windows_core::Interface::as_raw(this),
-                token,
             )
             .ok()
         }
@@ -4323,16 +3385,6 @@ impl FrameworkElement {
             (windows_core::Interface::vtable(this).SetKeyboardAcceleratorPlacementTarget)(
                 windows_core::Interface::as_raw(this),
                 value.param().abi(),
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveBringIntoViewRequested(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement8>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveBringIntoViewRequested)(
-                windows_core::Interface::as_raw(this),
-                token,
             )
             .ok()
         }
@@ -8699,16 +7751,6 @@ impl TextBox {
             .ok()
         }
     }
-    pub fn RemoveIsEnabledChanged(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IControl>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveIsEnabledChanged)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
     pub fn ApplyTemplate(&self) -> windows_core::Result<bool> {
         let this = &windows_core::Interface::cast::<IControl>(self)?;
         unsafe {
@@ -8896,26 +7938,6 @@ impl TextBox {
             (windows_core::Interface::vtable(this).SetXYFocusDown)(
                 windows_core::Interface::as_raw(this),
                 value.param().abi(),
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveFocusEngaged(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IControl4>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveFocusEngaged)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveFocusDisengaged(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IControl4>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveFocusDisengaged)(
-                windows_core::Interface::as_raw(this),
-                token,
             )
             .ok()
         }
@@ -9263,59 +8285,33 @@ impl TextBox {
             .and_then(|| windows_core::Type::from_abi(result__))
         }
     }
-    pub fn RemoveLoaded(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IFrameworkElement>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveLoaded)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveUnloaded(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IFrameworkElement>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveUnloaded)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveSizeChanged(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IFrameworkElement>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveSizeChanged)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn LayoutUpdated<P0>(&self, handler: P0) -> windows_core::Result<i64>
+    pub fn LayoutUpdated<F>(&self, handler: F) -> windows_core::Result<windows_core::EventRevoker>
     where
-        P0: windows_core::Param<windows::Foundation::EventHandler<windows_core::IInspectable>>,
+        F: Fn(
+                windows_core::Ref<windows_core::IInspectable>,
+                windows_core::Ref<windows_core::IInspectable>,
+            ) + Send
+            + 'static,
     {
         let this = &windows_core::Interface::cast::<IFrameworkElement>(self)?;
+        let handler =
+            <windows::Foundation::EventHandler<windows_core::IInspectable>>::new(move |a0, a1| {
+                handler(a0, a1);
+                Ok(())
+            });
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(this).LayoutUpdated)(
+            let token__ = (windows_core::Interface::vtable(this).LayoutUpdated)(
                 windows_core::Interface::as_raw(this),
-                handler.param().abi(),
+                windows_core::Interface::as_raw(&handler),
                 &mut result__,
             )
-            .map(|| result__)
-        }
-    }
-    pub fn RemoveLayoutUpdated(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IFrameworkElement>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveLayoutUpdated)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
+            .map(|| result__)?;
+            Ok(windows_core::EventRevoker::new(
+                this.clone(),
+                token__,
+                windows_core::Interface::vtable(this).RemoveLayoutUpdated,
+            ))
         }
     }
     pub fn FindName(
@@ -9333,44 +8329,33 @@ impl TextBox {
             .and_then(|| windows_core::Type::from_abi(result__))
         }
     }
-    pub fn RemoveDataContextChanged(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IFrameworkElement2>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveDataContextChanged)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn Loading<P0>(&self, handler: P0) -> windows_core::Result<i64>
+    pub fn Loading<F>(&self, handler: F) -> windows_core::Result<windows_core::EventRevoker>
     where
-        P0: windows_core::Param<
-                windows::Foundation::TypedEventHandler<
-                    FrameworkElement,
-                    windows_core::IInspectable,
-                >,
-            >,
+        F: Fn(windows_core::Ref<FrameworkElement>, windows_core::Ref<windows_core::IInspectable>)
+            + Send
+            + 'static,
     {
         let this = &windows_core::Interface::cast::<IFrameworkElement3>(self)?;
+        let handler = <windows::Foundation::TypedEventHandler<
+            FrameworkElement,
+            windows_core::IInspectable,
+        >>::new(move |a0, a1| {
+            handler(a0, a1);
+            Ok(())
+        });
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(this).Loading)(
+            let token__ = (windows_core::Interface::vtable(this).Loading)(
                 windows_core::Interface::as_raw(this),
-                handler.param().abi(),
+                windows_core::Interface::as_raw(&handler),
                 &mut result__,
             )
-            .map(|| result__)
-        }
-    }
-    pub fn RemoveLoading(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IFrameworkElement3>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveLoading)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
+            .map(|| result__)?;
+            Ok(windows_core::EventRevoker::new(
+                this.clone(),
+                token__,
+                windows_core::Interface::vtable(this).RemoveLoading,
+            ))
         }
     }
     pub fn AllowFocusOnInteraction(&self) -> windows_core::Result<bool> {
@@ -9415,34 +8400,36 @@ impl TextBox {
             .ok()
         }
     }
-    pub fn ActualThemeChanged<P0>(&self, handler: P0) -> windows_core::Result<i64>
+    pub fn ActualThemeChanged<F>(
+        &self,
+        handler: F,
+    ) -> windows_core::Result<windows_core::EventRevoker>
     where
-        P0: windows_core::Param<
-                windows::Foundation::TypedEventHandler<
-                    FrameworkElement,
-                    windows_core::IInspectable,
-                >,
-            >,
+        F: Fn(windows_core::Ref<FrameworkElement>, windows_core::Ref<windows_core::IInspectable>)
+            + Send
+            + 'static,
     {
         let this = &windows_core::Interface::cast::<IFrameworkElement6>(self)?;
+        let handler = <windows::Foundation::TypedEventHandler<
+            FrameworkElement,
+            windows_core::IInspectable,
+        >>::new(move |a0, a1| {
+            handler(a0, a1);
+            Ok(())
+        });
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(this).ActualThemeChanged)(
+            let token__ = (windows_core::Interface::vtable(this).ActualThemeChanged)(
                 windows_core::Interface::as_raw(this),
-                handler.param().abi(),
+                windows_core::Interface::as_raw(&handler),
                 &mut result__,
             )
-            .map(|| result__)
-        }
-    }
-    pub fn RemoveActualThemeChanged(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IFrameworkElement6>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveActualThemeChanged)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
+            .map(|| result__)?;
+            Ok(windows_core::EventRevoker::new(
+                this.clone(),
+                token__,
+                windows_core::Interface::vtable(this).RemoveActualThemeChanged,
+            ))
         }
     }
     pub fn IsLoaded(&self) -> windows_core::Result<bool> {
@@ -9454,16 +8441,6 @@ impl TextBox {
                 &mut result__,
             )
             .map(|| result__)
-        }
-    }
-    pub fn RemoveEffectiveViewportChanged(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IFrameworkElement7>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveEffectiveViewportChanged)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
         }
     }
     pub fn MeasureOverride(
@@ -9702,33 +8679,6 @@ impl TextBox {
             .ok()
         }
     }
-    pub fn RemoveTextChanged(&self, token: i64) -> windows_core::Result<()> {
-        unsafe {
-            (windows_core::Interface::vtable(self).RemoveTextChanged)(
-                windows_core::Interface::as_raw(self),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveSelectionChanged(&self, token: i64) -> windows_core::Result<()> {
-        unsafe {
-            (windows_core::Interface::vtable(self).RemoveSelectionChanged)(
-                windows_core::Interface::as_raw(self),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveContextMenuOpening(&self, token: i64) -> windows_core::Result<()> {
-        unsafe {
-            (windows_core::Interface::vtable(self).RemoveContextMenuOpening)(
-                windows_core::Interface::as_raw(self),
-                token,
-            )
-            .ok()
-        }
-    }
     pub fn Select(&self, start: i32, length: i32) -> windows_core::Result<()> {
         unsafe {
             (windows_core::Interface::vtable(self).Select)(
@@ -9851,66 +8801,6 @@ impl TextBox {
             .ok()
         }
     }
-    pub fn RemovePaste(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<ITextBox2>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemovePaste)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveTextCompositionStarted(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<ITextBox3>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveTextCompositionStarted)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveTextCompositionChanged(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<ITextBox3>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveTextCompositionChanged)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveTextCompositionEnded(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<ITextBox3>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveTextCompositionEnded)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveCandidateWindowBoundsChanged(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<ITextBox3>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveCandidateWindowBoundsChanged)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveTextChanging(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<ITextBox3>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveTextChanging)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
     pub fn GetLinguisticAlternativesAsync(
         &self,
     ) -> windows_core::Result<
@@ -9924,36 +8814,6 @@ impl TextBox {
                 &mut result__,
             )
             .and_then(|| windows_core::Type::from_abi(result__))
-        }
-    }
-    pub fn RemoveCopyingToClipboard(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<ITextBox6>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveCopyingToClipboard)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveCuttingToClipboard(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<ITextBox6>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveCuttingToClipboard)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveBeforeTextChanging(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<ITextBox6>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveBeforeTextChanging)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
         }
     }
     pub fn IsHandwritingViewEnabled(&self) -> windows_core::Result<bool> {
@@ -10030,16 +8890,6 @@ impl TextBox {
             (windows_core::Interface::vtable(this).SetDescription)(
                 windows_core::Interface::as_raw(this),
                 value.param().abi(),
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveSelectionChanging(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<ITextBox8>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveSelectionChanging)(
-                windows_core::Interface::as_raw(this),
-                token,
             )
             .ok()
         }
@@ -10336,256 +9186,6 @@ impl TextBox {
             .ok()
         }
     }
-    pub fn RemoveKeyUp(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveKeyUp)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveKeyDown(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveKeyDown)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveGotFocus(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveGotFocus)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveLostFocus(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveLostFocus)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveDragEnter(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveDragEnter)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveDragLeave(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveDragLeave)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveDragOver(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveDragOver)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveDrop(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveDrop)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemovePointerPressed(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemovePointerPressed)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemovePointerMoved(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemovePointerMoved)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemovePointerReleased(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemovePointerReleased)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemovePointerEntered(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemovePointerEntered)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemovePointerExited(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemovePointerExited)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemovePointerCaptureLost(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemovePointerCaptureLost)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemovePointerCanceled(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemovePointerCanceled)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemovePointerWheelChanged(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemovePointerWheelChanged)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveTapped(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveTapped)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveDoubleTapped(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveDoubleTapped)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveHolding(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveHolding)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveRightTapped(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveRightTapped)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveManipulationStarting(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveManipulationStarting)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveManipulationInertiaStarting(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveManipulationInertiaStarting)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveManipulationStarted(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveManipulationStarted)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveManipulationDelta(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveManipulationDelta)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveManipulationCompleted(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveManipulationCompleted)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
     pub fn Measure(&self, availablesize: windows::Foundation::Size) -> windows_core::Result<()> {
         let this = &windows_core::Interface::cast::<IUIElement>(self)?;
         unsafe {
@@ -10692,26 +9292,6 @@ impl TextBox {
             (windows_core::Interface::vtable(this).SetCanDrag)(
                 windows_core::Interface::as_raw(this),
                 value,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveDragStarting(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement3>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveDragStarting)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveDropCompleted(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement3>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveDropCompleted)(
-                windows_core::Interface::as_raw(this),
-                token,
             )
             .ok()
         }
@@ -10825,56 +9405,6 @@ impl TextBox {
             .ok()
         }
     }
-    pub fn RemoveContextRequested(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement4>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveContextRequested)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveContextCanceled(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement4>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveContextCanceled)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveAccessKeyDisplayRequested(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement4>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveAccessKeyDisplayRequested)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveAccessKeyDisplayDismissed(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement4>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveAccessKeyDisplayDismissed)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveAccessKeyInvoked(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement4>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveAccessKeyInvoked)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
     pub fn KeyTipHorizontalOffset(&self) -> windows_core::Result<f64> {
         let this = &windows_core::Interface::cast::<IUIElement5>(self)?;
         unsafe {
@@ -10917,81 +9447,11 @@ impl TextBox {
             .ok()
         }
     }
-    pub fn RemoveGettingFocus(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement5>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveGettingFocus)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveLosingFocus(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement5>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveLosingFocus)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveNoFocusCandidateFound(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement5>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveNoFocusCandidateFound)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
     pub fn StartBringIntoView(&self) -> windows_core::Result<()> {
         let this = &windows_core::Interface::cast::<IUIElement5>(self)?;
         unsafe {
             (windows_core::Interface::vtable(this).StartBringIntoView)(
                 windows_core::Interface::as_raw(this),
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveCharacterReceived(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement7>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveCharacterReceived)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveProcessKeyboardAccelerators(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement7>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveProcessKeyboardAccelerators)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemovePreviewKeyDown(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement7>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemovePreviewKeyDown)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemovePreviewKeyUp(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement7>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemovePreviewKeyUp)(
-                windows_core::Interface::as_raw(this),
-                token,
             )
             .ok()
         }
@@ -11040,16 +9500,6 @@ impl TextBox {
             (windows_core::Interface::vtable(this).SetKeyboardAcceleratorPlacementTarget)(
                 windows_core::Interface::as_raw(this),
                 value.param().abi(),
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveBringIntoViewRequested(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement8>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveBringIntoViewRequested)(
-                windows_core::Interface::as_raw(this),
-                token,
             )
             .ok()
         }
@@ -11598,231 +10048,6 @@ impl UIElement {
             .ok()
         }
     }
-    pub fn RemoveKeyUp(&self, token: i64) -> windows_core::Result<()> {
-        unsafe {
-            (windows_core::Interface::vtable(self).RemoveKeyUp)(
-                windows_core::Interface::as_raw(self),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveKeyDown(&self, token: i64) -> windows_core::Result<()> {
-        unsafe {
-            (windows_core::Interface::vtable(self).RemoveKeyDown)(
-                windows_core::Interface::as_raw(self),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveGotFocus(&self, token: i64) -> windows_core::Result<()> {
-        unsafe {
-            (windows_core::Interface::vtable(self).RemoveGotFocus)(
-                windows_core::Interface::as_raw(self),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveLostFocus(&self, token: i64) -> windows_core::Result<()> {
-        unsafe {
-            (windows_core::Interface::vtable(self).RemoveLostFocus)(
-                windows_core::Interface::as_raw(self),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveDragEnter(&self, token: i64) -> windows_core::Result<()> {
-        unsafe {
-            (windows_core::Interface::vtable(self).RemoveDragEnter)(
-                windows_core::Interface::as_raw(self),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveDragLeave(&self, token: i64) -> windows_core::Result<()> {
-        unsafe {
-            (windows_core::Interface::vtable(self).RemoveDragLeave)(
-                windows_core::Interface::as_raw(self),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveDragOver(&self, token: i64) -> windows_core::Result<()> {
-        unsafe {
-            (windows_core::Interface::vtable(self).RemoveDragOver)(
-                windows_core::Interface::as_raw(self),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveDrop(&self, token: i64) -> windows_core::Result<()> {
-        unsafe {
-            (windows_core::Interface::vtable(self).RemoveDrop)(
-                windows_core::Interface::as_raw(self),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemovePointerPressed(&self, token: i64) -> windows_core::Result<()> {
-        unsafe {
-            (windows_core::Interface::vtable(self).RemovePointerPressed)(
-                windows_core::Interface::as_raw(self),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemovePointerMoved(&self, token: i64) -> windows_core::Result<()> {
-        unsafe {
-            (windows_core::Interface::vtable(self).RemovePointerMoved)(
-                windows_core::Interface::as_raw(self),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemovePointerReleased(&self, token: i64) -> windows_core::Result<()> {
-        unsafe {
-            (windows_core::Interface::vtable(self).RemovePointerReleased)(
-                windows_core::Interface::as_raw(self),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemovePointerEntered(&self, token: i64) -> windows_core::Result<()> {
-        unsafe {
-            (windows_core::Interface::vtable(self).RemovePointerEntered)(
-                windows_core::Interface::as_raw(self),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemovePointerExited(&self, token: i64) -> windows_core::Result<()> {
-        unsafe {
-            (windows_core::Interface::vtable(self).RemovePointerExited)(
-                windows_core::Interface::as_raw(self),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemovePointerCaptureLost(&self, token: i64) -> windows_core::Result<()> {
-        unsafe {
-            (windows_core::Interface::vtable(self).RemovePointerCaptureLost)(
-                windows_core::Interface::as_raw(self),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemovePointerCanceled(&self, token: i64) -> windows_core::Result<()> {
-        unsafe {
-            (windows_core::Interface::vtable(self).RemovePointerCanceled)(
-                windows_core::Interface::as_raw(self),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemovePointerWheelChanged(&self, token: i64) -> windows_core::Result<()> {
-        unsafe {
-            (windows_core::Interface::vtable(self).RemovePointerWheelChanged)(
-                windows_core::Interface::as_raw(self),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveTapped(&self, token: i64) -> windows_core::Result<()> {
-        unsafe {
-            (windows_core::Interface::vtable(self).RemoveTapped)(
-                windows_core::Interface::as_raw(self),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveDoubleTapped(&self, token: i64) -> windows_core::Result<()> {
-        unsafe {
-            (windows_core::Interface::vtable(self).RemoveDoubleTapped)(
-                windows_core::Interface::as_raw(self),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveHolding(&self, token: i64) -> windows_core::Result<()> {
-        unsafe {
-            (windows_core::Interface::vtable(self).RemoveHolding)(
-                windows_core::Interface::as_raw(self),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveRightTapped(&self, token: i64) -> windows_core::Result<()> {
-        unsafe {
-            (windows_core::Interface::vtable(self).RemoveRightTapped)(
-                windows_core::Interface::as_raw(self),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveManipulationStarting(&self, token: i64) -> windows_core::Result<()> {
-        unsafe {
-            (windows_core::Interface::vtable(self).RemoveManipulationStarting)(
-                windows_core::Interface::as_raw(self),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveManipulationInertiaStarting(&self, token: i64) -> windows_core::Result<()> {
-        unsafe {
-            (windows_core::Interface::vtable(self).RemoveManipulationInertiaStarting)(
-                windows_core::Interface::as_raw(self),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveManipulationStarted(&self, token: i64) -> windows_core::Result<()> {
-        unsafe {
-            (windows_core::Interface::vtable(self).RemoveManipulationStarted)(
-                windows_core::Interface::as_raw(self),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveManipulationDelta(&self, token: i64) -> windows_core::Result<()> {
-        unsafe {
-            (windows_core::Interface::vtable(self).RemoveManipulationDelta)(
-                windows_core::Interface::as_raw(self),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveManipulationCompleted(&self, token: i64) -> windows_core::Result<()> {
-        unsafe {
-            (windows_core::Interface::vtable(self).RemoveManipulationCompleted)(
-                windows_core::Interface::as_raw(self),
-                token,
-            )
-            .ok()
-        }
-    }
     pub fn Measure(&self, availablesize: windows::Foundation::Size) -> windows_core::Result<()> {
         unsafe {
             (windows_core::Interface::vtable(self).Measure)(
@@ -11923,26 +10148,6 @@ impl UIElement {
             (windows_core::Interface::vtable(this).SetCanDrag)(
                 windows_core::Interface::as_raw(this),
                 value,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveDragStarting(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement3>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveDragStarting)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveDropCompleted(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement3>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveDropCompleted)(
-                windows_core::Interface::as_raw(this),
-                token,
             )
             .ok()
         }
@@ -12056,56 +10261,6 @@ impl UIElement {
             .ok()
         }
     }
-    pub fn RemoveContextRequested(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement4>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveContextRequested)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveContextCanceled(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement4>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveContextCanceled)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveAccessKeyDisplayRequested(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement4>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveAccessKeyDisplayRequested)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveAccessKeyDisplayDismissed(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement4>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveAccessKeyDisplayDismissed)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveAccessKeyInvoked(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement4>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveAccessKeyInvoked)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
     pub fn KeyTipHorizontalOffset(&self) -> windows_core::Result<f64> {
         let this = &windows_core::Interface::cast::<IUIElement5>(self)?;
         unsafe {
@@ -12148,81 +10303,11 @@ impl UIElement {
             .ok()
         }
     }
-    pub fn RemoveGettingFocus(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement5>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveGettingFocus)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveLosingFocus(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement5>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveLosingFocus)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveNoFocusCandidateFound(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement5>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveNoFocusCandidateFound)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
     pub fn StartBringIntoView(&self) -> windows_core::Result<()> {
         let this = &windows_core::Interface::cast::<IUIElement5>(self)?;
         unsafe {
             (windows_core::Interface::vtable(this).StartBringIntoView)(
                 windows_core::Interface::as_raw(this),
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveCharacterReceived(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement7>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveCharacterReceived)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveProcessKeyboardAccelerators(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement7>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveProcessKeyboardAccelerators)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemovePreviewKeyDown(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement7>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemovePreviewKeyDown)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemovePreviewKeyUp(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement7>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemovePreviewKeyUp)(
-                windows_core::Interface::as_raw(this),
-                token,
             )
             .ok()
         }
@@ -12271,16 +10356,6 @@ impl UIElement {
             (windows_core::Interface::vtable(this).SetKeyboardAcceleratorPlacementTarget)(
                 windows_core::Interface::as_raw(this),
                 value.param().abi(),
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveBringIntoViewRequested(&self, token: i64) -> windows_core::Result<()> {
-        let this = &windows_core::Interface::cast::<IUIElement8>(self)?;
-        unsafe {
-            (windows_core::Interface::vtable(this).RemoveBringIntoViewRequested)(
-                windows_core::Interface::as_raw(this),
-                token,
             )
             .ok()
         }
@@ -12681,42 +10756,6 @@ impl Window {
                 &mut result__,
             )
             .and_then(|| windows_core::Type::from_abi(result__))
-        }
-    }
-    pub fn RemoveActivated(&self, token: i64) -> windows_core::Result<()> {
-        unsafe {
-            (windows_core::Interface::vtable(self).RemoveActivated)(
-                windows_core::Interface::as_raw(self),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveClosed(&self, token: i64) -> windows_core::Result<()> {
-        unsafe {
-            (windows_core::Interface::vtable(self).RemoveClosed)(
-                windows_core::Interface::as_raw(self),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveSizeChanged(&self, token: i64) -> windows_core::Result<()> {
-        unsafe {
-            (windows_core::Interface::vtable(self).RemoveSizeChanged)(
-                windows_core::Interface::as_raw(self),
-                token,
-            )
-            .ok()
-        }
-    }
-    pub fn RemoveVisibilityChanged(&self, token: i64) -> windows_core::Result<()> {
-        unsafe {
-            (windows_core::Interface::vtable(self).RemoveVisibilityChanged)(
-                windows_core::Interface::as_raw(self),
-                token,
-            )
-            .ok()
         }
     }
     pub fn Activate(&self) -> windows_core::Result<()> {

--- a/crates/tests/libs/bindgen/data/bindgen/reference_dependency_flat/expected.rs
+++ b/crates/tests/libs/bindgen/data/bindgen/reference_dependency_flat/expected.rs
@@ -81,15 +81,6 @@ impl IMemoryBufferReference {
             .map(|| result__)
         }
     }
-    pub fn RemoveClosed(&self, cookie: i64) -> windows_core::Result<()> {
-        unsafe {
-            (windows_core::Interface::vtable(self).RemoveClosed)(
-                windows_core::Interface::as_raw(self),
-                cookie,
-            )
-            .ok()
-        }
-    }
     pub fn Close(&self) -> windows_core::Result<()> {
         let this = &windows_core::Interface::cast::<IClosable>(self)?;
         unsafe {

--- a/crates/tests/libs/bindgen/data/bindgen/reference_dependency_full/expected.rs
+++ b/crates/tests/libs/bindgen/data/bindgen/reference_dependency_full/expected.rs
@@ -86,15 +86,6 @@ pub mod Windows {
                     .map(|| result__)
                 }
             }
-            pub fn RemoveClosed(&self, cookie: i64) -> windows_core::Result<()> {
-                unsafe {
-                    (windows_core::Interface::vtable(self).RemoveClosed)(
-                        windows_core::Interface::as_raw(self),
-                        cookie,
-                    )
-                    .ok()
-                }
-            }
             pub fn Close(&self) -> windows_core::Result<()> {
                 let this = &windows_core::Interface::cast::<IClosable>(self)?;
                 unsafe {

--- a/crates/tests/libs/bindgen/data/bindgen/reference_dependency_skip_root/expected.rs
+++ b/crates/tests/libs/bindgen/data/bindgen/reference_dependency_skip_root/expected.rs
@@ -86,15 +86,6 @@ pub mod Windows {
                     .map(|| result__)
                 }
             }
-            pub fn RemoveClosed(&self, cookie: i64) -> windows_core::Result<()> {
-                unsafe {
-                    (windows_core::Interface::vtable(self).RemoveClosed)(
-                        windows_core::Interface::as_raw(self),
-                        cookie,
-                    )
-                    .ok()
-                }
-            }
             pub fn Close(&self) -> windows_core::Result<()> {
                 let this = &windows_core::Interface::cast::<IClosable>(self)?;
                 unsafe {

--- a/crates/tests/libs/collections/tests/stock_observable_map.rs
+++ b/crates/tests/libs/collections/tests/stock_observable_map.rs
@@ -183,16 +183,12 @@ fn map_changed_event() -> Result<()> {
     let events = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
     let events_clone = events.clone();
 
-    let handler =
-        MapChangedEventHandler::new(move |_sender, args: Ref<IMapChangedEventArgs<i32>>| {
-            let args = args.ok()?;
-            let change = args.CollectionChange()?;
-            let key = args.Key().ok();
-            events_clone.lock().unwrap().push((change, key));
-            Ok(())
-        });
-
-    let token = m.MapChanged(&handler)?;
+    let revoker = m.MapChanged(move |_sender, args: Ref<IMapChangedEventArgs<i32>>| {
+        let args = args.unwrap();
+        let change = args.CollectionChange().unwrap();
+        let key = args.Key().ok();
+        events_clone.lock().unwrap().push((change, key));
+    })?;
 
     // Insert new key fires ItemInserted
     m.Insert(2, 20u64)?;
@@ -231,7 +227,7 @@ fn map_changed_event() -> Result<()> {
     }
 
     // Removing the handler means no more events
-    m.RemoveMapChanged(token)?;
+    drop(revoker);
     m.Insert(5, 50u64)?;
     {
         let ev = events.lock().unwrap();
@@ -249,31 +245,26 @@ fn multiple_handlers() -> Result<()> {
     let count2 = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
 
     let c1 = count1.clone();
-    let handler1 = MapChangedEventHandler::new(move |_, _| {
+    let revoker1 = m.MapChanged(move |_, _| {
         c1.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-        Ok(())
-    });
+    })?;
 
     let c2 = count2.clone();
-    let handler2 = MapChangedEventHandler::new(move |_, _| {
+    let revoker2 = m.MapChanged(move |_, _| {
         c2.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-        Ok(())
-    });
-
-    let token1 = m.MapChanged(&handler1)?;
-    let token2 = m.MapChanged(&handler2)?;
+    })?;
 
     m.Insert(1, 10u64)?;
     assert_eq!(count1.load(std::sync::atomic::Ordering::Relaxed), 1);
     assert_eq!(count2.load(std::sync::atomic::Ordering::Relaxed), 1);
 
     // Remove first handler
-    m.RemoveMapChanged(token1)?;
+    drop(revoker1);
     m.Insert(2, 20u64)?;
     assert_eq!(count1.load(std::sync::atomic::Ordering::Relaxed), 1); // no change
     assert_eq!(count2.load(std::sync::atomic::Ordering::Relaxed), 2);
 
-    m.RemoveMapChanged(token2)?;
+    drop(revoker2);
     m.Insert(3, 30u64)?;
     assert_eq!(count1.load(std::sync::atomic::Ordering::Relaxed), 1); // no change
     assert_eq!(count2.load(std::sync::atomic::Ordering::Relaxed), 2); // no change
@@ -322,16 +313,12 @@ fn hstring_map_changed_event() -> Result<()> {
         std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
     let events_clone = events.clone();
 
-    let handler =
-        MapChangedEventHandler::new(move |_sender, args: Ref<IMapChangedEventArgs<HSTRING>>| {
-            let args = args.ok()?;
-            let change = args.CollectionChange()?;
-            let key = args.Key()?;
-            events_clone.lock().unwrap().push((change, key));
-            Ok(())
-        });
-
-    let _token = m.MapChanged(&handler)?;
+    let _revoker = m.MapChanged(move |_sender, args: Ref<IMapChangedEventArgs<HSTRING>>| {
+        let args = args.unwrap();
+        let change = args.CollectionChange().unwrap();
+        let key = args.Key().unwrap();
+        events_clone.lock().unwrap().push((change, key));
+    })?;
 
     m.Insert(h!("alpha"), 1)?;
     {

--- a/crates/tests/libs/collections/tests/stock_observable_vector.rs
+++ b/crates/tests/libs/collections/tests/stock_observable_vector.rs
@@ -197,16 +197,12 @@ fn vector_changed_event() -> Result<()> {
         std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
     let events_clone = events.clone();
 
-    let handler =
-        VectorChangedEventHandler::new(move |_sender, args: Ref<IVectorChangedEventArgs>| {
-            let args = args.ok()?;
-            let change = args.CollectionChange()?;
-            let index = args.Index()?;
-            events_clone.lock().unwrap().push((change, index));
-            Ok(())
-        });
-
-    let token = v.VectorChanged(&handler)?;
+    let revoker = v.VectorChanged(move |_sender, args: Ref<IVectorChangedEventArgs>| {
+        let args = args.unwrap();
+        let change = args.CollectionChange().unwrap();
+        let index = args.Index().unwrap();
+        events_clone.lock().unwrap().push((change, index));
+    })?;
 
     // Append fires ItemInserted
     v.Append(4)?;
@@ -272,7 +268,7 @@ fn vector_changed_event() -> Result<()> {
     }
 
     // Removing the handler means no more events
-    v.RemoveVectorChanged(token)?;
+    drop(revoker);
     v.Append(5)?;
     {
         let ev = events.lock().unwrap();
@@ -290,31 +286,26 @@ fn multiple_handlers() -> Result<()> {
     let count2 = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
 
     let c1 = count1.clone();
-    let handler1 = VectorChangedEventHandler::new(move |_, _| {
+    let revoker1 = v.VectorChanged(move |_, _| {
         c1.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-        Ok(())
-    });
+    })?;
 
     let c2 = count2.clone();
-    let handler2 = VectorChangedEventHandler::new(move |_, _| {
+    let revoker2 = v.VectorChanged(move |_, _| {
         c2.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-        Ok(())
-    });
-
-    let token1 = v.VectorChanged(&handler1)?;
-    let token2 = v.VectorChanged(&handler2)?;
+    })?;
 
     v.Append(1)?;
     assert_eq!(count1.load(std::sync::atomic::Ordering::Relaxed), 1);
     assert_eq!(count2.load(std::sync::atomic::Ordering::Relaxed), 1);
 
     // Remove first handler
-    v.RemoveVectorChanged(token1)?;
+    drop(revoker1);
     v.Append(2)?;
     assert_eq!(count1.load(std::sync::atomic::Ordering::Relaxed), 1); // no change
     assert_eq!(count2.load(std::sync::atomic::Ordering::Relaxed), 2);
 
-    v.RemoveVectorChanged(token2)?;
+    drop(revoker2);
     v.Append(3)?;
     assert_eq!(count1.load(std::sync::atomic::Ordering::Relaxed), 1); // no change
     assert_eq!(count2.load(std::sync::atomic::Ordering::Relaxed), 2); // no change

--- a/crates/tests/winrt/events/src/bindings.rs
+++ b/crates/tests/winrt/events/src/bindings.rs
@@ -27,27 +27,27 @@ impl Class {
             .map(|| result__)
         }
     }
-    pub fn Event<P0>(&self, handler: P0) -> windows_core::Result<i64>
+    pub fn Event<F>(&self, handler: F) -> windows_core::Result<windows_core::EventRevoker>
     where
-        P0: windows_core::Param<windows::Foundation::TypedEventHandler<Class, i32>>,
+        F: Fn(windows_core::Ref<Class>, i32) + Send + 'static,
     {
+        let handler = <windows::Foundation::TypedEventHandler<Class, i32>>::new(move |a0, a1| {
+            handler(a0, a1);
+            Ok(())
+        });
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).Event)(
+            let token__ = (windows_core::Interface::vtable(self).Event)(
                 windows_core::Interface::as_raw(self),
-                handler.param().abi(),
+                windows_core::Interface::as_raw(&handler),
                 &mut result__,
             )
-            .map(|| result__)
-        }
-    }
-    pub fn RemoveEvent(&self, token: i64) -> windows_core::Result<()> {
-        unsafe {
-            (windows_core::Interface::vtable(self).RemoveEvent)(
-                windows_core::Interface::as_raw(self),
-                token,
-            )
-            .ok()
+            .map(|| result__)?;
+            Ok(windows_core::EventRevoker::new(
+                self.clone(),
+                token__,
+                windows_core::Interface::vtable(self).RemoveEvent,
+            ))
         }
     }
     pub fn StaticSignal(value: i32) -> windows_core::Result<i32> {
@@ -61,27 +61,27 @@ impl Class {
             .map(|| result__)
         })
     }
-    pub fn StaticEvent<P0>(handler: P0) -> windows_core::Result<i64>
+    pub fn StaticEvent<F>(handler: F) -> windows_core::Result<windows_core::EventRevoker>
     where
-        P0: windows_core::Param<windows::Foundation::EventHandler<i32>>,
+        F: Fn(windows_core::Ref<windows_core::IInspectable>, i32) + Send + 'static,
     {
+        let handler = <windows::Foundation::EventHandler<i32>>::new(move |a0, a1| {
+            handler(a0, a1);
+            Ok(())
+        });
         Self::IClassStatics(|this| unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(this).StaticEvent)(
+            let token__ = (windows_core::Interface::vtable(this).StaticEvent)(
                 windows_core::Interface::as_raw(this),
-                handler.param().abi(),
+                windows_core::Interface::as_raw(&handler),
                 &mut result__,
             )
-            .map(|| result__)
-        })
-    }
-    pub fn RemoveStaticEvent(token: i64) -> windows_core::Result<()> {
-        Self::IClassStatics(|this| unsafe {
-            (windows_core::Interface::vtable(this).RemoveStaticEvent)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
+            .map(|| result__)?;
+            Ok(windows_core::EventRevoker::new(
+                this.clone(),
+                token__,
+                windows_core::Interface::vtable(this).RemoveStaticEvent,
+            ))
         })
     }
     fn IClassStatics<R, F: FnOnce(&IClassStatics) -> windows_core::Result<R>>(

--- a/crates/tests/winrt/events_client/Cargo.toml
+++ b/crates/tests/winrt/events_client/Cargo.toml
@@ -13,7 +13,6 @@ windows-bindgen = { workspace = true }
 
 [dependencies]
 windows-core = { workspace = true }
-windows = { workspace = true, features = ["Foundation", "Win32_Foundation"] }
 test_events = { path = "../events" }
 
 [lints]

--- a/crates/tests/winrt/events_client/build.rs
+++ b/crates/tests/winrt/events_client/build.rs
@@ -11,9 +11,9 @@ fn main() {
         "src/bindings.rs",
         "--filter",
         "test_events",
+        "Windows.Foundation.TypedEventHandler",
+        "Windows.Foundation.EventHandler",
         "--flat",
-        "--reference",
-        "windows",
     ])
     .unwrap();
 }

--- a/crates/tests/winrt/events_client/src/bindings.rs
+++ b/crates/tests/winrt/events_client/src/bindings.rs
@@ -27,27 +27,27 @@ impl Class {
             .map(|| result__)
         }
     }
-    pub fn Event<P0>(&self, handler: P0) -> windows_core::Result<i64>
+    pub fn Event<F>(&self, handler: F) -> windows_core::Result<windows_core::EventRevoker>
     where
-        P0: windows_core::Param<windows::Foundation::TypedEventHandler<Class, i32>>,
+        F: Fn(windows_core::Ref<Class>, i32) + Send + 'static,
     {
+        let handler = <TypedEventHandler<Class, i32>>::new(move |a0, a1| {
+            handler(a0, a1);
+            Ok(())
+        });
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).Event)(
+            let token__ = (windows_core::Interface::vtable(self).Event)(
                 windows_core::Interface::as_raw(self),
-                handler.param().abi(),
+                windows_core::Interface::as_raw(&handler),
                 &mut result__,
             )
-            .map(|| result__)
-        }
-    }
-    pub fn RemoveEvent(&self, token: i64) -> windows_core::Result<()> {
-        unsafe {
-            (windows_core::Interface::vtable(self).RemoveEvent)(
-                windows_core::Interface::as_raw(self),
-                token,
-            )
-            .ok()
+            .map(|| result__)?;
+            Ok(windows_core::EventRevoker::new(
+                self.clone(),
+                token__,
+                windows_core::Interface::vtable(self).RemoveEvent,
+            ))
         }
     }
     pub fn StaticSignal(value: i32) -> windows_core::Result<i32> {
@@ -61,27 +61,27 @@ impl Class {
             .map(|| result__)
         })
     }
-    pub fn StaticEvent<P0>(handler: P0) -> windows_core::Result<i64>
+    pub fn StaticEvent<F>(handler: F) -> windows_core::Result<windows_core::EventRevoker>
     where
-        P0: windows_core::Param<windows::Foundation::EventHandler<i32>>,
+        F: Fn(windows_core::Ref<windows_core::IInspectable>, i32) + Send + 'static,
     {
+        let handler = <EventHandler<i32>>::new(move |a0, a1| {
+            handler(a0, a1);
+            Ok(())
+        });
         Self::IClassStatics(|this| unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(this).StaticEvent)(
+            let token__ = (windows_core::Interface::vtable(this).StaticEvent)(
                 windows_core::Interface::as_raw(this),
-                handler.param().abi(),
+                windows_core::Interface::as_raw(&handler),
                 &mut result__,
             )
-            .map(|| result__)
-        })
-    }
-    pub fn RemoveStaticEvent(token: i64) -> windows_core::Result<()> {
-        Self::IClassStatics(|this| unsafe {
-            (windows_core::Interface::vtable(this).RemoveStaticEvent)(
-                windows_core::Interface::as_raw(this),
-                token,
-            )
-            .ok()
+            .map(|| result__)?;
+            Ok(windows_core::EventRevoker::new(
+                this.clone(),
+                token__,
+                windows_core::Interface::vtable(this).RemoveStaticEvent,
+            ))
         })
     }
     fn IClassStatics<R, F: FnOnce(&IClassStatics) -> windows_core::Result<R>>(
@@ -105,6 +105,114 @@ impl windows_core::RuntimeName for Class {
 }
 unsafe impl Send for Class {}
 unsafe impl Sync for Class {}
+#[repr(transparent)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct EventHandler<T>(windows_core::IUnknown, core::marker::PhantomData<T>)
+where
+    T: windows_core::RuntimeType + 'static;
+unsafe impl<T: windows_core::RuntimeType + 'static> windows_core::Interface for EventHandler<T> {
+    type Vtable = EventHandler_Vtbl<T>;
+    const IID: windows_core::GUID =
+        windows_core::GUID::from_signature(<Self as windows_core::RuntimeType>::SIGNATURE);
+}
+impl<T: windows_core::RuntimeType + 'static> windows_core::RuntimeType for EventHandler<T> {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::new()
+        .push_slice(b"pinterface({9de1c535-6ae1-11e0-84e1-18a905bcc53f}")
+        .push_slice(b";")
+        .push_other(T::SIGNATURE)
+        .push_slice(b")");
+}
+impl<T: windows_core::RuntimeType + 'static> EventHandler<T> {
+    pub fn new<
+        F: Fn(
+                windows_core::Ref<windows_core::IInspectable>,
+                windows_core::Ref<T>,
+            ) -> windows_core::Result<()>
+            + Send
+            + 'static,
+    >(
+        invoke: F,
+    ) -> Self {
+        let com = windows_core::imp::DelegateBox::<EventHandler<T>, F>::new(
+            &EventHandlerBox::<T, F>::VTABLE,
+            invoke,
+        );
+        unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
+    }
+    pub fn Invoke<P0, P1>(&self, sender: P0, args: P1) -> windows_core::Result<()>
+    where
+        P0: windows_core::Param<windows_core::IInspectable>,
+        P1: windows_core::Param<T>,
+    {
+        unsafe {
+            (windows_core::Interface::vtable(self).Invoke)(
+                windows_core::Interface::as_raw(self),
+                sender.param().abi(),
+                args.param().abi(),
+            )
+            .ok()
+        }
+    }
+}
+#[repr(C)]
+pub struct EventHandler_Vtbl<T>
+where
+    T: windows_core::RuntimeType + 'static,
+{
+    base__: windows_core::IUnknown_Vtbl,
+    Invoke: unsafe extern "system" fn(
+        this: *mut core::ffi::c_void,
+        sender: *mut core::ffi::c_void,
+        args: windows_core::AbiType<T>,
+    ) -> windows_core::HRESULT,
+    T: core::marker::PhantomData<T>,
+}
+struct EventHandlerBox<
+    T,
+    F: Fn(
+            windows_core::Ref<windows_core::IInspectable>,
+            windows_core::Ref<T>,
+        ) -> windows_core::Result<()>
+        + Send
+        + 'static,
+>(core::marker::PhantomData<(T, fn() -> F)>)
+where
+    T: windows_core::RuntimeType + 'static;
+impl<
+    T: windows_core::RuntimeType + 'static,
+    F: Fn(
+            windows_core::Ref<windows_core::IInspectable>,
+            windows_core::Ref<T>,
+        ) -> windows_core::Result<()>
+        + Send
+        + 'static,
+> EventHandlerBox<T, F>
+{
+    const VTABLE: EventHandler_Vtbl<T> = EventHandler_Vtbl::<T> {
+        base__: windows_core::IUnknown_Vtbl {
+            QueryInterface: windows_core::imp::DelegateBox::<EventHandler<T>, F>::QueryInterface,
+            AddRef: windows_core::imp::DelegateBox::<EventHandler<T>, F>::AddRef,
+            Release: windows_core::imp::DelegateBox::<EventHandler<T>, F>::Release,
+        },
+        Invoke: Self::Invoke,
+        T: core::marker::PhantomData::<T>,
+    };
+    unsafe extern "system" fn Invoke(
+        this: *mut core::ffi::c_void,
+        sender: *mut core::ffi::c_void,
+        args: windows_core::AbiType<T>,
+    ) -> windows_core::HRESULT {
+        unsafe {
+            let this = &mut *(this as *mut *mut core::ffi::c_void
+                as *mut windows_core::imp::DelegateBox<EventHandler<T>, F>);
+            (this.invoke)(
+                core::mem::transmute_copy(&sender),
+                core::mem::transmute_copy(&args),
+            )
+            .into()
+        }
+    }
+}
 windows_core::imp::define_interface!(IClass, IClass_Vtbl, 0x692a46c8_496e_525b_8d21_d7e12ca7cafa);
 impl windows_core::RuntimeType for IClass {
     const SIGNATURE: windows_core::imp::ConstBuffer =
@@ -148,4 +256,115 @@ pub struct IClassStatics_Vtbl {
     ) -> windows_core::HRESULT,
     pub RemoveStaticEvent:
         unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
+}
+#[repr(transparent)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TypedEventHandler<TSender, TResult>(
+    windows_core::IUnknown,
+    core::marker::PhantomData<TSender>,
+    core::marker::PhantomData<TResult>,
+)
+where
+    TSender: windows_core::RuntimeType + 'static,
+    TResult: windows_core::RuntimeType + 'static;
+unsafe impl<
+    TSender: windows_core::RuntimeType + 'static,
+    TResult: windows_core::RuntimeType + 'static,
+> windows_core::Interface for TypedEventHandler<TSender, TResult>
+{
+    type Vtable = TypedEventHandler_Vtbl<TSender, TResult>;
+    const IID: windows_core::GUID =
+        windows_core::GUID::from_signature(<Self as windows_core::RuntimeType>::SIGNATURE);
+}
+impl<TSender: windows_core::RuntimeType + 'static, TResult: windows_core::RuntimeType + 'static>
+    windows_core::RuntimeType for TypedEventHandler<TSender, TResult>
+{
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::new()
+        .push_slice(b"pinterface({9de1c534-6ae1-11e0-84e1-18a905bcc53f}")
+        .push_slice(b";")
+        .push_other(TSender::SIGNATURE)
+        .push_slice(b";")
+        .push_other(TResult::SIGNATURE)
+        .push_slice(b")");
+}
+impl<TSender: windows_core::RuntimeType + 'static, TResult: windows_core::RuntimeType + 'static>
+    TypedEventHandler<TSender, TResult>
+{
+    pub fn new<
+        F: Fn(windows_core::Ref<TSender>, windows_core::Ref<TResult>) -> windows_core::Result<()>
+            + Send
+            + 'static,
+    >(
+        invoke: F,
+    ) -> Self {
+        let com = windows_core::imp::DelegateBox::<TypedEventHandler<TSender, TResult>, F>::new(
+            &TypedEventHandlerBox::<TSender, TResult, F>::VTABLE,
+            invoke,
+        );
+        unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
+    }
+    pub fn Invoke<P0, P1>(&self, sender: P0, args: P1) -> windows_core::Result<()>
+    where
+        P0: windows_core::Param<TSender>,
+        P1: windows_core::Param<TResult>,
+    {
+        unsafe {
+            (windows_core::Interface::vtable(self).Invoke)(
+                windows_core::Interface::as_raw(self),
+                sender.param().abi(),
+                args.param().abi(),
+            )
+            .ok()
+        }
+    }
+}
+#[repr(C)]
+pub struct TypedEventHandler_Vtbl<TSender, TResult>
+where
+    TSender: windows_core::RuntimeType + 'static,
+    TResult: windows_core::RuntimeType + 'static,
+{
+    base__: windows_core::IUnknown_Vtbl,
+    Invoke: unsafe extern "system" fn(
+        this: *mut core::ffi::c_void,
+        sender: windows_core::AbiType<TSender>,
+        args: windows_core::AbiType<TResult>,
+    ) -> windows_core::HRESULT,
+    TSender: core::marker::PhantomData<TSender>,
+    TResult: core::marker::PhantomData<TResult>,
+}
+struct TypedEventHandlerBox<
+    TSender,
+    TResult,
+    F: Fn(windows_core::Ref<TSender>, windows_core::Ref<TResult>) -> windows_core::Result<()>
+        + Send
+        + 'static,
+>(core::marker::PhantomData<(TSender, TResult, fn() -> F)>)
+where
+    TSender: windows_core::RuntimeType + 'static,
+    TResult: windows_core::RuntimeType + 'static;
+impl<
+    TSender: windows_core::RuntimeType + 'static,
+    TResult: windows_core::RuntimeType + 'static,
+    F: Fn(windows_core::Ref<TSender>, windows_core::Ref<TResult>) -> windows_core::Result<()>
+        + Send
+        + 'static,
+> TypedEventHandlerBox<TSender, TResult, F>
+{
+    const VTABLE : TypedEventHandler_Vtbl < TSender , TResult , > = TypedEventHandler_Vtbl::< TSender , TResult , > { base__ : windows_core::IUnknown_Vtbl { QueryInterface : windows_core::imp::DelegateBox::< TypedEventHandler < TSender , TResult > , F >::QueryInterface , AddRef : windows_core::imp::DelegateBox::< TypedEventHandler < TSender , TResult > , F >::AddRef , Release : windows_core::imp::DelegateBox::< TypedEventHandler < TSender , TResult > , F >::Release , } , Invoke : Self::Invoke , TSender : core::marker::PhantomData::< TSender > , TResult : core::marker::PhantomData::< TResult > } ;
+    unsafe extern "system" fn Invoke(
+        this: *mut core::ffi::c_void,
+        sender: windows_core::AbiType<TSender>,
+        args: windows_core::AbiType<TResult>,
+    ) -> windows_core::HRESULT {
+        unsafe {
+            let this = &mut *(this as *mut *mut core::ffi::c_void
+                as *mut windows_core::imp::DelegateBox<TypedEventHandler<TSender, TResult>, F>);
+            (this.invoke)(
+                core::mem::transmute_copy(&sender),
+                core::mem::transmute_copy(&args),
+            )
+            .into()
+        }
+    }
 }

--- a/crates/tests/winrt/events_client/src/lib.rs
+++ b/crates/tests/winrt/events_client/src/lib.rs
@@ -40,15 +40,19 @@ fn test() -> Result<()> {
 
     // Handlers without a stored revoker are immediately revoked on drop.
     // Use .forget() to keep them alive indefinitely.
-    class.Event(move |sender: Ref<Class>, args: i32| {
-        assert_eq!(sender.as_ref().unwrap(), class);
-        assert_eq!(args, 4);
-    })?.forget();
+    class
+        .Event(move |sender: Ref<Class>, args: i32| {
+            assert_eq!(sender.as_ref().unwrap(), class);
+            assert_eq!(args, 4);
+        })?
+        .forget();
 
-    class.Event(move |sender: Ref<Class>, args: i32| {
-        assert_eq!(sender.as_ref().unwrap(), class);
-        assert_eq!(args, 4);
-    })?.forget();
+    class
+        .Event(move |sender: Ref<Class>, args: i32| {
+            assert_eq!(sender.as_ref().unwrap(), class);
+            assert_eq!(args, 4);
+        })?
+        .forget();
 
     assert_eq!(2, class.Signal(4)?);
     Ok(())
@@ -69,11 +73,13 @@ fn test_static() -> Result<()> {
 
     Class::StaticEvent(move |_, args| {
         assert_eq!(args, 4);
-    })?.forget();
+    })?
+    .forget();
 
     Class::StaticEvent(move |_, args| {
         assert_eq!(args, 4);
-    })?.forget();
+    })?
+    .forget();
 
     assert_eq!(2, Class::StaticSignal(4)?);
     Ok(())

--- a/crates/tests/winrt/events_client/src/lib.rs
+++ b/crates/tests/winrt/events_client/src/lib.rs
@@ -10,7 +10,7 @@
 mod bindings;
 use bindings::*;
 use std::sync::{Mutex, MutexGuard};
-use windows::{Foundation::*, core::*};
+use windows_core::*;
 
 static STATIC_EVENT_TEST_LOCK: Mutex<()> = Mutex::new(());
 
@@ -29,33 +29,26 @@ fn test() -> Result<()> {
     // The signal value is passed to each delegate.
     assert_eq!(0, class.Signal(1)?);
 
-    let token = class.Event(&TypedEventHandler::new(
-        move |sender: Ref<Class>, args: i32| {
-            assert_eq!(sender.as_ref().unwrap(), class);
-            assert_eq!(args, 2);
-            Ok(())
-        },
-    ))?;
+    let revoker = class.Event(move |sender: Ref<Class>, args: i32| {
+        assert_eq!(sender.as_ref().unwrap(), class);
+        assert_eq!(args, 2);
+    })?;
 
     assert_eq!(1, class.Signal(2)?);
-    class.RemoveEvent(token)?;
+    drop(revoker);
     assert_eq!(0, class.Signal(3)?);
 
-    class.Event(&TypedEventHandler::new(
-        move |sender: Ref<Class>, args: i32| {
-            assert_eq!(sender.as_ref().unwrap(), class);
-            assert_eq!(args, 4);
-            Ok(())
-        },
-    ))?;
+    // Handlers without a stored revoker are immediately revoked on drop.
+    // Use .forget() to keep them alive indefinitely.
+    class.Event(move |sender: Ref<Class>, args: i32| {
+        assert_eq!(sender.as_ref().unwrap(), class);
+        assert_eq!(args, 4);
+    })?.forget();
 
-    class.Event(&TypedEventHandler::new(
-        move |sender: Ref<Class>, args: i32| {
-            assert_eq!(sender.as_ref().unwrap(), class);
-            assert_eq!(args, 4);
-            Ok(())
-        },
-    ))?;
+    class.Event(move |sender: Ref<Class>, args: i32| {
+        assert_eq!(sender.as_ref().unwrap(), class);
+        assert_eq!(args, 4);
+    })?.forget();
 
     assert_eq!(2, class.Signal(4)?);
     Ok(())
@@ -66,27 +59,22 @@ fn test_static() -> Result<()> {
     let _lock = lock_static_event_tests();
     assert_eq!(0, Class::StaticSignal(1)?);
 
-    let token = Class::StaticEvent(&EventHandler::new(move |_, args| {
+    let revoker = Class::StaticEvent(move |_, args| {
         assert_eq!(args, 2);
-        Ok(())
-    }))?;
+    })?;
 
     assert_eq!(1, Class::StaticSignal(2)?);
-    Class::RemoveStaticEvent(token)?;
+    drop(revoker);
     assert_eq!(0, Class::StaticSignal(3)?);
 
-    let token1 = Class::StaticEvent(&EventHandler::new(move |_, args| {
+    Class::StaticEvent(move |_, args| {
         assert_eq!(args, 4);
-        Ok(())
-    }))?;
+    })?.forget();
 
-    let token2 = Class::StaticEvent(&EventHandler::new(move |_, args| {
+    Class::StaticEvent(move |_, args| {
         assert_eq!(args, 4);
-        Ok(())
-    }))?;
+    })?.forget();
 
     assert_eq!(2, Class::StaticSignal(4)?);
-    Class::RemoveStaticEvent(token1)?;
-    Class::RemoveStaticEvent(token2)?;
     Ok(())
 }


### PR DESCRIPTION
Another improvement from the `--minimal` mode  now largely universal (except for the `windows` crate) that greatly simplfies event subscription in WinRT APIs. 