### PR TITLE
`windows-bindgen` method name unification

### DIFF
--- a/crates/libs/bindgen/src/config.rs
+++ b/crates/libs/bindgen/src/config.rs
@@ -16,10 +16,10 @@ pub struct Config<'a> {
     /// `new()` and `Invoke()` methods suppressed because the event-add wrapper
     /// inlines the DelegateBox construction directly.
     pub event_only_delegates: &'a HashSet<TypeName>,
-    /// `true` when MinimalTypeMap was used for type closure — enables
-    /// minimal-style method emission on exclusive interfaces (since their
-    /// owning class may not be in the type map).
-    pub minimal_closure: bool,
+    /// Enables minimal-style codegen: suppresses class wrappers, inherited
+    /// forwarders, NAME constants, etc. Driven by `--minimal` flag or
+    /// auto-detected when all filter entries are precise (method-level).
+    pub minimal_codegen: bool,
 }
 
 impl Config<'_> {

--- a/crates/libs/bindgen/src/lib.rs
+++ b/crates/libs/bindgen/src/lib.rs
@@ -536,7 +536,8 @@ impl Bindgen {
 
             // Minimal codegen style: suppress class wrappers, inherited
             // forwarders, NAME constants, etc. Enabled by `--minimal` or
-            // auto-detected from method-level filter syntax.
+            // auto-detected when all filter entries are precise (no broad
+            // patterns like namespaces or name-globs).
             let minimal_codegen = self.style.is_minimal() || use_minimal_type_closure;
 
             (filter, types, minimal_codegen)
@@ -560,7 +561,7 @@ impl Bindgen {
             link,
             namespace: "",
             event_only_delegates: &event_only_delegates,
-            minimal_closure: minimal_codegen,
+            minimal_codegen,
         };
 
         let tree = TypeTree::new(&types);

--- a/crates/libs/bindgen/src/method_names.rs
+++ b/crates/libs/bindgen/src/method_names.rs
@@ -36,40 +36,21 @@ pub fn method_overload_name(row: MethodDef) -> Option<String> {
 #[derive(Default)]
 pub struct MethodNames {
     map: HashMap<String, u32>,
-    raw: bool,
 }
 
 impl MethodNames {
     pub fn new() -> Self {
         Self {
             map: HashMap::new(),
-            raw: false,
         }
     }
 
-    pub fn new_raw() -> Self {
-        Self {
-            map: HashMap::new(),
-            raw: true,
-        }
-    }
-
-    /// Creates a MethodNames that uses raw metadata names when `minimal` is true.
-    pub(crate) fn for_style(style: &Style) -> Self {
-        if style.is_minimal() {
-            Self::new_raw()
-        } else {
-            Self::new()
-        }
+    pub(crate) fn for_style(_style: &Style) -> Self {
+        Self::new()
     }
 
     pub fn add(&mut self, method: MethodDef) -> TokenStream {
-        let name = if self.raw && method.flags().contains(MethodAttributes::SpecialName) {
-            // In raw/minimal mode, keep the raw metadata name for property/event accessors
-            method.name().to_string()
-        } else {
-            method_def_special_name(method)
-        };
+        let name = method_def_special_name(method);
         let overload = self.map.entry(name.clone()).or_insert(0);
         *overload += 1;
         if *overload > 1 {

--- a/crates/libs/bindgen/src/types/cpp_interface.rs
+++ b/crates/libs/bindgen/src/types/cpp_interface.rs
@@ -36,7 +36,7 @@ impl CppInterface {
             .methods()
             .map(|def| {
                 let method = CppMethod::new(def, namespace, config.reader);
-                if !config.minimal_closure && !method.dependencies.included(config) {
+                if !config.minimal_codegen && !method.dependencies.included(config) {
                     CppMethodOrName::Name(method.def)
                 } else if !config.includes_method(type_name, def) {
                     // Method-level filter demoted this slot to opaque.
@@ -57,7 +57,7 @@ impl CppInterface {
         let type_name = self.def.type_name();
         self.def.methods().any(|def| {
             let method = CppMethod::new(def, namespace, config.reader);
-            (!config.minimal_closure && !method.dependencies.included(config))
+            (!config.minimal_codegen && !method.dependencies.included(config))
                 || !config.includes_method(type_name, def)
         })
     }

--- a/crates/libs/bindgen/src/types/enum.rs
+++ b/crates/libs/bindgen/src/types/enum.rs
@@ -100,7 +100,7 @@ impl Enum {
             // useful when the enum appears as a generic type argument in an
             // implemented parameterized interface. In minimal mode we skip it
             // unconditionally — the trait default (empty) is sufficient.
-            let name_const = if config.minimal_closure {
+            let name_const = if config.minimal_codegen {
                 quote! {}
             } else {
                 let type_name_bytes =

--- a/crates/libs/bindgen/src/types/interface.rs
+++ b/crates/libs/bindgen/src/types/interface.rs
@@ -59,7 +59,7 @@ impl Interface {
             .methods()
             .map(|def| {
                 let method = Method::new(def, &self.generics, config.reader);
-                if !config.minimal_closure && !method.dependencies.included(config) {
+                if !config.minimal_codegen && !method.dependencies.included(config) {
                     MethodOrName::Name(method.def)
                 } else if !config.includes_method(type_name, def) {
                     // Method-level filter demoted this slot to opaque.
@@ -79,7 +79,7 @@ impl Interface {
         let type_name = self.def.type_name();
         self.def.methods().any(|def| {
             let method = Method::new(def, &self.generics, config.reader);
-            (!config.minimal_closure && !method.dependencies.included(config))
+            (!config.minimal_codegen && !method.dependencies.included(config))
                 || !config.includes_method(type_name, def)
         })
     }
@@ -189,7 +189,7 @@ impl Interface {
                 // In minimal mode, NAME is only needed for interfaces that are
                 // being implemented (for GetRuntimeClassName). The trait provides
                 // an empty default, so omitting it is safe.
-                let name_const = if config.minimal_closure
+                let name_const = if config.minimal_codegen
                     && !config.should_implement(type_name, false)
                 {
                     quote! {}
@@ -224,7 +224,7 @@ impl Interface {
                 // In minimal mode, NAME on parameterized interfaces is only needed
                 // when the interface is implemented (for GetRuntimeClassName via
                 // RUNTIME_CLASS_NAME). Skip it otherwise.
-                let name_const = if config.minimal_closure
+                let name_const = if config.minimal_codegen
                     && !config.should_implement(type_name, false)
                 {
                     quote! {}
@@ -279,7 +279,7 @@ impl Interface {
                     let interfaces: Vec<_> = required_interfaces
                         .iter()
                         .filter(|ty| {
-                            if config.minimal_closure {
+                            if config.minimal_codegen {
                                 let tn = Type::Interface((*ty).clone()).type_name();
                                 config.types.contains_key(&tn)
                             } else {
@@ -317,7 +317,7 @@ impl Interface {
             // exclusive `--implement` interfaces (like overrides) are meant to be *implemented*
             // via the `_Impl` trait — not called. In both cases we suppress the caller-side
             // method wrapper to avoid dead code.
-            let use_minimal_methods = config.minimal_closure;
+            let use_minimal_methods = config.minimal_codegen;
             let suppress_methods = is_exclusive
                 && use_minimal_methods
                 && (self.is_factory(config.reader) || config.should_implement(type_name, false));

--- a/crates/libs/bindgen/src/types/method.rs
+++ b/crates/libs/bindgen/src/types/method.rs
@@ -784,13 +784,7 @@ impl Method {
             // since the remove method is suppressed and there's no ambiguity.
             let name = to_ident(event_part);
 
-            let remove_vname = if config.bindgen.style.is_minimal() {
-                // Raw mode: vtbl field is "remove_Click"
-                to_ident(&format!("remove_{event_part}"))
-            } else {
-                // Default mode: vtbl field is "RemoveClick"
-                to_ident(&format!("Remove{event_part}"))
-            };
+            let remove_vname = to_ident(&format!("Remove{event_part}"));
 
             // Promote the delegate parameter (typically the only input) to a
             // generic closure so callers can pass a closure directly without

--- a/crates/libs/bindgen/src/types/struct.rs
+++ b/crates/libs/bindgen/src/types/struct.rs
@@ -67,7 +67,7 @@ impl Struct {
             // useful when the struct appears as a generic type argument in an
             // implemented parameterized interface. In minimal mode we skip it
             // unconditionally — the trait default (empty) is sufficient.
-            let name_const = if config.minimal_closure {
+            let name_const = if config.minimal_codegen {
                 quote! {}
             } else {
                 let type_name_bytes =

--- a/crates/libs/reactor/src/app_shim.rs
+++ b/crates/libs/reactor/src/app_shim.rs
@@ -66,8 +66,8 @@ pub fn create_reactor_application(
 pub fn install_xaml_controls_resources(app: &Application) -> Result<()> {
     let controls = XamlControlsResources::new()?;
     let as_rd: ResourceDictionary = controls.cast()?;
-    let resources = app.get_Resources()?;
-    let merged = resources.get_MergedDictionaries()?;
+    let resources = app.Resources()?;
+    let merged = resources.MergedDictionaries()?;
     merged.Append(&as_rd)?;
     Ok(())
 }

--- a/crates/libs/reactor/src/backend/winui/convert.rs
+++ b/crates/libs/reactor/src/backend/winui/convert.rs
@@ -26,13 +26,13 @@ pub(super) fn to_xaml_gridlength(v: GridLength) -> Result<bindings::GridLength> 
 
 pub(super) fn solid_brush(c: Color) -> Result<bindings::SolidColorBrush> {
     let brush = bindings::SolidColorBrush::new()?;
-    brush.put_Color(c)?;
+    brush.SetColor(c)?;
     Ok(brush)
 }
 
 pub(super) fn string_as_textblock(s: &str) -> Result<bindings::TextBlock> {
     let tb = bindings::TextBlock::new()?;
-    tb.put_Text(s)?;
+    tb.SetText(s)?;
     Ok(tb)
 }
 
@@ -40,27 +40,27 @@ pub(super) fn build_nav_view_item(item: &NavViewItem) -> Result<windows_core::II
     if item.is_header {
         let h = bindings::NavigationViewItemHeader::new()?;
         let tb = string_as_textblock(&item.content)?;
-        h.cast::<bindings::IContentControl>()?.put_Content(&tb)?;
+        h.cast::<bindings::IContentControl>()?.SetContent(&tb)?;
         return h.cast();
     }
     let nv_item = bindings::NavigationViewItem::new()?;
     let tb = string_as_textblock(&item.content)?;
     nv_item
         .cast::<bindings::IContentControl>()?
-        .put_Content(&tb)?;
+        .SetContent(&tb)?;
     let tag = item.tag.clone().unwrap_or_else(|| item.content.clone());
     let tag_inspectable = windows_reference::IReference::from(tag.as_str());
     nv_item
         .cast::<bindings::IFrameworkElement>()?
-        .put_Tag(&tag_inspectable)?;
+        .SetTag(&tag_inspectable)?;
     if let Some(sym) = &item.icon {
         let icon_elem = bindings::SymbolIcon::CreateInstanceWithSymbol(*sym)?;
-        nv_item.put_Icon(&icon_elem)?;
+        nv_item.SetIcon(&icon_elem)?;
     }
     if !item.children.is_empty() {
         let menu = nv_item
             .cast::<bindings::INavigationViewItem2>()?
-            .get_MenuItems()?;
+            .MenuItems()?;
         for child in &item.children {
             let child_obj = build_nav_view_item(child)?;
             menu.Append(&child_obj)?;
@@ -72,7 +72,7 @@ pub(super) fn build_nav_view_item(item: &NavViewItem) -> Result<windows_core::II
 fn nav_item_tag(item: &bindings::NavigationViewItem) -> Option<String> {
     item.cast::<bindings::IFrameworkElement>()
         .ok()?
-        .get_Tag()
+        .Tag()
         .ok()?
         .cast::<windows_reference::IReference<windows_core::HSTRING>>()
         .ok()?
@@ -82,7 +82,7 @@ fn nav_item_tag(item: &bindings::NavigationViewItem) -> Option<String> {
 }
 
 pub(super) fn select_nav_item_by_tag(nv: &bindings::NavigationView, tag: &str) -> Result<()> {
-    let menu = nv.get_MenuItems()?;
+    let menu = nv.MenuItems()?;
     let len = menu.Size()?;
 
     for i in 0..len {
@@ -92,12 +92,9 @@ pub(super) fn select_nav_item_by_tag(nv: &bindings::NavigationView, tag: &str) -
         };
         if nav_item_tag(&item).as_deref() == Some(tag) {
             let inspectable: windows_core::IInspectable = item.cast()?;
-            return nv.put_SelectedItem(&inspectable);
+            return nv.SetSelectedItem(&inspectable);
         }
-        if let Ok(children) = item
-            .cast::<bindings::INavigationViewItem2>()?
-            .get_MenuItems()
-        {
+        if let Ok(children) = item.cast::<bindings::INavigationViewItem2>()?.MenuItems() {
             let child_count = children.Size().unwrap_or(0);
             for j in 0..child_count {
                 let Ok(child_obj) = children.GetAt(j) else {
@@ -108,7 +105,7 @@ pub(super) fn select_nav_item_by_tag(nv: &bindings::NavigationView, tag: &str) -
                 };
                 if nav_item_tag(&child).as_deref() == Some(tag) {
                     let inspectable: windows_core::IInspectable = child.cast()?;
-                    return nv.put_SelectedItem(&inspectable);
+                    return nv.SetSelectedItem(&inspectable);
                 }
             }
         }
@@ -123,7 +120,7 @@ pub(super) fn build_menu_flyout_item_base(
     match def {
         MenuItemDef::Item { text } => {
             let item = bindings::MenuFlyoutItem::new()?;
-            item.put_Text(text)?;
+            item.SetText(text)?;
             item.cast()
         }
         MenuItemDef::Separator => {
@@ -132,8 +129,8 @@ pub(super) fn build_menu_flyout_item_base(
         }
         MenuItemDef::SubItem { text, children } => {
             let sub = bindings::MenuFlyoutSubItem::new()?;
-            sub.put_Text(text)?;
-            let sub_items = sub.get_Items()?;
+            sub.SetText(text)?;
+            let sub_items = sub.Items()?;
             for child in children {
                 let child_item = build_menu_flyout_item_base(child)?;
                 sub_items.Append(&child_item)?;
@@ -151,10 +148,10 @@ pub(super) fn build_tree_view_node(def: &TreeNodeDef) -> Result<bindings::TreeVi
             &def.text,
         ))
         .cast()?;
-    node.put_Content(&content)?;
-    node.put_IsExpanded(def.is_expanded)?;
+    node.SetContent(&content)?;
+    node.SetIsExpanded(def.is_expanded)?;
     if !def.children.is_empty() {
-        let children = node.get_Children()?;
+        let children = node.Children()?;
         for child_def in &def.children {
             let child_node = build_tree_view_node(child_def)?;
             children.Append(&child_node)?;
@@ -170,19 +167,19 @@ pub(super) fn build_command_bar_element(
     match def {
         CommandBarCommandDef::Button { label, icon } => {
             let btn = bindings::AppBarButton::new()?;
-            btn.put_Label(label)?;
+            btn.SetLabel(label)?;
             if let Some(sym) = icon {
                 let icon_elem = bindings::SymbolIcon::CreateInstanceWithSymbol(*sym)?;
-                btn.put_Icon(&icon_elem)?;
+                btn.SetIcon(&icon_elem)?;
             }
             btn.cast()
         }
         CommandBarCommandDef::Toggle { label, icon } => {
             let btn = bindings::AppBarToggleButton::new()?;
-            btn.put_Label(label)?;
+            btn.SetLabel(label)?;
             if let Some(sym) = icon {
                 let icon_elem = bindings::SymbolIcon::CreateInstanceWithSymbol(*sym)?;
-                btn.put_Icon(&icon_elem)?;
+                btn.SetIcon(&icon_elem)?;
             }
             btn.cast()
         }

--- a/crates/libs/reactor/src/backend/winui/generated_attach_event.rs
+++ b/crates/libs/reactor/src/backend/winui/generated_attach_event.rs
@@ -15,7 +15,7 @@ pub fn dispatch(
             revokers.push(
                 h.ItemClicked(move |_sender, args| {
                     if let Some(a) = args.as_ref()
-                        && let Ok(v) = a.get_Index()
+                        && let Ok(v) = a.Index()
                     {
                         handler.invoke_i32(v);
                     }
@@ -126,7 +126,7 @@ pub fn dispatch(
             revokers.push(
                 h.ValueChanged(move |_sender, args| {
                     if let Some(a) = args.as_ref()
-                        && let Ok(v) = a.get_NewValue()
+                        && let Ok(v) = a.NewValue()
                     {
                         handler.invoke_f64(v);
                     }
@@ -141,7 +141,7 @@ pub fn dispatch(
                     let v = sender
                         .as_ref()
                         .and_then(|s| s.cast::<bindings::PasswordBox>().ok())
-                        .and_then(|s| s.get_Password().ok())
+                        .and_then(|s| s.Password().ok())
                         .unwrap_or(Default::default());
                     handler.invoke_string(v);
                 })
@@ -193,7 +193,7 @@ pub fn dispatch(
                     let v = sender
                         .as_ref()
                         .and_then(|s| s.cast::<bindings::RadioButtons>().ok())
-                        .and_then(|s| s.get_SelectedIndex().ok())
+                        .and_then(|s| s.SelectedIndex().ok())
                         .unwrap_or(-1);
                     handler.invoke_i32(v);
                 })
@@ -207,7 +207,7 @@ pub fn dispatch(
                     let v = sender
                         .as_ref()
                         .and_then(|s| s.cast::<bindings::RatingControl>().ok())
-                        .and_then(|s| s.get_Value().ok())
+                        .and_then(|s| s.Value().ok())
                         .unwrap_or(-1.0);
                     handler.invoke_f64(v);
                 })
@@ -221,7 +221,7 @@ pub fn dispatch(
                     .unwrap()
                     .ValueChanged(move |_sender, args| {
                         if let Some(a) = args.as_ref()
-                            && let Ok(v) = a.get_NewValue()
+                            && let Ok(v) = a.NewValue()
                         {
                             handler.invoke_f64(v);
                         }
@@ -281,7 +281,7 @@ pub fn dispatch(
                     let v = sender
                         .as_ref()
                         .and_then(|s| s.cast::<bindings::TextBox>().ok())
-                        .and_then(|s| s.get_Text().ok())
+                        .and_then(|s| s.Text().ok())
                         .unwrap_or(Default::default());
                     handler.invoke_string(v);
                 })
@@ -313,7 +313,7 @@ pub fn dispatch(
                     let v = sender
                         .as_ref()
                         .and_then(|s| s.cast::<bindings::ToggleSwitch>().ok())
-                        .and_then(|s| s.get_IsOn().ok())
+                        .and_then(|s| s.IsOn().ok())
                         .unwrap_or(false);
                     handler.invoke_bool(v);
                 })

--- a/crates/libs/reactor/src/backend/winui/generated_set_prop.rs
+++ b/crates/libs/reactor/src/backend/winui/generated_set_prop.rs
@@ -7,31 +7,31 @@ use super::*;
 pub fn dispatch(handle: &Handle, prop: Prop, value: &PropValue) -> Result<bool> {
     match (prop, value, handle) {
         (Prop::AcceptsReturn, PropValue::Bool(v), Handle::TextBox(h)) => {
-            h.put_AcceptsReturn(*v)?;
+            h.SetAcceptsReturn(*v)?;
         }
         (Prop::CanReorderTabs, PropValue::Bool(v), Handle::TabView(h)) => {
-            h.put_CanReorderTabs(*v)?;
+            h.SetCanReorderTabs(*v)?;
         }
         (Prop::Caption, PropValue::Str(v), Handle::RatingControl(h)) => {
-            h.put_Caption(v.as_str())?;
+            h.SetCaption(v.as_str())?;
         }
         (Prop::ClockIdentifier, PropValue::Str(v), Handle::TimePicker(h)) => {
-            h.put_ClockIdentifier(v.as_str())?;
+            h.SetClockIdentifier(v.as_str())?;
         }
         (Prop::CloseButtonText, PropValue::Str(v), Handle::ContentDialog(h)) => {
-            h.put_CloseButtonText(v.as_str())?;
+            h.SetCloseButtonText(v.as_str())?;
         }
         (Prop::ColumnSpacing, PropValue::F64(v), Handle::Grid(h)) => {
-            h.put_ColumnSpacing(*v)?;
+            h.SetColumnSpacing(*v)?;
         }
         (Prop::CompactPaneLength, PropValue::F64(v), Handle::SplitView(h)) => {
-            h.put_CompactPaneLength(*v)?;
+            h.SetCompactPaneLength(*v)?;
         }
         (Prop::Content, PropValue::Str(v), Handle::DropDownButton(_) | Handle::SplitButton(_)) => {
             let insp = windows_reference::IReference::from(v.as_str());
             handle
                 .cast_inner::<bindings::IContentControl>()?
-                .put_Content(&insp)?;
+                .SetContent(&insp)?;
         }
         (
             Prop::Content,
@@ -46,7 +46,7 @@ pub fn dispatch(handle: &Handle, prop: Prop, value: &PropValue) -> Result<bool> 
             let tb = string_as_textblock(v.as_str())?;
             handle
                 .cast_inner::<bindings::IContentControl>()?
-                .put_Content(&tb)?;
+                .SetContent(&tb)?;
         }
         (
             Prop::Content,
@@ -62,147 +62,147 @@ pub fn dispatch(handle: &Handle, prop: Prop, value: &PropValue) -> Result<bool> 
         ) => {
             handle
                 .cast_inner::<bindings::IContentControl>()?
-                .put_Content(None)?;
+                .SetContent(None)?;
         }
         (Prop::DayVisible, PropValue::Bool(v), Handle::DatePicker(h)) => {
-            h.put_DayVisible(*v)?;
+            h.SetDayVisible(*v)?;
         }
         (Prop::DefaultLabelPosition, PropValue::I32(v), Handle::CommandBar(h)) => {
-            h.put_DefaultLabelPosition(CommandBarDefaultLabelPosition(*v))?;
+            h.SetDefaultLabelPosition(CommandBarDefaultLabelPosition(*v))?;
         }
         (Prop::Delay, PropValue::I32(v), Handle::RepeatButton(h)) => {
-            h.put_Delay(*v)?;
+            h.SetDelay(*v)?;
         }
         (Prop::DisplayName, PropValue::Str(v), Handle::PersonPicture(h)) => {
-            h.put_DisplayName(v.as_str())?;
+            h.SetDisplayName(v.as_str())?;
         }
         (Prop::GroupName, PropValue::Str(v), Handle::RadioButton(h)) => {
-            h.put_GroupName(v.as_str())?;
+            h.SetGroupName(v.as_str())?;
         }
         (Prop::Header, PropValue::Str(v), Handle::AutoSuggestBox(h)) => {
             let insp = windows_reference::IReference::from(v.as_str());
-            h.put_Header(&insp)?;
+            h.SetHeader(&insp)?;
         }
         (Prop::Header, PropValue::Str(v), Handle::CalendarDatePicker(h)) => {
             let tb = string_as_textblock(v.as_str())?;
-            h.put_Header(&tb)?;
+            h.SetHeader(&tb)?;
         }
         (Prop::Header, PropValue::Str(v), Handle::ComboBox(h)) => {
             let tb = string_as_textblock(v.as_str())?;
-            h.put_Header(&tb)?;
+            h.SetHeader(&tb)?;
         }
         (Prop::Header, PropValue::Str(v), Handle::DatePicker(h)) => {
             let tb = string_as_textblock(v.as_str())?;
-            h.put_Header(&tb)?;
+            h.SetHeader(&tb)?;
         }
         (Prop::Header, PropValue::Str(v), Handle::NavigationView(h)) => {
             let tb = string_as_textblock(v.as_str())?;
-            h.put_Header(&tb)?;
+            h.SetHeader(&tb)?;
         }
         (Prop::Header, PropValue::Str(v), Handle::NumberBox(h)) => {
             let tb = string_as_textblock(v.as_str())?;
-            h.put_Header(&tb)?;
+            h.SetHeader(&tb)?;
         }
         (Prop::Header, PropValue::Str(v), Handle::PasswordBox(h)) => {
             let tb = string_as_textblock(v.as_str())?;
-            h.put_Header(&tb)?;
+            h.SetHeader(&tb)?;
         }
         (Prop::Header, PropValue::Str(v), Handle::RadioButtons(h)) => {
             let tb = string_as_textblock(v.as_str())?;
-            h.put_Header(&tb)?;
+            h.SetHeader(&tb)?;
         }
         (Prop::Header, PropValue::Str(v), Handle::RichEditBox(h)) => {
             let tb = string_as_textblock(v.as_str())?;
-            h.put_Header(&tb)?;
+            h.SetHeader(&tb)?;
         }
         (Prop::Header, PropValue::Str(v), Handle::Slider(h)) => {
             let tb = string_as_textblock(v.as_str())?;
-            h.put_Header(&tb)?;
+            h.SetHeader(&tb)?;
         }
         (Prop::Header, PropValue::Str(v), Handle::TextBox(h)) => {
             let tb = string_as_textblock(v.as_str())?;
-            h.put_Header(&tb)?;
+            h.SetHeader(&tb)?;
         }
         (Prop::Header, PropValue::Str(v), Handle::TimePicker(h)) => {
             let tb = string_as_textblock(v.as_str())?;
-            h.put_Header(&tb)?;
+            h.SetHeader(&tb)?;
         }
         (Prop::Header, PropValue::Str(v), Handle::ToggleSwitch(h)) => {
             let tb = string_as_textblock(v.as_str())?;
-            h.put_Header(&tb)?;
+            h.SetHeader(&tb)?;
         }
         (Prop::Header, PropValue::Unset, Handle::AutoSuggestBox(h)) => {
-            h.put_Header(None)?;
+            h.SetHeader(None)?;
         }
         (Prop::Header, PropValue::Unset, Handle::CalendarDatePicker(h)) => {
-            h.put_Header(None)?;
+            h.SetHeader(None)?;
         }
         (Prop::Header, PropValue::Unset, Handle::ComboBox(h)) => {
-            h.put_Header(None)?;
+            h.SetHeader(None)?;
         }
         (Prop::Header, PropValue::Unset, Handle::DatePicker(h)) => {
-            h.put_Header(None)?;
+            h.SetHeader(None)?;
         }
         (Prop::Header, PropValue::Unset, Handle::NavigationView(h)) => {
-            h.put_Header(None)?;
+            h.SetHeader(None)?;
         }
         (Prop::Header, PropValue::Unset, Handle::NumberBox(h)) => {
-            h.put_Header(None)?;
+            h.SetHeader(None)?;
         }
         (Prop::Header, PropValue::Unset, Handle::PasswordBox(h)) => {
-            h.put_Header(None)?;
+            h.SetHeader(None)?;
         }
         (Prop::Header, PropValue::Unset, Handle::RadioButtons(h)) => {
-            h.put_Header(None)?;
+            h.SetHeader(None)?;
         }
         (Prop::Header, PropValue::Unset, Handle::RichEditBox(h)) => {
-            h.put_Header(None)?;
+            h.SetHeader(None)?;
         }
         (Prop::Header, PropValue::Unset, Handle::Slider(h)) => {
-            h.put_Header(None)?;
+            h.SetHeader(None)?;
         }
         (Prop::Header, PropValue::Unset, Handle::TextBox(h)) => {
-            h.put_Header(None)?;
+            h.SetHeader(None)?;
         }
         (Prop::Header, PropValue::Unset, Handle::TimePicker(h)) => {
-            h.put_Header(None)?;
+            h.SetHeader(None)?;
         }
         (Prop::Header, PropValue::Unset, Handle::ToggleSwitch(h)) => {
-            h.put_Header(None)?;
+            h.SetHeader(None)?;
         }
         (Prop::HorizontalScrollBarVisibility, PropValue::I32(v), Handle::ScrollView(h)) => {
-            h.put_HorizontalScrollBarVisibility(ScrollingScrollBarVisibility(*v))?;
+            h.SetHorizontalScrollBarVisibility(ScrollingScrollBarVisibility(*v))?;
         }
         (Prop::HorizontalScrollBarVisibility, PropValue::I32(v), Handle::ScrollViewer(h)) => {
-            h.put_HorizontalScrollBarVisibility(ScrollBarVisibility(*v))?;
+            h.SetHorizontalScrollBarVisibility(ScrollBarVisibility(*v))?;
         }
         (Prop::Initials, PropValue::Str(v), Handle::PersonPicture(h)) => {
-            h.put_Initials(v.as_str())?;
+            h.SetInitials(v.as_str())?;
         }
         (Prop::Interval, PropValue::I32(v), Handle::RepeatButton(h)) => {
-            h.put_Interval(*v)?;
+            h.SetInterval(*v)?;
         }
         (Prop::IsActive, PropValue::Bool(v), Handle::ProgressRing(h)) => {
-            h.put_IsActive(*v)?;
+            h.SetIsActive(*v)?;
         }
         (Prop::IsAddTabButtonVisible, PropValue::Bool(v), Handle::TabView(h)) => {
-            h.put_IsAddTabButtonVisible(*v)?;
+            h.SetIsAddTabButtonVisible(*v)?;
         }
         (Prop::IsAlphaEnabled, PropValue::Bool(v), Handle::ColorPicker(h)) => {
-            h.put_IsAlphaEnabled(*v)?;
+            h.SetIsAlphaEnabled(*v)?;
         }
         (Prop::IsBackButtonEnabled, PropValue::Bool(v), Handle::TitleBar(h)) => {
-            h.put_IsBackButtonEnabled(*v)?;
+            h.SetIsBackButtonEnabled(*v)?;
         }
         (Prop::IsBackButtonVisible, PropValue::Bool(v), Handle::TitleBar(h)) => {
-            h.put_IsBackButtonVisible(*v)?;
+            h.SetIsBackButtonVisible(*v)?;
         }
         (Prop::IsBackEnabled, PropValue::Bool(v), Handle::NavigationView(h)) => {
             h.cast::<bindings::INavigationView2>()?
-                .put_IsBackEnabled(*v)?;
+                .SetIsBackEnabled(*v)?;
         }
         (Prop::IsCalendarOpen, PropValue::Bool(v), Handle::CalendarDatePicker(h)) => {
-            h.put_IsCalendarOpen(*v)?;
+            h.SetIsCalendarOpen(*v)?;
         }
         (
             Prop::IsChecked,
@@ -211,7 +211,7 @@ pub fn dispatch(handle: &Handle, prop: Prop, value: &PropValue) -> Result<bool> 
         ) => {
             handle
                 .cast_inner::<bindings::IToggleButton>()?
-                .put_IsChecked(Some(*v))?;
+                .SetIsChecked(Some(*v))?;
         }
         (
             Prop::IsChecked,
@@ -220,19 +220,19 @@ pub fn dispatch(handle: &Handle, prop: Prop, value: &PropValue) -> Result<bool> 
         ) => {
             handle
                 .cast_inner::<bindings::IToggleButton>()?
-                .put_IsChecked(None)?;
+                .SetIsChecked(None)?;
         }
         (Prop::IsClosable, PropValue::Bool(v), Handle::InfoBar(h)) => {
-            h.put_IsClosable(*v)?;
+            h.SetIsClosable(*v)?;
         }
         (Prop::IsColorChannelTextInputVisible, PropValue::Bool(v), Handle::ColorPicker(h)) => {
-            h.put_IsColorChannelTextInputVisible(*v)?;
+            h.SetIsColorChannelTextInputVisible(*v)?;
         }
         (Prop::IsColorSliderVisible, PropValue::Bool(v), Handle::ColorPicker(h)) => {
-            h.put_IsColorSliderVisible(*v)?;
+            h.SetIsColorSliderVisible(*v)?;
         }
         (Prop::IsEditable, PropValue::Bool(v), Handle::ComboBox(h)) => {
-            h.put_IsEditable(*v)?;
+            h.SetIsEditable(*v)?;
         }
         (
             Prop::IsEnabled,
@@ -260,265 +260,265 @@ pub fn dispatch(handle: &Handle, prop: Prop, value: &PropValue) -> Result<bool> 
         ) => {
             handle
                 .cast_inner::<bindings::IControl>()?
-                .put_IsEnabled(*v)?;
+                .SetIsEnabled(*v)?;
         }
         (Prop::IsExpanded, PropValue::Bool(v), Handle::Expander(h)) => {
-            h.put_IsExpanded(*v)?;
+            h.SetIsExpanded(*v)?;
         }
         (Prop::IsGroupLabelVisible, PropValue::Bool(v), Handle::CalendarView(h)) => {
-            h.put_IsGroupLabelVisible(*v)?;
+            h.SetIsGroupLabelVisible(*v)?;
         }
         (Prop::IsHexInputVisible, PropValue::Bool(v), Handle::ColorPicker(h)) => {
-            h.put_IsHexInputVisible(*v)?;
+            h.SetIsHexInputVisible(*v)?;
         }
         (Prop::IsIndeterminate, PropValue::Bool(v), Handle::ProgressBar(h)) => {
-            h.put_IsIndeterminate(*v)?;
+            h.SetIsIndeterminate(*v)?;
         }
         (Prop::IsIndeterminate, PropValue::Bool(v), Handle::ProgressRing(h)) => {
-            h.put_IsIndeterminate(*v)?;
+            h.SetIsIndeterminate(*v)?;
         }
         (Prop::IsLightDismissEnabled, PropValue::Bool(v), Handle::TeachingTip(h)) => {
-            h.put_IsLightDismissEnabled(*v)?;
+            h.SetIsLightDismissEnabled(*v)?;
         }
         (Prop::IsOn, PropValue::Bool(v), Handle::ToggleSwitch(h)) => {
-            h.put_IsOn(*v)?;
+            h.SetIsOn(*v)?;
         }
         (Prop::IsOpen, PropValue::Bool(v), Handle::InfoBar(h)) => {
-            h.put_IsOpen(*v)?;
+            h.SetIsOpen(*v)?;
         }
         (Prop::IsOpen, PropValue::Bool(v), Handle::TeachingTip(h)) => {
-            h.put_IsOpen(*v)?;
+            h.SetIsOpen(*v)?;
         }
         (Prop::IsPaneOpen, PropValue::Bool(v), Handle::NavigationView(h)) => {
-            h.put_IsPaneOpen(*v)?;
+            h.SetIsPaneOpen(*v)?;
         }
         (Prop::IsPaneOpen, PropValue::Bool(v), Handle::SplitView(h)) => {
-            h.put_IsPaneOpen(*v)?;
+            h.SetIsPaneOpen(*v)?;
         }
         (Prop::IsPaneToggleButtonVisible, PropValue::Bool(v), Handle::NavigationView(h)) => {
-            h.put_IsPaneToggleButtonVisible(*v)?;
+            h.SetIsPaneToggleButtonVisible(*v)?;
         }
         (Prop::IsPaneToggleButtonVisible, PropValue::Bool(v), Handle::TitleBar(h)) => {
-            h.put_IsPaneToggleButtonVisible(*v)?;
+            h.SetIsPaneToggleButtonVisible(*v)?;
         }
         (Prop::IsPasswordRevealButtonEnabled, PropValue::Bool(v), Handle::PasswordBox(h)) => {
-            h.put_IsPasswordRevealButtonEnabled(*v)?;
+            h.SetIsPasswordRevealButtonEnabled(*v)?;
         }
         (Prop::IsPrimaryButtonEnabled, PropValue::Bool(v), Handle::ContentDialog(h)) => {
-            h.put_IsPrimaryButtonEnabled(*v)?;
+            h.SetIsPrimaryButtonEnabled(*v)?;
         }
         (Prop::IsReadOnly, PropValue::Bool(v), Handle::RatingControl(h)) => {
-            h.put_IsReadOnly(*v)?;
+            h.SetIsReadOnly(*v)?;
         }
         (Prop::IsReadOnly, PropValue::Bool(v), Handle::RichEditBox(h)) => {
-            h.put_IsReadOnly(*v)?;
+            h.SetIsReadOnly(*v)?;
         }
         (Prop::IsSecondaryButtonEnabled, PropValue::Bool(v), Handle::ContentDialog(h)) => {
-            h.put_IsSecondaryButtonEnabled(*v)?;
+            h.SetIsSecondaryButtonEnabled(*v)?;
         }
         (Prop::IsSettingsVisible, PropValue::Bool(v), Handle::NavigationView(h)) => {
-            h.put_IsSettingsVisible(*v)?;
+            h.SetIsSettingsVisible(*v)?;
         }
         (Prop::IsTextSelectionEnabled, PropValue::Bool(v), Handle::TextBlock(h)) => {
-            h.put_IsTextSelectionEnabled(*v)?;
+            h.SetIsTextSelectionEnabled(*v)?;
         }
         (Prop::IsTodayHighlighted, PropValue::Bool(v), Handle::CalendarDatePicker(h)) => {
-            h.put_IsTodayHighlighted(*v)?;
+            h.SetIsTodayHighlighted(*v)?;
         }
         (Prop::IsTodayHighlighted, PropValue::Bool(v), Handle::CalendarView(h)) => {
-            h.put_IsTodayHighlighted(*v)?;
+            h.SetIsTodayHighlighted(*v)?;
         }
         (Prop::MaxColumns, PropValue::I32(v), Handle::RadioButtons(h)) => {
-            h.put_MaxColumns(*v)?;
+            h.SetMaxColumns(*v)?;
         }
         (Prop::MaxRating, PropValue::I32(v), Handle::RatingControl(h)) => {
-            h.put_MaxRating(*v)?;
+            h.SetMaxRating(*v)?;
         }
         (Prop::Maximum, PropValue::F64(v), Handle::NumberBox(h)) => {
-            h.put_Maximum(*v)?;
+            h.SetMaximum(*v)?;
         }
         (Prop::Maximum, PropValue::F64(v), Handle::ProgressRing(h)) => {
-            h.put_Maximum(*v)?;
+            h.SetMaximum(*v)?;
         }
         (Prop::Maximum, PropValue::F64(v), Handle::ProgressBar(_) | Handle::Slider(_)) => {
             handle
                 .cast_inner::<bindings::IRangeBase>()?
-                .put_Maximum(*v)?;
+                .SetMaximum(*v)?;
         }
         (Prop::Message, PropValue::Str(v), Handle::InfoBar(h)) => {
-            h.put_Message(v.as_str())?;
+            h.SetMessage(v.as_str())?;
         }
         (Prop::Minimum, PropValue::F64(v), Handle::NumberBox(h)) => {
-            h.put_Minimum(*v)?;
+            h.SetMinimum(*v)?;
         }
         (Prop::Minimum, PropValue::F64(v), Handle::ProgressRing(h)) => {
-            h.put_Minimum(*v)?;
+            h.SetMinimum(*v)?;
         }
         (Prop::Minimum, PropValue::F64(v), Handle::ProgressBar(_) | Handle::Slider(_)) => {
             handle
                 .cast_inner::<bindings::IRangeBase>()?
-                .put_Minimum(*v)?;
+                .SetMinimum(*v)?;
         }
         (Prop::MinuteIncrement, PropValue::I32(v), Handle::TimePicker(h)) => {
-            h.put_MinuteIncrement(*v)?;
+            h.SetMinuteIncrement(*v)?;
         }
         (Prop::MonthVisible, PropValue::Bool(v), Handle::DatePicker(h)) => {
-            h.put_MonthVisible(*v)?;
+            h.SetMonthVisible(*v)?;
         }
         (Prop::OffContent, PropValue::Str(v), Handle::ToggleSwitch(h)) => {
             let tb = string_as_textblock(v.as_str())?;
-            h.put_OffContent(&tb)?;
+            h.SetOffContent(&tb)?;
         }
         (Prop::OffContent, PropValue::Unset, Handle::ToggleSwitch(h)) => {
-            h.put_OffContent(None)?;
+            h.SetOffContent(None)?;
         }
         (Prop::OnContent, PropValue::Str(v), Handle::ToggleSwitch(h)) => {
             let tb = string_as_textblock(v.as_str())?;
-            h.put_OnContent(&tb)?;
+            h.SetOnContent(&tb)?;
         }
         (Prop::OnContent, PropValue::Unset, Handle::ToggleSwitch(h)) => {
-            h.put_OnContent(None)?;
+            h.SetOnContent(None)?;
         }
         (Prop::OpenPaneLength, PropValue::F64(v), Handle::SplitView(h)) => {
-            h.put_OpenPaneLength(*v)?;
+            h.SetOpenPaneLength(*v)?;
         }
         (Prop::Orientation, PropValue::I32(v), Handle::Slider(h)) => {
-            h.put_Orientation(Orientation(*v))?;
+            h.SetOrientation(Orientation(*v))?;
         }
         (Prop::Orientation, PropValue::I32(v), Handle::StackPanel(h)) => {
-            h.put_Orientation(Orientation(*v))?;
+            h.SetOrientation(Orientation(*v))?;
         }
         (Prop::PaneDisplayMode, PropValue::I32(v), Handle::NavigationView(h)) => {
             h.cast::<bindings::INavigationView2>()?
-                .put_PaneDisplayMode(NavigationViewPaneDisplayMode(*v))?;
+                .SetPaneDisplayMode(NavigationViewPaneDisplayMode(*v))?;
         }
         (Prop::PaneTitle, PropValue::Str(v), Handle::NavigationView(h)) => {
             h.cast::<bindings::INavigationView2>()?
-                .put_PaneTitle(v.as_str())?;
+                .SetPaneTitle(v.as_str())?;
         }
         (Prop::PasswordRevealMode, PropValue::I32(v), Handle::PasswordBox(h)) => {
-            h.put_PasswordRevealMode(PasswordRevealMode(*v))?;
+            h.SetPasswordRevealMode(PasswordRevealMode(*v))?;
         }
         (Prop::PlaceholderText, PropValue::Str(v), Handle::AutoSuggestBox(h)) => {
-            h.put_PlaceholderText(v.as_str())?;
+            h.SetPlaceholderText(v.as_str())?;
         }
         (Prop::PlaceholderText, PropValue::Str(v), Handle::CalendarDatePicker(h)) => {
-            h.put_PlaceholderText(v.as_str())?;
+            h.SetPlaceholderText(v.as_str())?;
         }
         (Prop::PlaceholderText, PropValue::Str(v), Handle::ComboBox(h)) => {
-            h.put_PlaceholderText(v.as_str())?;
+            h.SetPlaceholderText(v.as_str())?;
         }
         (Prop::PlaceholderText, PropValue::Str(v), Handle::PasswordBox(h)) => {
-            h.put_PlaceholderText(v.as_str())?;
+            h.SetPlaceholderText(v.as_str())?;
         }
         (Prop::PlaceholderText, PropValue::Str(v), Handle::RichEditBox(h)) => {
-            h.put_PlaceholderText(v.as_str())?;
+            h.SetPlaceholderText(v.as_str())?;
         }
         (Prop::PlaceholderText, PropValue::Str(v), Handle::TextBox(h)) => {
-            h.put_PlaceholderText(v.as_str())?;
+            h.SetPlaceholderText(v.as_str())?;
         }
         (Prop::PlaceholderValue, PropValue::F64(v), Handle::RatingControl(h)) => {
-            h.put_PlaceholderValue(*v)?;
+            h.SetPlaceholderValue(*v)?;
         }
         (Prop::PreferredPlacement, PropValue::I32(v), Handle::TeachingTip(h)) => {
-            h.put_PreferredPlacement(TeachingTipPlacementMode(*v))?;
+            h.SetPreferredPlacement(TeachingTipPlacementMode(*v))?;
         }
         (Prop::PrimaryButtonText, PropValue::Str(v), Handle::ContentDialog(h)) => {
-            h.put_PrimaryButtonText(v.as_str())?;
+            h.SetPrimaryButtonText(v.as_str())?;
         }
         (Prop::RowSpacing, PropValue::F64(v), Handle::Grid(h)) => {
-            h.put_RowSpacing(*v)?;
+            h.SetRowSpacing(*v)?;
         }
         (Prop::SecondaryButtonText, PropValue::Str(v), Handle::ContentDialog(h)) => {
-            h.put_SecondaryButtonText(v.as_str())?;
+            h.SetSecondaryButtonText(v.as_str())?;
         }
         (Prop::SelectedIndex, PropValue::I32(v), Handle::Pivot(h)) => {
-            h.put_SelectedIndex(*v)?;
+            h.SetSelectedIndex(*v)?;
         }
         (Prop::SelectedIndex, PropValue::I32(v), Handle::RadioButtons(h)) => {
-            h.put_SelectedIndex(*v)?;
+            h.SetSelectedIndex(*v)?;
         }
         (Prop::SelectedIndex, PropValue::I32(v), Handle::ComboBox(_) | Handle::ListBox(_)) => {
             handle
                 .cast_inner::<bindings::ISelector>()?
-                .put_SelectedIndex(*v)?;
+                .SetSelectedIndex(*v)?;
         }
         (Prop::SelectedIndex, PropValue::I32(v), Handle::TabView(h)) => {
-            h.put_SelectedIndex(*v)?;
+            h.SetSelectedIndex(*v)?;
         }
         (Prop::SelectionMode, PropValue::I32(v), Handle::TreeView(h)) => {
-            h.put_SelectionMode(TreeViewSelectionMode(*v))?;
+            h.SetSelectionMode(TreeViewSelectionMode(*v))?;
         }
         (Prop::Severity, PropValue::I32(v), Handle::InfoBar(h)) => {
-            h.put_Severity(InfoBarSeverity(*v))?;
+            h.SetSeverity(InfoBarSeverity(*v))?;
         }
         (Prop::Spacing, PropValue::F64(v), Handle::StackPanel(h)) => {
-            h.put_Spacing(*v)?;
+            h.SetSpacing(*v)?;
         }
         (Prop::Stretch, PropValue::I32(v), Handle::Image(h)) => {
-            h.put_Stretch(Stretch(*v))?;
+            h.SetStretch(Stretch(*v))?;
         }
         (Prop::Stretch, PropValue::I32(v), Handle::Viewbox(h)) => {
-            h.put_Stretch(Stretch(*v))?;
+            h.SetStretch(Stretch(*v))?;
         }
         (Prop::Subtitle, PropValue::Str(v), Handle::TeachingTip(h)) => {
-            h.put_Subtitle(v.as_str())?;
+            h.SetSubtitle(v.as_str())?;
         }
         (Prop::Subtitle, PropValue::Str(v), Handle::TitleBar(h)) => {
-            h.put_Subtitle(v.as_str())?;
+            h.SetSubtitle(v.as_str())?;
         }
         (Prop::Text, PropValue::Str(v), Handle::TextBlock(h)) => {
-            h.put_Text(v.as_str())?;
+            h.SetText(v.as_str())?;
         }
         (Prop::TextWrapping, PropValue::I32(v), Handle::TextBlock(h)) => {
-            h.put_TextWrapping(TextWrapping(*v))?;
+            h.SetTextWrapping(TextWrapping(*v))?;
         }
         (Prop::TextWrapping, PropValue::I32(v), Handle::TextBox(h)) => {
-            h.put_TextWrapping(TextWrapping(*v))?;
+            h.SetTextWrapping(TextWrapping(*v))?;
         }
         (Prop::Title, PropValue::Str(v), Handle::InfoBar(h)) => {
-            h.put_Title(v.as_str())?;
+            h.SetTitle(v.as_str())?;
         }
         (Prop::Title, PropValue::Str(v), Handle::TeachingTip(h)) => {
-            h.put_Title(v.as_str())?;
+            h.SetTitle(v.as_str())?;
         }
         (Prop::Title, PropValue::Str(v), Handle::TitleBar(h)) => {
-            h.put_Title(v.as_str())?;
+            h.SetTitle(v.as_str())?;
         }
         (Prop::Title, PropValue::Str(v), Handle::ContentDialog(h)) => {
             let insp = windows_reference::IReference::from(v.as_str());
-            h.put_Title(&insp)?;
+            h.SetTitle(&insp)?;
         }
         (Prop::Title, PropValue::Str(v), Handle::Pivot(h)) => {
             let tb = string_as_textblock(v.as_str())?;
-            h.put_Title(&tb)?;
+            h.SetTitle(&tb)?;
         }
         (Prop::Title, PropValue::Unset, Handle::ContentDialog(h)) => {
-            h.put_Title(None)?;
+            h.SetTitle(None)?;
         }
         (Prop::Title, PropValue::Unset, Handle::Pivot(h)) => {
-            h.put_Title(None)?;
+            h.SetTitle(None)?;
         }
         (Prop::Value, PropValue::F64(v), Handle::NumberBox(h)) => {
-            h.put_Value(*v)?;
+            h.SetValue(*v)?;
         }
         (Prop::Value, PropValue::F64(v), Handle::ProgressRing(h)) => {
-            h.put_Value(*v)?;
+            h.SetValue(*v)?;
         }
         (Prop::Value, PropValue::F64(v), Handle::ProgressBar(_) | Handle::Slider(_)) => {
-            handle.cast_inner::<bindings::IRangeBase>()?.put_Value(*v)?;
+            handle.cast_inner::<bindings::IRangeBase>()?.SetValue(*v)?;
         }
         (Prop::Value, PropValue::F64(v), Handle::RatingControl(h)) => {
-            h.put_Value(*v)?;
+            h.SetValue(*v)?;
         }
         (Prop::VerticalScrollBarVisibility, PropValue::I32(v), Handle::ScrollView(h)) => {
-            h.put_VerticalScrollBarVisibility(ScrollingScrollBarVisibility(*v))?;
+            h.SetVerticalScrollBarVisibility(ScrollingScrollBarVisibility(*v))?;
         }
         (Prop::VerticalScrollBarVisibility, PropValue::I32(v), Handle::ScrollViewer(h)) => {
-            h.put_VerticalScrollBarVisibility(ScrollBarVisibility(*v))?;
+            h.SetVerticalScrollBarVisibility(ScrollBarVisibility(*v))?;
         }
         (Prop::YearVisible, PropValue::Bool(v), Handle::DatePicker(h)) => {
-            h.put_YearVisible(*v)?;
+            h.SetYearVisible(*v)?;
         }
         _ => return Ok(false),
     }

--- a/crates/libs/reactor/src/backend/winui/mod.rs
+++ b/crates/libs/reactor/src/backend/winui/mod.rs
@@ -232,12 +232,12 @@ impl WinUIBackend {
         handler: &EventHandler,
     ) -> Vec<windows_core::EventRevoker> {
         let mut revokers = Vec::new();
-        let Ok(bar_items) = mb.get_Items() else {
+        let Ok(bar_items) = mb.Items() else {
             return revokers;
         };
         for i in 0..bar_items.Size().unwrap_or(0) {
             if let Ok(mbi) = bar_items.GetAt(i)
-                && let Ok(flyout_items) = mbi.get_Items()
+                && let Ok(flyout_items) = mbi.Items()
             {
                 Self::wire_flyout_items_click(&flyout_items, handler, &mut revokers);
             }
@@ -252,7 +252,7 @@ impl WinUIBackend {
         handler: &EventHandler,
     ) -> Vec<windows_core::EventRevoker> {
         let mut revokers = Vec::new();
-        if let Ok(items) = flyout.get_Items() {
+        if let Ok(items) = flyout.Items() {
             Self::wire_flyout_items_click(&items, handler, &mut revokers);
         }
         revokers
@@ -266,7 +266,7 @@ impl WinUIBackend {
         for i in 0..items.Size().unwrap_or(0) {
             let Ok(base) = items.GetAt(i) else { continue };
             if let Ok(item) = base.cast::<bindings::MenuFlyoutItem>() {
-                let text = item.get_Text().unwrap_or_default().clone();
+                let text = item.Text().unwrap_or_default().clone();
                 let handler = handler.clone();
                 if let Ok(rev) = item.Click(move |_s, _a| {
                     handler.invoke_string(text.clone());
@@ -274,7 +274,7 @@ impl WinUIBackend {
                     revokers.push(rev);
                 }
             } else if let Ok(sub) = base.cast::<bindings::MenuFlyoutSubItem>()
-                && let Ok(sub_items) = sub.get_Items()
+                && let Ok(sub_items) = sub.Items()
             {
                 Self::wire_flyout_items_click(&sub_items, handler, revokers);
             }
@@ -289,7 +289,7 @@ impl WinUIBackend {
         for i in 0..commands.Size().unwrap_or(0) {
             let Ok(el) = commands.GetAt(i) else { continue };
             if let Ok(btn) = el.cast::<bindings::AppBarButton>() {
-                let label = btn.get_Label().unwrap_or_default().clone();
+                let label = btn.Label().unwrap_or_default().clone();
                 let handler = handler.clone();
                 if let Ok(rev) = btn.cast::<bindings::ButtonBase>().and_then(|bb| {
                     bb.Click(move |_s, _a| {
@@ -372,7 +372,7 @@ fn classify_container(h: &Handle) -> Option<ContainerChildren<'_>> {
         Handle::StackPanel(s) => Some(ContainerChildren::Panel(
             s.cast::<bindings::IPanel>()
                 .ok()?
-                .get_Children()
+                .Children()
                 .ok()?
                 .cast()
                 .ok()?,
@@ -380,7 +380,7 @@ fn classify_container(h: &Handle) -> Option<ContainerChildren<'_>> {
         Handle::Grid(g) => Some(ContainerChildren::Panel(
             g.cast::<bindings::IPanel>()
                 .ok()?
-                .get_Children()
+                .Children()
                 .ok()?
                 .cast()
                 .ok()?,
@@ -388,7 +388,7 @@ fn classify_container(h: &Handle) -> Option<ContainerChildren<'_>> {
         Handle::Canvas(c) => Some(ContainerChildren::Panel(
             c.cast::<bindings::IPanel>()
                 .ok()?
-                .get_Children()
+                .Children()
                 .ok()?
                 .cast()
                 .ok()?,
@@ -396,7 +396,7 @@ fn classify_container(h: &Handle) -> Option<ContainerChildren<'_>> {
         Handle::RelativePanel(r) => Some(ContainerChildren::Panel(
             r.cast::<bindings::IPanel>()
                 .ok()?
-                .get_Children()
+                .Children()
                 .ok()?
                 .cast()
                 .ok()?,
@@ -408,13 +408,11 @@ fn classify_container(h: &Handle) -> Option<ContainerChildren<'_>> {
         Handle::NavigationView(nv) => Some(ContainerChildren::ContentControl(nv.cast().ok()?)),
         Handle::PivotItem(pi) => Some(ContainerChildren::ContentControl(pi.cast().ok()?)),
         Handle::ScrollView(_) | Handle::SplitView(_) => Some(ContainerChildren::DirectContent(h)),
-        Handle::TabView(tv) => Some(ContainerChildren::InspectableVector(
-            tv.get_TabItems().ok()?,
-        )),
+        Handle::TabView(tv) => Some(ContainerChildren::InspectableVector(tv.TabItems().ok()?)),
         Handle::Pivot(p) => Some(ContainerChildren::InspectableVector(
             p.cast::<bindings::IItemsControl>()
                 .ok()?
-                .get_Items()
+                .Items()
                 .ok()?
                 .cast()
                 .ok()?,
@@ -428,7 +426,7 @@ fn container_append(cc: &ContainerChildren<'_>, child: &bindings::UIElement) {
     match cc {
         ContainerChildren::Panel(vec) => vec.Append(child).unwrap(),
         ContainerChildren::SingleChild(h) => put_single_child(h, Some(child)),
-        ContainerChildren::ContentControl(c) => c.put_Content(child).unwrap(),
+        ContainerChildren::ContentControl(c) => c.SetContent(child).unwrap(),
         ContainerChildren::DirectContent(h) => put_direct_content(h, Some(child)),
         ContainerChildren::InspectableVector(vec) => {
             let insp: windows_core::IInspectable = child.cast().unwrap();
@@ -442,7 +440,7 @@ fn container_insert(cc: &ContainerChildren<'_>, index: usize, child: &bindings::
     match cc {
         ContainerChildren::Panel(vec) => vec.InsertAt(index as u32, child).unwrap(),
         ContainerChildren::SingleChild(h) => put_single_child(h, Some(child)),
-        ContainerChildren::ContentControl(c) => c.put_Content(child).unwrap(),
+        ContainerChildren::ContentControl(c) => c.SetContent(child).unwrap(),
         ContainerChildren::DirectContent(h) => put_direct_content(h, Some(child)),
         ContainerChildren::InspectableVector(vec) => {
             let insp: windows_core::IInspectable = child.cast().unwrap();
@@ -456,7 +454,7 @@ fn container_set(cc: &ContainerChildren<'_>, index: usize, child: &bindings::UIE
     match cc {
         ContainerChildren::Panel(vec) => vec.SetAt(index as u32, child).unwrap(),
         ContainerChildren::SingleChild(h) => put_single_child(h, Some(child)),
-        ContainerChildren::ContentControl(c) => c.put_Content(child).unwrap(),
+        ContainerChildren::ContentControl(c) => c.SetContent(child).unwrap(),
         ContainerChildren::DirectContent(h) => put_direct_content(h, Some(child)),
         ContainerChildren::InspectableVector(vec) => {
             let insp: windows_core::IInspectable = child.cast().unwrap();
@@ -475,7 +473,7 @@ fn container_remove(cc: &ContainerChildren<'_>, index: usize) {
         }
         ContainerChildren::ContentControl(c) => {
             debug_assert_eq!(index, 0);
-            c.put_Content(None::<&windows_core::IInspectable>).unwrap();
+            c.SetContent(None::<&windows_core::IInspectable>).unwrap();
         }
         ContainerChildren::DirectContent(h) => {
             debug_assert_eq!(index, 0);
@@ -507,16 +505,16 @@ fn container_move(cc: &ContainerChildren<'_>, from: usize, to: usize) {
 
 fn put_single_child(h: &Handle, child: Option<&bindings::UIElement>) {
     match h {
-        Handle::Border(b) => b.put_Child(child).unwrap(),
-        Handle::Viewbox(v) => v.put_Child(child).unwrap(),
+        Handle::Border(b) => b.SetChild(child).unwrap(),
+        Handle::Viewbox(v) => v.SetChild(child).unwrap(),
         _ => unreachable!(),
     }
 }
 
 fn put_direct_content(h: &Handle, child: Option<&bindings::UIElement>) {
     match h {
-        Handle::ScrollView(sv) => sv.put_Content(child).unwrap(),
-        Handle::SplitView(sv) => sv.put_Content(child).unwrap(),
+        Handle::ScrollView(sv) => sv.SetContent(child).unwrap(),
+        Handle::SplitView(sv) => sv.SetContent(child).unwrap(),
         _ => unreachable!(),
     }
 }
@@ -543,7 +541,7 @@ fn apply_theme_resource_style(handle: &Handle, bindings: &[(Prop, ThemeRef)]) {
     }
 
     if setters.is_empty() {
-        let _ = fe.put_Style(None);
+        let _ = fe.SetStyle(None);
         return;
     }
 
@@ -555,8 +553,8 @@ fn apply_theme_resource_style(handle: &Handle, bindings: &[(Prop, ThemeRef)]) {
         Ok(obj) => {
             if let Ok(style) = obj.cast::<bindings::Style>() {
                 // Clear first to force WinUI to re-resolve {ThemeResource} values
-                let _ = fe.put_Style(None);
-                let _ = fe.put_Style(&style);
+                let _ = fe.SetStyle(None);
+                let _ = fe.SetStyle(&style);
             }
         }
         Err(e) => {
@@ -623,12 +621,12 @@ fn apply_implicit_transitions(
     let obj2 = visual.cast::<bindings::ICompositionObject2>()?;
     // No transitions, or every slot empty: clear the implicit-animation collection.
     let Some(t) = transitions.filter(|t| !t.is_empty()) else {
-        obj2.put_ImplicitAnimations(None)?;
+        obj2.SetImplicitAnimations(None)?;
         return Ok(());
     };
     let compositor = visual
         .cast::<bindings::ICompositionObject>()?
-        .get_Compositor()?;
+        .Compositor()?;
     let icomp = compositor.cast::<bindings::ICompositor>()?;
     let icomp2 = compositor.cast::<bindings::ICompositor2>()?;
     let collection = icomp2.CreateImplicitAnimationCollection()?;
@@ -646,18 +644,18 @@ fn apply_implicit_transitions(
         let anim_base: bindings::ICompositionAnimationBase = if is_scalar {
             let a = icomp.CreateScalarKeyFrameAnimation()?;
             let kfa = a.cast::<bindings::IKeyFrameAnimation>()?;
-            kfa.put_Duration(anim_duration_to_timespan(duration))?;
+            kfa.SetDuration(anim_duration_to_timespan(duration))?;
             kfa.InsertExpressionKeyFrameWithEasingFunction(1.0, final_expr, &easing)?;
             let anim2 = a.cast::<bindings::ICompositionAnimation2>()?;
-            anim2.put_Target(target)?;
+            anim2.SetTarget(target)?;
             a.cast::<bindings::ICompositionAnimationBase>()?
         } else {
             let a = icomp.CreateVector3KeyFrameAnimation()?;
             let kfa = a.cast::<bindings::IKeyFrameAnimation>()?;
-            kfa.put_Duration(anim_duration_to_timespan(duration))?;
+            kfa.SetDuration(anim_duration_to_timespan(duration))?;
             kfa.InsertExpressionKeyFrameWithEasingFunction(1.0, final_expr, &easing)?;
             let anim2 = a.cast::<bindings::ICompositionAnimation2>()?;
-            anim2.put_Target(target)?;
+            anim2.SetTarget(target)?;
             a.cast::<bindings::ICompositionAnimationBase>()?
         };
         map.Insert(&target_hs, &anim_base)?;
@@ -678,21 +676,21 @@ fn apply_implicit_transitions(
         // correct target is the synthetic `Translation` channel.
         insert("Offset", v.duration, false)?;
     }
-    obj2.put_ImplicitAnimations(&collection)?;
+    obj2.SetImplicitAnimations(&collection)?;
     Ok(())
 }
 
 fn run_property_animation_inner(ui: &bindings::UIElement, cfg: AnimationConfig) -> Result<()> {
     let visual = bindings::ElementCompositionPreview::GetElementVisual(ui)?;
     let visual_obj = visual.cast::<bindings::ICompositionObject>()?;
-    let compositor = visual_obj.get_Compositor()?;
+    let compositor = visual_obj.Compositor()?;
     let icomp = compositor.cast::<bindings::ICompositor>()?;
 
     if let Some(opacity) = cfg.opacity {
         let a = icomp.CreateScalarKeyFrameAnimation()?;
         let ia = a.cast::<bindings::IScalarKeyFrameAnimation>()?;
         a.cast::<bindings::IKeyFrameAnimation>()?
-            .put_Duration(anim_duration_to_timespan(cfg.duration))?;
+            .SetDuration(anim_duration_to_timespan(cfg.duration))?;
         let easing = easing_for(&icomp, cfg.easing)?;
         ia.InsertKeyFrameWithEasingFunction(1.0, opacity as f32, &easing)?;
         let anim = a.cast::<bindings::CompositionAnimation>()?;
@@ -704,10 +702,10 @@ fn run_property_animation_inner(ui: &bindings::UIElement, cfg: AnimationConfig) 
         // previous CenterPoint is reused.
         let iv = visual.cast::<bindings::IVisual>()?;
         if let Ok(fe) = ui.cast::<bindings::IFrameworkElement>() {
-            let w = fe.get_ActualWidth().unwrap_or(0.0) as f32;
-            let h = fe.get_ActualHeight().unwrap_or(0.0) as f32;
+            let w = fe.ActualWidth().unwrap_or(0.0) as f32;
+            let h = fe.ActualHeight().unwrap_or(0.0) as f32;
             if w > 0.0 && h > 0.0 {
-                let _ = iv.put_CenterPoint(windows_numerics::Vector3 {
+                let _ = iv.SetCenterPoint(windows_numerics::Vector3 {
                     x: w / 2.0,
                     y: h / 2.0,
                     z: 0.0,
@@ -719,11 +717,11 @@ fn run_property_animation_inner(ui: &bindings::UIElement, cfg: AnimationConfig) 
             }
         }
         // Preserve current Scale.Z; cfg.scale is a uniform X/Y scalar.
-        let current_z = iv.get_Scale().map_or(1.0, |v| v.z);
+        let current_z = iv.Scale().map_or(1.0, |v| v.z);
         let a = icomp.CreateVector3KeyFrameAnimation()?;
         let ia = a.cast::<bindings::IVector3KeyFrameAnimation>()?;
         a.cast::<bindings::IKeyFrameAnimation>()?
-            .put_Duration(anim_duration_to_timespan(cfg.duration))?;
+            .SetDuration(anim_duration_to_timespan(cfg.duration))?;
         let easing = easing_for(&icomp, cfg.easing)?;
         let s = scale as f32;
         ia.InsertKeyFrameWithEasingFunction(
@@ -763,112 +761,112 @@ fn try_universal_prop(handle: &Handle, prop: Prop, value: &PropValue) -> Result<
             &bindings::FontFamily::CreateInstanceWithName("Segoe UI")?,
         ),
         (Prop::Margin, PropValue::Thickness(t)) => {
-            handle.as_framework_element().put_Margin(*t)?;
+            handle.as_framework_element().SetMargin(*t)?;
             Ok(true)
         }
         (Prop::Margin, PropValue::Unset) => {
             handle
                 .as_framework_element()
-                .put_Margin(Thickness::default())?;
+                .SetMargin(Thickness::default())?;
             Ok(true)
         }
         (Prop::Width, PropValue::F64(v)) => {
-            handle.as_framework_element().put_Width(*v)?;
+            handle.as_framework_element().SetWidth(*v)?;
             Ok(true)
         }
         (Prop::Width, PropValue::Unset) => {
-            handle.as_framework_element().put_Width(f64::NAN)?;
+            handle.as_framework_element().SetWidth(f64::NAN)?;
             Ok(true)
         }
         (Prop::Height, PropValue::F64(v)) => {
-            handle.as_framework_element().put_Height(*v)?;
+            handle.as_framework_element().SetHeight(*v)?;
             Ok(true)
         }
         (Prop::Height, PropValue::Unset) => {
-            handle.as_framework_element().put_Height(f64::NAN)?;
+            handle.as_framework_element().SetHeight(f64::NAN)?;
             Ok(true)
         }
         (Prop::MinWidth, PropValue::F64(v)) => {
-            handle.as_framework_element().put_MinWidth(*v)?;
+            handle.as_framework_element().SetMinWidth(*v)?;
             Ok(true)
         }
         (Prop::MinWidth, PropValue::Unset) => {
-            handle.as_framework_element().put_MinWidth(0.0)?;
+            handle.as_framework_element().SetMinWidth(0.0)?;
             Ok(true)
         }
         (Prop::MaxWidth, PropValue::F64(v)) => {
-            handle.as_framework_element().put_MaxWidth(*v)?;
+            handle.as_framework_element().SetMaxWidth(*v)?;
             Ok(true)
         }
         (Prop::MaxWidth, PropValue::Unset) => {
-            handle.as_framework_element().put_MaxWidth(f64::INFINITY)?;
+            handle.as_framework_element().SetMaxWidth(f64::INFINITY)?;
             Ok(true)
         }
         (Prop::MinHeight, PropValue::F64(v)) => {
-            handle.as_framework_element().put_MinHeight(*v)?;
+            handle.as_framework_element().SetMinHeight(*v)?;
             Ok(true)
         }
         (Prop::MinHeight, PropValue::Unset) => {
-            handle.as_framework_element().put_MinHeight(0.0)?;
+            handle.as_framework_element().SetMinHeight(0.0)?;
             Ok(true)
         }
         (Prop::MaxHeight, PropValue::F64(v)) => {
-            handle.as_framework_element().put_MaxHeight(*v)?;
+            handle.as_framework_element().SetMaxHeight(*v)?;
             Ok(true)
         }
         (Prop::MaxHeight, PropValue::Unset) => {
-            handle.as_framework_element().put_MaxHeight(f64::INFINITY)?;
+            handle.as_framework_element().SetMaxHeight(f64::INFINITY)?;
             Ok(true)
         }
         (Prop::HorizontalAlignment, PropValue::I32(v)) => {
             handle
                 .as_framework_element()
-                .put_HorizontalAlignment(HorizontalAlignment(*v))?;
+                .SetHorizontalAlignment(HorizontalAlignment(*v))?;
             Ok(true)
         }
         (Prop::HorizontalAlignment, PropValue::Unset) => {
             handle
                 .as_framework_element()
-                .put_HorizontalAlignment(HorizontalAlignment::Stretch)?;
+                .SetHorizontalAlignment(HorizontalAlignment::Stretch)?;
             Ok(true)
         }
         (Prop::VerticalAlignment, PropValue::I32(v)) => {
             handle
                 .as_framework_element()
-                .put_VerticalAlignment(VerticalAlignment(*v))?;
+                .SetVerticalAlignment(VerticalAlignment(*v))?;
             Ok(true)
         }
         (Prop::VerticalAlignment, PropValue::Unset) => {
             handle
                 .as_framework_element()
-                .put_VerticalAlignment(VerticalAlignment::Stretch)?;
+                .SetVerticalAlignment(VerticalAlignment::Stretch)?;
             Ok(true)
         }
         (Prop::Opacity, PropValue::F64(v)) => {
-            handle.as_ui_element().put_Opacity(*v)?;
+            handle.as_ui_element().SetOpacity(*v)?;
             Ok(true)
         }
         (Prop::Opacity, PropValue::Unset) => {
-            handle.as_ui_element().put_Opacity(1.0)?;
+            handle.as_ui_element().SetOpacity(1.0)?;
             Ok(true)
         }
         (Prop::AllowDrop, PropValue::Bool(v)) => {
-            handle.as_ui_element().put_AllowDrop(*v)?;
+            handle.as_ui_element().SetAllowDrop(*v)?;
             Ok(true)
         }
         (Prop::AllowDrop, PropValue::Unset) => {
-            handle.as_ui_element().put_AllowDrop(false)?;
+            handle.as_ui_element().SetAllowDrop(false)?;
             Ok(true)
         }
         (Prop::IsEnabled, PropValue::Unset) => {
             handle
                 .as_ui_element()
                 .cast::<bindings::IControl>()?
-                .put_IsEnabled(true)?;
+                .SetIsEnabled(true)?;
             Ok(true)
         }
         (Prop::Resources, PropValue::Resources(map)) => {
-            let rd = handle.as_framework_element().get_Resources()?;
+            let rd = handle.as_framework_element().Resources()?;
             let imap =
                 rd.cast::<windows_collections::IMap<
                     windows_core::IInspectable,
@@ -945,33 +943,33 @@ fn try_universal_prop(handle: &Handle, prop: Prop, value: &PropValue) -> Result<
         (Prop::Fill, PropValue::Color(b)) => {
             handle
                 .cast_inner::<bindings::IShape>()?
-                .put_Fill(&solid_brush(*b)?)?;
+                .SetFill(&solid_brush(*b)?)?;
             Ok(true)
         }
         (Prop::Fill, PropValue::Unset) => {
-            handle.cast_inner::<bindings::IShape>()?.put_Fill(None)?;
+            handle.cast_inner::<bindings::IShape>()?.SetFill(None)?;
             Ok(true)
         }
         (Prop::Stroke, PropValue::Color(b)) => {
             handle
                 .cast_inner::<bindings::IShape>()?
-                .put_Stroke(&solid_brush(*b)?)?;
+                .SetStroke(&solid_brush(*b)?)?;
             Ok(true)
         }
         (Prop::Stroke, PropValue::Unset) => {
-            handle.cast_inner::<bindings::IShape>()?.put_Stroke(None)?;
+            handle.cast_inner::<bindings::IShape>()?.SetStroke(None)?;
             Ok(true)
         }
         (Prop::StrokeThickness, PropValue::F64(v)) => {
             handle
                 .cast_inner::<bindings::IShape>()?
-                .put_StrokeThickness(*v)?;
+                .SetStrokeThickness(*v)?;
             Ok(true)
         }
         (Prop::StrokeThickness, PropValue::Unset) => {
             handle
                 .cast_inner::<bindings::IShape>()?
-                .put_StrokeThickness(0.0)?;
+                .SetStrokeThickness(0.0)?;
             Ok(true)
         }
         _ => Ok(false),
@@ -980,9 +978,9 @@ fn try_universal_prop(handle: &Handle, prop: Prop, value: &PropValue) -> Result<
 
 fn set_padding(handle: &Handle, thickness: Thickness) -> Result<bool> {
     if let Ok(border) = handle.cast_inner::<bindings::IBorder>() {
-        border.put_Padding(thickness)?;
+        border.SetPadding(thickness)?;
     } else if let Ok(ctl) = handle.cast_inner::<bindings::IControl>() {
-        ctl.put_Padding(thickness)?;
+        ctl.SetPadding(thickness)?;
     } else {
         diag::unhandled_modifier("set_prop", Prop::Padding, handle);
     }
@@ -994,11 +992,11 @@ fn set_background(
     brush: impl windows_core::Param<bindings::Brush>,
 ) -> Result<bool> {
     if let Ok(panel) = handle.cast_inner::<bindings::IPanel>() {
-        panel.put_Background(brush)?;
+        panel.SetBackground(brush)?;
     } else if let Ok(ctl) = handle.cast_inner::<bindings::IControl>() {
-        ctl.put_Background(brush)?;
+        ctl.SetBackground(brush)?;
     } else if let Ok(border) = handle.cast_inner::<bindings::IBorder>() {
-        border.put_Background(brush)?;
+        border.SetBackground(brush)?;
     } else {
         diag::unhandled_modifier("set_prop", Prop::Background, handle);
     }
@@ -1010,11 +1008,11 @@ fn set_foreground(
     brush: impl windows_core::Param<bindings::Brush>,
 ) -> Result<bool> {
     if let Ok(ctl) = handle.cast_inner::<bindings::IControl>() {
-        ctl.put_Foreground(brush)?;
+        ctl.SetForeground(brush)?;
     } else if let Ok(tb) = handle.cast_inner::<bindings::ITextBlock>() {
-        tb.put_Foreground(brush)?;
+        tb.SetForeground(brush)?;
     } else if let Ok(rtb) = handle.cast_inner::<bindings::IRichTextBlock>() {
-        rtb.put_Foreground(brush)?;
+        rtb.SetForeground(brush)?;
     } else {
         diag::unhandled_modifier("set_prop", Prop::Foreground, handle);
     }
@@ -1023,11 +1021,11 @@ fn set_foreground(
 
 fn set_font_f64(handle: &Handle, v: f64) -> Result<bool> {
     if let Ok(ctrl) = handle.cast_inner::<bindings::IControl>() {
-        ctrl.put_FontSize(v)?;
+        ctrl.SetFontSize(v)?;
     } else if let Ok(tb) = handle.cast_inner::<bindings::ITextBlock>() {
-        tb.put_FontSize(v)?;
+        tb.SetFontSize(v)?;
     } else if let Ok(rtb) = handle.cast_inner::<bindings::IRichTextBlock>() {
-        rtb.put_FontSize(v)?;
+        rtb.SetFontSize(v)?;
     } else {
         diag::unhandled_modifier("set_prop", Prop::FontSize, handle);
     }
@@ -1036,9 +1034,9 @@ fn set_font_f64(handle: &Handle, v: f64) -> Result<bool> {
 
 fn set_font_weight(handle: &Handle, fw: bindings::FontWeight) -> Result<bool> {
     if let Ok(ctrl) = handle.cast_inner::<bindings::IControl>() {
-        ctrl.put_FontWeight(fw)?;
+        ctrl.SetFontWeight(fw)?;
     } else if let Ok(tb) = handle.cast_inner::<bindings::ITextBlock>() {
-        tb.put_FontWeight(fw)?;
+        tb.SetFontWeight(fw)?;
     } else {
         diag::unhandled_modifier("set_prop", Prop::FontWeight, handle);
     }
@@ -1047,11 +1045,11 @@ fn set_font_weight(handle: &Handle, fw: bindings::FontWeight) -> Result<bool> {
 
 fn set_font_family(handle: &Handle, ff: &bindings::FontFamily) -> Result<bool> {
     if let Ok(ctrl) = handle.cast_inner::<bindings::IControl>() {
-        ctrl.put_FontFamily(ff)?;
+        ctrl.SetFontFamily(ff)?;
     } else if let Ok(tb) = handle.cast_inner::<bindings::ITextBlock>() {
-        tb.put_FontFamily(ff)?;
+        tb.SetFontFamily(ff)?;
     } else if let Ok(rtb) = handle.cast_inner::<bindings::IRichTextBlock>() {
-        rtb.put_FontFamily(ff)?;
+        rtb.SetFontFamily(ff)?;
     } else {
         diag::unhandled_modifier("set_prop", Prop::FontFamily, handle);
     }
@@ -1104,71 +1102,71 @@ impl Backend for WinUIBackend {
             }
             match (prop, value, handle) {
                 (Prop::IsTextSelectionEnabled, PropValue::Bool(v), Handle::RichTextBlock(tb)) => {
-                    tb.put_IsTextSelectionEnabled(*v)
+                    tb.SetIsTextSelectionEnabled(*v)
                 }
                 (Prop::IsTextSelectionEnabled, PropValue::Unset, Handle::RichTextBlock(tb)) => {
-                    tb.put_IsTextSelectionEnabled(false)
+                    tb.SetIsTextSelectionEnabled(false)
                 }
                 (Prop::TextWrappingWrap, PropValue::I32(v), Handle::RichTextBlock(tb)) => {
-                    tb.put_TextWrapping(TextWrapping(*v))
+                    tb.SetTextWrapping(TextWrapping(*v))
                 }
                 (Prop::Content, PropValue::Str(s), Handle::Button(b)) => {
                     let cc = b.cast::<bindings::IContentControl>()?;
                     // If the button has an icon+text layout (StackPanel from
                     // Icon), update just the TextBlock child so the icon
                     // is preserved when only the label changes.
-                    if let Ok(existing) = cc.get_Content()
+                    if let Ok(existing) = cc.Content()
                         && let Ok(panel) = existing.cast::<bindings::IPanel>()
                     {
-                        let children = panel.get_Children()?;
+                        let children = panel.Children()?;
                         if children.Size()? >= 2
                             && let Ok(tb) = children.GetAt(1)?.cast::<bindings::ITextBlock>()
                         {
-                            return tb.put_Text(s);
+                            return tb.SetText(s);
                         }
                     }
                     let tb = string_as_textblock(s)?;
-                    cc.put_Content(&tb)
+                    cc.SetContent(&tb)
                 }
                 (Prop::Icon, PropValue::I32(v), Handle::Button(b)) => {
                     let icon_elem = bindings::SymbolIcon::CreateInstanceWithSymbol(Symbol(*v))?;
                     let cc = b.cast::<bindings::IContentControl>()?;
                     // If the button already has an icon+text StackPanel layout,
                     // replace just the icon child (index 0) to preserve the text.
-                    if let Ok(existing) = cc.get_Content()
+                    if let Ok(existing) = cc.Content()
                         && let Ok(panel) = existing.cast::<bindings::IPanel>()
                     {
-                        let children = panel.get_Children()?;
+                        let children = panel.Children()?;
                         if children.Size()? >= 2 {
                             children.SetAt(0, &icon_elem.cast::<bindings::UIElement>()?)?;
                             return Ok(());
                         }
                     }
-                    let use_icon_only = if let Ok(existing) = cc.get_Content() {
+                    let use_icon_only = if let Ok(existing) = cc.Content() {
                         // Already in icon-only mode (existing is a SymbolIcon).
                         existing.cast::<bindings::ISymbolIcon>().is_ok()
                             || existing
                                 .cast::<bindings::ITextBlock>()
                                 .ok()
-                                .and_then(|tb| tb.get_Text().ok())
+                                .and_then(|tb| tb.Text().ok())
                                 .is_some_and(|t| t.is_empty())
                     } else {
                         true
                     };
                     if use_icon_only {
-                        cc.put_Content(&icon_elem)
+                        cc.SetContent(&icon_elem)
                     } else {
                         let panel = bindings::StackPanel::new()?;
-                        panel.put_Orientation(Orientation::Horizontal)?;
-                        panel.put_Spacing(8.0)?;
-                        let children = panel.cast::<bindings::IPanel>()?.get_Children()?;
+                        panel.SetOrientation(Orientation::Horizontal)?;
+                        panel.SetSpacing(8.0)?;
+                        let children = panel.cast::<bindings::IPanel>()?.Children()?;
                         children.Append(&icon_elem.cast::<bindings::UIElement>()?)?;
-                        if let Ok(existing) = cc.get_Content()
+                        if let Ok(existing) = cc.Content()
                             && let Ok(ui) = existing.cast::<bindings::UIElement>()
                         {
                             children.Append(&ui)?;
                         }
-                        cc.put_Content(&panel)
+                        cc.SetContent(&panel)
                     }
                 }
                 (Prop::StyleVariant, PropValue::I32(v), Handle::Button(b)) => {
@@ -1180,8 +1178,8 @@ impl Backend for WinUIBackend {
                         _ => None, // 0 = Default
                     };
                     if let Some(key_str) = style_key {
-                        let resources = bindings::Application::get_Current()
-                            .and_then(|app| app.get_Resources())?;
+                        let resources =
+                            bindings::Application::Current().and_then(|app| app.Resources())?;
                         let key = windows_reference::IReference::from(windows_core::HSTRING::from(
                             key_str,
                         ));
@@ -1192,62 +1190,62 @@ impl Backend for WinUIBackend {
                         if let Ok(style_obj) = map.Lookup(&key)
                             && let Ok(s) = style_obj.cast::<bindings::Style>()
                         {
-                            fe.put_Style(&s)?;
+                            fe.SetStyle(&s)?;
                         }
                     } else {
-                        fe.put_Style(None)?;
+                        fe.SetStyle(None)?;
                     }
                     Ok(())
                 }
                 (Prop::Value, PropValue::Str(s), Handle::TextBox(t)) => {
-                    if t.get_Text().ok().as_deref() == Some(s.as_str()) {
+                    if t.Text().ok().as_deref() == Some(s.as_str()) {
                         return Ok(());
                     }
-                    t.put_Text(s.as_str())
+                    t.SetText(s.as_str())
                 }
                 (Prop::GridRows, PropValue::GridLengths(rows), Handle::Grid(g)) => {
-                    let defs = g.get_RowDefinitions()?;
+                    let defs = g.RowDefinitions()?;
                     defs.cast::<windows_collections::IVector<bindings::RowDefinition>>()?
                         .Clear()?;
                     for r in rows {
                         let rd = bindings::RowDefinition::new()?;
                         rd.cast::<bindings::IRowDefinition>()?
-                            .put_Height(to_xaml_gridlength(*r)?)?;
+                            .SetHeight(to_xaml_gridlength(*r)?)?;
                         defs.cast::<windows_collections::IVector<bindings::RowDefinition>>()?
                             .Append(&rd)?;
                     }
                     Ok(())
                 }
                 (Prop::GridColumns, PropValue::GridLengths(cols), Handle::Grid(g)) => {
-                    let defs = g.get_ColumnDefinitions()?;
+                    let defs = g.ColumnDefinitions()?;
                     defs.cast::<windows_collections::IVector<bindings::ColumnDefinition>>()?
                         .Clear()?;
                     for c in cols {
                         let cd = bindings::ColumnDefinition::new()?;
                         cd.cast::<bindings::IColumnDefinition>()?
-                            .put_Width(to_xaml_gridlength(*c)?)?;
+                            .SetWidth(to_xaml_gridlength(*c)?)?;
                         defs.cast::<windows_collections::IVector<bindings::ColumnDefinition>>()?
                             .Append(&cd)?;
                     }
                     Ok(())
                 }
                 (Prop::Step, PropValue::F64(v), Handle::Slider(s)) => {
-                    s.put_StepFrequency(*v)?;
-                    s.cast::<bindings::IRangeBase>()?.put_SmallChange(*v)
+                    s.SetStepFrequency(*v)?;
+                    s.cast::<bindings::IRangeBase>()?.SetSmallChange(*v)
                 }
                 (Prop::Step, PropValue::Unset, Handle::Slider(s)) => {
-                    s.put_StepFrequency(1.0)?;
-                    s.cast::<bindings::IRangeBase>()?.put_SmallChange(1.0)
+                    s.SetStepFrequency(1.0)?;
+                    s.cast::<bindings::IRangeBase>()?.SetSmallChange(1.0)
                 }
                 (Prop::NavigateUri, PropValue::Str(s), Handle::HyperlinkButton(h)) => {
                     let uri = bindings::Uri::CreateUri(s.as_str())?;
-                    h.put_NavigateUri(&uri)
+                    h.SetNavigateUri(&uri)
                 }
                 (Prop::NavigateUri, PropValue::Unset, Handle::HyperlinkButton(h)) => {
-                    h.put_NavigateUri(None)
+                    h.SetNavigateUri(None)
                 }
                 (Prop::IsClosable, PropValue::Bool(v), Handle::TabViewItem(ti)) => {
-                    ti.put_IsClosable(*v)
+                    ti.SetIsClosable(*v)
                 }
                 // ContentDialog — modal popup hosted via ShowAsync.
                 (Prop::IsOpen, PropValue::Bool(v), Handle::ContentDialog(d)) => {
@@ -1264,13 +1262,12 @@ impl Backend for WinUIBackend {
                                     .as_ui_element()
                                     .cast::<bindings::IUIElement>()
                                     .ok()
-                                    .and_then(|u| u.get_XamlRoot().ok()),
+                                    .and_then(|u| u.XamlRoot().ok()),
                             })
                             .next();
                         match xroot {
                             Some(root) => {
-                                if let Err(e) =
-                                    d.cast::<bindings::IUIElement>()?.put_XamlRoot(&root)
+                                if let Err(e) = d.cast::<bindings::IUIElement>()?.SetXamlRoot(&root)
                                     && cfg!(debug_assertions)
                                 {
                                     eprintln!(
@@ -1300,23 +1297,23 @@ impl Backend for WinUIBackend {
                 }
                 (Prop::Value, PropValue::I32(v), Handle::InfoBadge(ib)) => {
                     if *v < 0 {
-                        ib.put_Value(-1)
+                        ib.SetValue(-1)
                     } else {
-                        ib.put_Value(*v)
+                        ib.SetValue(*v)
                     }
                 }
                 (Prop::DisplayName, PropValue::Unset, Handle::PersonPicture(p)) => {
-                    p.put_DisplayName("")
+                    p.SetDisplayName("")
                 }
-                (Prop::Initials, PropValue::Unset, Handle::PersonPicture(p)) => p.put_Initials(""),
+                (Prop::Initials, PropValue::Unset, Handle::PersonPicture(p)) => p.SetInitials(""),
                 (Prop::CornerRadius, PropValue::F64(v), Handle::Rectangle(r)) => {
-                    r.put_RadiusX(*v).and_then(|_| r.put_RadiusY(*v))
+                    r.SetRadiusX(*v).and_then(|_| r.SetRadiusY(*v))
                 }
                 (Prop::CornerRadius, PropValue::Unset, Handle::Rectangle(r)) => {
-                    r.put_RadiusX(0.0).and_then(|_| r.put_RadiusY(0.0))
+                    r.SetRadiusX(0.0).and_then(|_| r.SetRadiusY(0.0))
                 }
                 (Prop::CornerRadius, PropValue::F64(v), Handle::Border(b)) => {
-                    b.put_CornerRadius(bindings::CornerRadius {
+                    b.SetCornerRadius(bindings::CornerRadius {
                         top_left: *v,
                         top_right: *v,
                         bottom_right: *v,
@@ -1324,56 +1321,56 @@ impl Backend for WinUIBackend {
                     })
                 }
                 (Prop::CornerRadius, PropValue::Unset, Handle::Border(b)) => {
-                    b.put_CornerRadius(bindings::CornerRadius::default())
+                    b.SetCornerRadius(bindings::CornerRadius::default())
                 }
                 (Prop::BorderBrush, PropValue::Color(br), Handle::Border(b)) => {
-                    b.put_BorderBrush(&solid_brush(*br)?)
+                    b.SetBorderBrush(&solid_brush(*br)?)
                 }
-                (Prop::BorderBrush, PropValue::Unset, Handle::Border(b)) => b.put_BorderBrush(None),
+                (Prop::BorderBrush, PropValue::Unset, Handle::Border(b)) => b.SetBorderBrush(None),
                 (Prop::BorderBrush, _, h) => {
                     diag::unhandled_modifier("set_prop", Prop::BorderBrush, h);
                     Ok(())
                 }
                 (Prop::BorderThickness, PropValue::Thickness(t), Handle::Border(b)) => {
-                    b.put_BorderThickness(*t)
+                    b.SetBorderThickness(*t)
                 }
                 (Prop::BorderThickness, PropValue::Unset, Handle::Border(b)) => {
-                    b.put_BorderThickness(Thickness::default())
+                    b.SetBorderThickness(Thickness::default())
                 }
                 (Prop::BorderThickness, _, h) => {
                     diag::unhandled_modifier("set_prop", Prop::BorderThickness, h);
                     Ok(())
                 }
                 (Prop::LineEndpoints, PropValue::LineEndpoints(p), Handle::Line(l)) => l
-                    .put_X1(p.x1)
-                    .and_then(|_| l.put_Y1(p.y1))
-                    .and_then(|_| l.put_X2(p.x2))
-                    .and_then(|_| l.put_Y2(p.y2)),
+                    .SetX1(p.x1)
+                    .and_then(|_| l.SetY1(p.y1))
+                    .and_then(|_| l.SetX2(p.x2))
+                    .and_then(|_| l.SetY2(p.y2)),
                 (Prop::ImageSource, PropValue::Str(s), Handle::Image(img)) => {
                     let uri = bindings::Uri::CreateUri(s.as_str())?;
                     let bmp = bindings::BitmapImage::new()?;
-                    bmp.cast::<bindings::IBitmapImage>()?.put_UriSource(&uri)?;
-                    img.put_Source(&bmp.cast::<bindings::ImageSource>()?)
+                    bmp.cast::<bindings::IBitmapImage>()?.SetUriSource(&uri)?;
+                    img.SetSource(&bmp.cast::<bindings::ImageSource>()?)
                 }
                 (Prop::ImageSource, PropValue::SurfaceImageSource(sis), Handle::Image(img)) => {
-                    img.put_Source(&sis.image_source()?)
+                    img.SetSource(&sis.image_source()?)
                 }
-                (Prop::ImageSource, PropValue::Unset, Handle::Image(img)) => img.put_Source(None),
+                (Prop::ImageSource, PropValue::Unset, Handle::Image(img)) => img.SetSource(None),
                 (Prop::Header, PropValue::Str(s), Handle::TabViewItem(ti)) => {
                     let tb = string_as_textblock(s)?;
-                    ti.put_Header(&tb)
+                    ti.SetHeader(&tb)
                 }
                 (Prop::Header, PropValue::Str(s), Handle::Expander(e)) => {
                     let tb = string_as_textblock(s)?;
-                    e.put_Header(&tb)
+                    e.SetHeader(&tb)
                 }
-                (Prop::Header, PropValue::Unset, Handle::Expander(e)) => e.put_Header(None),
+                (Prop::Header, PropValue::Unset, Handle::Expander(e)) => e.SetHeader(None),
                 (Prop::ItemKey, PropValue::Str(s), Handle::TabViewItem(ti)) => {
                     let tag = windows_reference::IReference::from(s.as_str());
-                    ti.cast::<bindings::IFrameworkElement>()?.put_Tag(&tag)
+                    ti.cast::<bindings::IFrameworkElement>()?.SetTag(&tag)
                 }
                 (Prop::MenuItems, PropValue::NavMenuItems(items), Handle::NavigationView(nv)) => {
-                    let menu = nv.get_MenuItems()?;
+                    let menu = nv.MenuItems()?;
                     menu.Clear()?;
                     for item in items {
                         let nv_item = build_nav_view_item(item)?;
@@ -1385,25 +1382,25 @@ impl Backend for WinUIBackend {
                     select_nav_item_by_tag(nv, tag)
                 }
                 (Prop::SelectedTag, PropValue::Unset, Handle::NavigationView(nv)) => {
-                    nv.put_SelectedItem(None)
+                    nv.SetSelectedItem(None)
                 }
                 (Prop::AutoSuggestBox, PropValue::Bool(true), Handle::NavigationView(nv)) => {
                     let asb = bindings::AutoSuggestBox::new()?;
-                    nv.put_AutoSuggestBox(&asb)
+                    nv.SetAutoSuggestBox(&asb)
                 }
                 (Prop::AutoSuggestBox, PropValue::Bool(false), Handle::NavigationView(nv)) => {
-                    nv.put_AutoSuggestBox(None)
+                    nv.SetAutoSuggestBox(None)
                 }
                 (Prop::AutoSuggestPlaceholder, PropValue::Str(s), Handle::NavigationView(nv)) => {
-                    if let Ok(asb) = nv.get_AutoSuggestBox() {
-                        asb.put_PlaceholderText(s.as_str())?;
+                    if let Ok(asb) = nv.AutoSuggestBox() {
+                        asb.SetPlaceholderText(s.as_str())?;
                     }
                     Ok(())
                 }
                 (Prop::AutoSuggestItems, PropValue::StrList(items), Handle::NavigationView(nv)) => {
-                    if let Ok(asb) = nv.get_AutoSuggestBox() {
+                    if let Ok(asb) = nv.AutoSuggestBox() {
                         asb.cast::<bindings::IItemsControl>()?
-                            .put_ItemsSource(&str_list_as_ivector(items))?;
+                            .SetItemsSource(&str_list_as_ivector(items))?;
                     }
                     Ok(())
                 }
@@ -1418,58 +1415,56 @@ impl Backend for WinUIBackend {
                         bindings::NavigationViewBackButtonVisible::Collapsed
                     };
                     nv.cast::<bindings::INavigationView2>()?
-                        .put_IsBackButtonVisible(val)
+                        .SetIsBackButtonVisible(val)
                 }
                 (Prop::ItemHeader, PropValue::Str(s), Handle::PivotItem(pi)) => {
                     let tb = string_as_textblock(s)?;
-                    pi.put_Header(&tb)
+                    pi.SetHeader(&tb)
                 }
                 (Prop::Items, PropValue::StrList(items), Handle::BreadcrumbBar(bc)) => {
-                    bc.put_ItemsSource(&str_list_as_ivector(items))
+                    bc.SetItemsSource(&str_list_as_ivector(items))
                 }
                 (Prop::Value, PropValue::Str(s), Handle::PasswordBox(p)) => {
-                    if p.get_Password().ok().as_deref() == Some(s.as_str()) {
+                    if p.Password().ok().as_deref() == Some(s.as_str()) {
                         return Ok(());
                     }
-                    p.put_Password(s.as_str())
+                    p.SetPassword(s.as_str())
                 }
-                (Prop::Value, PropValue::Unset, Handle::PasswordBox(p)) => p.put_Password(""),
+                (Prop::Value, PropValue::Unset, Handle::PasswordBox(p)) => p.SetPassword(""),
                 (Prop::Items, PropValue::StrList(items), Handle::RadioButtons(r)) => {
-                    set_str_items(&r.get_Items()?.cast()?, items)
+                    set_str_items(&r.Items()?.cast()?, items)
                 }
                 (Prop::Items, PropValue::StrList(items), Handle::ComboBox(c)) => set_str_items(
-                    &c.cast::<bindings::IItemsControl>()?.get_Items()?.cast()?,
+                    &c.cast::<bindings::IItemsControl>()?.Items()?.cast()?,
                     items,
                 ),
-                (Prop::ColorValue, PropValue::Color(c), Handle::ColorPicker(cp)) => {
-                    cp.put_Color(*c)
-                }
+                (Prop::ColorValue, PropValue::Color(c), Handle::ColorPicker(cp)) => cp.SetColor(*c),
                 (Prop::Items, PropValue::StrList(items), Handle::ListBox(lb)) => set_str_items(
-                    &lb.cast::<bindings::IItemsControl>()?.get_Items()?.cast()?,
+                    &lb.cast::<bindings::IItemsControl>()?.Items()?.cast()?,
                     items,
                 ),
                 (Prop::Text, PropValue::Str(s), Handle::AutoSuggestBox(asb)) => {
                     // Skip SetText when the control already has this value —
                     // calling SetText during a user-initiated TextChanged
                     // cycle steals focus from the input field.
-                    if asb.get_Text().ok().as_deref() == Some(s.as_str()) {
+                    if asb.Text().ok().as_deref() == Some(s.as_str()) {
                         return Ok(());
                     }
-                    asb.put_Text(s)
+                    asb.SetText(s)
                 }
                 (Prop::Items, PropValue::StrList(items), Handle::AutoSuggestBox(asb)) => asb
                     .cast::<bindings::IItemsControl>()?
-                    .put_ItemsSource(&str_list_as_ivector(items)),
+                    .SetItemsSource(&str_list_as_ivector(items)),
                 (Prop::DisplayMode, PropValue::I32(m), Handle::SplitView(sv)) => {
-                    sv.put_DisplayMode(bindings::SplitViewDisplayMode(*m))
+                    sv.SetDisplayMode(bindings::SplitViewDisplayMode(*m))
                 }
                 (Prop::Items, PropValue::MenuBarItems(items), Handle::MenuBar(mb)) => {
-                    let winui_items = mb.get_Items()?;
+                    let winui_items = mb.Items()?;
                     winui_items.Clear()?;
                     for bar_item_def in items {
                         let mbi = bindings::MenuBarItem::new()?;
-                        mbi.put_Title(&bar_item_def.title)?;
-                        let flyout_items = mbi.get_Items()?;
+                        mbi.SetTitle(&bar_item_def.title)?;
+                        let flyout_items = mbi.Items()?;
                         for menu_def in &bar_item_def.items {
                             let fi = build_menu_flyout_item_base(menu_def)?;
                             flyout_items.Append(&fi)?;
@@ -1493,12 +1488,12 @@ impl Backend for WinUIBackend {
                     Handle::DropDownButton(btn),
                 ) => {
                     let flyout = bindings::MenuFlyout::new()?;
-                    let flyout_items = flyout.get_Items()?;
+                    let flyout_items = flyout.Items()?;
                     for def in items {
                         let fi = build_menu_flyout_item_base(def)?;
                         flyout_items.Append(&fi)?;
                     }
-                    btn.cast::<bindings::IButton>()?.put_Flyout(&flyout)?;
+                    btn.cast::<bindings::IButton>()?.SetFlyout(&flyout)?;
                     let handlers = self.menu_click_handlers.borrow();
                     if let Some(handler) = handlers.get(&id) {
                         let revs = Self::wire_flyout_clicks(&flyout, handler);
@@ -1512,12 +1507,12 @@ impl Backend for WinUIBackend {
                 }
                 (Prop::MenuFlyoutItems, PropValue::MenuFlyoutItems(items), Handle::Button(btn)) => {
                     let flyout = bindings::MenuFlyout::new()?;
-                    let flyout_items = flyout.get_Items()?;
+                    let flyout_items = flyout.Items()?;
                     for def in items {
                         let fi = build_menu_flyout_item_base(def)?;
                         flyout_items.Append(&fi)?;
                     }
-                    btn.put_Flyout(&flyout)?;
+                    btn.SetFlyout(&flyout)?;
                     let handlers = self.menu_click_handlers.borrow();
                     if let Some(handler) = handlers.get(&id) {
                         let revs = Self::wire_flyout_clicks(&flyout, handler);
@@ -1535,8 +1530,8 @@ impl Backend for WinUIBackend {
                     Handle::Button(btn),
                 ) => {
                     let flyout = bindings::CommandBarFlyout::new()?;
-                    let primary_cmds = flyout.get_PrimaryCommands()?;
-                    let secondary_cmds = flyout.get_SecondaryCommands()?;
+                    let primary_cmds = flyout.PrimaryCommands()?;
+                    let secondary_cmds = flyout.SecondaryCommands()?;
                     for def in primary {
                         let el = build_command_bar_element(def)?;
                         primary_cmds.Append(&el)?;
@@ -1545,7 +1540,7 @@ impl Backend for WinUIBackend {
                         let el = build_command_bar_element(def)?;
                         secondary_cmds.Append(&el)?;
                     }
-                    btn.put_Flyout(&flyout)?;
+                    btn.SetFlyout(&flyout)?;
                     let handlers = self.command_bar_flyout_handlers.borrow();
                     if let Some(handler) = handlers.get(&id) {
                         let mut revs = Self::wire_command_bar_clicks(&primary_cmds, handler);
@@ -1559,7 +1554,7 @@ impl Backend for WinUIBackend {
                     Ok(())
                 }
                 (Prop::Nodes, PropValue::TreeViewNodes(nodes), Handle::TreeView(tv)) => {
-                    let root = tv.get_RootNodes()?;
+                    let root = tv.RootNodes()?;
                     root.Clear()?;
                     for node_def in nodes {
                         let node = build_tree_view_node(node_def)?;
@@ -1572,7 +1567,7 @@ impl Backend for WinUIBackend {
                     PropValue::CommandBarCommands(cmds),
                     Handle::CommandBar(cb),
                 ) => {
-                    let primary = cb.get_PrimaryCommands()?;
+                    let primary = cb.PrimaryCommands()?;
                     primary.Clear()?;
                     for def in cmds {
                         let el = build_command_bar_element(def)?;
@@ -1594,7 +1589,7 @@ impl Backend for WinUIBackend {
                     PropValue::CommandBarCommands(cmds),
                     Handle::CommandBar(cb),
                 ) => {
-                    let secondary = cb.get_SecondaryCommands()?;
+                    let secondary = cb.SecondaryCommands()?;
                     secondary.Clear()?;
                     for def in cmds {
                         let el = build_command_bar_element(def)?;
@@ -1616,7 +1611,7 @@ impl Backend for WinUIBackend {
                             windows_core::HSTRING::from(s.as_str()),
                         )
                         .cast()?;
-                    tt.put_ActionButtonContent(&boxed)
+                    tt.SetActionButtonContent(&boxed)
                 }
                 (Prop::CloseButton, PropValue::Str(s), Handle::TeachingTip(tt)) => {
                     let boxed: windows_core::IInspectable =
@@ -1624,24 +1619,24 @@ impl Backend for WinUIBackend {
                             windows_core::HSTRING::from(s.as_str()),
                         )
                         .cast()?;
-                    tt.put_CloseButtonContent(&boxed)
+                    tt.SetCloseButtonContent(&boxed)
                 }
                 (Prop::Items, PropValue::SelectorBarItems(items), Handle::SelectorBar(sb)) => {
-                    let vec = sb.get_Items()?;
+                    let vec = sb.Items()?;
                     vec.Clear()?;
                     for def in items {
                         let item = bindings::SelectorBarItem::new()?;
-                        item.put_Text(&def.text)?;
+                        item.SetText(&def.text)?;
                         if let Some(sym) = &def.icon {
                             let icon_elem = bindings::SymbolIcon::CreateInstanceWithSymbol(*sym)?;
-                            item.put_Icon(&icon_elem)?;
+                            item.SetIcon(&icon_elem)?;
                         }
                         vec.Append(&item)?;
                     }
                     Ok(())
                 }
                 (Prop::Text, PropValue::Str(s), Handle::RichEditBox(reb)) => {
-                    let doc = reb.get_Document()?;
+                    let doc = reb.Document()?;
                     let mut current = windows_core::HSTRING::default();
                     doc.GetText(bindings::TextGetOptions::None, &mut current)
                         .ok();
@@ -1652,22 +1647,22 @@ impl Backend for WinUIBackend {
                 }
                 (Prop::Header, PropValue::Str(s), Handle::RichEditBox(reb)) => {
                     let tb = string_as_textblock(s)?;
-                    reb.put_Header(&tb)
+                    reb.SetHeader(&tb)
                 }
-                (Prop::Header, PropValue::Unset, Handle::RichEditBox(reb)) => reb.put_Header(None),
+                (Prop::Header, PropValue::Unset, Handle::RichEditBox(reb)) => reb.SetHeader(None),
                 (Prop::FlyoutContent, PropValue::Str(s), Handle::Button(b)) => {
                     let flyout = bindings::Flyout::new()?;
                     let tb = string_as_textblock(s)?;
-                    flyout.put_Content(&tb)?;
-                    b.put_Flyout(&flyout)?;
+                    flyout.SetContent(&tb)?;
+                    b.SetFlyout(&flyout)?;
                     Ok(())
                 }
                 (Prop::FlyoutPlacement, PropValue::I32(v), Handle::Button(b)) => {
                     // The flyout must already exist (FlyoutContent set first).
-                    if let Ok(fb) = b.get_Flyout() {
+                    if let Ok(fb) = b.Flyout() {
                         let _ = fb
                             .cast::<bindings::IFlyoutBase>()?
-                            .put_Placement(FlyoutPlacementMode(*v));
+                            .SetPlacement(FlyoutPlacementMode(*v));
                     }
                     Ok(())
                 }
@@ -1837,7 +1832,7 @@ impl Backend for WinUIBackend {
             ),
         };
         let items = items_control
-            .get_Items()
+            .Items()
             .unwrap()
             .cast::<windows_collections::IVector<windows_core::IInspectable>>()
             .unwrap();
@@ -1872,7 +1867,7 @@ impl Backend for WinUIBackend {
             Handle::FlipView(fv) => fv.cast().unwrap(),
             _ => return,
         };
-        let _ = selector.put_SelectedIndex(index);
+        let _ = selector.SetSelectedIndex(index);
     }
 
     fn set_templated_selection_mode(&mut self, id: ControlId, mode: SelectionMode) {
@@ -1891,7 +1886,7 @@ impl Backend for WinUIBackend {
             SelectionMode::Multiple => bindings::ListViewSelectionMode::Multiple,
             SelectionMode::Extended => bindings::ListViewSelectionMode::Extended,
         };
-        let _ = lvb.put_SelectionMode(winui_mode);
+        let _ = lvb.SetSelectionMode(winui_mode);
     }
 
     fn set_templated_can_drag_items(&mut self, id: ControlId, value: bool) {
@@ -1902,7 +1897,7 @@ impl Backend for WinUIBackend {
             Handle::GridView(gv) => gv.cast().unwrap(),
             _ => return,
         };
-        let _ = lvb.put_CanDragItems(value);
+        let _ = lvb.SetCanDragItems(value);
     }
 
     fn set_templated_can_reorder_items(&mut self, id: ControlId, value: bool) {
@@ -1913,7 +1908,7 @@ impl Backend for WinUIBackend {
             Handle::GridView(gv) => gv.cast().unwrap(),
             _ => return,
         };
-        let _ = lvb.put_CanReorderItems(value);
+        let _ = lvb.SetCanReorderItems(value);
     }
 
     fn set_templated_allow_drop(&mut self, id: ControlId, value: bool) {
@@ -1925,7 +1920,7 @@ impl Backend for WinUIBackend {
             Handle::FlipView(fv) => fv.cast().unwrap(),
             _ => return,
         };
-        let _ = ui.put_AllowDrop(value);
+        let _ = ui.SetAllowDrop(value);
     }
 
     fn set_header_element(&mut self, id: ControlId, header_id: Option<ControlId>) {
@@ -1935,19 +1930,19 @@ impl Backend for WinUIBackend {
             if let Some(hdr_id) = header_id {
                 if let Some(hdr_handle) = map.get(&hdr_id) {
                     let ui_elem = hdr_handle.as_ui_element();
-                    let _ = e.put_Header(&ui_elem);
+                    let _ = e.SetHeader(&ui_elem);
                 }
             } else {
-                let _ = e.put_Header(None);
+                let _ = e.SetHeader(None);
             }
         } else if let Handle::TitleBar(tb) = handle {
             if let Some(hdr_id) = header_id {
                 if let Some(hdr_handle) = map.get(&hdr_id) {
                     let ui_elem = hdr_handle.as_ui_element();
-                    let _ = tb.put_Content(&ui_elem);
+                    let _ = tb.SetContent(&ui_elem);
                 }
             } else {
-                let _ = tb.put_Content(None);
+                let _ = tb.SetContent(None);
             }
         }
     }
@@ -1959,19 +1954,19 @@ impl Backend for WinUIBackend {
             if let Some(pid) = pane_id {
                 if let Some(pane_handle) = map.get(&pid) {
                     let ui_elem = pane_handle.as_ui_element();
-                    let _ = sv.put_Pane(&ui_elem);
+                    let _ = sv.SetPane(&ui_elem);
                 }
             } else {
-                let _ = sv.put_Pane(None);
+                let _ = sv.SetPane(None);
             }
         } else if let Handle::TitleBar(tb) = handle {
             if let Some(pid) = pane_id {
                 if let Some(pane_handle) = map.get(&pid) {
                     let ui_elem = pane_handle.as_ui_element();
-                    let _ = tb.put_RightHeader(&ui_elem);
+                    let _ = tb.SetRightHeader(&ui_elem);
                 }
             } else {
-                let _ = tb.put_RightHeader(None);
+                let _ = tb.SetRightHeader(None);
             }
         }
     }
@@ -1991,7 +1986,7 @@ impl Backend for WinUIBackend {
                 let _ = fv
                     .cast::<bindings::ISelector>()
                     .unwrap()
-                    .put_SelectedIndex(index);
+                    .SetSelectedIndex(index);
                 None
             }
             _ => return,
@@ -2002,7 +1997,7 @@ impl Backend for WinUIBackend {
                 Handle::GridView(gv) => gv.cast().unwrap(),
                 _ => return,
             };
-            if let Ok(items) = items_control.get_Items()
+            if let Ok(items) = items_control.Items()
                 && let Ok(coll) =
                     items.cast::<windows_collections::IVector<windows_core::IInspectable>>()
             {
@@ -2033,7 +2028,7 @@ impl Backend for WinUIBackend {
                 let idx = sender
                     .as_ref()
                     .and_then(|s| s.cast::<bindings::ISelector>().ok())
-                    .and_then(|sel| sel.get_SelectedIndex().ok())
+                    .and_then(|sel| sel.SelectedIndex().ok())
                     .unwrap_or(-1);
                 handler.invoke(idx);
             })
@@ -2096,7 +2091,7 @@ impl Backend for WinUIBackend {
                     d.Closed(move |_sender, args| {
                         let result = args
                             .as_ref()
-                            .and_then(|a| a.get_Result().ok())
+                            .and_then(|a| a.Result().ok())
                             .unwrap_or(bindings::ContentDialogResult(0));
                         handler.invoke_i32(result.0);
                     })
@@ -2109,7 +2104,7 @@ impl Backend for WinUIBackend {
                         let idx = sender
                             .as_ref()
                             .and_then(|s| s.cast::<bindings::TabView>().ok())
-                            .and_then(|t| t.get_SelectedIndex().ok())
+                            .and_then(|t| t.SelectedIndex().ok())
                             .unwrap_or(-1);
                         if idx >= 0 {
                             handler.invoke_i32(idx);
@@ -2123,11 +2118,11 @@ impl Backend for WinUIBackend {
                     tv.TabCloseRequested(move |_sender, args| {
                         let key = args
                             .as_ref()
-                            .and_then(|a| a.get_Tab().ok())
+                            .and_then(|a| a.Tab().ok())
                             .and_then(|tab| {
                                 tab.cast::<bindings::IFrameworkElement>()
                                     .unwrap()
-                                    .get_Tag()
+                                    .Tag()
                                     .ok()
                             })
                             .and_then(|tag_obj| {
@@ -2151,14 +2146,14 @@ impl Backend for WinUIBackend {
                             .and_then(|a| {
                                 a.cast::<bindings::INavigationViewSelectionChangedEventArgs>()
                                     .unwrap()
-                                    .get_SelectedItem()
+                                    .SelectedItem()
                                     .ok()
                             })
                             .and_then(|item| item.cast::<bindings::NavigationViewItem>().ok())
                             .and_then(|nvi| {
                                 nvi.cast::<bindings::IFrameworkElement>()
                                     .unwrap()
-                                    .get_Tag()
+                                    .Tag()
                                     .ok()
                             })
                             .and_then(|tag_obj| {
@@ -2175,12 +2170,12 @@ impl Backend for WinUIBackend {
                 );
             }
             (Event::QuerySubmitted, Handle::NavigationView(nv)) => {
-                if let Ok(asb) = nv.get_AutoSuggestBox() {
+                if let Ok(asb) = nv.AutoSuggestBox() {
                     revokers.push(
                         asb.QuerySubmitted(move |_sender, args| {
                             let query = args
                                 .as_ref()
-                                .and_then(|a| a.get_QueryText().ok())
+                                .and_then(|a| a.QueryText().ok())
                                 .unwrap_or_default();
                             handler.invoke_string(query);
                         })
@@ -2189,12 +2184,12 @@ impl Backend for WinUIBackend {
                 }
             }
             (Event::TextChanged, Handle::NavigationView(nv)) => {
-                if let Ok(asb) = nv.get_AutoSuggestBox() {
+                if let Ok(asb) = nv.AutoSuggestBox() {
                     revokers.push(
                         asb.TextChanged(move |sender, _args| {
                             let text = sender
                                 .as_ref()
-                                .and_then(|s| s.get_Text().ok())
+                                .and_then(|s| s.Text().ok())
                                 .unwrap_or_default();
                             handler.invoke_string(text);
                         })
@@ -2203,12 +2198,12 @@ impl Backend for WinUIBackend {
                 }
             }
             (Event::SuggestionChosen, Handle::NavigationView(nv)) => {
-                if let Ok(asb) = nv.get_AutoSuggestBox() {
+                if let Ok(asb) = nv.AutoSuggestBox() {
                     revokers.push(
                         asb.SuggestionChosen(move |_sender, args| {
                             let item = args
                                 .as_ref()
-                                .and_then(|a| a.get_SelectedItem().ok())
+                                .and_then(|a| a.SelectedItem().ok())
                                 .and_then(|insp| {
                                     insp.cast::<windows_reference::IReference<
                                         windows_core::HSTRING,
@@ -2233,7 +2228,7 @@ impl Backend for WinUIBackend {
                             .and_then(|sel| {
                                 sel.cast::<bindings::ISelector>()
                                     .unwrap()
-                                    .get_SelectedIndex()
+                                    .SelectedIndex()
                                     .ok()
                             })
                             .unwrap_or(-1);
@@ -2255,7 +2250,7 @@ impl Backend for WinUIBackend {
                                 .and_then(|sel| {
                                     sel.cast::<bindings::ISelector>()
                                         .unwrap()
-                                        .get_SelectedIndex()
+                                        .SelectedIndex()
                                         .ok()
                                 })
                                 .unwrap_or(-1);
@@ -2269,7 +2264,7 @@ impl Backend for WinUIBackend {
                     cp.ColorChanged(move |_sender, args| {
                         let color =
                             args.as_ref()
-                                .and_then(|a| a.get_NewColor().ok())
+                                .and_then(|a| a.NewColor().ok())
                                 .unwrap_or(Color {
                                     a: 255,
                                     r: 0,
@@ -2285,7 +2280,7 @@ impl Backend for WinUIBackend {
                 revokers.push(
                     dp.SelectedDateChanged(move |_sender, args| {
                         if let Some(a) = args.as_ref()
-                            && let Ok(dt) = a.get_NewDate()
+                            && let Ok(dt) = a.NewDate()
                         {
                             handler.invoke_datetime(dt);
                         }
@@ -2297,7 +2292,7 @@ impl Backend for WinUIBackend {
                 revokers.push(
                     tp.SelectedTimeChanged(move |_sender, args| {
                         if let Some(a) = args.as_ref()
-                            && let Ok(ts) = a.get_NewTime()
+                            && let Ok(ts) = a.NewTime()
                         {
                             handler.invoke_timespan(TimeSpan::from_ticks(ts.duration));
                         }
@@ -2309,7 +2304,7 @@ impl Backend for WinUIBackend {
                 revokers.push(
                     cdp.DateChanged(move |_sender, args| {
                         if let Some(a) = args.as_ref()
-                            && let Ok(dt) = a.get_NewDate()
+                            && let Ok(dt) = a.NewDate()
                         {
                             handler.invoke_datetime(dt);
                         }
@@ -2325,7 +2320,7 @@ impl Backend for WinUIBackend {
                             if let Some(sel) = _sender.as_ref()
                                 && let Ok(idx) = sel
                                     .cast::<bindings::ISelector>()
-                                    .and_then(|s| s.get_SelectedIndex())
+                                    .and_then(|s| s.SelectedIndex())
                             {
                                 handler.invoke_i32(idx);
                             }
@@ -2339,14 +2334,14 @@ impl Backend for WinUIBackend {
                         // Only fire for user input, not programmatic changes.
                         let is_user_input = args
                             .as_ref()
-                            .and_then(|a| a.get_Reason().ok())
+                            .and_then(|a| a.Reason().ok())
                             .is_some_and(|r| {
                                 r == bindings::AutoSuggestionBoxTextChangeReason::UserInput
                             });
                         if is_user_input {
                             let text = sender
                                 .as_ref()
-                                .and_then(|s| s.get_Text().ok())
+                                .and_then(|s| s.Text().ok())
                                 .unwrap_or_default();
                             handler.invoke_string(text);
                         }
@@ -2359,7 +2354,7 @@ impl Backend for WinUIBackend {
                     asb.QuerySubmitted(move |_sender, args| {
                         let text = args
                             .as_ref()
-                            .and_then(|a| a.get_QueryText().ok())
+                            .and_then(|a| a.QueryText().ok())
                             .unwrap_or_default();
                         handler.invoke_string(text);
                     })
@@ -2371,7 +2366,7 @@ impl Backend for WinUIBackend {
                     asb.SuggestionChosen(move |_sender, args| {
                         let item = args
                             .as_ref()
-                            .and_then(|a| a.get_SelectedItem().ok())
+                            .and_then(|a| a.SelectedItem().ok())
                             .and_then(|insp| {
                                 insp.cast::<windows_reference::IReference<windows_core::HSTRING>>()
                                     .ok()
@@ -2407,11 +2402,11 @@ impl Backend for WinUIBackend {
                     tv.ItemInvoked(move |_sender, args| {
                         let text = args
                             .as_ref()
-                            .and_then(|a| a.get_InvokedItem().ok())
+                            .and_then(|a| a.InvokedItem().ok())
                             .and_then(|insp| {
                                 insp.cast::<bindings::ITreeViewNode>()
                                     .ok()
-                                    .and_then(|node| node.get_Content().ok())
+                                    .and_then(|node| node.Content().ok())
                             })
                             .and_then(|content| {
                                 content
@@ -2431,11 +2426,11 @@ impl Backend for WinUIBackend {
                 self.menu_click_handlers
                     .borrow_mut()
                     .insert(id, handler.clone());
-                if let Ok(primary) = cb.get_PrimaryCommands() {
+                if let Ok(primary) = cb.PrimaryCommands() {
                     let revs = Self::wire_command_bar_clicks(&primary, &handler);
                     revokers.extend(revs);
                 }
-                if let Ok(secondary) = cb.get_SecondaryCommands() {
+                if let Ok(secondary) = cb.SecondaryCommands() {
                     let revs = Self::wire_command_bar_clicks(&secondary, &handler);
                     revokers.extend(revs);
                 }
@@ -2444,8 +2439,8 @@ impl Backend for WinUIBackend {
                 let sb2 = sb.clone();
                 revokers.push(
                     sb.SelectionChanged(move |_sender, _args| {
-                        if let Ok(selected) = sb2.get_SelectedItem()
-                            && let Ok(text) = selected.get_Text()
+                        if let Ok(selected) = sb2.SelectedItem()
+                            && let Ok(text) = selected.Text()
                         {
                             handler.invoke_string(text);
                         }
@@ -2460,7 +2455,7 @@ impl Backend for WinUIBackend {
                             .as_ref()
                             .and_then(|s| s.cast::<bindings::RichEditBox>().ok())
                             .and_then(|reb| {
-                                let doc = reb.get_Document().ok()?;
+                                let doc = reb.Document().ok()?;
                                 let mut buf = windows_core::HSTRING::default();
                                 doc.GetText(bindings::TextGetOptions::None, &mut buf).ok()?;
                                 Some(buf.to_string_lossy())
@@ -2505,7 +2500,7 @@ impl Backend for WinUIBackend {
             if let Some(handle) = map.get(&id)
                 && let Some((_, fe)) = style_target_for_handle(handle)
             {
-                let _ = fe.put_Style(None);
+                let _ = fe.SetStyle(None);
             }
             return;
         }
@@ -2572,14 +2567,14 @@ impl Backend for WinUIBackend {
             Err(_) => return,
         };
         let vec: windows_collections::IVector<bindings::KeyboardAccelerator> =
-            match iue.get_KeyboardAccelerators() {
+            match iue.KeyboardAccelerators() {
                 Ok(v) => v,
                 Err(_) => return,
             };
         let _ = vec.Clear();
 
         // Suppress the default accelerator tooltip that WinUI would otherwise show.
-        let _ = iue.put_KeyboardAcceleratorPlacementMode(
+        let _ = iue.SetKeyboardAcceleratorPlacementMode(
             bindings::KeyboardAcceleratorPlacementMode::Hidden,
         );
 
@@ -2590,15 +2585,15 @@ impl Backend for WinUIBackend {
             let Ok(ika) = ka.cast::<bindings::IKeyboardAccelerator>() else {
                 continue;
             };
-            let _ = ika.put_Key(accel.key);
-            let _ = ika.put_Modifiers(accel.modifiers);
+            let _ = ika.SetKey(accel.key);
+            let _ = ika.SetModifiers(accel.modifiers);
             let cb = accel.on_invoked.clone();
             let _ = ika
                 .Invoked(move |_sender, args| {
                     if let Some(a) = args.as_ref()
                         && let Ok(ia) = a.cast::<bindings::IKeyboardAcceleratorInvokedEventArgs>()
                     {
-                        let _ = ia.put_Handled(true);
+                        let _ = ia.SetHandled(true);
                     }
                     cb.invoke(());
                 })
@@ -2650,13 +2645,13 @@ impl Backend for WinUIBackend {
         let Handle::RichTextBlock(rtb) = handle else {
             return;
         };
-        let Ok(blocks) = rtb.get_Blocks() else { return };
+        let Ok(blocks) = rtb.Blocks() else { return };
         let _ = blocks.Clear();
         for para_def in paragraphs {
             let Ok(para) = bindings::Paragraph::new() else {
                 continue;
             };
-            let Ok(inlines) = para.get_Inlines() else {
+            let Ok(inlines) = para.Inlines() else {
                 continue;
             };
             for inline in &para_def.inlines {
@@ -2665,10 +2660,10 @@ impl Backend for WinUIBackend {
                         let Ok(run) = bindings::Run::new() else {
                             continue;
                         };
-                        let _ = run.put_Text(&r.text);
+                        let _ = run.SetText(&r.text);
                         if r.is_bold {
                             let _ = run.cast::<bindings::ITextElement>().and_then(|te| {
-                                te.put_FontWeight(bindings::FontWeight { weight: 700 })
+                                te.SetFontWeight(bindings::FontWeight { weight: 700 })
                             });
                         }
                         let _ = run
@@ -2680,7 +2675,7 @@ impl Backend for WinUIBackend {
                         let Ok(run) = bindings::Run::new() else {
                             continue;
                         };
-                        let _ = run.put_Text("\n");
+                        let _ = run.SetText("\n");
                         let _ = run
                             .cast::<bindings::Inline>()
                             .and_then(|i| inlines.Append(&i));
@@ -2690,7 +2685,7 @@ impl Backend for WinUIBackend {
                         let Ok(run) = bindings::Run::new() else {
                             continue;
                         };
-                        let _ = run.put_Text(&h.text);
+                        let _ = run.SetText(&h.text);
                         let _ = run
                             .cast::<bindings::Inline>()
                             .and_then(|i| inlines.Append(&i));
@@ -2736,7 +2731,7 @@ impl Backend for WinUIBackend {
                     if let Some(ui) = mount_static_tooltip_element(elem)
                         && let Ok(cc) = tt.cast::<bindings::IContentControl>()
                     {
-                        let _ = cc.put_Content(&ui);
+                        let _ = cc.SetContent(&ui);
                     }
                     Some(tt.into())
                 }
@@ -2847,7 +2842,7 @@ impl Backend for WinUIBackend {
                     };
 
                     let formats = drag_event_args
-                        .get_DataView()
+                        .DataView()
                         .ok()
                         .and_then(|dv| dv.cast::<bindings::IDataPackageView>().ok())
                         .map(|data_package_view| read_available_formats(&data_package_view))
@@ -2917,13 +2912,12 @@ impl Backend for WinUIBackend {
                         return;
                     };
 
-                    let data_view =
-                        drag_event_args
-                            .get_DataView()
-                            .ok()
-                            .and_then(|data_package_view| {
-                                data_package_view.cast::<bindings::IDataPackageView>().ok()
-                            });
+                    let data_view = drag_event_args
+                        .DataView()
+                        .ok()
+                        .and_then(|data_package_view| {
+                            data_package_view.cast::<bindings::IDataPackageView>().ok()
+                        });
 
                     let formats = data_view
                         .as_ref()
@@ -2965,9 +2959,9 @@ impl Backend for WinUIBackend {
                                     (0..size)
                                         .filter_map(|i| v.GetAt(i).ok())
                                         .map(|item| DroppedItem {
-                                            path: item.get_Path().unwrap_or_default(),
-                                            name: item.get_Name().unwrap_or_default(),
-                                            is_folder: item.get_Attributes().is_ok_and(|attrs| {
+                                            path: item.Path().unwrap_or_default(),
+                                            name: item.Name().unwrap_or_default(),
+                                            is_folder: item.Attributes().is_ok_and(|attrs| {
                                                 attrs.contains(bindings::FileAttributes::Directory)
                                             }),
                                         })
@@ -3040,7 +3034,7 @@ struct AvailableFormats {
 
 fn read_available_formats(data_package_view: &bindings::IDataPackageView) -> AvailableFormats {
     let mut available_formats = AvailableFormats::default();
-    let Ok(formats) = data_package_view.get_AvailableFormats() else {
+    let Ok(formats) = data_package_view.AvailableFormats() else {
         return available_formats;
     };
 
@@ -3086,7 +3080,7 @@ fn build_drag_context(args: Option<&bindings::DragEventArgs>) -> DragContext {
     let Ok(iargs) = a.cast::<bindings::IDragEventArgs>() else {
         return ctx;
     };
-    let Ok(dv) = iargs.get_DataView() else {
+    let Ok(dv) = iargs.DataView() else {
         return ctx;
     };
     let Ok(idv) = dv.cast::<bindings::IDataPackageView>() else {
@@ -3118,10 +3112,10 @@ fn build_drag_context(args: Option<&bindings::DragEventArgs>) -> DragContext {
         (0..size)
             .filter_map(|i| items.GetAt(i).ok())
             .map(|item| DroppedItem {
-                path: item.get_Path().unwrap_or_default(),
-                name: item.get_Name().unwrap_or_default(),
+                path: item.Path().unwrap_or_default(),
+                name: item.Name().unwrap_or_default(),
                 is_folder: item
-                    .get_Attributes()
+                    .Attributes()
                     .is_ok_and(|a| a.contains(bindings::FileAttributes::Directory)),
             })
             .collect()
@@ -3172,20 +3166,20 @@ fn dispatch_accept(
                 DragOperation::Move => bindings::DataPackageOperation::Move,
                 DragOperation::Link => bindings::DataPackageOperation::Link,
             };
-            let _ = iargs.put_AcceptedOperation(accepted);
+            let _ = iargs.SetAcceptedOperation(accepted);
             if (ctx.caption.is_some()
                 || ctx.glyph_visible.is_some()
                 || ctx.content_visible.is_some())
-                && let Ok(ui) = iargs.get_DragUIOverride()
+                && let Ok(ui) = iargs.DragUIOverride()
             {
                 if let Some(v) = ctx.caption {
-                    let _ = ui.put_Caption(&v);
+                    let _ = ui.SetCaption(&v);
                 }
                 if let Some(v) = ctx.glyph_visible {
-                    let _ = ui.put_IsGlyphVisible(v);
+                    let _ = ui.SetIsGlyphVisible(v);
                 }
                 if let Some(v) = ctx.content_visible {
-                    let _ = ui.put_IsContentVisible(v);
+                    let _ = ui.SetIsContentVisible(v);
                 }
             }
         }
@@ -3226,19 +3220,19 @@ fn accept_or_reject<C: CallAccept>(cb: &C, args: Option<&bindings::DragEventArgs
         DragOperation::Move => bindings::DataPackageOperation::Move,
         DragOperation::Link => bindings::DataPackageOperation::Link,
     };
-    let _ = iargs.put_AcceptedOperation(accepted);
+    let _ = iargs.SetAcceptedOperation(accepted);
 
     if (ctx.caption.is_some() || ctx.glyph_visible.is_some() || ctx.content_visible.is_some())
-        && let Ok(ui) = iargs.get_DragUIOverride()
+        && let Ok(ui) = iargs.DragUIOverride()
     {
         if let Some(v) = ctx.caption {
-            let _ = ui.put_Caption(&v);
+            let _ = ui.SetCaption(&v);
         }
         if let Some(v) = ctx.glyph_visible {
-            let _ = ui.put_IsGlyphVisible(v);
+            let _ = ui.SetIsGlyphVisible(v);
         }
         if let Some(v) = ctx.content_visible {
-            let _ = ui.put_IsContentVisible(v);
+            let _ = ui.SetIsContentVisible(v);
         }
     }
 }
@@ -3269,15 +3263,15 @@ fn pointer_event_info(
     let Ok(ipoint) = point.cast::<bindings::IPointerPoint>() else {
         return info;
     };
-    let Ok(props) = ipoint.get_Properties() else {
+    let Ok(props) = ipoint.Properties() else {
         return info;
     };
     let Ok(iprops) = props.cast::<bindings::IPointerPointProperties>() else {
         return info;
     };
-    info.is_left_button_pressed = iprops.get_IsLeftButtonPressed().unwrap_or(false);
-    info.is_right_button_pressed = iprops.get_IsRightButtonPressed().unwrap_or(false);
-    info.is_middle_button_pressed = iprops.get_IsMiddleButtonPressed().unwrap_or(false);
+    info.is_left_button_pressed = iprops.IsLeftButtonPressed().unwrap_or(false);
+    info.is_right_button_pressed = iprops.IsRightButtonPressed().unwrap_or(false);
+    info.is_middle_button_pressed = iprops.IsMiddleButtonPressed().unwrap_or(false);
     info
 }
 
@@ -3299,17 +3293,17 @@ fn mount_static_tooltip_element(el: &Element) -> Option<bindings::UIElement> {
     match el {
         Element::TextBlock(t) => {
             let tb = bindings::TextBlock::new().ok()?;
-            tb.put_Text(t.text.as_str()).ok()?;
+            tb.SetText(t.text.as_str()).ok()?;
             tb.cast::<bindings::UIElement>().ok()
         }
         Element::StackPanel(s) => {
             let sp = bindings::StackPanel::new().ok()?;
-            sp.put_Orientation(s.orientation).ok()?;
-            sp.put_Spacing(s.spacing).ok()?;
+            sp.SetOrientation(s.orientation).ok()?;
+            sp.SetSpacing(s.spacing).ok()?;
             let children = sp
                 .cast::<bindings::IPanel>()
                 .ok()?
-                .get_Children()
+                .Children()
                 .ok()?
                 .cast::<windows_collections::IVector<bindings::UIElement>>()
                 .ok()?;
@@ -3328,16 +3322,16 @@ fn mount_static_tooltip_element(el: &Element) -> Option<bindings::UIElement> {
                         && let Ok(bmp) = bindings::BitmapImage::new()
                     {
                         if let Ok(ibmp) = bmp.cast::<bindings::IBitmapImage>() {
-                            let _ = ibmp.put_UriSource(&uri);
+                            let _ = ibmp.SetUriSource(&uri);
                         }
                         if let Ok(src) = bmp.cast::<bindings::ImageSource>() {
-                            let _ = i.put_Source(&src);
+                            let _ = i.SetSource(&src);
                         }
                     }
                 }
                 ImageSource::Surface(sis) => {
                     if let Ok(src) = sis.image_source() {
-                        let _ = i.put_Source(&src);
+                        let _ = i.SetSource(&src);
                     }
                 }
                 ImageSource::None => {}
@@ -3348,7 +3342,7 @@ fn mount_static_tooltip_element(el: &Element) -> Option<bindings::UIElement> {
             // Fallback: surface the kind_name so the developer sees a
             // hint rather than an empty popup.
             let tb = bindings::TextBlock::new().ok()?;
-            tb.put_Text(el.kind_name()).ok()?;
+            tb.SetText(el.kind_name()).ok()?;
             tb.cast::<bindings::UIElement>().ok()
         }
     }

--- a/crates/libs/reactor/src/bindings.rs
+++ b/crates/libs/reactor/src/bindings.rs
@@ -344,10 +344,10 @@ impl Application {
             windows_core::Type::from_abi(result__)
         })
     }
-    pub(crate) fn get_Current() -> windows_core::Result<Application> {
+    pub(crate) fn Current() -> windows_core::Result<Application> {
         Self::IApplicationStatics(|this| unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(this).get_Current)(
+            (windows_core::Interface::vtable(this).Current)(
                 windows_core::Interface::as_raw(this),
                 &mut result__,
             )
@@ -1961,7 +1961,7 @@ impl CompositionTarget {
         };
         Self::ICompositionTargetStatics(|this| unsafe {
             let mut result__ = core::mem::zeroed();
-            let token__ = (windows_core::Interface::vtable(this).add_Rendering)(
+            let token__ = (windows_core::Interface::vtable(this).Rendering)(
                 windows_core::Interface::as_raw(this),
                 windows_core::Interface::as_raw(&handler),
                 &mut result__,
@@ -1970,7 +1970,7 @@ impl CompositionTarget {
             Ok(windows_core::EventRevoker::new(
                 this.clone(),
                 token__,
-                windows_core::Interface::vtable(this).remove_Rendering,
+                windows_core::Interface::vtable(this).RemoveRendering,
             ))
         })
     }
@@ -3700,10 +3700,10 @@ impl windows_core::RuntimeType for IAppBarButton {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IAppBarButton {
-    pub(crate) fn get_Label(&self) -> windows_core::Result<String> {
+    pub(crate) fn Label(&self) -> windows_core::Result<String> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_Label)(
+            (windows_core::Interface::vtable(self).Label)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
@@ -3713,21 +3713,21 @@ impl IAppBarButton {
             })
         }
     }
-    pub(crate) fn put_Label(&self, value: &str) -> windows_core::Result<()> {
+    pub(crate) fn SetLabel(&self, value: &str) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Label)(
+            (windows_core::Interface::vtable(self).SetLabel)(
                 windows_core::Interface::as_raw(self),
                 core::mem::transmute_copy(&windows_core::HSTRING::from(value)),
             )
             .ok()
         }
     }
-    pub(crate) fn put_Icon<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetIcon<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<IconElement>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Icon)(
+            (windows_core::Interface::vtable(self).SetIcon)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
@@ -3738,16 +3738,16 @@ impl IAppBarButton {
 #[repr(C)]
 pub struct IAppBarButton_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    pub get_Label: unsafe extern "system" fn(
+    pub Label: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    pub put_Label: unsafe extern "system" fn(
+    pub SetLabel: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_Icon: usize,
-    pub put_Icon: unsafe extern "system" fn(
+    Icon: usize,
+    pub SetIcon: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
@@ -3813,21 +3813,21 @@ impl windows_core::RuntimeType for IAppBarToggleButton {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IAppBarToggleButton {
-    pub(crate) fn put_Label(&self, value: &str) -> windows_core::Result<()> {
+    pub(crate) fn SetLabel(&self, value: &str) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Label)(
+            (windows_core::Interface::vtable(self).SetLabel)(
                 windows_core::Interface::as_raw(self),
                 core::mem::transmute_copy(&windows_core::HSTRING::from(value)),
             )
             .ok()
         }
     }
-    pub(crate) fn put_Icon<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetIcon<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<IconElement>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Icon)(
+            (windows_core::Interface::vtable(self).SetIcon)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
@@ -3838,13 +3838,13 @@ impl IAppBarToggleButton {
 #[repr(C)]
 pub struct IAppBarToggleButton_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_Label: usize,
-    pub put_Label: unsafe extern "system" fn(
+    Label: usize,
+    pub SetLabel: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_Icon: usize,
-    pub put_Icon: unsafe extern "system" fn(
+    Icon: usize,
+    pub SetIcon: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
@@ -3878,30 +3878,30 @@ impl windows_core::RuntimeType for IAppWindow {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IAppWindow {
-    pub(crate) fn get_Presenter(&self) -> windows_core::Result<AppWindowPresenter> {
+    pub(crate) fn Presenter(&self) -> windows_core::Result<AppWindowPresenter> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_Presenter)(
+            (windows_core::Interface::vtable(self).Presenter)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
             .and_then(|| windows_core::Type::from_abi(result__))
         }
     }
-    pub(crate) fn get_Size(&self) -> windows_core::Result<SizeInt32> {
+    pub(crate) fn Size(&self) -> windows_core::Result<SizeInt32> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_Size)(
+            (windows_core::Interface::vtable(self).Size)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
             .map(|| result__)
         }
     }
-    pub(crate) fn get_TitleBar(&self) -> windows_core::Result<AppWindowTitleBar> {
+    pub(crate) fn TitleBar(&self) -> windows_core::Result<AppWindowTitleBar> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_TitleBar)(
+            (windows_core::Interface::vtable(self).TitleBar)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
@@ -3924,21 +3924,21 @@ impl IAppWindow {
 #[repr(C)]
 pub struct IAppWindow_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_Id: usize,
-    get_IsShownInSwitchers: usize,
-    put_IsShownInSwitchers: usize,
-    get_IsVisible: usize,
-    get_OwnerWindowId: usize,
-    get_Position: usize,
-    pub get_Presenter: unsafe extern "system" fn(
+    Id: usize,
+    IsShownInSwitchers: usize,
+    SetIsShownInSwitchers: usize,
+    IsVisible: usize,
+    OwnerWindowId: usize,
+    Position: usize,
+    pub Presenter: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    pub get_Size:
+    pub Size:
         unsafe extern "system" fn(*mut core::ffi::c_void, *mut SizeInt32) -> windows_core::HRESULT,
-    get_Title: usize,
-    put_Title: usize,
-    pub get_TitleBar: unsafe extern "system" fn(
+    Title: usize,
+    SetTitle: usize,
+    pub TitleBar: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
@@ -3966,10 +3966,10 @@ impl windows_core::RuntimeType for IAppWindow2 {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IAppWindow2 {
-    pub(crate) fn get_ClientSize(&self) -> windows_core::Result<SizeInt32> {
+    pub(crate) fn ClientSize(&self) -> windows_core::Result<SizeInt32> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_ClientSize)(
+            (windows_core::Interface::vtable(self).ClientSize)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
@@ -3989,7 +3989,7 @@ impl IAppWindow2 {
 #[repr(C)]
 pub struct IAppWindow2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    pub get_ClientSize:
+    pub ClientSize:
         unsafe extern "system" fn(*mut core::ffi::c_void, *mut SizeInt32) -> windows_core::HRESULT,
     MoveInZOrderAtBottom: usize,
     MoveInZOrderAtTop: usize,
@@ -4033,12 +4033,12 @@ impl windows_core::RuntimeType for IAppWindowTitleBar2 {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IAppWindowTitleBar2 {
-    pub(crate) fn put_PreferredHeightOption(
+    pub(crate) fn SetPreferredHeightOption(
         &self,
         value: TitleBarHeightOption,
     ) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_PreferredHeightOption)(
+            (windows_core::Interface::vtable(self).SetPreferredHeightOption)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
@@ -4049,8 +4049,8 @@ impl IAppWindowTitleBar2 {
 #[repr(C)]
 pub struct IAppWindowTitleBar2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_PreferredHeightOption: usize,
-    pub put_PreferredHeightOption: unsafe extern "system" fn(
+    PreferredHeightOption: usize,
+    pub SetPreferredHeightOption: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         TitleBarHeightOption,
     ) -> windows_core::HRESULT,
@@ -4065,9 +4065,9 @@ impl windows_core::RuntimeType for IAppWindowTitleBar3 {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IAppWindowTitleBar3 {
-    pub(crate) fn put_PreferredTheme(&self, value: TitleBarTheme) -> windows_core::Result<()> {
+    pub(crate) fn SetPreferredTheme(&self, value: TitleBarTheme) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_PreferredTheme)(
+            (windows_core::Interface::vtable(self).SetPreferredTheme)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
@@ -4078,8 +4078,8 @@ impl IAppWindowTitleBar3 {
 #[repr(C)]
 pub struct IAppWindowTitleBar3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_PreferredTheme: usize,
-    pub put_PreferredTheme:
+    PreferredTheme: usize,
+    pub SetPreferredTheme:
         unsafe extern "system" fn(*mut core::ffi::c_void, TitleBarTheme) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
@@ -4092,10 +4092,10 @@ impl windows_core::RuntimeType for IApplication {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IApplication {
-    pub(crate) fn get_Resources(&self) -> windows_core::Result<ResourceDictionary> {
+    pub(crate) fn Resources(&self) -> windows_core::Result<ResourceDictionary> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_Resources)(
+            (windows_core::Interface::vtable(self).Resources)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
@@ -4106,7 +4106,7 @@ impl IApplication {
 #[repr(C)]
 pub struct IApplication_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    pub get_Resources: unsafe extern "system" fn(
+    pub Resources: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
@@ -4209,7 +4209,7 @@ impl windows_core::RuntimeType for IApplicationStatics {
 #[repr(C)]
 pub struct IApplicationStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    pub get_Current: unsafe extern "system" fn(
+    pub Current: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
@@ -4228,10 +4228,10 @@ impl windows_core::RuntimeType for IAutoSuggestBox {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IAutoSuggestBox {
-    pub(crate) fn get_Text(&self) -> windows_core::Result<String> {
+    pub(crate) fn Text(&self) -> windows_core::Result<String> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_Text)(
+            (windows_core::Interface::vtable(self).Text)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
@@ -4241,30 +4241,30 @@ impl IAutoSuggestBox {
             })
         }
     }
-    pub(crate) fn put_Text(&self, value: &str) -> windows_core::Result<()> {
+    pub(crate) fn SetText(&self, value: &str) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Text)(
+            (windows_core::Interface::vtable(self).SetText)(
                 windows_core::Interface::as_raw(self),
                 core::mem::transmute_copy(&windows_core::HSTRING::from(value)),
             )
             .ok()
         }
     }
-    pub(crate) fn put_PlaceholderText(&self, value: &str) -> windows_core::Result<()> {
+    pub(crate) fn SetPlaceholderText(&self, value: &str) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_PlaceholderText)(
+            (windows_core::Interface::vtable(self).SetPlaceholderText)(
                 windows_core::Interface::as_raw(self),
                 core::mem::transmute_copy(&windows_core::HSTRING::from(value)),
             )
             .ok()
         }
     }
-    pub(crate) fn put_Header<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetHeader<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<windows_core::IInspectable>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Header)(
+            (windows_core::Interface::vtable(self).SetHeader)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
@@ -4298,7 +4298,7 @@ impl IAutoSuggestBox {
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
-            let token__ = (windows_core::Interface::vtable(self).add_SuggestionChosen)(
+            let token__ = (windows_core::Interface::vtable(self).SuggestionChosen)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Interface::as_raw(&handler),
                 &mut result__,
@@ -4307,7 +4307,7 @@ impl IAutoSuggestBox {
             Ok(windows_core::EventRevoker::new(
                 self.clone(),
                 token__,
-                windows_core::Interface::vtable(self).remove_SuggestionChosen,
+                windows_core::Interface::vtable(self).RemoveSuggestionChosen,
             ))
         }
     }
@@ -4327,7 +4327,7 @@ impl IAutoSuggestBox {
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
-            let token__ = (windows_core::Interface::vtable(self).add_TextChanged)(
+            let token__ = (windows_core::Interface::vtable(self).TextChanged)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Interface::as_raw(&handler),
                 &mut result__,
@@ -4336,7 +4336,7 @@ impl IAutoSuggestBox {
             Ok(windows_core::EventRevoker::new(
                 self.clone(),
                 token__,
-                windows_core::Interface::vtable(self).remove_TextChanged,
+                windows_core::Interface::vtable(self).RemoveTextChanged,
             ))
         }
     }
@@ -4356,7 +4356,7 @@ impl IAutoSuggestBox {
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
-            let token__ = (windows_core::Interface::vtable(self).add_QuerySubmitted)(
+            let token__ = (windows_core::Interface::vtable(self).QuerySubmitted)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Interface::as_raw(&handler),
                 &mut result__,
@@ -4365,7 +4365,7 @@ impl IAutoSuggestBox {
             Ok(windows_core::EventRevoker::new(
                 self.clone(),
                 token__,
-                windows_core::Interface::vtable(self).remove_QuerySubmitted,
+                windows_core::Interface::vtable(self).RemoveQuerySubmitted,
             ))
         }
     }
@@ -4373,62 +4373,62 @@ impl IAutoSuggestBox {
 #[repr(C)]
 pub struct IAutoSuggestBox_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_MaxSuggestionListHeight: usize,
-    put_MaxSuggestionListHeight: usize,
-    get_IsSuggestionListOpen: usize,
-    put_IsSuggestionListOpen: usize,
-    get_TextMemberPath: usize,
-    put_TextMemberPath: usize,
-    pub get_Text: unsafe extern "system" fn(
+    MaxSuggestionListHeight: usize,
+    SetMaxSuggestionListHeight: usize,
+    IsSuggestionListOpen: usize,
+    SetIsSuggestionListOpen: usize,
+    TextMemberPath: usize,
+    SetTextMemberPath: usize,
+    pub Text: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    pub put_Text: unsafe extern "system" fn(
+    pub SetText: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_UpdateTextOnSelect: usize,
-    put_UpdateTextOnSelect: usize,
-    get_PlaceholderText: usize,
-    pub put_PlaceholderText: unsafe extern "system" fn(
+    UpdateTextOnSelect: usize,
+    SetUpdateTextOnSelect: usize,
+    PlaceholderText: usize,
+    pub SetPlaceholderText: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_Header: usize,
-    pub put_Header: unsafe extern "system" fn(
+    Header: usize,
+    pub SetHeader: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_AutoMaximizeSuggestionArea: usize,
-    put_AutoMaximizeSuggestionArea: usize,
-    get_TextBoxStyle: usize,
-    put_TextBoxStyle: usize,
-    get_QueryIcon: usize,
-    put_QueryIcon: usize,
-    get_LightDismissOverlayMode: usize,
-    put_LightDismissOverlayMode: usize,
-    get_Description: usize,
-    put_Description: usize,
-    pub add_SuggestionChosen: unsafe extern "system" fn(
+    AutoMaximizeSuggestionArea: usize,
+    SetAutoMaximizeSuggestionArea: usize,
+    TextBoxStyle: usize,
+    SetTextBoxStyle: usize,
+    QueryIcon: usize,
+    SetQueryIcon: usize,
+    LightDismissOverlayMode: usize,
+    SetLightDismissOverlayMode: usize,
+    Description: usize,
+    SetDescription: usize,
+    pub SuggestionChosen: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         *mut i64,
     ) -> windows_core::HRESULT,
-    pub remove_SuggestionChosen:
+    pub RemoveSuggestionChosen:
         unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
-    pub add_TextChanged: unsafe extern "system" fn(
+    pub TextChanged: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         *mut i64,
     ) -> windows_core::HRESULT,
-    pub remove_TextChanged:
+    pub RemoveTextChanged:
         unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
-    pub add_QuerySubmitted: unsafe extern "system" fn(
+    pub QuerySubmitted: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         *mut i64,
     ) -> windows_core::HRESULT,
-    pub remove_QuerySubmitted:
+    pub RemoveQuerySubmitted:
         unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
@@ -4441,10 +4441,10 @@ impl windows_core::RuntimeType for IAutoSuggestBoxQuerySubmittedEventArgs {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IAutoSuggestBoxQuerySubmittedEventArgs {
-    pub(crate) fn get_QueryText(&self) -> windows_core::Result<String> {
+    pub(crate) fn QueryText(&self) -> windows_core::Result<String> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_QueryText)(
+            (windows_core::Interface::vtable(self).QueryText)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
@@ -4458,7 +4458,7 @@ impl IAutoSuggestBoxQuerySubmittedEventArgs {
 #[repr(C)]
 pub struct IAutoSuggestBoxQuerySubmittedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    pub get_QueryText: unsafe extern "system" fn(
+    pub QueryText: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
@@ -4473,10 +4473,10 @@ impl windows_core::RuntimeType for IAutoSuggestBoxSuggestionChosenEventArgs {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IAutoSuggestBoxSuggestionChosenEventArgs {
-    pub(crate) fn get_SelectedItem(&self) -> windows_core::Result<windows_core::IInspectable> {
+    pub(crate) fn SelectedItem(&self) -> windows_core::Result<windows_core::IInspectable> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_SelectedItem)(
+            (windows_core::Interface::vtable(self).SelectedItem)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
@@ -4487,7 +4487,7 @@ impl IAutoSuggestBoxSuggestionChosenEventArgs {
 #[repr(C)]
 pub struct IAutoSuggestBoxSuggestionChosenEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    pub get_SelectedItem: unsafe extern "system" fn(
+    pub SelectedItem: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
@@ -4502,10 +4502,10 @@ impl windows_core::RuntimeType for IAutoSuggestBoxTextChangedEventArgs {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IAutoSuggestBoxTextChangedEventArgs {
-    pub(crate) fn get_Reason(&self) -> windows_core::Result<AutoSuggestionBoxTextChangeReason> {
+    pub(crate) fn Reason(&self) -> windows_core::Result<AutoSuggestionBoxTextChangeReason> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_Reason)(
+            (windows_core::Interface::vtable(self).Reason)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
@@ -4516,7 +4516,7 @@ impl IAutoSuggestBoxTextChangedEventArgs {
 #[repr(C)]
 pub struct IAutoSuggestBoxTextChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    pub get_Reason: unsafe extern "system" fn(
+    pub Reason: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut AutoSuggestionBoxTextChangeReason,
     ) -> windows_core::HRESULT,
@@ -4546,96 +4546,96 @@ impl windows_core::RuntimeType for IAutomationPropertiesStatics {
 #[repr(C)]
 pub struct IAutomationPropertiesStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_AcceleratorKeyProperty: usize,
+    AcceleratorKeyProperty: usize,
     GetAcceleratorKey: usize,
     SetAcceleratorKey: usize,
-    get_AccessKeyProperty: usize,
+    AccessKeyProperty: usize,
     GetAccessKey: usize,
     SetAccessKey: usize,
-    get_AutomationIdProperty: usize,
+    AutomationIdProperty: usize,
     GetAutomationId: usize,
     pub SetAutomationId: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_HelpTextProperty: usize,
+    HelpTextProperty: usize,
     GetHelpText: usize,
     pub SetHelpText: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_IsRequiredForFormProperty: usize,
+    IsRequiredForFormProperty: usize,
     GetIsRequiredForForm: usize,
     SetIsRequiredForForm: usize,
-    get_ItemStatusProperty: usize,
+    ItemStatusProperty: usize,
     GetItemStatus: usize,
     SetItemStatus: usize,
-    get_ItemTypeProperty: usize,
+    ItemTypeProperty: usize,
     GetItemType: usize,
     SetItemType: usize,
-    get_LabeledByProperty: usize,
+    LabeledByProperty: usize,
     GetLabeledBy: usize,
     SetLabeledBy: usize,
-    get_NameProperty: usize,
+    NameProperty: usize,
     GetName: usize,
     pub SetName: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_LiveSettingProperty: usize,
+    LiveSettingProperty: usize,
     GetLiveSetting: usize,
     pub SetLiveSetting: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         AutomationLiveSetting,
     ) -> windows_core::HRESULT,
-    get_AccessibilityViewProperty: usize,
+    AccessibilityViewProperty: usize,
     GetAccessibilityView: usize,
     SetAccessibilityView: usize,
-    get_ControlledPeersProperty: usize,
+    ControlledPeersProperty: usize,
     GetControlledPeers: usize,
-    get_PositionInSetProperty: usize,
+    PositionInSetProperty: usize,
     GetPositionInSet: usize,
     SetPositionInSet: usize,
-    get_SizeOfSetProperty: usize,
+    SizeOfSetProperty: usize,
     GetSizeOfSet: usize,
     SetSizeOfSet: usize,
-    get_LevelProperty: usize,
+    LevelProperty: usize,
     GetLevel: usize,
     SetLevel: usize,
-    get_AnnotationsProperty: usize,
+    AnnotationsProperty: usize,
     GetAnnotations: usize,
-    get_LandmarkTypeProperty: usize,
+    LandmarkTypeProperty: usize,
     GetLandmarkType: usize,
     SetLandmarkType: usize,
-    get_LocalizedLandmarkTypeProperty: usize,
+    LocalizedLandmarkTypeProperty: usize,
     GetLocalizedLandmarkType: usize,
     SetLocalizedLandmarkType: usize,
-    get_IsPeripheralProperty: usize,
+    IsPeripheralProperty: usize,
     GetIsPeripheral: usize,
     SetIsPeripheral: usize,
-    get_IsDataValidForFormProperty: usize,
+    IsDataValidForFormProperty: usize,
     GetIsDataValidForForm: usize,
     SetIsDataValidForForm: usize,
-    get_FullDescriptionProperty: usize,
+    FullDescriptionProperty: usize,
     GetFullDescription: usize,
     SetFullDescription: usize,
-    get_LocalizedControlTypeProperty: usize,
+    LocalizedControlTypeProperty: usize,
     GetLocalizedControlType: usize,
     SetLocalizedControlType: usize,
-    get_DescribedByProperty: usize,
+    DescribedByProperty: usize,
     GetDescribedBy: usize,
-    get_FlowsToProperty: usize,
+    FlowsToProperty: usize,
     GetFlowsTo: usize,
-    get_FlowsFromProperty: usize,
+    FlowsFromProperty: usize,
     GetFlowsFrom: usize,
-    get_CultureProperty: usize,
+    CultureProperty: usize,
     GetCulture: usize,
     SetCulture: usize,
-    get_HeadingLevelProperty: usize,
+    HeadingLevelProperty: usize,
     GetHeadingLevel: usize,
     pub SetHeadingLevel: unsafe extern "system" fn(
         *mut core::ffi::c_void,
@@ -4653,12 +4653,12 @@ impl windows_core::RuntimeType for IBitmapImage {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IBitmapImage {
-    pub(crate) fn put_UriSource<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetUriSource<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<Uri>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_UriSource)(
+            (windows_core::Interface::vtable(self).SetUriSource)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
@@ -4669,10 +4669,10 @@ impl IBitmapImage {
 #[repr(C)]
 pub struct IBitmapImage_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_CreateOptions: usize,
-    put_CreateOptions: usize,
-    get_UriSource: usize,
-    pub put_UriSource: unsafe extern "system" fn(
+    CreateOptions: usize,
+    SetCreateOptions: usize,
+    UriSource: usize,
+    pub SetUriSource: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
@@ -4709,63 +4709,63 @@ impl windows_core::RuntimeType for IBorder {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IBorder {
-    pub(crate) fn put_BorderBrush<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetBorderBrush<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<Brush>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_BorderBrush)(
+            (windows_core::Interface::vtable(self).SetBorderBrush)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
             .ok()
         }
     }
-    pub(crate) fn put_BorderThickness(&self, value: Thickness) -> windows_core::Result<()> {
+    pub(crate) fn SetBorderThickness(&self, value: Thickness) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_BorderThickness)(
+            (windows_core::Interface::vtable(self).SetBorderThickness)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_Background<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetBackground<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<Brush>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Background)(
+            (windows_core::Interface::vtable(self).SetBackground)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
             .ok()
         }
     }
-    pub(crate) fn put_CornerRadius(&self, value: CornerRadius) -> windows_core::Result<()> {
+    pub(crate) fn SetCornerRadius(&self, value: CornerRadius) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_CornerRadius)(
+            (windows_core::Interface::vtable(self).SetCornerRadius)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_Padding(&self, value: Thickness) -> windows_core::Result<()> {
+    pub(crate) fn SetPadding(&self, value: Thickness) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Padding)(
+            (windows_core::Interface::vtable(self).SetPadding)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_Child<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetChild<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<UIElement>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Child)(
+            (windows_core::Interface::vtable(self).SetChild)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
@@ -4776,29 +4776,29 @@ impl IBorder {
 #[repr(C)]
 pub struct IBorder_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_BorderBrush: usize,
-    pub put_BorderBrush: unsafe extern "system" fn(
+    BorderBrush: usize,
+    pub SetBorderBrush: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_BorderThickness: usize,
-    pub put_BorderThickness:
+    BorderThickness: usize,
+    pub SetBorderThickness:
         unsafe extern "system" fn(*mut core::ffi::c_void, Thickness) -> windows_core::HRESULT,
-    get_Background: usize,
-    pub put_Background: unsafe extern "system" fn(
+    Background: usize,
+    pub SetBackground: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_BackgroundSizing: usize,
-    put_BackgroundSizing: usize,
-    get_CornerRadius: usize,
-    pub put_CornerRadius:
+    BackgroundSizing: usize,
+    SetBackgroundSizing: usize,
+    CornerRadius: usize,
+    pub SetCornerRadius:
         unsafe extern "system" fn(*mut core::ffi::c_void, CornerRadius) -> windows_core::HRESULT,
-    get_Padding: usize,
-    pub put_Padding:
+    Padding: usize,
+    pub SetPadding:
         unsafe extern "system" fn(*mut core::ffi::c_void, Thickness) -> windows_core::HRESULT,
-    get_Child: usize,
-    pub put_Child: unsafe extern "system" fn(
+    Child: usize,
+    pub SetChild: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
@@ -4813,12 +4813,12 @@ impl windows_core::RuntimeType for IBreadcrumbBar {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IBreadcrumbBar {
-    pub(crate) fn put_ItemsSource<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetItemsSource<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<windows_core::IInspectable>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_ItemsSource)(
+            (windows_core::Interface::vtable(self).SetItemsSource)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
@@ -4841,7 +4841,7 @@ impl IBreadcrumbBar {
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
-            let token__ = (windows_core::Interface::vtable(self).add_ItemClicked)(
+            let token__ = (windows_core::Interface::vtable(self).ItemClicked)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Interface::as_raw(&handler),
                 &mut result__,
@@ -4850,7 +4850,7 @@ impl IBreadcrumbBar {
             Ok(windows_core::EventRevoker::new(
                 self.clone(),
                 token__,
-                windows_core::Interface::vtable(self).remove_ItemClicked,
+                windows_core::Interface::vtable(self).RemoveItemClicked,
             ))
         }
     }
@@ -4858,19 +4858,19 @@ impl IBreadcrumbBar {
 #[repr(C)]
 pub struct IBreadcrumbBar_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_ItemsSource: usize,
-    pub put_ItemsSource: unsafe extern "system" fn(
+    ItemsSource: usize,
+    pub SetItemsSource: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_ItemTemplate: usize,
-    put_ItemTemplate: usize,
-    pub add_ItemClicked: unsafe extern "system" fn(
+    ItemTemplate: usize,
+    SetItemTemplate: usize,
+    pub ItemClicked: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         *mut i64,
     ) -> windows_core::HRESULT,
-    pub remove_ItemClicked:
+    pub RemoveItemClicked:
         unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
@@ -4902,10 +4902,10 @@ impl windows_core::RuntimeType for IBreadcrumbBarItemClickedEventArgs {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IBreadcrumbBarItemClickedEventArgs {
-    pub(crate) fn get_Index(&self) -> windows_core::Result<i32> {
+    pub(crate) fn Index(&self) -> windows_core::Result<i32> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_Index)(
+            (windows_core::Interface::vtable(self).Index)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
@@ -4916,8 +4916,7 @@ impl IBreadcrumbBarItemClickedEventArgs {
 #[repr(C)]
 pub struct IBreadcrumbBarItemClickedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    pub get_Index:
-        unsafe extern "system" fn(*mut core::ffi::c_void, *mut i32) -> windows_core::HRESULT,
+    pub Index: unsafe extern "system" fn(*mut core::ffi::c_void, *mut i32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBrush, IBrush_Vtbl, 0x2de3cb83_1329_5679_88f8_c822bc5442cb);
 impl windows_core::RuntimeType for IBrush {
@@ -4938,22 +4937,22 @@ impl windows_core::RuntimeType for IButton {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IButton {
-    pub(crate) fn get_Flyout(&self) -> windows_core::Result<FlyoutBase> {
+    pub(crate) fn Flyout(&self) -> windows_core::Result<FlyoutBase> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_Flyout)(
+            (windows_core::Interface::vtable(self).Flyout)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
             .and_then(|| windows_core::Type::from_abi(result__))
         }
     }
-    pub(crate) fn put_Flyout<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetFlyout<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<FlyoutBase>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Flyout)(
+            (windows_core::Interface::vtable(self).SetFlyout)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
@@ -4964,11 +4963,11 @@ impl IButton {
 #[repr(C)]
 pub struct IButton_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    pub get_Flyout: unsafe extern "system" fn(
+    pub Flyout: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    pub put_Flyout: unsafe extern "system" fn(
+    pub SetFlyout: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
@@ -4997,7 +4996,7 @@ impl IButtonBase {
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
-            let token__ = (windows_core::Interface::vtable(self).add_Click)(
+            let token__ = (windows_core::Interface::vtable(self).Click)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Interface::as_raw(&handler),
                 &mut result__,
@@ -5006,7 +5005,7 @@ impl IButtonBase {
             Ok(windows_core::EventRevoker::new(
                 self.clone(),
                 token__,
-                windows_core::Interface::vtable(self).remove_Click,
+                windows_core::Interface::vtable(self).RemoveClick,
             ))
         }
     }
@@ -5014,20 +5013,20 @@ impl IButtonBase {
 #[repr(C)]
 pub struct IButtonBase_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_ClickMode: usize,
-    put_ClickMode: usize,
-    get_IsPointerOver: usize,
-    get_IsPressed: usize,
-    get_Command: usize,
-    put_Command: usize,
-    get_CommandParameter: usize,
-    put_CommandParameter: usize,
-    pub add_Click: unsafe extern "system" fn(
+    ClickMode: usize,
+    SetClickMode: usize,
+    IsPointerOver: usize,
+    IsPressed: usize,
+    Command: usize,
+    SetCommand: usize,
+    CommandParameter: usize,
+    SetCommandParameter: usize,
+    pub Click: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         *mut i64,
     ) -> windows_core::HRESULT,
-    pub remove_Click:
+    pub RemoveClick:
         unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
@@ -5059,39 +5058,39 @@ impl windows_core::RuntimeType for ICalendarDatePicker {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl ICalendarDatePicker {
-    pub(crate) fn put_IsCalendarOpen(&self, value: bool) -> windows_core::Result<()> {
+    pub(crate) fn SetIsCalendarOpen(&self, value: bool) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_IsCalendarOpen)(
+            (windows_core::Interface::vtable(self).SetIsCalendarOpen)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_PlaceholderText(&self, value: &str) -> windows_core::Result<()> {
+    pub(crate) fn SetPlaceholderText(&self, value: &str) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_PlaceholderText)(
+            (windows_core::Interface::vtable(self).SetPlaceholderText)(
                 windows_core::Interface::as_raw(self),
                 core::mem::transmute_copy(&windows_core::HSTRING::from(value)),
             )
             .ok()
         }
     }
-    pub(crate) fn put_Header<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetHeader<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<windows_core::IInspectable>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Header)(
+            (windows_core::Interface::vtable(self).SetHeader)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
             .ok()
         }
     }
-    pub(crate) fn put_IsTodayHighlighted(&self, value: bool) -> windows_core::Result<()> {
+    pub(crate) fn SetIsTodayHighlighted(&self, value: bool) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_IsTodayHighlighted)(
+            (windows_core::Interface::vtable(self).SetIsTodayHighlighted)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
@@ -5124,7 +5123,7 @@ impl ICalendarDatePicker {
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
-            let token__ = (windows_core::Interface::vtable(self).add_DateChanged)(
+            let token__ = (windows_core::Interface::vtable(self).DateChanged)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Interface::as_raw(&handler),
                 &mut result__,
@@ -5133,7 +5132,7 @@ impl ICalendarDatePicker {
             Ok(windows_core::EventRevoker::new(
                 self.clone(),
                 token__,
-                windows_core::Interface::vtable(self).remove_DateChanged,
+                windows_core::Interface::vtable(self).RemoveDateChanged,
             ))
         }
     }
@@ -5141,58 +5140,58 @@ impl ICalendarDatePicker {
 #[repr(C)]
 pub struct ICalendarDatePicker_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_Date: usize,
-    put_Date: usize,
-    get_IsCalendarOpen: usize,
-    pub put_IsCalendarOpen:
+    Date: usize,
+    SetDate: usize,
+    IsCalendarOpen: usize,
+    pub SetIsCalendarOpen:
         unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
-    get_DateFormat: usize,
-    put_DateFormat: usize,
-    get_PlaceholderText: usize,
-    pub put_PlaceholderText: unsafe extern "system" fn(
+    DateFormat: usize,
+    SetDateFormat: usize,
+    PlaceholderText: usize,
+    pub SetPlaceholderText: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_Header: usize,
-    pub put_Header: unsafe extern "system" fn(
+    Header: usize,
+    pub SetHeader: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_HeaderTemplate: usize,
-    put_HeaderTemplate: usize,
-    get_CalendarViewStyle: usize,
-    put_CalendarViewStyle: usize,
-    get_LightDismissOverlayMode: usize,
-    put_LightDismissOverlayMode: usize,
-    get_Description: usize,
-    put_Description: usize,
-    get_MinDate: usize,
-    put_MinDate: usize,
-    get_MaxDate: usize,
-    put_MaxDate: usize,
-    get_IsTodayHighlighted: usize,
-    pub put_IsTodayHighlighted:
+    HeaderTemplate: usize,
+    SetHeaderTemplate: usize,
+    CalendarViewStyle: usize,
+    SetCalendarViewStyle: usize,
+    LightDismissOverlayMode: usize,
+    SetLightDismissOverlayMode: usize,
+    Description: usize,
+    SetDescription: usize,
+    MinDate: usize,
+    SetMinDate: usize,
+    MaxDate: usize,
+    SetMaxDate: usize,
+    IsTodayHighlighted: usize,
+    pub SetIsTodayHighlighted:
         unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
-    get_DisplayMode: usize,
-    put_DisplayMode: usize,
-    get_FirstDayOfWeek: usize,
-    put_FirstDayOfWeek: usize,
-    get_DayOfWeekFormat: usize,
-    put_DayOfWeekFormat: usize,
-    get_CalendarIdentifier: usize,
-    put_CalendarIdentifier: usize,
-    get_IsOutOfScopeEnabled: usize,
-    put_IsOutOfScopeEnabled: usize,
-    get_IsGroupLabelVisible: usize,
-    put_IsGroupLabelVisible: usize,
-    add_CalendarViewDayItemChanging: usize,
-    remove_CalendarViewDayItemChanging: usize,
-    pub add_DateChanged: unsafe extern "system" fn(
+    DisplayMode: usize,
+    SetDisplayMode: usize,
+    FirstDayOfWeek: usize,
+    SetFirstDayOfWeek: usize,
+    DayOfWeekFormat: usize,
+    SetDayOfWeekFormat: usize,
+    CalendarIdentifier: usize,
+    SetCalendarIdentifier: usize,
+    IsOutOfScopeEnabled: usize,
+    SetIsOutOfScopeEnabled: usize,
+    IsGroupLabelVisible: usize,
+    SetIsGroupLabelVisible: usize,
+    CalendarViewDayItemChanging: usize,
+    RemoveCalendarViewDayItemChanging: usize,
+    pub DateChanged: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         *mut i64,
     ) -> windows_core::HRESULT,
-    pub remove_DateChanged:
+    pub RemoveDateChanged:
         unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
@@ -5205,10 +5204,10 @@ impl windows_core::RuntimeType for ICalendarDatePickerDateChangedEventArgs {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl ICalendarDatePickerDateChangedEventArgs {
-    pub(crate) fn get_NewDate(&self) -> windows_core::Result<windows_time::DateTime> {
+    pub(crate) fn NewDate(&self) -> windows_core::Result<windows_time::DateTime> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_NewDate)(
+            (windows_core::Interface::vtable(self).NewDate)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
@@ -5220,7 +5219,7 @@ impl ICalendarDatePickerDateChangedEventArgs {
 #[repr(C)]
 pub struct ICalendarDatePickerDateChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    pub get_NewDate: unsafe extern "system" fn(
+    pub NewDate: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
@@ -5254,18 +5253,18 @@ impl windows_core::RuntimeType for ICalendarView {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl ICalendarView {
-    pub(crate) fn put_IsGroupLabelVisible(&self, value: bool) -> windows_core::Result<()> {
+    pub(crate) fn SetIsGroupLabelVisible(&self, value: bool) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_IsGroupLabelVisible)(
+            (windows_core::Interface::vtable(self).SetIsGroupLabelVisible)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_IsTodayHighlighted(&self, value: bool) -> windows_core::Result<()> {
+    pub(crate) fn SetIsTodayHighlighted(&self, value: bool) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_IsTodayHighlighted)(
+            (windows_core::Interface::vtable(self).SetIsTodayHighlighted)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
@@ -5299,7 +5298,7 @@ impl ICalendarView {
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
-            let token__ = (windows_core::Interface::vtable(self).add_SelectedDatesChanged)(
+            let token__ = (windows_core::Interface::vtable(self).SelectedDatesChanged)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Interface::as_raw(&handler),
                 &mut result__,
@@ -5308,7 +5307,7 @@ impl ICalendarView {
             Ok(windows_core::EventRevoker::new(
                 self.clone(),
                 token__,
-                windows_core::Interface::vtable(self).remove_SelectedDatesChanged,
+                windows_core::Interface::vtable(self).RemoveSelectedDatesChanged,
             ))
         }
     }
@@ -5316,164 +5315,164 @@ impl ICalendarView {
 #[repr(C)]
 pub struct ICalendarView_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_CalendarIdentifier: usize,
-    put_CalendarIdentifier: usize,
-    get_DayOfWeekFormat: usize,
-    put_DayOfWeekFormat: usize,
-    get_IsGroupLabelVisible: usize,
-    pub put_IsGroupLabelVisible:
+    CalendarIdentifier: usize,
+    SetCalendarIdentifier: usize,
+    DayOfWeekFormat: usize,
+    SetDayOfWeekFormat: usize,
+    IsGroupLabelVisible: usize,
+    pub SetIsGroupLabelVisible:
         unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
-    get_DisplayMode: usize,
-    put_DisplayMode: usize,
-    get_FirstDayOfWeek: usize,
-    put_FirstDayOfWeek: usize,
-    get_IsOutOfScopeEnabled: usize,
-    put_IsOutOfScopeEnabled: usize,
-    get_IsTodayHighlighted: usize,
-    pub put_IsTodayHighlighted:
+    DisplayMode: usize,
+    SetDisplayMode: usize,
+    FirstDayOfWeek: usize,
+    SetFirstDayOfWeek: usize,
+    IsOutOfScopeEnabled: usize,
+    SetIsOutOfScopeEnabled: usize,
+    IsTodayHighlighted: usize,
+    pub SetIsTodayHighlighted:
         unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
-    get_MaxDate: usize,
-    put_MaxDate: usize,
-    get_MinDate: usize,
-    put_MinDate: usize,
-    get_NumberOfWeeksInView: usize,
-    put_NumberOfWeeksInView: usize,
-    get_SelectedDates: usize,
-    get_SelectionMode: usize,
-    put_SelectionMode: usize,
-    get_TemplateSettings: usize,
-    get_FocusBorderBrush: usize,
-    put_FocusBorderBrush: usize,
-    get_SelectedHoverBorderBrush: usize,
-    put_SelectedHoverBorderBrush: usize,
-    get_SelectedPressedBorderBrush: usize,
-    put_SelectedPressedBorderBrush: usize,
-    get_SelectedDisabledBorderBrush: usize,
-    put_SelectedDisabledBorderBrush: usize,
-    get_SelectedBorderBrush: usize,
-    put_SelectedBorderBrush: usize,
-    get_HoverBorderBrush: usize,
-    put_HoverBorderBrush: usize,
-    get_PressedBorderBrush: usize,
-    put_PressedBorderBrush: usize,
-    get_TodaySelectedInnerBorderBrush: usize,
-    put_TodaySelectedInnerBorderBrush: usize,
-    get_BlackoutStrikethroughBrush: usize,
-    put_BlackoutStrikethroughBrush: usize,
-    get_CalendarItemBorderBrush: usize,
-    put_CalendarItemBorderBrush: usize,
-    get_BlackoutBackground: usize,
-    put_BlackoutBackground: usize,
-    get_OutOfScopeBackground: usize,
-    put_OutOfScopeBackground: usize,
-    get_CalendarItemBackground: usize,
-    put_CalendarItemBackground: usize,
-    get_CalendarItemHoverBackground: usize,
-    put_CalendarItemHoverBackground: usize,
-    get_CalendarItemPressedBackground: usize,
-    put_CalendarItemPressedBackground: usize,
-    get_CalendarItemDisabledBackground: usize,
-    put_CalendarItemDisabledBackground: usize,
-    get_TodayBackground: usize,
-    put_TodayBackground: usize,
-    get_TodayBlackoutBackground: usize,
-    put_TodayBlackoutBackground: usize,
-    get_TodayHoverBackground: usize,
-    put_TodayHoverBackground: usize,
-    get_TodayPressedBackground: usize,
-    put_TodayPressedBackground: usize,
-    get_TodayDisabledBackground: usize,
-    put_TodayDisabledBackground: usize,
-    get_PressedForeground: usize,
-    put_PressedForeground: usize,
-    get_TodayForeground: usize,
-    put_TodayForeground: usize,
-    get_BlackoutForeground: usize,
-    put_BlackoutForeground: usize,
-    get_TodayBlackoutForeground: usize,
-    put_TodayBlackoutForeground: usize,
-    get_SelectedForeground: usize,
-    put_SelectedForeground: usize,
-    get_SelectedHoverForeground: usize,
-    put_SelectedHoverForeground: usize,
-    get_SelectedPressedForeground: usize,
-    put_SelectedPressedForeground: usize,
-    get_SelectedDisabledForeground: usize,
-    put_SelectedDisabledForeground: usize,
-    get_OutOfScopeForeground: usize,
-    put_OutOfScopeForeground: usize,
-    get_OutOfScopeHoverForeground: usize,
-    put_OutOfScopeHoverForeground: usize,
-    get_OutOfScopePressedForeground: usize,
-    put_OutOfScopePressedForeground: usize,
-    get_CalendarItemForeground: usize,
-    put_CalendarItemForeground: usize,
-    get_DisabledForeground: usize,
-    put_DisabledForeground: usize,
-    get_DayItemFontFamily: usize,
-    put_DayItemFontFamily: usize,
-    get_DayItemFontSize: usize,
-    put_DayItemFontSize: usize,
-    get_DayItemFontStyle: usize,
-    put_DayItemFontStyle: usize,
-    get_DayItemFontWeight: usize,
-    put_DayItemFontWeight: usize,
-    get_TodayFontWeight: usize,
-    put_TodayFontWeight: usize,
-    get_FirstOfMonthLabelFontFamily: usize,
-    put_FirstOfMonthLabelFontFamily: usize,
-    get_FirstOfMonthLabelFontSize: usize,
-    put_FirstOfMonthLabelFontSize: usize,
-    get_FirstOfMonthLabelFontStyle: usize,
-    put_FirstOfMonthLabelFontStyle: usize,
-    get_FirstOfMonthLabelFontWeight: usize,
-    put_FirstOfMonthLabelFontWeight: usize,
-    get_MonthYearItemFontFamily: usize,
-    put_MonthYearItemFontFamily: usize,
-    get_MonthYearItemFontSize: usize,
-    put_MonthYearItemFontSize: usize,
-    get_MonthYearItemFontStyle: usize,
-    put_MonthYearItemFontStyle: usize,
-    get_MonthYearItemFontWeight: usize,
-    put_MonthYearItemFontWeight: usize,
-    get_FirstOfYearDecadeLabelFontFamily: usize,
-    put_FirstOfYearDecadeLabelFontFamily: usize,
-    get_FirstOfYearDecadeLabelFontSize: usize,
-    put_FirstOfYearDecadeLabelFontSize: usize,
-    get_FirstOfYearDecadeLabelFontStyle: usize,
-    put_FirstOfYearDecadeLabelFontStyle: usize,
-    get_FirstOfYearDecadeLabelFontWeight: usize,
-    put_FirstOfYearDecadeLabelFontWeight: usize,
-    get_DayItemMargin: usize,
-    put_DayItemMargin: usize,
-    get_MonthYearItemMargin: usize,
-    put_MonthYearItemMargin: usize,
-    get_FirstOfMonthLabelMargin: usize,
-    put_FirstOfMonthLabelMargin: usize,
-    get_FirstOfYearDecadeLabelMargin: usize,
-    put_FirstOfYearDecadeLabelMargin: usize,
-    get_HorizontalDayItemAlignment: usize,
-    put_HorizontalDayItemAlignment: usize,
-    get_VerticalDayItemAlignment: usize,
-    put_VerticalDayItemAlignment: usize,
-    get_HorizontalFirstOfMonthLabelAlignment: usize,
-    put_HorizontalFirstOfMonthLabelAlignment: usize,
-    get_VerticalFirstOfMonthLabelAlignment: usize,
-    put_VerticalFirstOfMonthLabelAlignment: usize,
-    get_CalendarItemBorderThickness: usize,
-    put_CalendarItemBorderThickness: usize,
-    get_CalendarViewDayItemStyle: usize,
-    put_CalendarViewDayItemStyle: usize,
-    get_CalendarItemCornerRadius: usize,
-    put_CalendarItemCornerRadius: usize,
-    add_CalendarViewDayItemChanging: usize,
-    remove_CalendarViewDayItemChanging: usize,
-    pub add_SelectedDatesChanged: unsafe extern "system" fn(
+    MaxDate: usize,
+    SetMaxDate: usize,
+    MinDate: usize,
+    SetMinDate: usize,
+    NumberOfWeeksInView: usize,
+    SetNumberOfWeeksInView: usize,
+    SelectedDates: usize,
+    SelectionMode: usize,
+    SetSelectionMode: usize,
+    TemplateSettings: usize,
+    FocusBorderBrush: usize,
+    SetFocusBorderBrush: usize,
+    SelectedHoverBorderBrush: usize,
+    SetSelectedHoverBorderBrush: usize,
+    SelectedPressedBorderBrush: usize,
+    SetSelectedPressedBorderBrush: usize,
+    SelectedDisabledBorderBrush: usize,
+    SetSelectedDisabledBorderBrush: usize,
+    SelectedBorderBrush: usize,
+    SetSelectedBorderBrush: usize,
+    HoverBorderBrush: usize,
+    SetHoverBorderBrush: usize,
+    PressedBorderBrush: usize,
+    SetPressedBorderBrush: usize,
+    TodaySelectedInnerBorderBrush: usize,
+    SetTodaySelectedInnerBorderBrush: usize,
+    BlackoutStrikethroughBrush: usize,
+    SetBlackoutStrikethroughBrush: usize,
+    CalendarItemBorderBrush: usize,
+    SetCalendarItemBorderBrush: usize,
+    BlackoutBackground: usize,
+    SetBlackoutBackground: usize,
+    OutOfScopeBackground: usize,
+    SetOutOfScopeBackground: usize,
+    CalendarItemBackground: usize,
+    SetCalendarItemBackground: usize,
+    CalendarItemHoverBackground: usize,
+    SetCalendarItemHoverBackground: usize,
+    CalendarItemPressedBackground: usize,
+    SetCalendarItemPressedBackground: usize,
+    CalendarItemDisabledBackground: usize,
+    SetCalendarItemDisabledBackground: usize,
+    TodayBackground: usize,
+    SetTodayBackground: usize,
+    TodayBlackoutBackground: usize,
+    SetTodayBlackoutBackground: usize,
+    TodayHoverBackground: usize,
+    SetTodayHoverBackground: usize,
+    TodayPressedBackground: usize,
+    SetTodayPressedBackground: usize,
+    TodayDisabledBackground: usize,
+    SetTodayDisabledBackground: usize,
+    PressedForeground: usize,
+    SetPressedForeground: usize,
+    TodayForeground: usize,
+    SetTodayForeground: usize,
+    BlackoutForeground: usize,
+    SetBlackoutForeground: usize,
+    TodayBlackoutForeground: usize,
+    SetTodayBlackoutForeground: usize,
+    SelectedForeground: usize,
+    SetSelectedForeground: usize,
+    SelectedHoverForeground: usize,
+    SetSelectedHoverForeground: usize,
+    SelectedPressedForeground: usize,
+    SetSelectedPressedForeground: usize,
+    SelectedDisabledForeground: usize,
+    SetSelectedDisabledForeground: usize,
+    OutOfScopeForeground: usize,
+    SetOutOfScopeForeground: usize,
+    OutOfScopeHoverForeground: usize,
+    SetOutOfScopeHoverForeground: usize,
+    OutOfScopePressedForeground: usize,
+    SetOutOfScopePressedForeground: usize,
+    CalendarItemForeground: usize,
+    SetCalendarItemForeground: usize,
+    DisabledForeground: usize,
+    SetDisabledForeground: usize,
+    DayItemFontFamily: usize,
+    SetDayItemFontFamily: usize,
+    DayItemFontSize: usize,
+    SetDayItemFontSize: usize,
+    DayItemFontStyle: usize,
+    SetDayItemFontStyle: usize,
+    DayItemFontWeight: usize,
+    SetDayItemFontWeight: usize,
+    TodayFontWeight: usize,
+    SetTodayFontWeight: usize,
+    FirstOfMonthLabelFontFamily: usize,
+    SetFirstOfMonthLabelFontFamily: usize,
+    FirstOfMonthLabelFontSize: usize,
+    SetFirstOfMonthLabelFontSize: usize,
+    FirstOfMonthLabelFontStyle: usize,
+    SetFirstOfMonthLabelFontStyle: usize,
+    FirstOfMonthLabelFontWeight: usize,
+    SetFirstOfMonthLabelFontWeight: usize,
+    MonthYearItemFontFamily: usize,
+    SetMonthYearItemFontFamily: usize,
+    MonthYearItemFontSize: usize,
+    SetMonthYearItemFontSize: usize,
+    MonthYearItemFontStyle: usize,
+    SetMonthYearItemFontStyle: usize,
+    MonthYearItemFontWeight: usize,
+    SetMonthYearItemFontWeight: usize,
+    FirstOfYearDecadeLabelFontFamily: usize,
+    SetFirstOfYearDecadeLabelFontFamily: usize,
+    FirstOfYearDecadeLabelFontSize: usize,
+    SetFirstOfYearDecadeLabelFontSize: usize,
+    FirstOfYearDecadeLabelFontStyle: usize,
+    SetFirstOfYearDecadeLabelFontStyle: usize,
+    FirstOfYearDecadeLabelFontWeight: usize,
+    SetFirstOfYearDecadeLabelFontWeight: usize,
+    DayItemMargin: usize,
+    SetDayItemMargin: usize,
+    MonthYearItemMargin: usize,
+    SetMonthYearItemMargin: usize,
+    FirstOfMonthLabelMargin: usize,
+    SetFirstOfMonthLabelMargin: usize,
+    FirstOfYearDecadeLabelMargin: usize,
+    SetFirstOfYearDecadeLabelMargin: usize,
+    HorizontalDayItemAlignment: usize,
+    SetHorizontalDayItemAlignment: usize,
+    VerticalDayItemAlignment: usize,
+    SetVerticalDayItemAlignment: usize,
+    HorizontalFirstOfMonthLabelAlignment: usize,
+    SetHorizontalFirstOfMonthLabelAlignment: usize,
+    VerticalFirstOfMonthLabelAlignment: usize,
+    SetVerticalFirstOfMonthLabelAlignment: usize,
+    CalendarItemBorderThickness: usize,
+    SetCalendarItemBorderThickness: usize,
+    CalendarViewDayItemStyle: usize,
+    SetCalendarViewDayItemStyle: usize,
+    CalendarItemCornerRadius: usize,
+    SetCalendarItemCornerRadius: usize,
+    CalendarViewDayItemChanging: usize,
+    RemoveCalendarViewDayItemChanging: usize,
+    pub SelectedDatesChanged: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         *mut i64,
     ) -> windows_core::HRESULT,
-    pub remove_SelectedDatesChanged:
+    pub RemoveSelectedDatesChanged:
         unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
@@ -5552,21 +5551,21 @@ impl windows_core::RuntimeType for ICanvasStatics {
 #[repr(C)]
 pub struct ICanvasStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_LeftProperty: usize,
+    LeftProperty: usize,
     GetLeft: usize,
     pub SetLeft: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         f64,
     ) -> windows_core::HRESULT,
-    get_TopProperty: usize,
+    TopProperty: usize,
     GetTop: usize,
     pub SetTop: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         f64,
     ) -> windows_core::HRESULT,
-    get_ZIndexProperty: usize,
+    ZIndexProperty: usize,
     GetZIndex: usize,
     pub SetZIndex: unsafe extern "system" fn(
         *mut core::ffi::c_void,
@@ -5616,10 +5615,10 @@ impl windows_core::RuntimeType for IColorChangedEventArgs {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IColorChangedEventArgs {
-    pub(crate) fn get_NewColor(&self) -> windows_core::Result<Color> {
+    pub(crate) fn NewColor(&self) -> windows_core::Result<Color> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_NewColor)(
+            (windows_core::Interface::vtable(self).NewColor)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
@@ -5630,8 +5629,8 @@ impl IColorChangedEventArgs {
 #[repr(C)]
 pub struct IColorChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_OldColor: usize,
-    pub get_NewColor:
+    OldColor: usize,
+    pub NewColor:
         unsafe extern "system" fn(*mut core::ffi::c_void, *mut Color) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
@@ -5644,48 +5643,48 @@ impl windows_core::RuntimeType for IColorPicker {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IColorPicker {
-    pub(crate) fn put_Color(&self, value: Color) -> windows_core::Result<()> {
+    pub(crate) fn SetColor(&self, value: Color) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Color)(
+            (windows_core::Interface::vtable(self).SetColor)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_IsAlphaEnabled(&self, value: bool) -> windows_core::Result<()> {
+    pub(crate) fn SetIsAlphaEnabled(&self, value: bool) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_IsAlphaEnabled)(
+            (windows_core::Interface::vtable(self).SetIsAlphaEnabled)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_IsColorSliderVisible(&self, value: bool) -> windows_core::Result<()> {
+    pub(crate) fn SetIsColorSliderVisible(&self, value: bool) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_IsColorSliderVisible)(
+            (windows_core::Interface::vtable(self).SetIsColorSliderVisible)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_IsColorChannelTextInputVisible(
+    pub(crate) fn SetIsColorChannelTextInputVisible(
         &self,
         value: bool,
     ) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_IsColorChannelTextInputVisible)(
+            (windows_core::Interface::vtable(self).SetIsColorChannelTextInputVisible)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_IsHexInputVisible(&self, value: bool) -> windows_core::Result<()> {
+    pub(crate) fn SetIsHexInputVisible(&self, value: bool) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_IsHexInputVisible)(
+            (windows_core::Interface::vtable(self).SetIsHexInputVisible)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
@@ -5711,7 +5710,7 @@ impl IColorPicker {
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
-            let token__ = (windows_core::Interface::vtable(self).add_ColorChanged)(
+            let token__ = (windows_core::Interface::vtable(self).ColorChanged)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Interface::as_raw(&handler),
                 &mut result__,
@@ -5720,7 +5719,7 @@ impl IColorPicker {
             Ok(windows_core::EventRevoker::new(
                 self.clone(),
                 token__,
-                windows_core::Interface::vtable(self).remove_ColorChanged,
+                windows_core::Interface::vtable(self).RemoveColorChanged,
             ))
         }
     }
@@ -5728,55 +5727,54 @@ impl IColorPicker {
 #[repr(C)]
 pub struct IColorPicker_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_Color: usize,
-    pub put_Color:
-        unsafe extern "system" fn(*mut core::ffi::c_void, Color) -> windows_core::HRESULT,
-    get_PreviousColor: usize,
-    put_PreviousColor: usize,
-    get_IsAlphaEnabled: usize,
-    pub put_IsAlphaEnabled:
+    Color: usize,
+    pub SetColor: unsafe extern "system" fn(*mut core::ffi::c_void, Color) -> windows_core::HRESULT,
+    PreviousColor: usize,
+    SetPreviousColor: usize,
+    IsAlphaEnabled: usize,
+    pub SetIsAlphaEnabled:
         unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
-    get_IsColorSpectrumVisible: usize,
-    put_IsColorSpectrumVisible: usize,
-    get_IsColorPreviewVisible: usize,
-    put_IsColorPreviewVisible: usize,
-    get_IsColorSliderVisible: usize,
-    pub put_IsColorSliderVisible:
+    IsColorSpectrumVisible: usize,
+    SetIsColorSpectrumVisible: usize,
+    IsColorPreviewVisible: usize,
+    SetIsColorPreviewVisible: usize,
+    IsColorSliderVisible: usize,
+    pub SetIsColorSliderVisible:
         unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
-    get_IsAlphaSliderVisible: usize,
-    put_IsAlphaSliderVisible: usize,
-    get_IsMoreButtonVisible: usize,
-    put_IsMoreButtonVisible: usize,
-    get_IsColorChannelTextInputVisible: usize,
-    pub put_IsColorChannelTextInputVisible:
+    IsAlphaSliderVisible: usize,
+    SetIsAlphaSliderVisible: usize,
+    IsMoreButtonVisible: usize,
+    SetIsMoreButtonVisible: usize,
+    IsColorChannelTextInputVisible: usize,
+    pub SetIsColorChannelTextInputVisible:
         unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
-    get_IsAlphaTextInputVisible: usize,
-    put_IsAlphaTextInputVisible: usize,
-    get_IsHexInputVisible: usize,
-    pub put_IsHexInputVisible:
+    IsAlphaTextInputVisible: usize,
+    SetIsAlphaTextInputVisible: usize,
+    IsHexInputVisible: usize,
+    pub SetIsHexInputVisible:
         unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
-    get_MinHue: usize,
-    put_MinHue: usize,
-    get_MaxHue: usize,
-    put_MaxHue: usize,
-    get_MinSaturation: usize,
-    put_MinSaturation: usize,
-    get_MaxSaturation: usize,
-    put_MaxSaturation: usize,
-    get_MinValue: usize,
-    put_MinValue: usize,
-    get_MaxValue: usize,
-    put_MaxValue: usize,
-    get_ColorSpectrumShape: usize,
-    put_ColorSpectrumShape: usize,
-    get_ColorSpectrumComponents: usize,
-    put_ColorSpectrumComponents: usize,
-    pub add_ColorChanged: unsafe extern "system" fn(
+    MinHue: usize,
+    SetMinHue: usize,
+    MaxHue: usize,
+    SetMaxHue: usize,
+    MinSaturation: usize,
+    SetMinSaturation: usize,
+    MaxSaturation: usize,
+    SetMaxSaturation: usize,
+    MinValue: usize,
+    SetMinValue: usize,
+    MaxValue: usize,
+    SetMaxValue: usize,
+    ColorSpectrumShape: usize,
+    SetColorSpectrumShape: usize,
+    ColorSpectrumComponents: usize,
+    SetColorSpectrumComponents: usize,
+    pub ColorChanged: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         *mut i64,
     ) -> windows_core::HRESULT,
-    pub remove_ColorChanged:
+    pub RemoveColorChanged:
         unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
@@ -5808,9 +5806,9 @@ impl windows_core::RuntimeType for IColumnDefinition {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IColumnDefinition {
-    pub(crate) fn put_Width(&self, value: GridLength) -> windows_core::Result<()> {
+    pub(crate) fn SetWidth(&self, value: GridLength) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Width)(
+            (windows_core::Interface::vtable(self).SetWidth)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
@@ -5821,8 +5819,8 @@ impl IColumnDefinition {
 #[repr(C)]
 pub struct IColumnDefinition_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_Width: usize,
-    pub put_Width:
+    Width: usize,
+    pub SetWidth:
         unsafe extern "system" fn(*mut core::ffi::c_void, GridLength) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
@@ -5835,30 +5833,30 @@ impl windows_core::RuntimeType for IComboBox {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IComboBox {
-    pub(crate) fn put_IsEditable(&self, value: bool) -> windows_core::Result<()> {
+    pub(crate) fn SetIsEditable(&self, value: bool) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_IsEditable)(
+            (windows_core::Interface::vtable(self).SetIsEditable)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_Header<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetHeader<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<windows_core::IInspectable>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Header)(
+            (windows_core::Interface::vtable(self).SetHeader)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
             .ok()
         }
     }
-    pub(crate) fn put_PlaceholderText(&self, value: &str) -> windows_core::Result<()> {
+    pub(crate) fn SetPlaceholderText(&self, value: &str) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_PlaceholderText)(
+            (windows_core::Interface::vtable(self).SetPlaceholderText)(
                 windows_core::Interface::as_raw(self),
                 core::mem::transmute_copy(&windows_core::HSTRING::from(value)),
             )
@@ -5869,26 +5867,26 @@ impl IComboBox {
 #[repr(C)]
 pub struct IComboBox_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_IsDropDownOpen: usize,
-    put_IsDropDownOpen: usize,
-    get_IsEditable: usize,
-    pub put_IsEditable:
+    IsDropDownOpen: usize,
+    SetIsDropDownOpen: usize,
+    IsEditable: usize,
+    pub SetIsEditable:
         unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
-    get_IsSelectionBoxHighlighted: usize,
-    get_MaxDropDownHeight: usize,
-    put_MaxDropDownHeight: usize,
-    get_SelectionBoxItem: usize,
-    get_SelectionBoxItemTemplate: usize,
-    get_TemplateSettings: usize,
-    get_Header: usize,
-    pub put_Header: unsafe extern "system" fn(
+    IsSelectionBoxHighlighted: usize,
+    MaxDropDownHeight: usize,
+    SetMaxDropDownHeight: usize,
+    SelectionBoxItem: usize,
+    SelectionBoxItemTemplate: usize,
+    TemplateSettings: usize,
+    Header: usize,
+    pub SetHeader: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_HeaderTemplate: usize,
-    put_HeaderTemplate: usize,
-    get_PlaceholderText: usize,
-    pub put_PlaceholderText: unsafe extern "system" fn(
+    HeaderTemplate: usize,
+    SetHeaderTemplate: usize,
+    PlaceholderText: usize,
+    pub SetPlaceholderText: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
@@ -5922,36 +5920,36 @@ impl windows_core::RuntimeType for ICommandBar {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl ICommandBar {
-    pub(crate) fn get_PrimaryCommands(
+    pub(crate) fn PrimaryCommands(
         &self,
     ) -> windows_core::Result<windows_collections::IObservableVector<ICommandBarElement>> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_PrimaryCommands)(
+            (windows_core::Interface::vtable(self).PrimaryCommands)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
             .and_then(|| windows_core::Type::from_abi(result__))
         }
     }
-    pub(crate) fn get_SecondaryCommands(
+    pub(crate) fn SecondaryCommands(
         &self,
     ) -> windows_core::Result<windows_collections::IObservableVector<ICommandBarElement>> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_SecondaryCommands)(
+            (windows_core::Interface::vtable(self).SecondaryCommands)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
             .and_then(|| windows_core::Type::from_abi(result__))
         }
     }
-    pub(crate) fn put_DefaultLabelPosition(
+    pub(crate) fn SetDefaultLabelPosition(
         &self,
         value: CommandBarDefaultLabelPosition,
     ) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_DefaultLabelPosition)(
+            (windows_core::Interface::vtable(self).SetDefaultLabelPosition)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
@@ -5962,19 +5960,19 @@ impl ICommandBar {
 #[repr(C)]
 pub struct ICommandBar_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    pub get_PrimaryCommands: unsafe extern "system" fn(
+    pub PrimaryCommands: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    pub get_SecondaryCommands: unsafe extern "system" fn(
+    pub SecondaryCommands: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_CommandBarOverflowPresenterStyle: usize,
-    put_CommandBarOverflowPresenterStyle: usize,
-    get_CommandBarTemplateSettings: usize,
-    get_DefaultLabelPosition: usize,
-    pub put_DefaultLabelPosition: unsafe extern "system" fn(
+    CommandBarOverflowPresenterStyle: usize,
+    SetCommandBarOverflowPresenterStyle: usize,
+    CommandBarTemplateSettings: usize,
+    DefaultLabelPosition: usize,
+    pub SetDefaultLabelPosition: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         CommandBarDefaultLabelPosition,
     ) -> windows_core::HRESULT,
@@ -6026,24 +6024,24 @@ impl windows_core::RuntimeType for ICommandBarFlyout {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl ICommandBarFlyout {
-    pub(crate) fn get_PrimaryCommands(
+    pub(crate) fn PrimaryCommands(
         &self,
     ) -> windows_core::Result<windows_collections::IObservableVector<ICommandBarElement>> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_PrimaryCommands)(
+            (windows_core::Interface::vtable(self).PrimaryCommands)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
             .and_then(|| windows_core::Type::from_abi(result__))
         }
     }
-    pub(crate) fn get_SecondaryCommands(
+    pub(crate) fn SecondaryCommands(
         &self,
     ) -> windows_core::Result<windows_collections::IObservableVector<ICommandBarElement>> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_SecondaryCommands)(
+            (windows_core::Interface::vtable(self).SecondaryCommands)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
@@ -6054,11 +6052,11 @@ impl ICommandBarFlyout {
 #[repr(C)]
 pub struct ICommandBarFlyout_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    pub get_PrimaryCommands: unsafe extern "system" fn(
+    pub PrimaryCommands: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    pub get_SecondaryCommands: unsafe extern "system" fn(
+    pub SecondaryCommands: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
@@ -6105,9 +6103,9 @@ impl windows_core::RuntimeType for ICompositionAnimation2 {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl ICompositionAnimation2 {
-    pub(crate) fn put_Target(&self, value: &str) -> windows_core::Result<()> {
+    pub(crate) fn SetTarget(&self, value: &str) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Target)(
+            (windows_core::Interface::vtable(self).SetTarget)(
                 windows_core::Interface::as_raw(self),
                 core::mem::transmute_copy(&windows_core::HSTRING::from(value)),
             )
@@ -6119,8 +6117,8 @@ impl ICompositionAnimation2 {
 pub struct ICompositionAnimation2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     SetBooleanParameter: usize,
-    get_Target: usize,
-    pub put_Target: unsafe extern "system" fn(
+    Target: usize,
+    pub SetTarget: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
@@ -6166,10 +6164,10 @@ impl windows_core::RuntimeType for ICompositionObject {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl ICompositionObject {
-    pub(crate) fn get_Compositor(&self) -> windows_core::Result<Compositor> {
+    pub(crate) fn Compositor(&self) -> windows_core::Result<Compositor> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_Compositor)(
+            (windows_core::Interface::vtable(self).Compositor)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
@@ -6197,11 +6195,11 @@ impl ICompositionObject {
 #[repr(C)]
 pub struct ICompositionObject_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    pub get_Compositor: unsafe extern "system" fn(
+    pub Compositor: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_Properties: usize,
+    Properties: usize,
     pub StartAnimation: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
@@ -6218,12 +6216,12 @@ impl windows_core::RuntimeType for ICompositionObject2 {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl ICompositionObject2 {
-    pub(crate) fn put_ImplicitAnimations<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetImplicitAnimations<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<ImplicitAnimationCollection>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_ImplicitAnimations)(
+            (windows_core::Interface::vtable(self).SetImplicitAnimations)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
@@ -6234,10 +6232,10 @@ impl ICompositionObject2 {
 #[repr(C)]
 pub struct ICompositionObject2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_Comment: usize,
-    put_Comment: usize,
-    get_ImplicitAnimations: usize,
-    pub put_ImplicitAnimations: unsafe extern "system" fn(
+    Comment: usize,
+    SetComment: usize,
+    ImplicitAnimations: usize,
+    pub SetImplicitAnimations: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
@@ -6267,12 +6265,12 @@ impl windows_core::RuntimeType for ICompositionTargetStatics {
 #[repr(C)]
 pub struct ICompositionTargetStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    pub add_Rendering: unsafe extern "system" fn(
+    pub Rendering: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         *mut i64,
     ) -> windows_core::HRESULT,
-    pub remove_Rendering:
+    pub RemoveRendering:
         unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
@@ -6421,22 +6419,22 @@ impl windows_core::RuntimeType for IContentControl {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IContentControl {
-    pub(crate) fn get_Content(&self) -> windows_core::Result<windows_core::IInspectable> {
+    pub(crate) fn Content(&self) -> windows_core::Result<windows_core::IInspectable> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_Content)(
+            (windows_core::Interface::vtable(self).Content)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
             .and_then(|| windows_core::Type::from_abi(result__))
         }
     }
-    pub(crate) fn put_Content<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetContent<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<windows_core::IInspectable>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Content)(
+            (windows_core::Interface::vtable(self).SetContent)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
@@ -6447,11 +6445,11 @@ impl IContentControl {
 #[repr(C)]
 pub struct IContentControl_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    pub get_Content: unsafe extern "system" fn(
+    pub Content: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    pub put_Content: unsafe extern "system" fn(
+    pub SetContent: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
@@ -6466,57 +6464,57 @@ impl windows_core::RuntimeType for IContentDialog {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IContentDialog {
-    pub(crate) fn put_Title<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetTitle<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<windows_core::IInspectable>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Title)(
+            (windows_core::Interface::vtable(self).SetTitle)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
             .ok()
         }
     }
-    pub(crate) fn put_PrimaryButtonText(&self, value: &str) -> windows_core::Result<()> {
+    pub(crate) fn SetPrimaryButtonText(&self, value: &str) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_PrimaryButtonText)(
+            (windows_core::Interface::vtable(self).SetPrimaryButtonText)(
                 windows_core::Interface::as_raw(self),
                 core::mem::transmute_copy(&windows_core::HSTRING::from(value)),
             )
             .ok()
         }
     }
-    pub(crate) fn put_SecondaryButtonText(&self, value: &str) -> windows_core::Result<()> {
+    pub(crate) fn SetSecondaryButtonText(&self, value: &str) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_SecondaryButtonText)(
+            (windows_core::Interface::vtable(self).SetSecondaryButtonText)(
                 windows_core::Interface::as_raw(self),
                 core::mem::transmute_copy(&windows_core::HSTRING::from(value)),
             )
             .ok()
         }
     }
-    pub(crate) fn put_CloseButtonText(&self, value: &str) -> windows_core::Result<()> {
+    pub(crate) fn SetCloseButtonText(&self, value: &str) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_CloseButtonText)(
+            (windows_core::Interface::vtable(self).SetCloseButtonText)(
                 windows_core::Interface::as_raw(self),
                 core::mem::transmute_copy(&windows_core::HSTRING::from(value)),
             )
             .ok()
         }
     }
-    pub(crate) fn put_IsPrimaryButtonEnabled(&self, value: bool) -> windows_core::Result<()> {
+    pub(crate) fn SetIsPrimaryButtonEnabled(&self, value: bool) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_IsPrimaryButtonEnabled)(
+            (windows_core::Interface::vtable(self).SetIsPrimaryButtonEnabled)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_IsSecondaryButtonEnabled(&self, value: bool) -> windows_core::Result<()> {
+    pub(crate) fn SetIsSecondaryButtonEnabled(&self, value: bool) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_IsSecondaryButtonEnabled)(
+            (windows_core::Interface::vtable(self).SetIsSecondaryButtonEnabled)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
@@ -6540,7 +6538,7 @@ impl IContentDialog {
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
-            let token__ = (windows_core::Interface::vtable(self).add_Closed)(
+            let token__ = (windows_core::Interface::vtable(self).Closed)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Interface::as_raw(&handler),
                 &mut result__,
@@ -6549,7 +6547,7 @@ impl IContentDialog {
             Ok(windows_core::EventRevoker::new(
                 self.clone(),
                 token__,
-                windows_core::Interface::vtable(self).remove_Closed,
+                windows_core::Interface::vtable(self).RemoveClosed,
             ))
         }
     }
@@ -6574,73 +6572,73 @@ impl IContentDialog {
 #[repr(C)]
 pub struct IContentDialog_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_Title: usize,
-    pub put_Title: unsafe extern "system" fn(
+    Title: usize,
+    pub SetTitle: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_TitleTemplate: usize,
-    put_TitleTemplate: usize,
-    get_FullSizeDesired: usize,
-    put_FullSizeDesired: usize,
-    get_PrimaryButtonText: usize,
-    pub put_PrimaryButtonText: unsafe extern "system" fn(
+    TitleTemplate: usize,
+    SetTitleTemplate: usize,
+    FullSizeDesired: usize,
+    SetFullSizeDesired: usize,
+    PrimaryButtonText: usize,
+    pub SetPrimaryButtonText: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_SecondaryButtonText: usize,
-    pub put_SecondaryButtonText: unsafe extern "system" fn(
+    SecondaryButtonText: usize,
+    pub SetSecondaryButtonText: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_CloseButtonText: usize,
-    pub put_CloseButtonText: unsafe extern "system" fn(
+    CloseButtonText: usize,
+    pub SetCloseButtonText: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_PrimaryButtonCommand: usize,
-    put_PrimaryButtonCommand: usize,
-    get_SecondaryButtonCommand: usize,
-    put_SecondaryButtonCommand: usize,
-    get_CloseButtonCommand: usize,
-    put_CloseButtonCommand: usize,
-    get_PrimaryButtonCommandParameter: usize,
-    put_PrimaryButtonCommandParameter: usize,
-    get_SecondaryButtonCommandParameter: usize,
-    put_SecondaryButtonCommandParameter: usize,
-    get_CloseButtonCommandParameter: usize,
-    put_CloseButtonCommandParameter: usize,
-    get_IsPrimaryButtonEnabled: usize,
-    pub put_IsPrimaryButtonEnabled:
+    PrimaryButtonCommand: usize,
+    SetPrimaryButtonCommand: usize,
+    SecondaryButtonCommand: usize,
+    SetSecondaryButtonCommand: usize,
+    CloseButtonCommand: usize,
+    SetCloseButtonCommand: usize,
+    PrimaryButtonCommandParameter: usize,
+    SetPrimaryButtonCommandParameter: usize,
+    SecondaryButtonCommandParameter: usize,
+    SetSecondaryButtonCommandParameter: usize,
+    CloseButtonCommandParameter: usize,
+    SetCloseButtonCommandParameter: usize,
+    IsPrimaryButtonEnabled: usize,
+    pub SetIsPrimaryButtonEnabled:
         unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
-    get_IsSecondaryButtonEnabled: usize,
-    pub put_IsSecondaryButtonEnabled:
+    IsSecondaryButtonEnabled: usize,
+    pub SetIsSecondaryButtonEnabled:
         unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
-    get_PrimaryButtonStyle: usize,
-    put_PrimaryButtonStyle: usize,
-    get_SecondaryButtonStyle: usize,
-    put_SecondaryButtonStyle: usize,
-    get_CloseButtonStyle: usize,
-    put_CloseButtonStyle: usize,
-    get_DefaultButton: usize,
-    put_DefaultButton: usize,
-    add_Closing: usize,
-    remove_Closing: usize,
-    pub add_Closed: unsafe extern "system" fn(
+    PrimaryButtonStyle: usize,
+    SetPrimaryButtonStyle: usize,
+    SecondaryButtonStyle: usize,
+    SetSecondaryButtonStyle: usize,
+    CloseButtonStyle: usize,
+    SetCloseButtonStyle: usize,
+    DefaultButton: usize,
+    SetDefaultButton: usize,
+    Closing: usize,
+    RemoveClosing: usize,
+    pub Closed: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         *mut i64,
     ) -> windows_core::HRESULT,
-    pub remove_Closed:
+    pub RemoveClosed:
         unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
-    add_Opened: usize,
-    remove_Opened: usize,
-    add_PrimaryButtonClick: usize,
-    remove_PrimaryButtonClick: usize,
-    add_SecondaryButtonClick: usize,
-    remove_SecondaryButtonClick: usize,
-    add_CloseButtonClick: usize,
-    remove_CloseButtonClick: usize,
+    Opened: usize,
+    RemoveOpened: usize,
+    PrimaryButtonClick: usize,
+    RemovePrimaryButtonClick: usize,
+    SecondaryButtonClick: usize,
+    RemoveSecondaryButtonClick: usize,
+    CloseButtonClick: usize,
+    RemoveCloseButtonClick: usize,
     pub Hide: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
     pub ShowAsync: unsafe extern "system" fn(
         *mut core::ffi::c_void,
@@ -6657,10 +6655,10 @@ impl windows_core::RuntimeType for IContentDialogClosedEventArgs {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IContentDialogClosedEventArgs {
-    pub(crate) fn get_Result(&self) -> windows_core::Result<ContentDialogResult> {
+    pub(crate) fn Result(&self) -> windows_core::Result<ContentDialogResult> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_Result)(
+            (windows_core::Interface::vtable(self).Result)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
@@ -6671,7 +6669,7 @@ impl IContentDialogClosedEventArgs {
 #[repr(C)]
 pub struct IContentDialogClosedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    pub get_Result: unsafe extern "system" fn(
+    pub Result: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut ContentDialogResult,
     ) -> windows_core::HRESULT,
@@ -6705,72 +6703,72 @@ impl windows_core::RuntimeType for IControl {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IControl {
-    pub(crate) fn put_FontSize(&self, value: f64) -> windows_core::Result<()> {
+    pub(crate) fn SetFontSize(&self, value: f64) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_FontSize)(
+            (windows_core::Interface::vtable(self).SetFontSize)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_FontFamily<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetFontFamily<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<FontFamily>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_FontFamily)(
+            (windows_core::Interface::vtable(self).SetFontFamily)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
             .ok()
         }
     }
-    pub(crate) fn put_FontWeight(&self, value: FontWeight) -> windows_core::Result<()> {
+    pub(crate) fn SetFontWeight(&self, value: FontWeight) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_FontWeight)(
+            (windows_core::Interface::vtable(self).SetFontWeight)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_Foreground<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetForeground<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<Brush>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Foreground)(
+            (windows_core::Interface::vtable(self).SetForeground)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
             .ok()
         }
     }
-    pub(crate) fn put_IsEnabled(&self, value: bool) -> windows_core::Result<()> {
+    pub(crate) fn SetIsEnabled(&self, value: bool) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_IsEnabled)(
+            (windows_core::Interface::vtable(self).SetIsEnabled)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_Padding(&self, value: Thickness) -> windows_core::Result<()> {
+    pub(crate) fn SetPadding(&self, value: Thickness) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Padding)(
+            (windows_core::Interface::vtable(self).SetPadding)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_Background<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetBackground<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<Brush>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Background)(
+            (windows_core::Interface::vtable(self).SetBackground)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
@@ -6781,52 +6779,52 @@ impl IControl {
 #[repr(C)]
 pub struct IControl_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_IsFocusEngagementEnabled: usize,
-    put_IsFocusEngagementEnabled: usize,
-    get_IsFocusEngaged: usize,
-    put_IsFocusEngaged: usize,
-    get_RequiresPointer: usize,
-    put_RequiresPointer: usize,
-    get_FontSize: usize,
-    pub put_FontSize:
+    IsFocusEngagementEnabled: usize,
+    SetIsFocusEngagementEnabled: usize,
+    IsFocusEngaged: usize,
+    SetIsFocusEngaged: usize,
+    RequiresPointer: usize,
+    SetRequiresPointer: usize,
+    FontSize: usize,
+    pub SetFontSize:
         unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
-    get_FontFamily: usize,
-    pub put_FontFamily: unsafe extern "system" fn(
+    FontFamily: usize,
+    pub SetFontFamily: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_FontWeight: usize,
-    pub put_FontWeight:
+    FontWeight: usize,
+    pub SetFontWeight:
         unsafe extern "system" fn(*mut core::ffi::c_void, FontWeight) -> windows_core::HRESULT,
-    get_FontStyle: usize,
-    put_FontStyle: usize,
-    get_FontStretch: usize,
-    put_FontStretch: usize,
-    get_CharacterSpacing: usize,
-    put_CharacterSpacing: usize,
-    get_Foreground: usize,
-    pub put_Foreground: unsafe extern "system" fn(
+    FontStyle: usize,
+    SetFontStyle: usize,
+    FontStretch: usize,
+    SetFontStretch: usize,
+    CharacterSpacing: usize,
+    SetCharacterSpacing: usize,
+    Foreground: usize,
+    pub SetForeground: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_IsTextScaleFactorEnabled: usize,
-    put_IsTextScaleFactorEnabled: usize,
-    get_IsEnabled: usize,
-    pub put_IsEnabled:
+    IsTextScaleFactorEnabled: usize,
+    SetIsTextScaleFactorEnabled: usize,
+    IsEnabled: usize,
+    pub SetIsEnabled:
         unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
-    get_TabNavigation: usize,
-    put_TabNavigation: usize,
-    get_Template: usize,
-    put_Template: usize,
-    get_Padding: usize,
-    pub put_Padding:
+    TabNavigation: usize,
+    SetTabNavigation: usize,
+    Template: usize,
+    SetTemplate: usize,
+    Padding: usize,
+    pub SetPadding:
         unsafe extern "system" fn(*mut core::ffi::c_void, Thickness) -> windows_core::HRESULT,
-    get_HorizontalContentAlignment: usize,
-    put_HorizontalContentAlignment: usize,
-    get_VerticalContentAlignment: usize,
-    put_VerticalContentAlignment: usize,
-    get_Background: usize,
-    pub put_Background: unsafe extern "system" fn(
+    HorizontalContentAlignment: usize,
+    SetHorizontalContentAlignment: usize,
+    VerticalContentAlignment: usize,
+    SetVerticalContentAlignment: usize,
+    Background: usize,
+    pub SetBackground: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
@@ -6854,12 +6852,12 @@ impl windows_core::RuntimeType for IDataPackageView {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IDataPackageView {
-    pub(crate) fn get_AvailableFormats(
+    pub(crate) fn AvailableFormats(
         &self,
     ) -> windows_core::Result<windows_collections::IVectorView<windows_core::HSTRING>> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_AvailableFormats)(
+            (windows_core::Interface::vtable(self).AvailableFormats)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
@@ -6896,10 +6894,10 @@ impl IDataPackageView {
 #[repr(C)]
 pub struct IDataPackageView_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_Properties: usize,
-    get_RequestedOperation: usize,
+    Properties: usize,
+    RequestedOperation: usize,
     ReportOperationCompleted: usize,
-    pub get_AvailableFormats: unsafe extern "system" fn(
+    pub AvailableFormats: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
@@ -6930,39 +6928,39 @@ impl windows_core::RuntimeType for IDatePicker {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IDatePicker {
-    pub(crate) fn put_Header<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetHeader<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<windows_core::IInspectable>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Header)(
+            (windows_core::Interface::vtable(self).SetHeader)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
             .ok()
         }
     }
-    pub(crate) fn put_DayVisible(&self, value: bool) -> windows_core::Result<()> {
+    pub(crate) fn SetDayVisible(&self, value: bool) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_DayVisible)(
+            (windows_core::Interface::vtable(self).SetDayVisible)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_MonthVisible(&self, value: bool) -> windows_core::Result<()> {
+    pub(crate) fn SetMonthVisible(&self, value: bool) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_MonthVisible)(
+            (windows_core::Interface::vtable(self).SetMonthVisible)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_YearVisible(&self, value: bool) -> windows_core::Result<()> {
+    pub(crate) fn SetYearVisible(&self, value: bool) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_YearVisible)(
+            (windows_core::Interface::vtable(self).SetYearVisible)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
@@ -6985,7 +6983,7 @@ impl IDatePicker {
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
-            let token__ = (windows_core::Interface::vtable(self).add_SelectedDateChanged)(
+            let token__ = (windows_core::Interface::vtable(self).SelectedDateChanged)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Interface::as_raw(&handler),
                 &mut result__,
@@ -6994,7 +6992,7 @@ impl IDatePicker {
             Ok(windows_core::EventRevoker::new(
                 self.clone(),
                 token__,
-                windows_core::Interface::vtable(self).remove_SelectedDateChanged,
+                windows_core::Interface::vtable(self).RemoveSelectedDateChanged,
             ))
         }
     }
@@ -7002,50 +7000,50 @@ impl IDatePicker {
 #[repr(C)]
 pub struct IDatePicker_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_Header: usize,
-    pub put_Header: unsafe extern "system" fn(
+    Header: usize,
+    pub SetHeader: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_HeaderTemplate: usize,
-    put_HeaderTemplate: usize,
-    get_CalendarIdentifier: usize,
-    put_CalendarIdentifier: usize,
-    get_Date: usize,
-    put_Date: usize,
-    get_DayVisible: usize,
-    pub put_DayVisible:
+    HeaderTemplate: usize,
+    SetHeaderTemplate: usize,
+    CalendarIdentifier: usize,
+    SetCalendarIdentifier: usize,
+    Date: usize,
+    SetDate: usize,
+    DayVisible: usize,
+    pub SetDayVisible:
         unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
-    get_MonthVisible: usize,
-    pub put_MonthVisible:
+    MonthVisible: usize,
+    pub SetMonthVisible:
         unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
-    get_YearVisible: usize,
-    pub put_YearVisible:
+    YearVisible: usize,
+    pub SetYearVisible:
         unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
-    get_DayFormat: usize,
-    put_DayFormat: usize,
-    get_MonthFormat: usize,
-    put_MonthFormat: usize,
-    get_YearFormat: usize,
-    put_YearFormat: usize,
-    get_MinYear: usize,
-    put_MinYear: usize,
-    get_MaxYear: usize,
-    put_MaxYear: usize,
-    get_Orientation: usize,
-    put_Orientation: usize,
-    get_LightDismissOverlayMode: usize,
-    put_LightDismissOverlayMode: usize,
-    get_SelectedDate: usize,
-    put_SelectedDate: usize,
-    add_DateChanged: usize,
-    remove_DateChanged: usize,
-    pub add_SelectedDateChanged: unsafe extern "system" fn(
+    DayFormat: usize,
+    SetDayFormat: usize,
+    MonthFormat: usize,
+    SetMonthFormat: usize,
+    YearFormat: usize,
+    SetYearFormat: usize,
+    MinYear: usize,
+    SetMinYear: usize,
+    MaxYear: usize,
+    SetMaxYear: usize,
+    Orientation: usize,
+    SetOrientation: usize,
+    LightDismissOverlayMode: usize,
+    SetLightDismissOverlayMode: usize,
+    SelectedDate: usize,
+    SetSelectedDate: usize,
+    DateChanged: usize,
+    RemoveDateChanged: usize,
+    pub SelectedDateChanged: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         *mut i64,
     ) -> windows_core::HRESULT,
-    pub remove_SelectedDateChanged:
+    pub RemoveSelectedDateChanged:
         unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
@@ -7077,10 +7075,10 @@ impl windows_core::RuntimeType for IDatePickerSelectedValueChangedEventArgs {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IDatePickerSelectedValueChangedEventArgs {
-    pub(crate) fn get_NewDate(&self) -> windows_core::Result<windows_time::DateTime> {
+    pub(crate) fn NewDate(&self) -> windows_core::Result<windows_time::DateTime> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_NewDate)(
+            (windows_core::Interface::vtable(self).NewDate)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
@@ -7092,8 +7090,8 @@ impl IDatePickerSelectedValueChangedEventArgs {
 #[repr(C)]
 pub struct IDatePickerSelectedValueChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_OldDate: usize,
-    pub get_NewDate: unsafe extern "system" fn(
+    OldDate: usize,
+    pub NewDate: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
@@ -7225,18 +7223,18 @@ impl windows_core::RuntimeType for IDispatcherQueueTimer {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IDispatcherQueueTimer {
-    pub(crate) fn put_Interval(&self, value: windows_time::TimeSpan) -> windows_core::Result<()> {
+    pub(crate) fn SetInterval(&self, value: windows_time::TimeSpan) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Interval)(
+            (windows_core::Interface::vtable(self).SetInterval)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_IsRepeating(&self, value: bool) -> windows_core::Result<()> {
+    pub(crate) fn SetIsRepeating(&self, value: bool) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_IsRepeating)(
+            (windows_core::Interface::vtable(self).SetIsRepeating)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
@@ -7267,7 +7265,7 @@ impl IDispatcherQueueTimer {
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
-            let token__ = (windows_core::Interface::vtable(self).add_Tick)(
+            let token__ = (windows_core::Interface::vtable(self).Tick)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Interface::as_raw(&handler),
                 &mut result__,
@@ -7276,7 +7274,7 @@ impl IDispatcherQueueTimer {
             Ok(windows_core::EventRevoker::new(
                 self.clone(),
                 token__,
-                windows_core::Interface::vtable(self).remove_Tick,
+                windows_core::Interface::vtable(self).RemoveTick,
             ))
         }
     }
@@ -7284,24 +7282,23 @@ impl IDispatcherQueueTimer {
 #[repr(C)]
 pub struct IDispatcherQueueTimer_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_Interval: usize,
-    pub put_Interval: unsafe extern "system" fn(
+    Interval: usize,
+    pub SetInterval: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         windows_time::TimeSpan,
     ) -> windows_core::HRESULT,
-    get_IsRunning: usize,
-    get_IsRepeating: usize,
-    pub put_IsRepeating:
+    IsRunning: usize,
+    IsRepeating: usize,
+    pub SetIsRepeating:
         unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
     pub Start: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
     pub Stop: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
-    pub add_Tick: unsafe extern "system" fn(
+    pub Tick: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         *mut i64,
     ) -> windows_core::HRESULT,
-    pub remove_Tick:
-        unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
+    pub RemoveTick: unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
     IDragEventArgs,
@@ -7313,32 +7310,32 @@ impl windows_core::RuntimeType for IDragEventArgs {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IDragEventArgs {
-    pub(crate) fn get_DataView(&self) -> windows_core::Result<DataPackageView> {
+    pub(crate) fn DataView(&self) -> windows_core::Result<DataPackageView> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_DataView)(
+            (windows_core::Interface::vtable(self).DataView)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
             .and_then(|| windows_core::Type::from_abi(result__))
         }
     }
-    pub(crate) fn get_DragUIOverride(&self) -> windows_core::Result<DragUIOverride> {
+    pub(crate) fn DragUIOverride(&self) -> windows_core::Result<DragUIOverride> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_DragUIOverride)(
+            (windows_core::Interface::vtable(self).DragUIOverride)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
             .and_then(|| windows_core::Type::from_abi(result__))
         }
     }
-    pub(crate) fn put_AcceptedOperation(
+    pub(crate) fn SetAcceptedOperation(
         &self,
         value: DataPackageOperation,
     ) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_AcceptedOperation)(
+            (windows_core::Interface::vtable(self).SetAcceptedOperation)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
@@ -7359,25 +7356,25 @@ impl IDragEventArgs {
 #[repr(C)]
 pub struct IDragEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_Handled: usize,
-    put_Handled: usize,
-    get_Data: usize,
-    put_Data: usize,
-    pub get_DataView: unsafe extern "system" fn(
+    Handled: usize,
+    SetHandled: usize,
+    Data: usize,
+    SetData: usize,
+    pub DataView: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    pub get_DragUIOverride: unsafe extern "system" fn(
+    pub DragUIOverride: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_Modifiers: usize,
-    get_AcceptedOperation: usize,
-    pub put_AcceptedOperation: unsafe extern "system" fn(
+    Modifiers: usize,
+    AcceptedOperation: usize,
+    pub SetAcceptedOperation: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         DataPackageOperation,
     ) -> windows_core::HRESULT,
-    get_AllowedOperations: usize,
+    AllowedOperations: usize,
     pub GetDeferral: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
@@ -7415,27 +7412,27 @@ impl windows_core::RuntimeType for IDragUIOverride {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IDragUIOverride {
-    pub(crate) fn put_Caption(&self, value: &str) -> windows_core::Result<()> {
+    pub(crate) fn SetCaption(&self, value: &str) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Caption)(
+            (windows_core::Interface::vtable(self).SetCaption)(
                 windows_core::Interface::as_raw(self),
                 core::mem::transmute_copy(&windows_core::HSTRING::from(value)),
             )
             .ok()
         }
     }
-    pub(crate) fn put_IsContentVisible(&self, value: bool) -> windows_core::Result<()> {
+    pub(crate) fn SetIsContentVisible(&self, value: bool) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_IsContentVisible)(
+            (windows_core::Interface::vtable(self).SetIsContentVisible)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_IsGlyphVisible(&self, value: bool) -> windows_core::Result<()> {
+    pub(crate) fn SetIsGlyphVisible(&self, value: bool) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_IsGlyphVisible)(
+            (windows_core::Interface::vtable(self).SetIsGlyphVisible)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
@@ -7446,18 +7443,18 @@ impl IDragUIOverride {
 #[repr(C)]
 pub struct IDragUIOverride_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_Caption: usize,
-    pub put_Caption: unsafe extern "system" fn(
+    Caption: usize,
+    pub SetCaption: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_IsContentVisible: usize,
-    pub put_IsContentVisible:
+    IsContentVisible: usize,
+    pub SetIsContentVisible:
         unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
-    get_IsCaptionVisible: usize,
-    put_IsCaptionVisible: usize,
-    get_IsGlyphVisible: usize,
-    pub put_IsGlyphVisible:
+    IsCaptionVisible: usize,
+    SetIsCaptionVisible: usize,
+    IsGlyphVisible: usize,
+    pub SetIsGlyphVisible:
         unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
@@ -7546,21 +7543,21 @@ impl windows_core::RuntimeType for IExpander {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IExpander {
-    pub(crate) fn put_Header<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetHeader<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<windows_core::IInspectable>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Header)(
+            (windows_core::Interface::vtable(self).SetHeader)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
             .ok()
         }
     }
-    pub(crate) fn put_IsExpanded(&self, value: bool) -> windows_core::Result<()> {
+    pub(crate) fn SetIsExpanded(&self, value: bool) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_IsExpanded)(
+            (windows_core::Interface::vtable(self).SetIsExpanded)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
@@ -7586,7 +7583,7 @@ impl IExpander {
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
-            let token__ = (windows_core::Interface::vtable(self).add_Expanding)(
+            let token__ = (windows_core::Interface::vtable(self).Expanding)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Interface::as_raw(&handler),
                 &mut result__,
@@ -7595,7 +7592,7 @@ impl IExpander {
             Ok(windows_core::EventRevoker::new(
                 self.clone(),
                 token__,
-                windows_core::Interface::vtable(self).remove_Expanding,
+                windows_core::Interface::vtable(self).RemoveExpanding,
             ))
         }
     }
@@ -7618,7 +7615,7 @@ impl IExpander {
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
-            let token__ = (windows_core::Interface::vtable(self).add_Collapsed)(
+            let token__ = (windows_core::Interface::vtable(self).Collapsed)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Interface::as_raw(&handler),
                 &mut result__,
@@ -7627,7 +7624,7 @@ impl IExpander {
             Ok(windows_core::EventRevoker::new(
                 self.clone(),
                 token__,
-                windows_core::Interface::vtable(self).remove_Collapsed,
+                windows_core::Interface::vtable(self).RemoveCollapsed,
             ))
         }
     }
@@ -7635,33 +7632,33 @@ impl IExpander {
 #[repr(C)]
 pub struct IExpander_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_Header: usize,
-    pub put_Header: unsafe extern "system" fn(
+    Header: usize,
+    pub SetHeader: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_HeaderTemplate: usize,
-    put_HeaderTemplate: usize,
-    get_HeaderTemplateSelector: usize,
-    put_HeaderTemplateSelector: usize,
-    get_IsExpanded: usize,
-    pub put_IsExpanded:
+    HeaderTemplate: usize,
+    SetHeaderTemplate: usize,
+    HeaderTemplateSelector: usize,
+    SetHeaderTemplateSelector: usize,
+    IsExpanded: usize,
+    pub SetIsExpanded:
         unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
-    get_ExpandDirection: usize,
-    put_ExpandDirection: usize,
-    pub add_Expanding: unsafe extern "system" fn(
+    ExpandDirection: usize,
+    SetExpandDirection: usize,
+    pub Expanding: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         *mut i64,
     ) -> windows_core::HRESULT,
-    pub remove_Expanding:
+    pub RemoveExpanding:
         unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
-    pub add_Collapsed: unsafe extern "system" fn(
+    pub Collapsed: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         *mut i64,
     ) -> windows_core::HRESULT,
-    pub remove_Collapsed:
+    pub RemoveCollapsed:
         unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
@@ -7751,12 +7748,12 @@ impl windows_core::RuntimeType for IFlyout {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IFlyout {
-    pub(crate) fn put_Content<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetContent<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<UIElement>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Content)(
+            (windows_core::Interface::vtable(self).SetContent)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
@@ -7767,8 +7764,8 @@ impl IFlyout {
 #[repr(C)]
 pub struct IFlyout_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_Content: usize,
-    pub put_Content: unsafe extern "system" fn(
+    Content: usize,
+    pub SetContent: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
@@ -7783,9 +7780,9 @@ impl windows_core::RuntimeType for IFlyoutBase {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IFlyoutBase {
-    pub(crate) fn put_Placement(&self, value: FlyoutPlacementMode) -> windows_core::Result<()> {
+    pub(crate) fn SetPlacement(&self, value: FlyoutPlacementMode) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Placement)(
+            (windows_core::Interface::vtable(self).SetPlacement)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
@@ -7796,8 +7793,8 @@ impl IFlyoutBase {
 #[repr(C)]
 pub struct IFlyoutBase_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_Placement: usize,
-    pub put_Placement: unsafe extern "system" fn(
+    Placement: usize,
+    pub SetPlacement: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         FlyoutPlacementMode,
     ) -> windows_core::HRESULT,
@@ -7864,170 +7861,170 @@ impl windows_core::RuntimeType for IFrameworkElement {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IFrameworkElement {
-    pub(crate) fn get_Resources(&self) -> windows_core::Result<ResourceDictionary> {
+    pub(crate) fn Resources(&self) -> windows_core::Result<ResourceDictionary> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_Resources)(
+            (windows_core::Interface::vtable(self).Resources)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
             .and_then(|| windows_core::Type::from_abi(result__))
         }
     }
-    pub(crate) fn get_Tag(&self) -> windows_core::Result<windows_core::IInspectable> {
+    pub(crate) fn Tag(&self) -> windows_core::Result<windows_core::IInspectable> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_Tag)(
+            (windows_core::Interface::vtable(self).Tag)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
             .and_then(|| windows_core::Type::from_abi(result__))
         }
     }
-    pub(crate) fn put_Tag<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetTag<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<windows_core::IInspectable>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Tag)(
+            (windows_core::Interface::vtable(self).SetTag)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
             .ok()
         }
     }
-    pub(crate) fn get_ActualWidth(&self) -> windows_core::Result<f64> {
+    pub(crate) fn ActualWidth(&self) -> windows_core::Result<f64> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_ActualWidth)(
+            (windows_core::Interface::vtable(self).ActualWidth)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
             .map(|| result__)
         }
     }
-    pub(crate) fn get_ActualHeight(&self) -> windows_core::Result<f64> {
+    pub(crate) fn ActualHeight(&self) -> windows_core::Result<f64> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_ActualHeight)(
+            (windows_core::Interface::vtable(self).ActualHeight)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
             .map(|| result__)
         }
     }
-    pub(crate) fn put_Width(&self, value: f64) -> windows_core::Result<()> {
+    pub(crate) fn SetWidth(&self, value: f64) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Width)(
+            (windows_core::Interface::vtable(self).SetWidth)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_Height(&self, value: f64) -> windows_core::Result<()> {
+    pub(crate) fn SetHeight(&self, value: f64) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Height)(
+            (windows_core::Interface::vtable(self).SetHeight)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_MinWidth(&self, value: f64) -> windows_core::Result<()> {
+    pub(crate) fn SetMinWidth(&self, value: f64) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_MinWidth)(
+            (windows_core::Interface::vtable(self).SetMinWidth)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_MaxWidth(&self, value: f64) -> windows_core::Result<()> {
+    pub(crate) fn SetMaxWidth(&self, value: f64) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_MaxWidth)(
+            (windows_core::Interface::vtable(self).SetMaxWidth)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_MinHeight(&self, value: f64) -> windows_core::Result<()> {
+    pub(crate) fn SetMinHeight(&self, value: f64) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_MinHeight)(
+            (windows_core::Interface::vtable(self).SetMinHeight)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_MaxHeight(&self, value: f64) -> windows_core::Result<()> {
+    pub(crate) fn SetMaxHeight(&self, value: f64) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_MaxHeight)(
+            (windows_core::Interface::vtable(self).SetMaxHeight)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_HorizontalAlignment(
+    pub(crate) fn SetHorizontalAlignment(
         &self,
         value: HorizontalAlignment,
     ) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_HorizontalAlignment)(
+            (windows_core::Interface::vtable(self).SetHorizontalAlignment)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_VerticalAlignment(
+    pub(crate) fn SetVerticalAlignment(
         &self,
         value: VerticalAlignment,
     ) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_VerticalAlignment)(
+            (windows_core::Interface::vtable(self).SetVerticalAlignment)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_Margin(&self, value: Thickness) -> windows_core::Result<()> {
+    pub(crate) fn SetMargin(&self, value: Thickness) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Margin)(
+            (windows_core::Interface::vtable(self).SetMargin)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_Style<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetStyle<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<Style>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Style)(
+            (windows_core::Interface::vtable(self).SetStyle)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
             .ok()
         }
     }
-    pub(crate) fn put_RequestedTheme(&self, value: ElementTheme) -> windows_core::Result<()> {
+    pub(crate) fn SetRequestedTheme(&self, value: ElementTheme) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_RequestedTheme)(
+            (windows_core::Interface::vtable(self).SetRequestedTheme)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn get_ActualTheme(&self) -> windows_core::Result<ElementTheme> {
+    pub(crate) fn ActualTheme(&self) -> windows_core::Result<ElementTheme> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_ActualTheme)(
+            (windows_core::Interface::vtable(self).ActualTheme)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
@@ -8053,7 +8050,7 @@ impl IFrameworkElement {
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
-            let token__ = (windows_core::Interface::vtable(self).add_SizeChanged)(
+            let token__ = (windows_core::Interface::vtable(self).SizeChanged)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Interface::as_raw(&handler),
                 &mut result__,
@@ -8062,7 +8059,7 @@ impl IFrameworkElement {
             Ok(windows_core::EventRevoker::new(
                 self.clone(),
                 token__,
-                windows_core::Interface::vtable(self).remove_SizeChanged,
+                windows_core::Interface::vtable(self).RemoveSizeChanged,
             ))
         }
     }
@@ -8086,7 +8083,7 @@ impl IFrameworkElement {
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
-            let token__ = (windows_core::Interface::vtable(self).add_ActualThemeChanged)(
+            let token__ = (windows_core::Interface::vtable(self).ActualThemeChanged)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Interface::as_raw(&handler),
                 &mut result__,
@@ -8095,7 +8092,7 @@ impl IFrameworkElement {
             Ok(windows_core::EventRevoker::new(
                 self.clone(),
                 token__,
-                windows_core::Interface::vtable(self).remove_ActualThemeChanged,
+                windows_core::Interface::vtable(self).RemoveActualThemeChanged,
             ))
         }
     }
@@ -8103,113 +8100,113 @@ impl IFrameworkElement {
 #[repr(C)]
 pub struct IFrameworkElement_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_Triggers: usize,
-    pub get_Resources: unsafe extern "system" fn(
+    Triggers: usize,
+    pub Resources: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    put_Resources: usize,
-    pub get_Tag: unsafe extern "system" fn(
+    SetResources: usize,
+    pub Tag: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    pub put_Tag: unsafe extern "system" fn(
+    pub SetTag: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_Language: usize,
-    put_Language: usize,
-    pub get_ActualWidth:
+    Language: usize,
+    SetLanguage: usize,
+    pub ActualWidth:
         unsafe extern "system" fn(*mut core::ffi::c_void, *mut f64) -> windows_core::HRESULT,
-    pub get_ActualHeight:
+    pub ActualHeight:
         unsafe extern "system" fn(*mut core::ffi::c_void, *mut f64) -> windows_core::HRESULT,
-    get_Width: usize,
-    pub put_Width: unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
-    get_Height: usize,
-    pub put_Height: unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
-    get_MinWidth: usize,
-    pub put_MinWidth:
+    Width: usize,
+    pub SetWidth: unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
+    Height: usize,
+    pub SetHeight: unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
+    MinWidth: usize,
+    pub SetMinWidth:
         unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
-    get_MaxWidth: usize,
-    pub put_MaxWidth:
+    MaxWidth: usize,
+    pub SetMaxWidth:
         unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
-    get_MinHeight: usize,
-    pub put_MinHeight:
+    MinHeight: usize,
+    pub SetMinHeight:
         unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
-    get_MaxHeight: usize,
-    pub put_MaxHeight:
+    MaxHeight: usize,
+    pub SetMaxHeight:
         unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
-    get_HorizontalAlignment: usize,
-    pub put_HorizontalAlignment: unsafe extern "system" fn(
+    HorizontalAlignment: usize,
+    pub SetHorizontalAlignment: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         HorizontalAlignment,
     ) -> windows_core::HRESULT,
-    get_VerticalAlignment: usize,
-    pub put_VerticalAlignment: unsafe extern "system" fn(
+    VerticalAlignment: usize,
+    pub SetVerticalAlignment: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         VerticalAlignment,
     ) -> windows_core::HRESULT,
-    get_Margin: usize,
-    pub put_Margin:
+    Margin: usize,
+    pub SetMargin:
         unsafe extern "system" fn(*mut core::ffi::c_void, Thickness) -> windows_core::HRESULT,
-    get_Name: usize,
-    put_Name: usize,
-    get_BaseUri: usize,
-    get_DataContext: usize,
-    put_DataContext: usize,
-    get_AllowFocusOnInteraction: usize,
-    put_AllowFocusOnInteraction: usize,
-    get_FocusVisualMargin: usize,
-    put_FocusVisualMargin: usize,
-    get_FocusVisualSecondaryThickness: usize,
-    put_FocusVisualSecondaryThickness: usize,
-    get_FocusVisualPrimaryThickness: usize,
-    put_FocusVisualPrimaryThickness: usize,
-    get_FocusVisualSecondaryBrush: usize,
-    put_FocusVisualSecondaryBrush: usize,
-    get_FocusVisualPrimaryBrush: usize,
-    put_FocusVisualPrimaryBrush: usize,
-    get_AllowFocusWhenDisabled: usize,
-    put_AllowFocusWhenDisabled: usize,
-    get_Style: usize,
-    pub put_Style: unsafe extern "system" fn(
+    Name: usize,
+    SetName: usize,
+    BaseUri: usize,
+    DataContext: usize,
+    SetDataContext: usize,
+    AllowFocusOnInteraction: usize,
+    SetAllowFocusOnInteraction: usize,
+    FocusVisualMargin: usize,
+    SetFocusVisualMargin: usize,
+    FocusVisualSecondaryThickness: usize,
+    SetFocusVisualSecondaryThickness: usize,
+    FocusVisualPrimaryThickness: usize,
+    SetFocusVisualPrimaryThickness: usize,
+    FocusVisualSecondaryBrush: usize,
+    SetFocusVisualSecondaryBrush: usize,
+    FocusVisualPrimaryBrush: usize,
+    SetFocusVisualPrimaryBrush: usize,
+    AllowFocusWhenDisabled: usize,
+    SetAllowFocusWhenDisabled: usize,
+    Style: usize,
+    pub SetStyle: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_Parent: usize,
-    get_FlowDirection: usize,
-    put_FlowDirection: usize,
-    get_RequestedTheme: usize,
-    pub put_RequestedTheme:
+    Parent: usize,
+    FlowDirection: usize,
+    SetFlowDirection: usize,
+    RequestedTheme: usize,
+    pub SetRequestedTheme:
         unsafe extern "system" fn(*mut core::ffi::c_void, ElementTheme) -> windows_core::HRESULT,
-    get_IsLoaded: usize,
-    pub get_ActualTheme: unsafe extern "system" fn(
+    IsLoaded: usize,
+    pub ActualTheme: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut ElementTheme,
     ) -> windows_core::HRESULT,
-    add_Loaded: usize,
-    remove_Loaded: usize,
-    add_Unloaded: usize,
-    remove_Unloaded: usize,
-    add_DataContextChanged: usize,
-    remove_DataContextChanged: usize,
-    pub add_SizeChanged: unsafe extern "system" fn(
+    Loaded: usize,
+    RemoveLoaded: usize,
+    Unloaded: usize,
+    RemoveUnloaded: usize,
+    DataContextChanged: usize,
+    RemoveDataContextChanged: usize,
+    pub SizeChanged: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         *mut i64,
     ) -> windows_core::HRESULT,
-    pub remove_SizeChanged:
+    pub RemoveSizeChanged:
         unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
-    add_LayoutUpdated: usize,
-    remove_LayoutUpdated: usize,
-    add_Loading: usize,
-    remove_Loading: usize,
-    pub add_ActualThemeChanged: unsafe extern "system" fn(
+    LayoutUpdated: usize,
+    RemoveLayoutUpdated: usize,
+    Loading: usize,
+    RemoveLoading: usize,
+    pub ActualThemeChanged: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         *mut i64,
     ) -> windows_core::HRESULT,
-    pub remove_ActualThemeChanged:
+    pub RemoveActualThemeChanged:
         unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGrid, IGrid_Vtbl, 0xc4496219_9014_58a1_b4ad_c5044913a5bb);
@@ -8218,38 +8215,38 @@ impl windows_core::RuntimeType for IGrid {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IGrid {
-    pub(crate) fn get_RowDefinitions(&self) -> windows_core::Result<RowDefinitionCollection> {
+    pub(crate) fn RowDefinitions(&self) -> windows_core::Result<RowDefinitionCollection> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_RowDefinitions)(
+            (windows_core::Interface::vtable(self).RowDefinitions)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
             .and_then(|| windows_core::Type::from_abi(result__))
         }
     }
-    pub(crate) fn get_ColumnDefinitions(&self) -> windows_core::Result<ColumnDefinitionCollection> {
+    pub(crate) fn ColumnDefinitions(&self) -> windows_core::Result<ColumnDefinitionCollection> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_ColumnDefinitions)(
+            (windows_core::Interface::vtable(self).ColumnDefinitions)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
             .and_then(|| windows_core::Type::from_abi(result__))
         }
     }
-    pub(crate) fn put_RowSpacing(&self, value: f64) -> windows_core::Result<()> {
+    pub(crate) fn SetRowSpacing(&self, value: f64) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_RowSpacing)(
+            (windows_core::Interface::vtable(self).SetRowSpacing)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_ColumnSpacing(&self, value: f64) -> windows_core::Result<()> {
+    pub(crate) fn SetColumnSpacing(&self, value: f64) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_ColumnSpacing)(
+            (windows_core::Interface::vtable(self).SetColumnSpacing)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
@@ -8260,29 +8257,29 @@ impl IGrid {
 #[repr(C)]
 pub struct IGrid_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    pub get_RowDefinitions: unsafe extern "system" fn(
+    pub RowDefinitions: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    pub get_ColumnDefinitions: unsafe extern "system" fn(
+    pub ColumnDefinitions: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_BackgroundSizing: usize,
-    put_BackgroundSizing: usize,
-    get_BorderBrush: usize,
-    put_BorderBrush: usize,
-    get_BorderThickness: usize,
-    put_BorderThickness: usize,
-    get_CornerRadius: usize,
-    put_CornerRadius: usize,
-    get_Padding: usize,
-    put_Padding: usize,
-    get_RowSpacing: usize,
-    pub put_RowSpacing:
+    BackgroundSizing: usize,
+    SetBackgroundSizing: usize,
+    BorderBrush: usize,
+    SetBorderBrush: usize,
+    BorderThickness: usize,
+    SetBorderThickness: usize,
+    CornerRadius: usize,
+    SetCornerRadius: usize,
+    Padding: usize,
+    SetPadding: usize,
+    RowSpacing: usize,
+    pub SetRowSpacing:
         unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
-    get_ColumnSpacing: usize,
-    pub put_ColumnSpacing:
+    ColumnSpacing: usize,
+    pub SetColumnSpacing:
         unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
@@ -8316,35 +8313,35 @@ impl windows_core::RuntimeType for IGridStatics {
 #[repr(C)]
 pub struct IGridStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_BackgroundSizingProperty: usize,
-    get_BorderBrushProperty: usize,
-    get_BorderThicknessProperty: usize,
-    get_CornerRadiusProperty: usize,
-    get_PaddingProperty: usize,
-    get_RowSpacingProperty: usize,
-    get_ColumnSpacingProperty: usize,
-    get_RowProperty: usize,
+    BackgroundSizingProperty: usize,
+    BorderBrushProperty: usize,
+    BorderThicknessProperty: usize,
+    CornerRadiusProperty: usize,
+    PaddingProperty: usize,
+    RowSpacingProperty: usize,
+    ColumnSpacingProperty: usize,
+    RowProperty: usize,
     GetRow: usize,
     pub SetRow: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         i32,
     ) -> windows_core::HRESULT,
-    get_ColumnProperty: usize,
+    ColumnProperty: usize,
     GetColumn: usize,
     pub SetColumn: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         i32,
     ) -> windows_core::HRESULT,
-    get_RowSpanProperty: usize,
+    RowSpanProperty: usize,
     GetRowSpan: usize,
     pub SetRowSpan: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         i32,
     ) -> windows_core::HRESULT,
-    get_ColumnSpanProperty: usize,
+    ColumnSpanProperty: usize,
     GetColumnSpan: usize,
     pub SetColumnSpan: unsafe extern "system" fn(
         *mut core::ffi::c_void,
@@ -8394,12 +8391,12 @@ impl windows_core::RuntimeType for IHyperlinkButton {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IHyperlinkButton {
-    pub(crate) fn put_NavigateUri<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetNavigateUri<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<Uri>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_NavigateUri)(
+            (windows_core::Interface::vtable(self).SetNavigateUri)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
@@ -8410,8 +8407,8 @@ impl IHyperlinkButton {
 #[repr(C)]
 pub struct IHyperlinkButton_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_NavigateUri: usize,
-    pub put_NavigateUri: unsafe extern "system" fn(
+    NavigateUri: usize,
+    pub SetNavigateUri: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
@@ -8454,21 +8451,21 @@ impl windows_core::RuntimeType for IImage {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IImage {
-    pub(crate) fn put_Source<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetSource<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<ImageSource>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Source)(
+            (windows_core::Interface::vtable(self).SetSource)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
             .ok()
         }
     }
-    pub(crate) fn put_Stretch(&self, value: Stretch) -> windows_core::Result<()> {
+    pub(crate) fn SetStretch(&self, value: Stretch) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Stretch)(
+            (windows_core::Interface::vtable(self).SetStretch)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
@@ -8479,13 +8476,13 @@ impl IImage {
 #[repr(C)]
 pub struct IImage_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_Source: usize,
-    pub put_Source: unsafe extern "system" fn(
+    Source: usize,
+    pub SetSource: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_Stretch: usize,
-    pub put_Stretch:
+    Stretch: usize,
+    pub SetStretch:
         unsafe extern "system" fn(*mut core::ffi::c_void, Stretch) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
@@ -8524,9 +8521,9 @@ impl windows_core::RuntimeType for IInfoBadge {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IInfoBadge {
-    pub(crate) fn put_Value(&self, value: i32) -> windows_core::Result<()> {
+    pub(crate) fn SetValue(&self, value: i32) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Value)(
+            (windows_core::Interface::vtable(self).SetValue)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
@@ -8537,8 +8534,8 @@ impl IInfoBadge {
 #[repr(C)]
 pub struct IInfoBadge_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_Value: usize,
-    pub put_Value: unsafe extern "system" fn(*mut core::ffi::c_void, i32) -> windows_core::HRESULT,
+    Value: usize,
+    pub SetValue: unsafe extern "system" fn(*mut core::ffi::c_void, i32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
     IInfoBadgeFactory,
@@ -8569,45 +8566,45 @@ impl windows_core::RuntimeType for IInfoBar {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IInfoBar {
-    pub(crate) fn put_IsOpen(&self, value: bool) -> windows_core::Result<()> {
+    pub(crate) fn SetIsOpen(&self, value: bool) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_IsOpen)(
+            (windows_core::Interface::vtable(self).SetIsOpen)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_Title(&self, value: &str) -> windows_core::Result<()> {
+    pub(crate) fn SetTitle(&self, value: &str) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Title)(
+            (windows_core::Interface::vtable(self).SetTitle)(
                 windows_core::Interface::as_raw(self),
                 core::mem::transmute_copy(&windows_core::HSTRING::from(value)),
             )
             .ok()
         }
     }
-    pub(crate) fn put_Message(&self, value: &str) -> windows_core::Result<()> {
+    pub(crate) fn SetMessage(&self, value: &str) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Message)(
+            (windows_core::Interface::vtable(self).SetMessage)(
                 windows_core::Interface::as_raw(self),
                 core::mem::transmute_copy(&windows_core::HSTRING::from(value)),
             )
             .ok()
         }
     }
-    pub(crate) fn put_Severity(&self, value: InfoBarSeverity) -> windows_core::Result<()> {
+    pub(crate) fn SetSeverity(&self, value: InfoBarSeverity) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Severity)(
+            (windows_core::Interface::vtable(self).SetSeverity)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_IsClosable(&self, value: bool) -> windows_core::Result<()> {
+    pub(crate) fn SetIsClosable(&self, value: bool) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_IsClosable)(
+            (windows_core::Interface::vtable(self).SetIsClosable)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
@@ -8630,7 +8627,7 @@ impl IInfoBar {
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
-            let token__ = (windows_core::Interface::vtable(self).add_Closed)(
+            let token__ = (windows_core::Interface::vtable(self).Closed)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Interface::as_raw(&handler),
                 &mut result__,
@@ -8639,7 +8636,7 @@ impl IInfoBar {
             Ok(windows_core::EventRevoker::new(
                 self.clone(),
                 token__,
-                windows_core::Interface::vtable(self).remove_Closed,
+                windows_core::Interface::vtable(self).RemoveClosed,
             ))
         }
     }
@@ -8647,52 +8644,51 @@ impl IInfoBar {
 #[repr(C)]
 pub struct IInfoBar_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_IsOpen: usize,
-    pub put_IsOpen:
-        unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
-    get_Title: usize,
-    pub put_Title: unsafe extern "system" fn(
+    IsOpen: usize,
+    pub SetIsOpen: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
+    Title: usize,
+    pub SetTitle: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_Message: usize,
-    pub put_Message: unsafe extern "system" fn(
+    Message: usize,
+    pub SetMessage: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_Severity: usize,
-    pub put_Severity:
+    Severity: usize,
+    pub SetSeverity:
         unsafe extern "system" fn(*mut core::ffi::c_void, InfoBarSeverity) -> windows_core::HRESULT,
-    get_IconSource: usize,
-    put_IconSource: usize,
-    get_IsIconVisible: usize,
-    put_IsIconVisible: usize,
-    get_IsClosable: usize,
-    pub put_IsClosable:
+    IconSource: usize,
+    SetIconSource: usize,
+    IsIconVisible: usize,
+    SetIsIconVisible: usize,
+    IsClosable: usize,
+    pub SetIsClosable:
         unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
-    get_CloseButtonStyle: usize,
-    put_CloseButtonStyle: usize,
-    get_CloseButtonCommand: usize,
-    put_CloseButtonCommand: usize,
-    get_CloseButtonCommandParameter: usize,
-    put_CloseButtonCommandParameter: usize,
-    get_ActionButton: usize,
-    put_ActionButton: usize,
-    get_Content: usize,
-    put_Content: usize,
-    get_ContentTemplate: usize,
-    put_ContentTemplate: usize,
-    get_TemplateSettings: usize,
-    add_CloseButtonClick: usize,
-    remove_CloseButtonClick: usize,
-    add_Closing: usize,
-    remove_Closing: usize,
-    pub add_Closed: unsafe extern "system" fn(
+    CloseButtonStyle: usize,
+    SetCloseButtonStyle: usize,
+    CloseButtonCommand: usize,
+    SetCloseButtonCommand: usize,
+    CloseButtonCommandParameter: usize,
+    SetCloseButtonCommandParameter: usize,
+    ActionButton: usize,
+    SetActionButton: usize,
+    Content: usize,
+    SetContent: usize,
+    ContentTemplate: usize,
+    SetContentTemplate: usize,
+    TemplateSettings: usize,
+    CloseButtonClick: usize,
+    RemoveCloseButtonClick: usize,
+    Closing: usize,
+    RemoveClosing: usize,
+    pub Closed: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         *mut i64,
     ) -> windows_core::HRESULT,
-    pub remove_Closed:
+    pub RemoveClosed:
         unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
@@ -8763,22 +8759,22 @@ impl windows_core::RuntimeType for IItemsControl {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IItemsControl {
-    pub(crate) fn put_ItemsSource<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetItemsSource<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<windows_core::IInspectable>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_ItemsSource)(
+            (windows_core::Interface::vtable(self).SetItemsSource)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
             .ok()
         }
     }
-    pub(crate) fn get_Items(&self) -> windows_core::Result<ItemCollection> {
+    pub(crate) fn Items(&self) -> windows_core::Result<ItemCollection> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_Items)(
+            (windows_core::Interface::vtable(self).Items)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
@@ -8789,12 +8785,12 @@ impl IItemsControl {
 #[repr(C)]
 pub struct IItemsControl_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_ItemsSource: usize,
-    pub put_ItemsSource: unsafe extern "system" fn(
+    ItemsSource: usize,
+    pub SetItemsSource: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    pub get_Items: unsafe extern "system" fn(
+    pub Items: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
@@ -8809,9 +8805,9 @@ impl windows_core::RuntimeType for IKeyFrameAnimation {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IKeyFrameAnimation {
-    pub(crate) fn put_Duration(&self, value: windows_time::TimeSpan) -> windows_core::Result<()> {
+    pub(crate) fn SetDuration(&self, value: windows_time::TimeSpan) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Duration)(
+            (windows_core::Interface::vtable(self).SetDuration)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
@@ -8841,20 +8837,20 @@ impl IKeyFrameAnimation {
 #[repr(C)]
 pub struct IKeyFrameAnimation_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_DelayTime: usize,
-    put_DelayTime: usize,
-    get_Duration: usize,
-    pub put_Duration: unsafe extern "system" fn(
+    DelayTime: usize,
+    SetDelayTime: usize,
+    Duration: usize,
+    pub SetDuration: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         windows_time::TimeSpan,
     ) -> windows_core::HRESULT,
-    get_IterationBehavior: usize,
-    put_IterationBehavior: usize,
-    get_IterationCount: usize,
-    put_IterationCount: usize,
-    get_KeyFrameCount: usize,
-    get_StopBehavior: usize,
-    put_StopBehavior: usize,
+    IterationBehavior: usize,
+    SetIterationBehavior: usize,
+    IterationCount: usize,
+    SetIterationCount: usize,
+    KeyFrameCount: usize,
+    StopBehavior: usize,
+    SetStopBehavior: usize,
     InsertExpressionKeyFrame: usize,
     pub InsertExpressionKeyFrameWithEasingFunction:
         unsafe extern "system" fn(
@@ -8874,18 +8870,18 @@ impl windows_core::RuntimeType for IKeyboardAccelerator {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IKeyboardAccelerator {
-    pub(crate) fn put_Key(&self, value: VirtualKey) -> windows_core::Result<()> {
+    pub(crate) fn SetKey(&self, value: VirtualKey) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Key)(
+            (windows_core::Interface::vtable(self).SetKey)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_Modifiers(&self, value: VirtualKeyModifiers) -> windows_core::Result<()> {
+    pub(crate) fn SetModifiers(&self, value: VirtualKeyModifiers) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Modifiers)(
+            (windows_core::Interface::vtable(self).SetModifiers)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
@@ -8916,7 +8912,7 @@ impl IKeyboardAccelerator {
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
-            let token__ = (windows_core::Interface::vtable(self).add_Invoked)(
+            let token__ = (windows_core::Interface::vtable(self).Invoked)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Interface::as_raw(&handler),
                 &mut result__,
@@ -8925,7 +8921,7 @@ impl IKeyboardAccelerator {
             Ok(windows_core::EventRevoker::new(
                 self.clone(),
                 token__,
-                windows_core::Interface::vtable(self).remove_Invoked,
+                windows_core::Interface::vtable(self).RemoveInvoked,
             ))
         }
     }
@@ -8933,24 +8929,24 @@ impl IKeyboardAccelerator {
 #[repr(C)]
 pub struct IKeyboardAccelerator_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_Key: usize,
-    pub put_Key:
+    Key: usize,
+    pub SetKey:
         unsafe extern "system" fn(*mut core::ffi::c_void, VirtualKey) -> windows_core::HRESULT,
-    get_Modifiers: usize,
-    pub put_Modifiers: unsafe extern "system" fn(
+    Modifiers: usize,
+    pub SetModifiers: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         VirtualKeyModifiers,
     ) -> windows_core::HRESULT,
-    get_IsEnabled: usize,
-    put_IsEnabled: usize,
-    get_ScopeOwner: usize,
-    put_ScopeOwner: usize,
-    pub add_Invoked: unsafe extern "system" fn(
+    IsEnabled: usize,
+    SetIsEnabled: usize,
+    ScopeOwner: usize,
+    SetScopeOwner: usize,
+    pub Invoked: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         *mut i64,
     ) -> windows_core::HRESULT,
-    pub remove_Invoked:
+    pub RemoveInvoked:
         unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
@@ -8982,9 +8978,9 @@ impl windows_core::RuntimeType for IKeyboardAcceleratorInvokedEventArgs {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IKeyboardAcceleratorInvokedEventArgs {
-    pub(crate) fn put_Handled(&self, value: bool) -> windows_core::Result<()> {
+    pub(crate) fn SetHandled(&self, value: bool) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Handled)(
+            (windows_core::Interface::vtable(self).SetHandled)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
@@ -8995,8 +8991,8 @@ impl IKeyboardAcceleratorInvokedEventArgs {
 #[repr(C)]
 pub struct IKeyboardAcceleratorInvokedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_Handled: usize,
-    pub put_Handled:
+    Handled: usize,
+    pub SetHandled:
         unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
@@ -9018,36 +9014,36 @@ impl windows_core::RuntimeType for ILine {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl ILine {
-    pub(crate) fn put_X1(&self, value: f64) -> windows_core::Result<()> {
+    pub(crate) fn SetX1(&self, value: f64) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_X1)(
+            (windows_core::Interface::vtable(self).SetX1)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_Y1(&self, value: f64) -> windows_core::Result<()> {
+    pub(crate) fn SetY1(&self, value: f64) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Y1)(
+            (windows_core::Interface::vtable(self).SetY1)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_X2(&self, value: f64) -> windows_core::Result<()> {
+    pub(crate) fn SetX2(&self, value: f64) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_X2)(
+            (windows_core::Interface::vtable(self).SetX2)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_Y2(&self, value: f64) -> windows_core::Result<()> {
+    pub(crate) fn SetY2(&self, value: f64) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Y2)(
+            (windows_core::Interface::vtable(self).SetY2)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
@@ -9058,14 +9054,14 @@ impl ILine {
 #[repr(C)]
 pub struct ILine_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_X1: usize,
-    pub put_X1: unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
-    get_Y1: usize,
-    pub put_Y1: unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
-    get_X2: usize,
-    pub put_X2: unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
-    get_Y2: usize,
-    pub put_Y2: unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
+    X1: usize,
+    pub SetX1: unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
+    Y1: usize,
+    pub SetY1: unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
+    X2: usize,
+    pub SetX2: unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
+    Y2: usize,
+    pub SetY2: unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
     ILinearEasingFunction,
@@ -9135,30 +9131,30 @@ impl windows_core::RuntimeType for IListViewBase {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IListViewBase {
-    pub(crate) fn put_SelectionMode(
+    pub(crate) fn SetSelectionMode(
         &self,
         value: ListViewSelectionMode,
     ) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_SelectionMode)(
+            (windows_core::Interface::vtable(self).SetSelectionMode)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_CanDragItems(&self, value: bool) -> windows_core::Result<()> {
+    pub(crate) fn SetCanDragItems(&self, value: bool) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_CanDragItems)(
+            (windows_core::Interface::vtable(self).SetCanDragItems)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_CanReorderItems(&self, value: bool) -> windows_core::Result<()> {
+    pub(crate) fn SetCanReorderItems(&self, value: bool) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_CanReorderItems)(
+            (windows_core::Interface::vtable(self).SetCanReorderItems)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
@@ -9181,49 +9177,49 @@ impl IListViewBase {
 #[repr(C)]
 pub struct IListViewBase_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_SelectedItems: usize,
-    get_SelectionMode: usize,
-    pub put_SelectionMode: unsafe extern "system" fn(
+    SelectedItems: usize,
+    SelectionMode: usize,
+    pub SetSelectionMode: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         ListViewSelectionMode,
     ) -> windows_core::HRESULT,
-    get_IsSwipeEnabled: usize,
-    put_IsSwipeEnabled: usize,
-    get_CanDragItems: usize,
-    pub put_CanDragItems:
+    IsSwipeEnabled: usize,
+    SetIsSwipeEnabled: usize,
+    CanDragItems: usize,
+    pub SetCanDragItems:
         unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
-    get_CanReorderItems: usize,
-    pub put_CanReorderItems:
+    CanReorderItems: usize,
+    pub SetCanReorderItems:
         unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
-    get_IsItemClickEnabled: usize,
-    put_IsItemClickEnabled: usize,
-    get_DataFetchSize: usize,
-    put_DataFetchSize: usize,
-    get_IncrementalLoadingThreshold: usize,
-    put_IncrementalLoadingThreshold: usize,
-    get_IncrementalLoadingTrigger: usize,
-    put_IncrementalLoadingTrigger: usize,
-    get_ShowsScrollingPlaceholders: usize,
-    put_ShowsScrollingPlaceholders: usize,
-    get_ReorderMode: usize,
-    put_ReorderMode: usize,
-    get_SelectedRanges: usize,
-    get_IsMultiSelectCheckBoxEnabled: usize,
-    put_IsMultiSelectCheckBoxEnabled: usize,
-    get_SingleSelectionFollowsFocus: usize,
-    put_SingleSelectionFollowsFocus: usize,
-    add_ItemClick: usize,
-    remove_ItemClick: usize,
-    add_DragItemsStarting: usize,
-    remove_DragItemsStarting: usize,
-    add_DragItemsCompleted: usize,
-    remove_DragItemsCompleted: usize,
-    add_ContainerContentChanging: usize,
-    remove_ContainerContentChanging: usize,
-    add_ChoosingItemContainer: usize,
-    remove_ChoosingItemContainer: usize,
-    add_ChoosingGroupHeaderContainer: usize,
-    remove_ChoosingGroupHeaderContainer: usize,
+    IsItemClickEnabled: usize,
+    SetIsItemClickEnabled: usize,
+    DataFetchSize: usize,
+    SetDataFetchSize: usize,
+    IncrementalLoadingThreshold: usize,
+    SetIncrementalLoadingThreshold: usize,
+    IncrementalLoadingTrigger: usize,
+    SetIncrementalLoadingTrigger: usize,
+    ShowsScrollingPlaceholders: usize,
+    SetShowsScrollingPlaceholders: usize,
+    ReorderMode: usize,
+    SetReorderMode: usize,
+    SelectedRanges: usize,
+    IsMultiSelectCheckBoxEnabled: usize,
+    SetIsMultiSelectCheckBoxEnabled: usize,
+    SingleSelectionFollowsFocus: usize,
+    SetSingleSelectionFollowsFocus: usize,
+    ItemClick: usize,
+    RemoveItemClick: usize,
+    DragItemsStarting: usize,
+    RemoveDragItemsStarting: usize,
+    DragItemsCompleted: usize,
+    RemoveDragItemsCompleted: usize,
+    ContainerContentChanging: usize,
+    RemoveContainerContentChanging: usize,
+    ChoosingItemContainer: usize,
+    RemoveChoosingItemContainer: usize,
+    ChoosingGroupHeaderContainer: usize,
+    RemoveChoosingGroupHeaderContainer: usize,
     pub ScrollIntoView: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
@@ -9271,12 +9267,10 @@ impl windows_core::RuntimeType for IMenuBar {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IMenuBar {
-    pub(crate) fn get_Items(
-        &self,
-    ) -> windows_core::Result<windows_collections::IVector<MenuBarItem>> {
+    pub(crate) fn Items(&self) -> windows_core::Result<windows_collections::IVector<MenuBarItem>> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_Items)(
+            (windows_core::Interface::vtable(self).Items)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
@@ -9287,7 +9281,7 @@ impl IMenuBar {
 #[repr(C)]
 pub struct IMenuBar_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    pub get_Items: unsafe extern "system" fn(
+    pub Items: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
@@ -9321,21 +9315,21 @@ impl windows_core::RuntimeType for IMenuBarItem {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IMenuBarItem {
-    pub(crate) fn put_Title(&self, value: &str) -> windows_core::Result<()> {
+    pub(crate) fn SetTitle(&self, value: &str) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Title)(
+            (windows_core::Interface::vtable(self).SetTitle)(
                 windows_core::Interface::as_raw(self),
                 core::mem::transmute_copy(&windows_core::HSTRING::from(value)),
             )
             .ok()
         }
     }
-    pub(crate) fn get_Items(
+    pub(crate) fn Items(
         &self,
     ) -> windows_core::Result<windows_collections::IVector<MenuFlyoutItemBase>> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_Items)(
+            (windows_core::Interface::vtable(self).Items)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
@@ -9346,12 +9340,12 @@ impl IMenuBarItem {
 #[repr(C)]
 pub struct IMenuBarItem_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_Title: usize,
-    pub put_Title: unsafe extern "system" fn(
+    Title: usize,
+    pub SetTitle: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    pub get_Items: unsafe extern "system" fn(
+    pub Items: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
@@ -9385,12 +9379,12 @@ impl windows_core::RuntimeType for IMenuFlyout {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IMenuFlyout {
-    pub(crate) fn get_Items(
+    pub(crate) fn Items(
         &self,
     ) -> windows_core::Result<windows_collections::IVector<MenuFlyoutItemBase>> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_Items)(
+            (windows_core::Interface::vtable(self).Items)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
@@ -9401,7 +9395,7 @@ impl IMenuFlyout {
 #[repr(C)]
 pub struct IMenuFlyout_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    pub get_Items: unsafe extern "system" fn(
+    pub Items: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
@@ -9435,10 +9429,10 @@ impl windows_core::RuntimeType for IMenuFlyoutItem {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IMenuFlyoutItem {
-    pub(crate) fn get_Text(&self) -> windows_core::Result<String> {
+    pub(crate) fn Text(&self) -> windows_core::Result<String> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_Text)(
+            (windows_core::Interface::vtable(self).Text)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
@@ -9448,9 +9442,9 @@ impl IMenuFlyoutItem {
             })
         }
     }
-    pub(crate) fn put_Text(&self, value: &str) -> windows_core::Result<()> {
+    pub(crate) fn SetText(&self, value: &str) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Text)(
+            (windows_core::Interface::vtable(self).SetText)(
                 windows_core::Interface::as_raw(self),
                 core::mem::transmute_copy(&windows_core::HSTRING::from(value)),
             )
@@ -9471,7 +9465,7 @@ impl IMenuFlyoutItem {
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
-            let token__ = (windows_core::Interface::vtable(self).add_Click)(
+            let token__ = (windows_core::Interface::vtable(self).Click)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Interface::as_raw(&handler),
                 &mut result__,
@@ -9480,7 +9474,7 @@ impl IMenuFlyoutItem {
             Ok(windows_core::EventRevoker::new(
                 self.clone(),
                 token__,
-                windows_core::Interface::vtable(self).remove_Click,
+                windows_core::Interface::vtable(self).RemoveClick,
             ))
         }
     }
@@ -9488,29 +9482,29 @@ impl IMenuFlyoutItem {
 #[repr(C)]
 pub struct IMenuFlyoutItem_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    pub get_Text: unsafe extern "system" fn(
+    pub Text: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    pub put_Text: unsafe extern "system" fn(
+    pub SetText: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_Command: usize,
-    put_Command: usize,
-    get_CommandParameter: usize,
-    put_CommandParameter: usize,
-    get_Icon: usize,
-    put_Icon: usize,
-    get_KeyboardAcceleratorTextOverride: usize,
-    put_KeyboardAcceleratorTextOverride: usize,
-    get_TemplateSettings: usize,
-    pub add_Click: unsafe extern "system" fn(
+    Command: usize,
+    SetCommand: usize,
+    CommandParameter: usize,
+    SetCommandParameter: usize,
+    Icon: usize,
+    SetIcon: usize,
+    KeyboardAcceleratorTextOverride: usize,
+    SetKeyboardAcceleratorTextOverride: usize,
+    TemplateSettings: usize,
+    pub Click: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         *mut i64,
     ) -> windows_core::HRESULT,
-    pub remove_Click:
+    pub RemoveClick:
         unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
@@ -9587,21 +9581,21 @@ impl windows_core::RuntimeType for IMenuFlyoutSubItem {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IMenuFlyoutSubItem {
-    pub(crate) fn get_Items(
+    pub(crate) fn Items(
         &self,
     ) -> windows_core::Result<windows_collections::IVector<MenuFlyoutItemBase>> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_Items)(
+            (windows_core::Interface::vtable(self).Items)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
             .and_then(|| windows_core::Type::from_abi(result__))
         }
     }
-    pub(crate) fn put_Text(&self, value: &str) -> windows_core::Result<()> {
+    pub(crate) fn SetText(&self, value: &str) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Text)(
+            (windows_core::Interface::vtable(self).SetText)(
                 windows_core::Interface::as_raw(self),
                 core::mem::transmute_copy(&windows_core::HSTRING::from(value)),
             )
@@ -9612,12 +9606,12 @@ impl IMenuFlyoutSubItem {
 #[repr(C)]
 pub struct IMenuFlyoutSubItem_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    pub get_Items: unsafe extern "system" fn(
+    pub Items: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_Text: usize,
-    pub put_Text: unsafe extern "system" fn(
+    Text: usize,
+    pub SetText: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
@@ -9632,9 +9626,9 @@ impl windows_core::RuntimeType for IMicaBackdrop {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IMicaBackdrop {
-    pub(crate) fn put_Kind(&self, value: MicaKind) -> windows_core::Result<()> {
+    pub(crate) fn SetKind(&self, value: MicaKind) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Kind)(
+            (windows_core::Interface::vtable(self).SetKind)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
@@ -9645,8 +9639,8 @@ impl IMicaBackdrop {
 #[repr(C)]
 pub struct IMicaBackdrop_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_Kind: usize,
-    pub put_Kind:
+    Kind: usize,
+    pub SetKind:
         unsafe extern "system" fn(*mut core::ffi::c_void, MicaKind) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
@@ -9678,85 +9672,85 @@ impl windows_core::RuntimeType for INavigationView {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl INavigationView {
-    pub(crate) fn put_IsPaneOpen(&self, value: bool) -> windows_core::Result<()> {
+    pub(crate) fn SetIsPaneOpen(&self, value: bool) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_IsPaneOpen)(
+            (windows_core::Interface::vtable(self).SetIsPaneOpen)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_Header<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetHeader<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<windows_core::IInspectable>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Header)(
+            (windows_core::Interface::vtable(self).SetHeader)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
             .ok()
         }
     }
-    pub(crate) fn put_IsSettingsVisible(&self, value: bool) -> windows_core::Result<()> {
+    pub(crate) fn SetIsSettingsVisible(&self, value: bool) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_IsSettingsVisible)(
+            (windows_core::Interface::vtable(self).SetIsSettingsVisible)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_IsPaneToggleButtonVisible(&self, value: bool) -> windows_core::Result<()> {
+    pub(crate) fn SetIsPaneToggleButtonVisible(&self, value: bool) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_IsPaneToggleButtonVisible)(
+            (windows_core::Interface::vtable(self).SetIsPaneToggleButtonVisible)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_SelectedItem<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetSelectedItem<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<windows_core::IInspectable>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_SelectedItem)(
+            (windows_core::Interface::vtable(self).SetSelectedItem)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
             .ok()
         }
     }
-    pub(crate) fn get_MenuItems(
+    pub(crate) fn MenuItems(
         &self,
     ) -> windows_core::Result<windows_collections::IVector<windows_core::IInspectable>> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_MenuItems)(
+            (windows_core::Interface::vtable(self).MenuItems)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
             .and_then(|| windows_core::Type::from_abi(result__))
         }
     }
-    pub(crate) fn get_AutoSuggestBox(&self) -> windows_core::Result<AutoSuggestBox> {
+    pub(crate) fn AutoSuggestBox(&self) -> windows_core::Result<AutoSuggestBox> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_AutoSuggestBox)(
+            (windows_core::Interface::vtable(self).AutoSuggestBox)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
             .and_then(|| windows_core::Type::from_abi(result__))
         }
     }
-    pub(crate) fn put_AutoSuggestBox<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetAutoSuggestBox<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<AutoSuggestBox>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_AutoSuggestBox)(
+            (windows_core::Interface::vtable(self).SetAutoSuggestBox)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
@@ -9790,7 +9784,7 @@ impl INavigationView {
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
-            let token__ = (windows_core::Interface::vtable(self).add_SelectionChanged)(
+            let token__ = (windows_core::Interface::vtable(self).SelectionChanged)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Interface::as_raw(&handler),
                 &mut result__,
@@ -9799,7 +9793,7 @@ impl INavigationView {
             Ok(windows_core::EventRevoker::new(
                 self.clone(),
                 token__,
-                windows_core::Interface::vtable(self).remove_SelectionChanged,
+                windows_core::Interface::vtable(self).RemoveSelectionChanged,
             ))
         }
     }
@@ -9807,76 +9801,76 @@ impl INavigationView {
 #[repr(C)]
 pub struct INavigationView_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_IsPaneOpen: usize,
-    pub put_IsPaneOpen:
+    IsPaneOpen: usize,
+    pub SetIsPaneOpen:
         unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
-    get_CompactModeThresholdWidth: usize,
-    put_CompactModeThresholdWidth: usize,
-    get_ExpandedModeThresholdWidth: usize,
-    put_ExpandedModeThresholdWidth: usize,
-    get_FooterMenuItems: usize,
-    get_FooterMenuItemsSource: usize,
-    put_FooterMenuItemsSource: usize,
-    get_PaneFooter: usize,
-    put_PaneFooter: usize,
-    get_Header: usize,
-    pub put_Header: unsafe extern "system" fn(
+    CompactModeThresholdWidth: usize,
+    SetCompactModeThresholdWidth: usize,
+    ExpandedModeThresholdWidth: usize,
+    SetExpandedModeThresholdWidth: usize,
+    FooterMenuItems: usize,
+    FooterMenuItemsSource: usize,
+    SetFooterMenuItemsSource: usize,
+    PaneFooter: usize,
+    SetPaneFooter: usize,
+    Header: usize,
+    pub SetHeader: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_HeaderTemplate: usize,
-    put_HeaderTemplate: usize,
-    get_DisplayMode: usize,
-    get_IsSettingsVisible: usize,
-    pub put_IsSettingsVisible:
+    HeaderTemplate: usize,
+    SetHeaderTemplate: usize,
+    DisplayMode: usize,
+    IsSettingsVisible: usize,
+    pub SetIsSettingsVisible:
         unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
-    get_IsPaneToggleButtonVisible: usize,
-    pub put_IsPaneToggleButtonVisible:
+    IsPaneToggleButtonVisible: usize,
+    pub SetIsPaneToggleButtonVisible:
         unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
-    get_AlwaysShowHeader: usize,
-    put_AlwaysShowHeader: usize,
-    get_CompactPaneLength: usize,
-    put_CompactPaneLength: usize,
-    get_OpenPaneLength: usize,
-    put_OpenPaneLength: usize,
-    get_PaneToggleButtonStyle: usize,
-    put_PaneToggleButtonStyle: usize,
-    get_SelectedItem: usize,
-    pub put_SelectedItem: unsafe extern "system" fn(
+    AlwaysShowHeader: usize,
+    SetAlwaysShowHeader: usize,
+    CompactPaneLength: usize,
+    SetCompactPaneLength: usize,
+    OpenPaneLength: usize,
+    SetOpenPaneLength: usize,
+    PaneToggleButtonStyle: usize,
+    SetPaneToggleButtonStyle: usize,
+    SelectedItem: usize,
+    pub SetSelectedItem: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    pub get_MenuItems: unsafe extern "system" fn(
+    pub MenuItems: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_MenuItemsSource: usize,
-    put_MenuItemsSource: usize,
-    get_SettingsItem: usize,
-    pub get_AutoSuggestBox: unsafe extern "system" fn(
+    MenuItemsSource: usize,
+    SetMenuItemsSource: usize,
+    SettingsItem: usize,
+    pub AutoSuggestBox: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    pub put_AutoSuggestBox: unsafe extern "system" fn(
+    pub SetAutoSuggestBox: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_MenuItemTemplate: usize,
-    put_MenuItemTemplate: usize,
-    get_MenuItemTemplateSelector: usize,
-    put_MenuItemTemplateSelector: usize,
-    get_MenuItemContainerStyle: usize,
-    put_MenuItemContainerStyle: usize,
-    get_MenuItemContainerStyleSelector: usize,
-    put_MenuItemContainerStyleSelector: usize,
+    MenuItemTemplate: usize,
+    SetMenuItemTemplate: usize,
+    MenuItemTemplateSelector: usize,
+    SetMenuItemTemplateSelector: usize,
+    MenuItemContainerStyle: usize,
+    SetMenuItemContainerStyle: usize,
+    MenuItemContainerStyleSelector: usize,
+    SetMenuItemContainerStyleSelector: usize,
     MenuItemFromContainer: usize,
     ContainerFromMenuItem: usize,
-    pub add_SelectionChanged: unsafe extern "system" fn(
+    pub SelectionChanged: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         *mut i64,
     ) -> windows_core::HRESULT,
-    pub remove_SelectionChanged:
+    pub RemoveSelectionChanged:
         unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
@@ -9889,30 +9883,30 @@ impl windows_core::RuntimeType for INavigationView2 {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl INavigationView2 {
-    pub(crate) fn put_IsBackButtonVisible(
+    pub(crate) fn SetIsBackButtonVisible(
         &self,
         value: NavigationViewBackButtonVisible,
     ) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_IsBackButtonVisible)(
+            (windows_core::Interface::vtable(self).SetIsBackButtonVisible)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_IsBackEnabled(&self, value: bool) -> windows_core::Result<()> {
+    pub(crate) fn SetIsBackEnabled(&self, value: bool) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_IsBackEnabled)(
+            (windows_core::Interface::vtable(self).SetIsBackEnabled)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_PaneTitle(&self, value: &str) -> windows_core::Result<()> {
+    pub(crate) fn SetPaneTitle(&self, value: &str) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_PaneTitle)(
+            (windows_core::Interface::vtable(self).SetPaneTitle)(
                 windows_core::Interface::as_raw(self),
                 core::mem::transmute_copy(&windows_core::HSTRING::from(value)),
             )
@@ -9935,7 +9929,7 @@ impl INavigationView2 {
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
-            let token__ = (windows_core::Interface::vtable(self).add_BackRequested)(
+            let token__ = (windows_core::Interface::vtable(self).BackRequested)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Interface::as_raw(&handler),
                 &mut result__,
@@ -9944,16 +9938,16 @@ impl INavigationView2 {
             Ok(windows_core::EventRevoker::new(
                 self.clone(),
                 token__,
-                windows_core::Interface::vtable(self).remove_BackRequested,
+                windows_core::Interface::vtable(self).RemoveBackRequested,
             ))
         }
     }
-    pub(crate) fn put_PaneDisplayMode(
+    pub(crate) fn SetPaneDisplayMode(
         &self,
         value: NavigationViewPaneDisplayMode,
     ) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_PaneDisplayMode)(
+            (windows_core::Interface::vtable(self).SetPaneDisplayMode)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
@@ -9964,36 +9958,36 @@ impl INavigationView2 {
 #[repr(C)]
 pub struct INavigationView2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_IsBackButtonVisible: usize,
-    pub put_IsBackButtonVisible: unsafe extern "system" fn(
+    IsBackButtonVisible: usize,
+    pub SetIsBackButtonVisible: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         NavigationViewBackButtonVisible,
     ) -> windows_core::HRESULT,
-    get_IsBackEnabled: usize,
-    pub put_IsBackEnabled:
+    IsBackEnabled: usize,
+    pub SetIsBackEnabled:
         unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
-    get_PaneTitle: usize,
-    pub put_PaneTitle: unsafe extern "system" fn(
+    PaneTitle: usize,
+    pub SetPaneTitle: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    pub add_BackRequested: unsafe extern "system" fn(
+    pub BackRequested: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         *mut i64,
     ) -> windows_core::HRESULT,
-    pub remove_BackRequested:
+    pub RemoveBackRequested:
         unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
-    add_PaneClosed: usize,
-    remove_PaneClosed: usize,
-    add_PaneClosing: usize,
-    remove_PaneClosing: usize,
-    add_PaneOpened: usize,
-    remove_PaneOpened: usize,
-    add_PaneOpening: usize,
-    remove_PaneOpening: usize,
-    get_PaneDisplayMode: usize,
-    pub put_PaneDisplayMode: unsafe extern "system" fn(
+    PaneClosed: usize,
+    RemovePaneClosed: usize,
+    PaneClosing: usize,
+    RemovePaneClosing: usize,
+    PaneOpened: usize,
+    RemovePaneOpened: usize,
+    PaneOpening: usize,
+    RemovePaneOpening: usize,
+    PaneDisplayMode: usize,
+    pub SetPaneDisplayMode: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         NavigationViewPaneDisplayMode,
     ) -> windows_core::HRESULT,
@@ -10040,12 +10034,12 @@ impl windows_core::RuntimeType for INavigationViewItem {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl INavigationViewItem {
-    pub(crate) fn put_Icon<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetIcon<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<IconElement>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Icon)(
+            (windows_core::Interface::vtable(self).SetIcon)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
@@ -10056,8 +10050,8 @@ impl INavigationViewItem {
 #[repr(C)]
 pub struct INavigationViewItem_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_Icon: usize,
-    pub put_Icon: unsafe extern "system" fn(
+    Icon: usize,
+    pub SetIcon: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
@@ -10072,12 +10066,12 @@ impl windows_core::RuntimeType for INavigationViewItem2 {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl INavigationViewItem2 {
-    pub(crate) fn get_MenuItems(
+    pub(crate) fn MenuItems(
         &self,
     ) -> windows_core::Result<windows_collections::IVector<windows_core::IInspectable>> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_MenuItems)(
+            (windows_core::Interface::vtable(self).MenuItems)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
@@ -10088,15 +10082,15 @@ impl INavigationViewItem2 {
 #[repr(C)]
 pub struct INavigationViewItem2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_SelectsOnInvoked: usize,
-    put_SelectsOnInvoked: usize,
-    get_IsExpanded: usize,
-    put_IsExpanded: usize,
-    get_HasUnrealizedChildren: usize,
-    put_HasUnrealizedChildren: usize,
-    get_IsChildSelected: usize,
-    put_IsChildSelected: usize,
-    pub get_MenuItems: unsafe extern "system" fn(
+    SelectsOnInvoked: usize,
+    SetSelectsOnInvoked: usize,
+    IsExpanded: usize,
+    SetIsExpanded: usize,
+    HasUnrealizedChildren: usize,
+    SetHasUnrealizedChildren: usize,
+    IsChildSelected: usize,
+    SetIsChildSelected: usize,
+    pub MenuItems: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
@@ -10175,10 +10169,10 @@ impl windows_core::RuntimeType for INavigationViewSelectionChangedEventArgs {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl INavigationViewSelectionChangedEventArgs {
-    pub(crate) fn get_SelectedItem(&self) -> windows_core::Result<windows_core::IInspectable> {
+    pub(crate) fn SelectedItem(&self) -> windows_core::Result<windows_core::IInspectable> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_SelectedItem)(
+            (windows_core::Interface::vtable(self).SelectedItem)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
@@ -10189,7 +10183,7 @@ impl INavigationViewSelectionChangedEventArgs {
 #[repr(C)]
 pub struct INavigationViewSelectionChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    pub get_SelectedItem: unsafe extern "system" fn(
+    pub SelectedItem: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
@@ -10204,39 +10198,39 @@ impl windows_core::RuntimeType for INumberBox {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl INumberBox {
-    pub(crate) fn put_Minimum(&self, value: f64) -> windows_core::Result<()> {
+    pub(crate) fn SetMinimum(&self, value: f64) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Minimum)(
+            (windows_core::Interface::vtable(self).SetMinimum)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_Maximum(&self, value: f64) -> windows_core::Result<()> {
+    pub(crate) fn SetMaximum(&self, value: f64) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Maximum)(
+            (windows_core::Interface::vtable(self).SetMaximum)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_Value(&self, value: f64) -> windows_core::Result<()> {
+    pub(crate) fn SetValue(&self, value: f64) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Value)(
+            (windows_core::Interface::vtable(self).SetValue)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_Header<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetHeader<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<windows_core::IInspectable>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Header)(
+            (windows_core::Interface::vtable(self).SetHeader)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
@@ -10263,7 +10257,7 @@ impl INumberBox {
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
-            let token__ = (windows_core::Interface::vtable(self).add_ValueChanged)(
+            let token__ = (windows_core::Interface::vtable(self).ValueChanged)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Interface::as_raw(&handler),
                 &mut result__,
@@ -10272,7 +10266,7 @@ impl INumberBox {
             Ok(windows_core::EventRevoker::new(
                 self.clone(),
                 token__,
-                windows_core::Interface::vtable(self).remove_ValueChanged,
+                windows_core::Interface::vtable(self).RemoveValueChanged,
             ))
         }
     }
@@ -10280,55 +10274,53 @@ impl INumberBox {
 #[repr(C)]
 pub struct INumberBox_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_Minimum: usize,
-    pub put_Minimum:
-        unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
-    get_Maximum: usize,
-    pub put_Maximum:
-        unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
-    get_Value: usize,
-    pub put_Value: unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
-    get_SmallChange: usize,
-    put_SmallChange: usize,
-    get_LargeChange: usize,
-    put_LargeChange: usize,
-    get_Text: usize,
-    put_Text: usize,
-    get_Header: usize,
-    pub put_Header: unsafe extern "system" fn(
+    Minimum: usize,
+    pub SetMinimum: unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
+    Maximum: usize,
+    pub SetMaximum: unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
+    Value: usize,
+    pub SetValue: unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
+    SmallChange: usize,
+    SetSmallChange: usize,
+    LargeChange: usize,
+    SetLargeChange: usize,
+    Text: usize,
+    SetText: usize,
+    Header: usize,
+    pub SetHeader: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_HeaderTemplate: usize,
-    put_HeaderTemplate: usize,
-    get_PlaceholderText: usize,
-    put_PlaceholderText: usize,
-    get_SelectionFlyout: usize,
-    put_SelectionFlyout: usize,
-    get_SelectionHighlightColor: usize,
-    put_SelectionHighlightColor: usize,
-    get_TextReadingOrder: usize,
-    put_TextReadingOrder: usize,
-    get_PreventKeyboardDisplayOnProgrammaticFocus: usize,
-    put_PreventKeyboardDisplayOnProgrammaticFocus: usize,
-    get_Description: usize,
-    put_Description: usize,
-    get_ValidationMode: usize,
-    put_ValidationMode: usize,
-    get_SpinButtonPlacementMode: usize,
-    put_SpinButtonPlacementMode: usize,
-    get_IsWrapEnabled: usize,
-    put_IsWrapEnabled: usize,
-    get_AcceptsExpression: usize,
-    put_AcceptsExpression: usize,
-    get_NumberFormatter: usize,
-    put_NumberFormatter: usize,
-    pub add_ValueChanged: unsafe extern "system" fn(
+    HeaderTemplate: usize,
+    SetHeaderTemplate: usize,
+    PlaceholderText: usize,
+    SetPlaceholderText: usize,
+    SelectionFlyout: usize,
+    SetSelectionFlyout: usize,
+    SelectionHighlightColor: usize,
+    SetSelectionHighlightColor: usize,
+    TextReadingOrder: usize,
+    SetTextReadingOrder: usize,
+    PreventKeyboardDisplayOnProgrammaticFocus: usize,
+    SetPreventKeyboardDisplayOnProgrammaticFocus: usize,
+    Description: usize,
+    SetDescription: usize,
+    ValidationMode: usize,
+    SetValidationMode: usize,
+    SpinButtonPlacementMode: usize,
+    SetSpinButtonPlacementMode: usize,
+    IsWrapEnabled: usize,
+    SetIsWrapEnabled: usize,
+    AcceptsExpression: usize,
+    SetAcceptsExpression: usize,
+    NumberFormatter: usize,
+    SetNumberFormatter: usize,
+    pub ValueChanged: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         *mut i64,
     ) -> windows_core::HRESULT,
-    pub remove_ValueChanged:
+    pub RemoveValueChanged:
         unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
@@ -10360,10 +10352,10 @@ impl windows_core::RuntimeType for INumberBoxValueChangedEventArgs {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl INumberBoxValueChangedEventArgs {
-    pub(crate) fn get_NewValue(&self) -> windows_core::Result<f64> {
+    pub(crate) fn NewValue(&self) -> windows_core::Result<f64> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_NewValue)(
+            (windows_core::Interface::vtable(self).NewValue)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
@@ -10374,8 +10366,8 @@ impl INumberBoxValueChangedEventArgs {
 #[repr(C)]
 pub struct INumberBoxValueChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_OldValue: usize,
-    pub get_NewValue:
+    OldValue: usize,
+    pub NewValue:
         unsafe extern "system" fn(*mut core::ffi::c_void, *mut f64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
@@ -10388,46 +10380,40 @@ impl windows_core::RuntimeType for IOverlappedPresenter3 {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IOverlappedPresenter3 {
-    pub(crate) fn put_PreferredMinimumHeight(
-        &self,
-        value: Option<i32>,
-    ) -> windows_core::Result<()> {
+    pub(crate) fn SetPreferredMinimumHeight(&self, value: Option<i32>) -> windows_core::Result<()> {
         let value__ = value.map(<windows_reference::IReference<i32> as From<_>>::from);
         unsafe {
-            (windows_core::Interface::vtable(self).put_PreferredMinimumHeight)(
+            (windows_core::Interface::vtable(self).SetPreferredMinimumHeight)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Param::param(value__.as_ref()).abi(),
             )
             .ok()
         }
     }
-    pub(crate) fn put_PreferredMinimumWidth(&self, value: Option<i32>) -> windows_core::Result<()> {
+    pub(crate) fn SetPreferredMinimumWidth(&self, value: Option<i32>) -> windows_core::Result<()> {
         let value__ = value.map(<windows_reference::IReference<i32> as From<_>>::from);
         unsafe {
-            (windows_core::Interface::vtable(self).put_PreferredMinimumWidth)(
+            (windows_core::Interface::vtable(self).SetPreferredMinimumWidth)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Param::param(value__.as_ref()).abi(),
             )
             .ok()
         }
     }
-    pub(crate) fn put_PreferredMaximumWidth(&self, value: Option<i32>) -> windows_core::Result<()> {
+    pub(crate) fn SetPreferredMaximumWidth(&self, value: Option<i32>) -> windows_core::Result<()> {
         let value__ = value.map(<windows_reference::IReference<i32> as From<_>>::from);
         unsafe {
-            (windows_core::Interface::vtable(self).put_PreferredMaximumWidth)(
+            (windows_core::Interface::vtable(self).SetPreferredMaximumWidth)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Param::param(value__.as_ref()).abi(),
             )
             .ok()
         }
     }
-    pub(crate) fn put_PreferredMaximumHeight(
-        &self,
-        value: Option<i32>,
-    ) -> windows_core::Result<()> {
+    pub(crate) fn SetPreferredMaximumHeight(&self, value: Option<i32>) -> windows_core::Result<()> {
         let value__ = value.map(<windows_reference::IReference<i32> as From<_>>::from);
         unsafe {
-            (windows_core::Interface::vtable(self).put_PreferredMaximumHeight)(
+            (windows_core::Interface::vtable(self).SetPreferredMaximumHeight)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Param::param(value__.as_ref()).abi(),
             )
@@ -10438,23 +10424,23 @@ impl IOverlappedPresenter3 {
 #[repr(C)]
 pub struct IOverlappedPresenter3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_PreferredMinimumHeight: usize,
-    pub put_PreferredMinimumHeight: unsafe extern "system" fn(
+    PreferredMinimumHeight: usize,
+    pub SetPreferredMinimumHeight: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_PreferredMinimumWidth: usize,
-    pub put_PreferredMinimumWidth: unsafe extern "system" fn(
+    PreferredMinimumWidth: usize,
+    pub SetPreferredMinimumWidth: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_PreferredMaximumWidth: usize,
-    pub put_PreferredMaximumWidth: unsafe extern "system" fn(
+    PreferredMaximumWidth: usize,
+    pub SetPreferredMaximumWidth: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_PreferredMaximumHeight: usize,
-    pub put_PreferredMaximumHeight: unsafe extern "system" fn(
+    PreferredMaximumHeight: usize,
+    pub SetPreferredMaximumHeight: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
@@ -10465,22 +10451,22 @@ impl windows_core::RuntimeType for IPanel {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IPanel {
-    pub(crate) fn get_Children(&self) -> windows_core::Result<UIElementCollection> {
+    pub(crate) fn Children(&self) -> windows_core::Result<UIElementCollection> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_Children)(
+            (windows_core::Interface::vtable(self).Children)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
             .and_then(|| windows_core::Type::from_abi(result__))
         }
     }
-    pub(crate) fn put_Background<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetBackground<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<Brush>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Background)(
+            (windows_core::Interface::vtable(self).SetBackground)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
@@ -10491,12 +10477,12 @@ impl IPanel {
 #[repr(C)]
 pub struct IPanel_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    pub get_Children: unsafe extern "system" fn(
+    pub Children: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_Background: usize,
-    pub put_Background: unsafe extern "system" fn(
+    Background: usize,
+    pub SetBackground: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
@@ -10511,10 +10497,10 @@ impl windows_core::RuntimeType for IParagraph {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IParagraph {
-    pub(crate) fn get_Inlines(&self) -> windows_core::Result<InlineCollection> {
+    pub(crate) fn Inlines(&self) -> windows_core::Result<InlineCollection> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_Inlines)(
+            (windows_core::Interface::vtable(self).Inlines)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
@@ -10525,7 +10511,7 @@ impl IParagraph {
 #[repr(C)]
 pub struct IParagraph_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    pub get_Inlines: unsafe extern "system" fn(
+    pub Inlines: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
@@ -10540,10 +10526,10 @@ impl windows_core::RuntimeType for IPasswordBox {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IPasswordBox {
-    pub(crate) fn get_Password(&self) -> windows_core::Result<String> {
+    pub(crate) fn Password(&self) -> windows_core::Result<String> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_Password)(
+            (windows_core::Interface::vtable(self).Password)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
@@ -10553,54 +10539,51 @@ impl IPasswordBox {
             })
         }
     }
-    pub(crate) fn put_Password(&self, value: &str) -> windows_core::Result<()> {
+    pub(crate) fn SetPassword(&self, value: &str) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Password)(
+            (windows_core::Interface::vtable(self).SetPassword)(
                 windows_core::Interface::as_raw(self),
                 core::mem::transmute_copy(&windows_core::HSTRING::from(value)),
             )
             .ok()
         }
     }
-    pub(crate) fn put_IsPasswordRevealButtonEnabled(
-        &self,
-        value: bool,
-    ) -> windows_core::Result<()> {
+    pub(crate) fn SetIsPasswordRevealButtonEnabled(&self, value: bool) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_IsPasswordRevealButtonEnabled)(
+            (windows_core::Interface::vtable(self).SetIsPasswordRevealButtonEnabled)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_Header<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetHeader<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<windows_core::IInspectable>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Header)(
+            (windows_core::Interface::vtable(self).SetHeader)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
             .ok()
         }
     }
-    pub(crate) fn put_PlaceholderText(&self, value: &str) -> windows_core::Result<()> {
+    pub(crate) fn SetPlaceholderText(&self, value: &str) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_PlaceholderText)(
+            (windows_core::Interface::vtable(self).SetPlaceholderText)(
                 windows_core::Interface::as_raw(self),
                 core::mem::transmute_copy(&windows_core::HSTRING::from(value)),
             )
             .ok()
         }
     }
-    pub(crate) fn put_PasswordRevealMode(
+    pub(crate) fn SetPasswordRevealMode(
         &self,
         value: PasswordRevealMode,
     ) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_PasswordRevealMode)(
+            (windows_core::Interface::vtable(self).SetPasswordRevealMode)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
@@ -10624,7 +10607,7 @@ impl IPasswordBox {
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
-            let token__ = (windows_core::Interface::vtable(self).add_PasswordChanged)(
+            let token__ = (windows_core::Interface::vtable(self).PasswordChanged)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Interface::as_raw(&handler),
                 &mut result__,
@@ -10633,7 +10616,7 @@ impl IPasswordBox {
             Ok(windows_core::EventRevoker::new(
                 self.clone(),
                 token__,
-                windows_core::Interface::vtable(self).remove_PasswordChanged,
+                windows_core::Interface::vtable(self).RemovePasswordChanged,
             ))
         }
     }
@@ -10641,57 +10624,57 @@ impl IPasswordBox {
 #[repr(C)]
 pub struct IPasswordBox_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    pub get_Password: unsafe extern "system" fn(
+    pub Password: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    pub put_Password: unsafe extern "system" fn(
+    pub SetPassword: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_PasswordChar: usize,
-    put_PasswordChar: usize,
-    get_IsPasswordRevealButtonEnabled: usize,
-    pub put_IsPasswordRevealButtonEnabled:
+    PasswordChar: usize,
+    SetPasswordChar: usize,
+    IsPasswordRevealButtonEnabled: usize,
+    pub SetIsPasswordRevealButtonEnabled:
         unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
-    get_MaxLength: usize,
-    put_MaxLength: usize,
-    get_Header: usize,
-    pub put_Header: unsafe extern "system" fn(
+    MaxLength: usize,
+    SetMaxLength: usize,
+    Header: usize,
+    pub SetHeader: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_HeaderTemplate: usize,
-    put_HeaderTemplate: usize,
-    get_PlaceholderText: usize,
-    pub put_PlaceholderText: unsafe extern "system" fn(
+    HeaderTemplate: usize,
+    SetHeaderTemplate: usize,
+    PlaceholderText: usize,
+    pub SetPlaceholderText: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_SelectionHighlightColor: usize,
-    put_SelectionHighlightColor: usize,
-    get_PreventKeyboardDisplayOnProgrammaticFocus: usize,
-    put_PreventKeyboardDisplayOnProgrammaticFocus: usize,
-    get_PasswordRevealMode: usize,
-    pub put_PasswordRevealMode: unsafe extern "system" fn(
+    SelectionHighlightColor: usize,
+    SetSelectionHighlightColor: usize,
+    PreventKeyboardDisplayOnProgrammaticFocus: usize,
+    SetPreventKeyboardDisplayOnProgrammaticFocus: usize,
+    PasswordRevealMode: usize,
+    pub SetPasswordRevealMode: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         PasswordRevealMode,
     ) -> windows_core::HRESULT,
-    get_TextReadingOrder: usize,
-    put_TextReadingOrder: usize,
-    get_InputScope: usize,
-    put_InputScope: usize,
-    get_CanPasteClipboardContent: usize,
-    get_SelectionFlyout: usize,
-    put_SelectionFlyout: usize,
-    get_Description: usize,
-    put_Description: usize,
-    pub add_PasswordChanged: unsafe extern "system" fn(
+    TextReadingOrder: usize,
+    SetTextReadingOrder: usize,
+    InputScope: usize,
+    SetInputScope: usize,
+    CanPasteClipboardContent: usize,
+    SelectionFlyout: usize,
+    SetSelectionFlyout: usize,
+    Description: usize,
+    SetDescription: usize,
+    pub PasswordChanged: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         *mut i64,
     ) -> windows_core::HRESULT,
-    pub remove_PasswordChanged:
+    pub RemovePasswordChanged:
         unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
@@ -10704,18 +10687,18 @@ impl windows_core::RuntimeType for IPersonPicture {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IPersonPicture {
-    pub(crate) fn put_DisplayName(&self, value: &str) -> windows_core::Result<()> {
+    pub(crate) fn SetDisplayName(&self, value: &str) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_DisplayName)(
+            (windows_core::Interface::vtable(self).SetDisplayName)(
                 windows_core::Interface::as_raw(self),
                 core::mem::transmute_copy(&windows_core::HSTRING::from(value)),
             )
             .ok()
         }
     }
-    pub(crate) fn put_Initials(&self, value: &str) -> windows_core::Result<()> {
+    pub(crate) fn SetInitials(&self, value: &str) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Initials)(
+            (windows_core::Interface::vtable(self).SetInitials)(
                 windows_core::Interface::as_raw(self),
                 core::mem::transmute_copy(&windows_core::HSTRING::from(value)),
             )
@@ -10726,25 +10709,25 @@ impl IPersonPicture {
 #[repr(C)]
 pub struct IPersonPicture_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_BadgeNumber: usize,
-    put_BadgeNumber: usize,
-    get_BadgeGlyph: usize,
-    put_BadgeGlyph: usize,
-    get_BadgeImageSource: usize,
-    put_BadgeImageSource: usize,
-    get_BadgeText: usize,
-    put_BadgeText: usize,
-    get_IsGroup: usize,
-    put_IsGroup: usize,
-    get_Contact: usize,
-    put_Contact: usize,
-    get_DisplayName: usize,
-    pub put_DisplayName: unsafe extern "system" fn(
+    BadgeNumber: usize,
+    SetBadgeNumber: usize,
+    BadgeGlyph: usize,
+    SetBadgeGlyph: usize,
+    BadgeImageSource: usize,
+    SetBadgeImageSource: usize,
+    BadgeText: usize,
+    SetBadgeText: usize,
+    IsGroup: usize,
+    SetIsGroup: usize,
+    Contact: usize,
+    SetContact: usize,
+    DisplayName: usize,
+    pub SetDisplayName: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_Initials: usize,
-    pub put_Initials: unsafe extern "system" fn(
+    Initials: usize,
+    pub SetInitials: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
@@ -10774,21 +10757,21 @@ impl windows_core::RuntimeType for IPivot {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IPivot {
-    pub(crate) fn put_Title<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetTitle<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<windows_core::IInspectable>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Title)(
+            (windows_core::Interface::vtable(self).SetTitle)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
             .ok()
         }
     }
-    pub(crate) fn put_SelectedIndex(&self, value: i32) -> windows_core::Result<()> {
+    pub(crate) fn SetSelectedIndex(&self, value: i32) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_SelectedIndex)(
+            (windows_core::Interface::vtable(self).SetSelectedIndex)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
@@ -10814,7 +10797,7 @@ impl IPivot {
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
-            let token__ = (windows_core::Interface::vtable(self).add_SelectionChanged)(
+            let token__ = (windows_core::Interface::vtable(self).SelectionChanged)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Interface::as_raw(&handler),
                 &mut result__,
@@ -10823,7 +10806,7 @@ impl IPivot {
             Ok(windows_core::EventRevoker::new(
                 self.clone(),
                 token__,
-                windows_core::Interface::vtable(self).remove_SelectionChanged,
+                windows_core::Interface::vtable(self).RemoveSelectionChanged,
             ))
         }
     }
@@ -10831,40 +10814,40 @@ impl IPivot {
 #[repr(C)]
 pub struct IPivot_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_Title: usize,
-    pub put_Title: unsafe extern "system" fn(
+    Title: usize,
+    pub SetTitle: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_TitleTemplate: usize,
-    put_TitleTemplate: usize,
-    get_LeftHeader: usize,
-    put_LeftHeader: usize,
-    get_LeftHeaderTemplate: usize,
-    put_LeftHeaderTemplate: usize,
-    get_RightHeader: usize,
-    put_RightHeader: usize,
-    get_RightHeaderTemplate: usize,
-    put_RightHeaderTemplate: usize,
-    get_HeaderTemplate: usize,
-    put_HeaderTemplate: usize,
-    get_SelectedIndex: usize,
-    pub put_SelectedIndex:
+    TitleTemplate: usize,
+    SetTitleTemplate: usize,
+    LeftHeader: usize,
+    SetLeftHeader: usize,
+    LeftHeaderTemplate: usize,
+    SetLeftHeaderTemplate: usize,
+    RightHeader: usize,
+    SetRightHeader: usize,
+    RightHeaderTemplate: usize,
+    SetRightHeaderTemplate: usize,
+    HeaderTemplate: usize,
+    SetHeaderTemplate: usize,
+    SelectedIndex: usize,
+    pub SetSelectedIndex:
         unsafe extern "system" fn(*mut core::ffi::c_void, i32) -> windows_core::HRESULT,
-    get_SelectedItem: usize,
-    put_SelectedItem: usize,
-    get_IsLocked: usize,
-    put_IsLocked: usize,
-    get_HeaderFocusVisualPlacement: usize,
-    put_HeaderFocusVisualPlacement: usize,
-    get_IsHeaderItemsCarouselEnabled: usize,
-    put_IsHeaderItemsCarouselEnabled: usize,
-    pub add_SelectionChanged: unsafe extern "system" fn(
+    SelectedItem: usize,
+    SetSelectedItem: usize,
+    IsLocked: usize,
+    SetIsLocked: usize,
+    HeaderFocusVisualPlacement: usize,
+    SetHeaderFocusVisualPlacement: usize,
+    IsHeaderItemsCarouselEnabled: usize,
+    SetIsHeaderItemsCarouselEnabled: usize,
+    pub SelectionChanged: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         *mut i64,
     ) -> windows_core::HRESULT,
-    pub remove_SelectionChanged:
+    pub RemoveSelectionChanged:
         unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
@@ -10896,12 +10879,12 @@ impl windows_core::RuntimeType for IPivotItem {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IPivotItem {
-    pub(crate) fn put_Header<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetHeader<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<windows_core::IInspectable>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Header)(
+            (windows_core::Interface::vtable(self).SetHeader)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
@@ -10912,8 +10895,8 @@ impl IPivotItem {
 #[repr(C)]
 pub struct IPivotItem_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_Header: usize,
-    pub put_Header: unsafe extern "system" fn(
+    Header: usize,
+    pub SetHeader: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
@@ -10947,10 +10930,10 @@ impl windows_core::RuntimeType for IPointerPoint {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IPointerPoint {
-    pub(crate) fn get_Properties(&self) -> windows_core::Result<PointerPointProperties> {
+    pub(crate) fn Properties(&self) -> windows_core::Result<PointerPointProperties> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_Properties)(
+            (windows_core::Interface::vtable(self).Properties)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
@@ -10961,12 +10944,12 @@ impl IPointerPoint {
 #[repr(C)]
 pub struct IPointerPoint_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_FrameId: usize,
-    get_IsInContact: usize,
-    get_PointerDeviceType: usize,
-    get_PointerId: usize,
-    get_Position: usize,
-    pub get_Properties: unsafe extern "system" fn(
+    FrameId: usize,
+    IsInContact: usize,
+    PointerDeviceType: usize,
+    PointerId: usize,
+    Position: usize,
+    pub Properties: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
@@ -10981,30 +10964,30 @@ impl windows_core::RuntimeType for IPointerPointProperties {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IPointerPointProperties {
-    pub(crate) fn get_IsLeftButtonPressed(&self) -> windows_core::Result<bool> {
+    pub(crate) fn IsLeftButtonPressed(&self) -> windows_core::Result<bool> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_IsLeftButtonPressed)(
+            (windows_core::Interface::vtable(self).IsLeftButtonPressed)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
             .map(|| result__)
         }
     }
-    pub(crate) fn get_IsMiddleButtonPressed(&self) -> windows_core::Result<bool> {
+    pub(crate) fn IsMiddleButtonPressed(&self) -> windows_core::Result<bool> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_IsMiddleButtonPressed)(
+            (windows_core::Interface::vtable(self).IsMiddleButtonPressed)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
             .map(|| result__)
         }
     }
-    pub(crate) fn get_IsRightButtonPressed(&self) -> windows_core::Result<bool> {
+    pub(crate) fn IsRightButtonPressed(&self) -> windows_core::Result<bool> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_IsRightButtonPressed)(
+            (windows_core::Interface::vtable(self).IsRightButtonPressed)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
@@ -11015,19 +10998,19 @@ impl IPointerPointProperties {
 #[repr(C)]
 pub struct IPointerPointProperties_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_ContactRect: usize,
-    get_IsBarrelButtonPressed: usize,
-    get_IsCanceled: usize,
-    get_IsEraser: usize,
-    get_IsHorizontalMouseWheel: usize,
-    get_IsInRange: usize,
-    get_IsInverted: usize,
-    pub get_IsLeftButtonPressed:
+    ContactRect: usize,
+    IsBarrelButtonPressed: usize,
+    IsCanceled: usize,
+    IsEraser: usize,
+    IsHorizontalMouseWheel: usize,
+    IsInRange: usize,
+    IsInverted: usize,
+    pub IsLeftButtonPressed:
         unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
-    pub get_IsMiddleButtonPressed:
+    pub IsMiddleButtonPressed:
         unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
-    get_IsPrimary: usize,
-    pub get_IsRightButtonPressed:
+    IsPrimary: usize,
+    pub IsRightButtonPressed:
         unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
@@ -11058,11 +11041,11 @@ impl IPointerRoutedEventArgs {
 #[repr(C)]
 pub struct IPointerRoutedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_Pointer: usize,
-    get_KeyModifiers: usize,
-    get_Handled: usize,
-    put_Handled: usize,
-    get_IsGenerated: usize,
+    Pointer: usize,
+    KeyModifiers: usize,
+    Handled: usize,
+    SetHandled: usize,
+    IsGenerated: usize,
     pub GetCurrentPoint: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
@@ -11079,9 +11062,9 @@ impl windows_core::RuntimeType for IProgressBar {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IProgressBar {
-    pub(crate) fn put_IsIndeterminate(&self, value: bool) -> windows_core::Result<()> {
+    pub(crate) fn SetIsIndeterminate(&self, value: bool) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_IsIndeterminate)(
+            (windows_core::Interface::vtable(self).SetIsIndeterminate)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
@@ -11092,8 +11075,8 @@ impl IProgressBar {
 #[repr(C)]
 pub struct IProgressBar_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_IsIndeterminate: usize,
-    pub put_IsIndeterminate:
+    IsIndeterminate: usize,
+    pub SetIsIndeterminate:
         unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
@@ -11125,45 +11108,45 @@ impl windows_core::RuntimeType for IProgressRing {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IProgressRing {
-    pub(crate) fn put_IsActive(&self, value: bool) -> windows_core::Result<()> {
+    pub(crate) fn SetIsActive(&self, value: bool) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_IsActive)(
+            (windows_core::Interface::vtable(self).SetIsActive)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_IsIndeterminate(&self, value: bool) -> windows_core::Result<()> {
+    pub(crate) fn SetIsIndeterminate(&self, value: bool) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_IsIndeterminate)(
+            (windows_core::Interface::vtable(self).SetIsIndeterminate)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_Value(&self, value: f64) -> windows_core::Result<()> {
+    pub(crate) fn SetValue(&self, value: f64) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Value)(
+            (windows_core::Interface::vtable(self).SetValue)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_Minimum(&self, value: f64) -> windows_core::Result<()> {
+    pub(crate) fn SetMinimum(&self, value: f64) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Minimum)(
+            (windows_core::Interface::vtable(self).SetMinimum)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_Maximum(&self, value: f64) -> windows_core::Result<()> {
+    pub(crate) fn SetMaximum(&self, value: f64) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Maximum)(
+            (windows_core::Interface::vtable(self).SetMaximum)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
@@ -11174,21 +11157,19 @@ impl IProgressRing {
 #[repr(C)]
 pub struct IProgressRing_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_IsActive: usize,
-    pub put_IsActive:
+    IsActive: usize,
+    pub SetIsActive:
         unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
-    get_IsIndeterminate: usize,
-    pub put_IsIndeterminate:
+    IsIndeterminate: usize,
+    pub SetIsIndeterminate:
         unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
-    get_TemplateSettings: usize,
-    get_Value: usize,
-    pub put_Value: unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
-    get_Minimum: usize,
-    pub put_Minimum:
-        unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
-    get_Maximum: usize,
-    pub put_Maximum:
-        unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
+    TemplateSettings: usize,
+    Value: usize,
+    pub SetValue: unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
+    Minimum: usize,
+    pub SetMinimum: unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
+    Maximum: usize,
+    pub SetMaximum: unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
     IProgressRingFactory,
@@ -11219,9 +11200,9 @@ impl windows_core::RuntimeType for IRadioButton {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IRadioButton {
-    pub(crate) fn put_GroupName(&self, value: &str) -> windows_core::Result<()> {
+    pub(crate) fn SetGroupName(&self, value: &str) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_GroupName)(
+            (windows_core::Interface::vtable(self).SetGroupName)(
                 windows_core::Interface::as_raw(self),
                 core::mem::transmute_copy(&windows_core::HSTRING::from(value)),
             )
@@ -11232,8 +11213,8 @@ impl IRadioButton {
 #[repr(C)]
 pub struct IRadioButton_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_GroupName: usize,
-    pub put_GroupName: unsafe extern "system" fn(
+    GroupName: usize,
+    pub SetGroupName: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
@@ -11267,31 +11248,31 @@ impl windows_core::RuntimeType for IRadioButtons {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IRadioButtons {
-    pub(crate) fn get_Items(
+    pub(crate) fn Items(
         &self,
     ) -> windows_core::Result<windows_collections::IVector<windows_core::IInspectable>> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_Items)(
+            (windows_core::Interface::vtable(self).Items)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
             .and_then(|| windows_core::Type::from_abi(result__))
         }
     }
-    pub(crate) fn get_SelectedIndex(&self) -> windows_core::Result<i32> {
+    pub(crate) fn SelectedIndex(&self) -> windows_core::Result<i32> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_SelectedIndex)(
+            (windows_core::Interface::vtable(self).SelectedIndex)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
             .map(|| result__)
         }
     }
-    pub(crate) fn put_SelectedIndex(&self, value: i32) -> windows_core::Result<()> {
+    pub(crate) fn SetSelectedIndex(&self, value: i32) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_SelectedIndex)(
+            (windows_core::Interface::vtable(self).SetSelectedIndex)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
@@ -11317,7 +11298,7 @@ impl IRadioButtons {
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
-            let token__ = (windows_core::Interface::vtable(self).add_SelectionChanged)(
+            let token__ = (windows_core::Interface::vtable(self).SelectionChanged)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Interface::as_raw(&handler),
                 &mut result__,
@@ -11326,25 +11307,25 @@ impl IRadioButtons {
             Ok(windows_core::EventRevoker::new(
                 self.clone(),
                 token__,
-                windows_core::Interface::vtable(self).remove_SelectionChanged,
+                windows_core::Interface::vtable(self).RemoveSelectionChanged,
             ))
         }
     }
-    pub(crate) fn put_MaxColumns(&self, value: i32) -> windows_core::Result<()> {
+    pub(crate) fn SetMaxColumns(&self, value: i32) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_MaxColumns)(
+            (windows_core::Interface::vtable(self).SetMaxColumns)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_Header<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetHeader<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<windows_core::IInspectable>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Header)(
+            (windows_core::Interface::vtable(self).SetHeader)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
@@ -11355,33 +11336,33 @@ impl IRadioButtons {
 #[repr(C)]
 pub struct IRadioButtons_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_ItemsSource: usize,
-    put_ItemsSource: usize,
-    pub get_Items: unsafe extern "system" fn(
+    ItemsSource: usize,
+    SetItemsSource: usize,
+    pub Items: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_ItemTemplate: usize,
-    put_ItemTemplate: usize,
+    ItemTemplate: usize,
+    SetItemTemplate: usize,
     ContainerFromIndex: usize,
-    pub get_SelectedIndex:
+    pub SelectedIndex:
         unsafe extern "system" fn(*mut core::ffi::c_void, *mut i32) -> windows_core::HRESULT,
-    pub put_SelectedIndex:
+    pub SetSelectedIndex:
         unsafe extern "system" fn(*mut core::ffi::c_void, i32) -> windows_core::HRESULT,
-    get_SelectedItem: usize,
-    put_SelectedItem: usize,
-    pub add_SelectionChanged: unsafe extern "system" fn(
+    SelectedItem: usize,
+    SetSelectedItem: usize,
+    pub SelectionChanged: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         *mut i64,
     ) -> windows_core::HRESULT,
-    pub remove_SelectionChanged:
+    pub RemoveSelectionChanged:
         unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
-    get_MaxColumns: usize,
-    pub put_MaxColumns:
+    MaxColumns: usize,
+    pub SetMaxColumns:
         unsafe extern "system" fn(*mut core::ffi::c_void, i32) -> windows_core::HRESULT,
-    get_Header: usize,
-    pub put_Header: unsafe extern "system" fn(
+    Header: usize,
+    pub SetHeader: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
@@ -11415,36 +11396,36 @@ impl windows_core::RuntimeType for IRangeBase {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IRangeBase {
-    pub(crate) fn put_Minimum(&self, value: f64) -> windows_core::Result<()> {
+    pub(crate) fn SetMinimum(&self, value: f64) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Minimum)(
+            (windows_core::Interface::vtable(self).SetMinimum)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_Maximum(&self, value: f64) -> windows_core::Result<()> {
+    pub(crate) fn SetMaximum(&self, value: f64) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Maximum)(
+            (windows_core::Interface::vtable(self).SetMaximum)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_SmallChange(&self, value: f64) -> windows_core::Result<()> {
+    pub(crate) fn SetSmallChange(&self, value: f64) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_SmallChange)(
+            (windows_core::Interface::vtable(self).SetSmallChange)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_Value(&self, value: f64) -> windows_core::Result<()> {
+    pub(crate) fn SetValue(&self, value: f64) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Value)(
+            (windows_core::Interface::vtable(self).SetValue)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
@@ -11470,7 +11451,7 @@ impl IRangeBase {
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
-            let token__ = (windows_core::Interface::vtable(self).add_ValueChanged)(
+            let token__ = (windows_core::Interface::vtable(self).ValueChanged)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Interface::as_raw(&handler),
                 &mut result__,
@@ -11479,7 +11460,7 @@ impl IRangeBase {
             Ok(windows_core::EventRevoker::new(
                 self.clone(),
                 token__,
-                windows_core::Interface::vtable(self).remove_ValueChanged,
+                windows_core::Interface::vtable(self).RemoveValueChanged,
             ))
         }
     }
@@ -11487,25 +11468,23 @@ impl IRangeBase {
 #[repr(C)]
 pub struct IRangeBase_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_Minimum: usize,
-    pub put_Minimum:
+    Minimum: usize,
+    pub SetMinimum: unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
+    Maximum: usize,
+    pub SetMaximum: unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
+    SmallChange: usize,
+    pub SetSmallChange:
         unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
-    get_Maximum: usize,
-    pub put_Maximum:
-        unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
-    get_SmallChange: usize,
-    pub put_SmallChange:
-        unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
-    get_LargeChange: usize,
-    put_LargeChange: usize,
-    get_Value: usize,
-    pub put_Value: unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
-    pub add_ValueChanged: unsafe extern "system" fn(
+    LargeChange: usize,
+    SetLargeChange: usize,
+    Value: usize,
+    pub SetValue: unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
+    pub ValueChanged: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         *mut i64,
     ) -> windows_core::HRESULT,
-    pub remove_ValueChanged:
+    pub RemoveValueChanged:
         unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
@@ -11518,10 +11497,10 @@ impl windows_core::RuntimeType for IRangeBaseValueChangedEventArgs {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IRangeBaseValueChangedEventArgs {
-    pub(crate) fn get_NewValue(&self) -> windows_core::Result<f64> {
+    pub(crate) fn NewValue(&self) -> windows_core::Result<f64> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_NewValue)(
+            (windows_core::Interface::vtable(self).NewValue)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
@@ -11532,8 +11511,8 @@ impl IRangeBaseValueChangedEventArgs {
 #[repr(C)]
 pub struct IRangeBaseValueChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_OldValue: usize,
-    pub get_NewValue:
+    OldValue: usize,
+    pub NewValue:
         unsafe extern "system" fn(*mut core::ffi::c_void, *mut f64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
@@ -11546,55 +11525,55 @@ impl windows_core::RuntimeType for IRatingControl {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IRatingControl {
-    pub(crate) fn put_Caption(&self, value: &str) -> windows_core::Result<()> {
+    pub(crate) fn SetCaption(&self, value: &str) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Caption)(
+            (windows_core::Interface::vtable(self).SetCaption)(
                 windows_core::Interface::as_raw(self),
                 core::mem::transmute_copy(&windows_core::HSTRING::from(value)),
             )
             .ok()
         }
     }
-    pub(crate) fn put_IsReadOnly(&self, value: bool) -> windows_core::Result<()> {
+    pub(crate) fn SetIsReadOnly(&self, value: bool) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_IsReadOnly)(
+            (windows_core::Interface::vtable(self).SetIsReadOnly)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_MaxRating(&self, value: i32) -> windows_core::Result<()> {
+    pub(crate) fn SetMaxRating(&self, value: i32) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_MaxRating)(
+            (windows_core::Interface::vtable(self).SetMaxRating)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_PlaceholderValue(&self, value: f64) -> windows_core::Result<()> {
+    pub(crate) fn SetPlaceholderValue(&self, value: f64) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_PlaceholderValue)(
+            (windows_core::Interface::vtable(self).SetPlaceholderValue)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn get_Value(&self) -> windows_core::Result<f64> {
+    pub(crate) fn Value(&self) -> windows_core::Result<f64> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_Value)(
+            (windows_core::Interface::vtable(self).Value)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
             .map(|| result__)
         }
     }
-    pub(crate) fn put_Value(&self, value: f64) -> windows_core::Result<()> {
+    pub(crate) fn SetValue(&self, value: f64) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Value)(
+            (windows_core::Interface::vtable(self).SetValue)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
@@ -11621,7 +11600,7 @@ impl IRatingControl {
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
-            let token__ = (windows_core::Interface::vtable(self).add_ValueChanged)(
+            let token__ = (windows_core::Interface::vtable(self).ValueChanged)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Interface::as_raw(&handler),
                 &mut result__,
@@ -11630,7 +11609,7 @@ impl IRatingControl {
             Ok(windows_core::EventRevoker::new(
                 self.clone(),
                 token__,
-                windows_core::Interface::vtable(self).remove_ValueChanged,
+                windows_core::Interface::vtable(self).RemoveValueChanged,
             ))
         }
     }
@@ -11638,35 +11617,34 @@ impl IRatingControl {
 #[repr(C)]
 pub struct IRatingControl_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_Caption: usize,
-    pub put_Caption: unsafe extern "system" fn(
+    Caption: usize,
+    pub SetCaption: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_InitialSetValue: usize,
-    put_InitialSetValue: usize,
-    get_IsClearEnabled: usize,
-    put_IsClearEnabled: usize,
-    get_IsReadOnly: usize,
-    pub put_IsReadOnly:
+    InitialSetValue: usize,
+    SetInitialSetValue: usize,
+    IsClearEnabled: usize,
+    SetIsClearEnabled: usize,
+    IsReadOnly: usize,
+    pub SetIsReadOnly:
         unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
-    get_MaxRating: usize,
-    pub put_MaxRating:
+    MaxRating: usize,
+    pub SetMaxRating:
         unsafe extern "system" fn(*mut core::ffi::c_void, i32) -> windows_core::HRESULT,
-    get_PlaceholderValue: usize,
-    pub put_PlaceholderValue:
+    PlaceholderValue: usize,
+    pub SetPlaceholderValue:
         unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
-    get_ItemInfo: usize,
-    put_ItemInfo: usize,
-    pub get_Value:
-        unsafe extern "system" fn(*mut core::ffi::c_void, *mut f64) -> windows_core::HRESULT,
-    pub put_Value: unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
-    pub add_ValueChanged: unsafe extern "system" fn(
+    ItemInfo: usize,
+    SetItemInfo: usize,
+    pub Value: unsafe extern "system" fn(*mut core::ffi::c_void, *mut f64) -> windows_core::HRESULT,
+    pub SetValue: unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
+    pub ValueChanged: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         *mut i64,
     ) -> windows_core::HRESULT,
-    pub remove_ValueChanged:
+    pub RemoveValueChanged:
         unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
@@ -11698,18 +11676,18 @@ impl windows_core::RuntimeType for IRectangle {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IRectangle {
-    pub(crate) fn put_RadiusX(&self, value: f64) -> windows_core::Result<()> {
+    pub(crate) fn SetRadiusX(&self, value: f64) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_RadiusX)(
+            (windows_core::Interface::vtable(self).SetRadiusX)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_RadiusY(&self, value: f64) -> windows_core::Result<()> {
+    pub(crate) fn SetRadiusY(&self, value: f64) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_RadiusY)(
+            (windows_core::Interface::vtable(self).SetRadiusY)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
@@ -11720,12 +11698,10 @@ impl IRectangle {
 #[repr(C)]
 pub struct IRectangle_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_RadiusX: usize,
-    pub put_RadiusX:
-        unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
-    get_RadiusY: usize,
-    pub put_RadiusY:
-        unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
+    RadiusX: usize,
+    pub SetRadiusX: unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
+    RadiusY: usize,
+    pub SetRadiusY: unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
     IRelativePanel,
@@ -11771,73 +11747,73 @@ impl windows_core::RuntimeType for IRelativePanelStatics {
 #[repr(C)]
 pub struct IRelativePanelStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_BackgroundSizingProperty: usize,
-    get_LeftOfProperty: usize,
+    BackgroundSizingProperty: usize,
+    LeftOfProperty: usize,
     GetLeftOf: usize,
     SetLeftOf: usize,
-    get_AboveProperty: usize,
+    AboveProperty: usize,
     GetAbove: usize,
     SetAbove: usize,
-    get_RightOfProperty: usize,
+    RightOfProperty: usize,
     GetRightOf: usize,
     SetRightOf: usize,
-    get_BelowProperty: usize,
+    BelowProperty: usize,
     GetBelow: usize,
     SetBelow: usize,
-    get_AlignHorizontalCenterWithProperty: usize,
+    AlignHorizontalCenterWithProperty: usize,
     GetAlignHorizontalCenterWith: usize,
     SetAlignHorizontalCenterWith: usize,
-    get_AlignVerticalCenterWithProperty: usize,
+    AlignVerticalCenterWithProperty: usize,
     GetAlignVerticalCenterWith: usize,
     SetAlignVerticalCenterWith: usize,
-    get_AlignLeftWithProperty: usize,
+    AlignLeftWithProperty: usize,
     GetAlignLeftWith: usize,
     SetAlignLeftWith: usize,
-    get_AlignTopWithProperty: usize,
+    AlignTopWithProperty: usize,
     GetAlignTopWith: usize,
     SetAlignTopWith: usize,
-    get_AlignRightWithProperty: usize,
+    AlignRightWithProperty: usize,
     GetAlignRightWith: usize,
     SetAlignRightWith: usize,
-    get_AlignBottomWithProperty: usize,
+    AlignBottomWithProperty: usize,
     GetAlignBottomWith: usize,
     SetAlignBottomWith: usize,
-    get_AlignLeftWithPanelProperty: usize,
+    AlignLeftWithPanelProperty: usize,
     GetAlignLeftWithPanel: usize,
     pub SetAlignLeftWithPanel: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         bool,
     ) -> windows_core::HRESULT,
-    get_AlignTopWithPanelProperty: usize,
+    AlignTopWithPanelProperty: usize,
     GetAlignTopWithPanel: usize,
     pub SetAlignTopWithPanel: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         bool,
     ) -> windows_core::HRESULT,
-    get_AlignRightWithPanelProperty: usize,
+    AlignRightWithPanelProperty: usize,
     GetAlignRightWithPanel: usize,
     pub SetAlignRightWithPanel: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         bool,
     ) -> windows_core::HRESULT,
-    get_AlignBottomWithPanelProperty: usize,
+    AlignBottomWithPanelProperty: usize,
     GetAlignBottomWithPanel: usize,
     pub SetAlignBottomWithPanel: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         bool,
     ) -> windows_core::HRESULT,
-    get_AlignHorizontalCenterWithPanelProperty: usize,
+    AlignHorizontalCenterWithPanelProperty: usize,
     GetAlignHorizontalCenterWithPanel: usize,
     pub SetAlignHorizontalCenterWithPanel: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         bool,
     ) -> windows_core::HRESULT,
-    get_AlignVerticalCenterWithPanelProperty: usize,
+    AlignVerticalCenterWithPanelProperty: usize,
     GetAlignVerticalCenterWithPanel: usize,
     pub SetAlignVerticalCenterWithPanel: unsafe extern "system" fn(
         *mut core::ffi::c_void,
@@ -11855,18 +11831,18 @@ impl windows_core::RuntimeType for IRepeatButton {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IRepeatButton {
-    pub(crate) fn put_Delay(&self, value: i32) -> windows_core::Result<()> {
+    pub(crate) fn SetDelay(&self, value: i32) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Delay)(
+            (windows_core::Interface::vtable(self).SetDelay)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_Interval(&self, value: i32) -> windows_core::Result<()> {
+    pub(crate) fn SetInterval(&self, value: i32) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Interval)(
+            (windows_core::Interface::vtable(self).SetInterval)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
@@ -11877,10 +11853,10 @@ impl IRepeatButton {
 #[repr(C)]
 pub struct IRepeatButton_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_Delay: usize,
-    pub put_Delay: unsafe extern "system" fn(*mut core::ffi::c_void, i32) -> windows_core::HRESULT,
-    get_Interval: usize,
-    pub put_Interval:
+    Delay: usize,
+    pub SetDelay: unsafe extern "system" fn(*mut core::ffi::c_void, i32) -> windows_core::HRESULT,
+    Interval: usize,
+    pub SetInterval:
         unsafe extern "system" fn(*mut core::ffi::c_void, i32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
@@ -11893,12 +11869,12 @@ impl windows_core::RuntimeType for IResourceDictionary {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IResourceDictionary {
-    pub(crate) fn get_MergedDictionaries(
+    pub(crate) fn MergedDictionaries(
         &self,
     ) -> windows_core::Result<windows_collections::IVector<ResourceDictionary>> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_MergedDictionaries)(
+            (windows_core::Interface::vtable(self).MergedDictionaries)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
@@ -11909,9 +11885,9 @@ impl IResourceDictionary {
 #[repr(C)]
 pub struct IResourceDictionary_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_Source: usize,
-    put_Source: usize,
-    pub get_MergedDictionaries: unsafe extern "system" fn(
+    Source: usize,
+    SetSource: usize,
+    pub MergedDictionaries: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
@@ -11926,40 +11902,40 @@ impl windows_core::RuntimeType for IRichEditBox {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IRichEditBox {
-    pub(crate) fn put_IsReadOnly(&self, value: bool) -> windows_core::Result<()> {
+    pub(crate) fn SetIsReadOnly(&self, value: bool) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_IsReadOnly)(
+            (windows_core::Interface::vtable(self).SetIsReadOnly)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn get_Document(&self) -> windows_core::Result<RichEditTextDocument> {
+    pub(crate) fn Document(&self) -> windows_core::Result<RichEditTextDocument> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_Document)(
+            (windows_core::Interface::vtable(self).Document)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
             .and_then(|| windows_core::Type::from_abi(result__))
         }
     }
-    pub(crate) fn put_Header<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetHeader<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<windows_core::IInspectable>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Header)(
+            (windows_core::Interface::vtable(self).SetHeader)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
             .ok()
         }
     }
-    pub(crate) fn put_PlaceholderText(&self, value: &str) -> windows_core::Result<()> {
+    pub(crate) fn SetPlaceholderText(&self, value: &str) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_PlaceholderText)(
+            (windows_core::Interface::vtable(self).SetPlaceholderText)(
                 windows_core::Interface::as_raw(self),
                 core::mem::transmute_copy(&windows_core::HSTRING::from(value)),
             )
@@ -11983,7 +11959,7 @@ impl IRichEditBox {
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
-            let token__ = (windows_core::Interface::vtable(self).add_TextChanged)(
+            let token__ = (windows_core::Interface::vtable(self).TextChanged)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Interface::as_raw(&handler),
                 &mut result__,
@@ -11992,7 +11968,7 @@ impl IRichEditBox {
             Ok(windows_core::EventRevoker::new(
                 self.clone(),
                 token__,
-                windows_core::Interface::vtable(self).remove_TextChanged,
+                windows_core::Interface::vtable(self).RemoveTextChanged,
             ))
         }
     }
@@ -12000,65 +11976,65 @@ impl IRichEditBox {
 #[repr(C)]
 pub struct IRichEditBox_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_IsReadOnly: usize,
-    pub put_IsReadOnly:
+    IsReadOnly: usize,
+    pub SetIsReadOnly:
         unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
-    get_AcceptsReturn: usize,
-    put_AcceptsReturn: usize,
-    get_TextAlignment: usize,
-    put_TextAlignment: usize,
-    get_TextWrapping: usize,
-    put_TextWrapping: usize,
-    get_IsSpellCheckEnabled: usize,
-    put_IsSpellCheckEnabled: usize,
-    get_IsTextPredictionEnabled: usize,
-    put_IsTextPredictionEnabled: usize,
-    pub get_Document: unsafe extern "system" fn(
+    AcceptsReturn: usize,
+    SetAcceptsReturn: usize,
+    TextAlignment: usize,
+    SetTextAlignment: usize,
+    TextWrapping: usize,
+    SetTextWrapping: usize,
+    IsSpellCheckEnabled: usize,
+    SetIsSpellCheckEnabled: usize,
+    IsTextPredictionEnabled: usize,
+    SetIsTextPredictionEnabled: usize,
+    pub Document: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_InputScope: usize,
-    put_InputScope: usize,
-    get_Header: usize,
-    pub put_Header: unsafe extern "system" fn(
+    InputScope: usize,
+    SetInputScope: usize,
+    Header: usize,
+    pub SetHeader: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_HeaderTemplate: usize,
-    put_HeaderTemplate: usize,
-    get_PlaceholderText: usize,
-    pub put_PlaceholderText: unsafe extern "system" fn(
+    HeaderTemplate: usize,
+    SetHeaderTemplate: usize,
+    PlaceholderText: usize,
+    pub SetPlaceholderText: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_SelectionHighlightColor: usize,
-    put_SelectionHighlightColor: usize,
-    get_PreventKeyboardDisplayOnProgrammaticFocus: usize,
-    put_PreventKeyboardDisplayOnProgrammaticFocus: usize,
-    get_IsColorFontEnabled: usize,
-    put_IsColorFontEnabled: usize,
-    get_SelectionHighlightColorWhenNotFocused: usize,
-    put_SelectionHighlightColorWhenNotFocused: usize,
-    get_MaxLength: usize,
-    put_MaxLength: usize,
-    get_HorizontalTextAlignment: usize,
-    put_HorizontalTextAlignment: usize,
-    get_CharacterCasing: usize,
-    put_CharacterCasing: usize,
-    get_DisabledFormattingAccelerators: usize,
-    put_DisabledFormattingAccelerators: usize,
-    get_TextDocument: usize,
-    get_SelectionFlyout: usize,
-    put_SelectionFlyout: usize,
-    get_ProofingMenuFlyout: usize,
-    get_Description: usize,
-    put_Description: usize,
-    pub add_TextChanged: unsafe extern "system" fn(
+    SelectionHighlightColor: usize,
+    SetSelectionHighlightColor: usize,
+    PreventKeyboardDisplayOnProgrammaticFocus: usize,
+    SetPreventKeyboardDisplayOnProgrammaticFocus: usize,
+    IsColorFontEnabled: usize,
+    SetIsColorFontEnabled: usize,
+    SelectionHighlightColorWhenNotFocused: usize,
+    SetSelectionHighlightColorWhenNotFocused: usize,
+    MaxLength: usize,
+    SetMaxLength: usize,
+    HorizontalTextAlignment: usize,
+    SetHorizontalTextAlignment: usize,
+    CharacterCasing: usize,
+    SetCharacterCasing: usize,
+    DisabledFormattingAccelerators: usize,
+    SetDisabledFormattingAccelerators: usize,
+    TextDocument: usize,
+    SelectionFlyout: usize,
+    SetSelectionFlyout: usize,
+    ProofingMenuFlyout: usize,
+    Description: usize,
+    SetDescription: usize,
+    pub TextChanged: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         *mut i64,
     ) -> windows_core::HRESULT,
-    pub remove_TextChanged:
+    pub RemoveTextChanged:
         unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
@@ -12090,61 +12066,61 @@ impl windows_core::RuntimeType for IRichTextBlock {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IRichTextBlock {
-    pub(crate) fn put_FontSize(&self, value: f64) -> windows_core::Result<()> {
+    pub(crate) fn SetFontSize(&self, value: f64) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_FontSize)(
+            (windows_core::Interface::vtable(self).SetFontSize)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_FontFamily<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetFontFamily<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<FontFamily>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_FontFamily)(
+            (windows_core::Interface::vtable(self).SetFontFamily)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
             .ok()
         }
     }
-    pub(crate) fn put_Foreground<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetForeground<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<Brush>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Foreground)(
+            (windows_core::Interface::vtable(self).SetForeground)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
             .ok()
         }
     }
-    pub(crate) fn put_TextWrapping(&self, value: TextWrapping) -> windows_core::Result<()> {
+    pub(crate) fn SetTextWrapping(&self, value: TextWrapping) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_TextWrapping)(
+            (windows_core::Interface::vtable(self).SetTextWrapping)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn get_Blocks(&self) -> windows_core::Result<BlockCollection> {
+    pub(crate) fn Blocks(&self) -> windows_core::Result<BlockCollection> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_Blocks)(
+            (windows_core::Interface::vtable(self).Blocks)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
             .and_then(|| windows_core::Type::from_abi(result__))
         }
     }
-    pub(crate) fn put_IsTextSelectionEnabled(&self, value: bool) -> windows_core::Result<()> {
+    pub(crate) fn SetIsTextSelectionEnabled(&self, value: bool) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_IsTextSelectionEnabled)(
+            (windows_core::Interface::vtable(self).SetIsTextSelectionEnabled)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
@@ -12155,48 +12131,48 @@ impl IRichTextBlock {
 #[repr(C)]
 pub struct IRichTextBlock_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_FontSize: usize,
-    pub put_FontSize:
+    FontSize: usize,
+    pub SetFontSize:
         unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
-    get_FontFamily: usize,
-    pub put_FontFamily: unsafe extern "system" fn(
+    FontFamily: usize,
+    pub SetFontFamily: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_FontWeight: usize,
-    put_FontWeight: usize,
-    get_FontStyle: usize,
-    put_FontStyle: usize,
-    get_FontStretch: usize,
-    put_FontStretch: usize,
-    get_Foreground: usize,
-    pub put_Foreground: unsafe extern "system" fn(
+    FontWeight: usize,
+    SetFontWeight: usize,
+    FontStyle: usize,
+    SetFontStyle: usize,
+    FontStretch: usize,
+    SetFontStretch: usize,
+    Foreground: usize,
+    pub SetForeground: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_TextWrapping: usize,
-    pub put_TextWrapping:
+    TextWrapping: usize,
+    pub SetTextWrapping:
         unsafe extern "system" fn(*mut core::ffi::c_void, TextWrapping) -> windows_core::HRESULT,
-    get_TextTrimming: usize,
-    put_TextTrimming: usize,
-    get_TextAlignment: usize,
-    put_TextAlignment: usize,
-    pub get_Blocks: unsafe extern "system" fn(
+    TextTrimming: usize,
+    SetTextTrimming: usize,
+    TextAlignment: usize,
+    SetTextAlignment: usize,
+    pub Blocks: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_Padding: usize,
-    put_Padding: usize,
-    get_LineHeight: usize,
-    put_LineHeight: usize,
-    get_LineStackingStrategy: usize,
-    put_LineStackingStrategy: usize,
-    get_CharacterSpacing: usize,
-    put_CharacterSpacing: usize,
-    get_OverflowContentTarget: usize,
-    put_OverflowContentTarget: usize,
-    get_IsTextSelectionEnabled: usize,
-    pub put_IsTextSelectionEnabled:
+    Padding: usize,
+    SetPadding: usize,
+    LineHeight: usize,
+    SetLineHeight: usize,
+    LineStackingStrategy: usize,
+    SetLineStackingStrategy: usize,
+    CharacterSpacing: usize,
+    SetCharacterSpacing: usize,
+    OverflowContentTarget: usize,
+    SetOverflowContentTarget: usize,
+    IsTextSelectionEnabled: usize,
+    pub SetIsTextSelectionEnabled:
         unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
@@ -12235,9 +12211,9 @@ impl windows_core::RuntimeType for IRowDefinition {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IRowDefinition {
-    pub(crate) fn put_Height(&self, value: GridLength) -> windows_core::Result<()> {
+    pub(crate) fn SetHeight(&self, value: GridLength) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Height)(
+            (windows_core::Interface::vtable(self).SetHeight)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
@@ -12248,8 +12224,8 @@ impl IRowDefinition {
 #[repr(C)]
 pub struct IRowDefinition_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_Height: usize,
-    pub put_Height:
+    Height: usize,
+    pub SetHeight:
         unsafe extern "system" fn(*mut core::ffi::c_void, GridLength) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRun, IRun_Vtbl, 0x1f905239_37cb_590b_9132_3ffb7741906e);
@@ -12258,9 +12234,9 @@ impl windows_core::RuntimeType for IRun {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IRun {
-    pub(crate) fn put_Text(&self, value: &str) -> windows_core::Result<()> {
+    pub(crate) fn SetText(&self, value: &str) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Text)(
+            (windows_core::Interface::vtable(self).SetText)(
                 windows_core::Interface::as_raw(self),
                 core::mem::transmute_copy(&windows_core::HSTRING::from(value)),
             )
@@ -12271,8 +12247,8 @@ impl IRun {
 #[repr(C)]
 pub struct IRun_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_Text: usize,
-    pub put_Text: unsafe extern "system" fn(
+    Text: usize,
+    pub SetText: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
@@ -12328,36 +12304,36 @@ impl windows_core::RuntimeType for IScrollView {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IScrollView {
-    pub(crate) fn put_Content<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetContent<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<UIElement>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Content)(
+            (windows_core::Interface::vtable(self).SetContent)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
             .ok()
         }
     }
-    pub(crate) fn put_HorizontalScrollBarVisibility(
+    pub(crate) fn SetHorizontalScrollBarVisibility(
         &self,
         value: ScrollingScrollBarVisibility,
     ) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_HorizontalScrollBarVisibility)(
+            (windows_core::Interface::vtable(self).SetHorizontalScrollBarVisibility)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_VerticalScrollBarVisibility(
+    pub(crate) fn SetVerticalScrollBarVisibility(
         &self,
         value: ScrollingScrollBarVisibility,
     ) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_VerticalScrollBarVisibility)(
+            (windows_core::Interface::vtable(self).SetVerticalScrollBarVisibility)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
@@ -12368,31 +12344,31 @@ impl IScrollView {
 #[repr(C)]
 pub struct IScrollView_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_Content: usize,
-    pub put_Content: unsafe extern "system" fn(
+    Content: usize,
+    pub SetContent: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_CurrentAnchor: usize,
-    get_ScrollPresenter: usize,
-    get_ExpressionAnimationSources: usize,
-    get_HorizontalOffset: usize,
-    get_VerticalOffset: usize,
-    get_ZoomFactor: usize,
-    get_ExtentWidth: usize,
-    get_ExtentHeight: usize,
-    get_ViewportWidth: usize,
-    get_ViewportHeight: usize,
-    get_ScrollableWidth: usize,
-    get_ScrollableHeight: usize,
-    get_State: usize,
-    get_HorizontalScrollBarVisibility: usize,
-    pub put_HorizontalScrollBarVisibility: unsafe extern "system" fn(
+    CurrentAnchor: usize,
+    ScrollPresenter: usize,
+    ExpressionAnimationSources: usize,
+    HorizontalOffset: usize,
+    VerticalOffset: usize,
+    ZoomFactor: usize,
+    ExtentWidth: usize,
+    ExtentHeight: usize,
+    ViewportWidth: usize,
+    ViewportHeight: usize,
+    ScrollableWidth: usize,
+    ScrollableHeight: usize,
+    State: usize,
+    HorizontalScrollBarVisibility: usize,
+    pub SetHorizontalScrollBarVisibility: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         ScrollingScrollBarVisibility,
     ) -> windows_core::HRESULT,
-    get_VerticalScrollBarVisibility: usize,
-    pub put_VerticalScrollBarVisibility: unsafe extern "system" fn(
+    VerticalScrollBarVisibility: usize,
+    pub SetVerticalScrollBarVisibility: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         ScrollingScrollBarVisibility,
     ) -> windows_core::HRESULT,
@@ -12426,24 +12402,24 @@ impl windows_core::RuntimeType for IScrollViewer {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IScrollViewer {
-    pub(crate) fn put_HorizontalScrollBarVisibility(
+    pub(crate) fn SetHorizontalScrollBarVisibility(
         &self,
         value: ScrollBarVisibility,
     ) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_HorizontalScrollBarVisibility)(
+            (windows_core::Interface::vtable(self).SetHorizontalScrollBarVisibility)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_VerticalScrollBarVisibility(
+    pub(crate) fn SetVerticalScrollBarVisibility(
         &self,
         value: ScrollBarVisibility,
     ) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_VerticalScrollBarVisibility)(
+            (windows_core::Interface::vtable(self).SetVerticalScrollBarVisibility)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
@@ -12454,13 +12430,13 @@ impl IScrollViewer {
 #[repr(C)]
 pub struct IScrollViewer_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_HorizontalScrollBarVisibility: usize,
-    pub put_HorizontalScrollBarVisibility: unsafe extern "system" fn(
+    HorizontalScrollBarVisibility: usize,
+    pub SetHorizontalScrollBarVisibility: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         ScrollBarVisibility,
     ) -> windows_core::HRESULT,
-    get_VerticalScrollBarVisibility: usize,
-    pub put_VerticalScrollBarVisibility: unsafe extern "system" fn(
+    VerticalScrollBarVisibility: usize,
+    pub SetVerticalScrollBarVisibility: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         ScrollBarVisibility,
     ) -> windows_core::HRESULT,
@@ -12488,19 +12464,19 @@ impl windows_core::RuntimeType for ISelector {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl ISelector {
-    pub(crate) fn get_SelectedIndex(&self) -> windows_core::Result<i32> {
+    pub(crate) fn SelectedIndex(&self) -> windows_core::Result<i32> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_SelectedIndex)(
+            (windows_core::Interface::vtable(self).SelectedIndex)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
             .map(|| result__)
         }
     }
-    pub(crate) fn put_SelectedIndex(&self, value: i32) -> windows_core::Result<()> {
+    pub(crate) fn SetSelectedIndex(&self, value: i32) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_SelectedIndex)(
+            (windows_core::Interface::vtable(self).SetSelectedIndex)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
@@ -12526,7 +12502,7 @@ impl ISelector {
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
-            let token__ = (windows_core::Interface::vtable(self).add_SelectionChanged)(
+            let token__ = (windows_core::Interface::vtable(self).SelectionChanged)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Interface::as_raw(&handler),
                 &mut result__,
@@ -12535,7 +12511,7 @@ impl ISelector {
             Ok(windows_core::EventRevoker::new(
                 self.clone(),
                 token__,
-                windows_core::Interface::vtable(self).remove_SelectionChanged,
+                windows_core::Interface::vtable(self).RemoveSelectionChanged,
             ))
         }
     }
@@ -12543,24 +12519,24 @@ impl ISelector {
 #[repr(C)]
 pub struct ISelector_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    pub get_SelectedIndex:
+    pub SelectedIndex:
         unsafe extern "system" fn(*mut core::ffi::c_void, *mut i32) -> windows_core::HRESULT,
-    pub put_SelectedIndex:
+    pub SetSelectedIndex:
         unsafe extern "system" fn(*mut core::ffi::c_void, i32) -> windows_core::HRESULT,
-    get_SelectedItem: usize,
-    put_SelectedItem: usize,
-    get_SelectedValue: usize,
-    put_SelectedValue: usize,
-    get_SelectedValuePath: usize,
-    put_SelectedValuePath: usize,
-    get_IsSynchronizedWithCurrentItem: usize,
-    put_IsSynchronizedWithCurrentItem: usize,
-    pub add_SelectionChanged: unsafe extern "system" fn(
+    SelectedItem: usize,
+    SetSelectedItem: usize,
+    SelectedValue: usize,
+    SetSelectedValue: usize,
+    SelectedValuePath: usize,
+    SetSelectedValuePath: usize,
+    IsSynchronizedWithCurrentItem: usize,
+    SetIsSynchronizedWithCurrentItem: usize,
+    pub SelectionChanged: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         *mut i64,
     ) -> windows_core::HRESULT,
-    pub remove_SelectionChanged:
+    pub RemoveSelectionChanged:
         unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
@@ -12573,22 +12549,22 @@ impl windows_core::RuntimeType for ISelectorBar {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl ISelectorBar {
-    pub(crate) fn get_Items(
+    pub(crate) fn Items(
         &self,
     ) -> windows_core::Result<windows_collections::IVector<SelectorBarItem>> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_Items)(
+            (windows_core::Interface::vtable(self).Items)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
             .and_then(|| windows_core::Type::from_abi(result__))
         }
     }
-    pub(crate) fn get_SelectedItem(&self) -> windows_core::Result<SelectorBarItem> {
+    pub(crate) fn SelectedItem(&self) -> windows_core::Result<SelectorBarItem> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_SelectedItem)(
+            (windows_core::Interface::vtable(self).SelectedItem)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
@@ -12611,7 +12587,7 @@ impl ISelectorBar {
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
-            let token__ = (windows_core::Interface::vtable(self).add_SelectionChanged)(
+            let token__ = (windows_core::Interface::vtable(self).SelectionChanged)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Interface::as_raw(&handler),
                 &mut result__,
@@ -12620,7 +12596,7 @@ impl ISelectorBar {
             Ok(windows_core::EventRevoker::new(
                 self.clone(),
                 token__,
-                windows_core::Interface::vtable(self).remove_SelectionChanged,
+                windows_core::Interface::vtable(self).RemoveSelectionChanged,
             ))
         }
     }
@@ -12628,21 +12604,21 @@ impl ISelectorBar {
 #[repr(C)]
 pub struct ISelectorBar_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    pub get_Items: unsafe extern "system" fn(
+    pub Items: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    pub get_SelectedItem: unsafe extern "system" fn(
+    pub SelectedItem: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    put_SelectedItem: usize,
-    pub add_SelectionChanged: unsafe extern "system" fn(
+    SetSelectedItem: usize,
+    pub SelectionChanged: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         *mut i64,
     ) -> windows_core::HRESULT,
-    pub remove_SelectionChanged:
+    pub RemoveSelectionChanged:
         unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
@@ -12674,10 +12650,10 @@ impl windows_core::RuntimeType for ISelectorBarItem {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl ISelectorBarItem {
-    pub(crate) fn get_Text(&self) -> windows_core::Result<String> {
+    pub(crate) fn Text(&self) -> windows_core::Result<String> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_Text)(
+            (windows_core::Interface::vtable(self).Text)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
@@ -12687,21 +12663,21 @@ impl ISelectorBarItem {
             })
         }
     }
-    pub(crate) fn put_Text(&self, value: &str) -> windows_core::Result<()> {
+    pub(crate) fn SetText(&self, value: &str) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Text)(
+            (windows_core::Interface::vtable(self).SetText)(
                 windows_core::Interface::as_raw(self),
                 core::mem::transmute_copy(&windows_core::HSTRING::from(value)),
             )
             .ok()
         }
     }
-    pub(crate) fn put_Icon<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetIcon<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<IconElement>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Icon)(
+            (windows_core::Interface::vtable(self).SetIcon)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
@@ -12712,16 +12688,16 @@ impl ISelectorBarItem {
 #[repr(C)]
 pub struct ISelectorBarItem_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    pub get_Text: unsafe extern "system" fn(
+    pub Text: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    pub put_Text: unsafe extern "system" fn(
+    pub SetText: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_Icon: usize,
-    pub put_Icon: unsafe extern "system" fn(
+    Icon: usize,
+    pub SetIcon: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
@@ -12790,33 +12766,33 @@ impl windows_core::RuntimeType for IShape {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IShape {
-    pub(crate) fn put_Fill<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetFill<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<Brush>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Fill)(
+            (windows_core::Interface::vtable(self).SetFill)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
             .ok()
         }
     }
-    pub(crate) fn put_Stroke<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetStroke<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<Brush>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Stroke)(
+            (windows_core::Interface::vtable(self).SetStroke)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
             .ok()
         }
     }
-    pub(crate) fn put_StrokeThickness(&self, value: f64) -> windows_core::Result<()> {
+    pub(crate) fn SetStrokeThickness(&self, value: f64) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_StrokeThickness)(
+            (windows_core::Interface::vtable(self).SetStrokeThickness)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
@@ -12827,20 +12803,20 @@ impl IShape {
 #[repr(C)]
 pub struct IShape_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_Fill: usize,
-    pub put_Fill: unsafe extern "system" fn(
+    Fill: usize,
+    pub SetFill: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_Stroke: usize,
-    pub put_Stroke: unsafe extern "system" fn(
+    Stroke: usize,
+    pub SetStroke: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_StrokeMiterLimit: usize,
-    put_StrokeMiterLimit: usize,
-    get_StrokeThickness: usize,
-    pub put_StrokeThickness:
+    StrokeMiterLimit: usize,
+    SetStrokeMiterLimit: usize,
+    StrokeThickness: usize,
+    pub SetStrokeThickness:
         unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
@@ -12853,10 +12829,10 @@ impl windows_core::RuntimeType for ISizeChangedEventArgs {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl ISizeChangedEventArgs {
-    pub(crate) fn get_NewSize(&self) -> windows_core::Result<Size> {
+    pub(crate) fn NewSize(&self) -> windows_core::Result<Size> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_NewSize)(
+            (windows_core::Interface::vtable(self).NewSize)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
@@ -12867,8 +12843,8 @@ impl ISizeChangedEventArgs {
 #[repr(C)]
 pub struct ISizeChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_PreviousSize: usize,
-    pub get_NewSize:
+    PreviousSize: usize,
+    pub NewSize:
         unsafe extern "system" fn(*mut core::ffi::c_void, *mut Size) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
@@ -12881,30 +12857,30 @@ impl windows_core::RuntimeType for ISlider {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl ISlider {
-    pub(crate) fn put_StepFrequency(&self, value: f64) -> windows_core::Result<()> {
+    pub(crate) fn SetStepFrequency(&self, value: f64) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_StepFrequency)(
+            (windows_core::Interface::vtable(self).SetStepFrequency)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_Orientation(&self, value: Orientation) -> windows_core::Result<()> {
+    pub(crate) fn SetOrientation(&self, value: Orientation) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Orientation)(
+            (windows_core::Interface::vtable(self).SetOrientation)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_Header<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetHeader<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<windows_core::IInspectable>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Header)(
+            (windows_core::Interface::vtable(self).SetHeader)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
@@ -12915,28 +12891,28 @@ impl ISlider {
 #[repr(C)]
 pub struct ISlider_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_IntermediateValue: usize,
-    put_IntermediateValue: usize,
-    get_StepFrequency: usize,
-    pub put_StepFrequency:
+    IntermediateValue: usize,
+    SetIntermediateValue: usize,
+    StepFrequency: usize,
+    pub SetStepFrequency:
         unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
-    get_SnapsTo: usize,
-    put_SnapsTo: usize,
-    get_TickFrequency: usize,
-    put_TickFrequency: usize,
-    get_TickPlacement: usize,
-    put_TickPlacement: usize,
-    get_Orientation: usize,
-    pub put_Orientation:
+    SnapsTo: usize,
+    SetSnapsTo: usize,
+    TickFrequency: usize,
+    SetTickFrequency: usize,
+    TickPlacement: usize,
+    SetTickPlacement: usize,
+    Orientation: usize,
+    pub SetOrientation:
         unsafe extern "system" fn(*mut core::ffi::c_void, Orientation) -> windows_core::HRESULT,
-    get_IsDirectionReversed: usize,
-    put_IsDirectionReversed: usize,
-    get_IsThumbToolTipEnabled: usize,
-    put_IsThumbToolTipEnabled: usize,
-    get_ThumbToolTipValueConverter: usize,
-    put_ThumbToolTipValueConverter: usize,
-    get_Header: usize,
-    pub put_Header: unsafe extern "system" fn(
+    IsDirectionReversed: usize,
+    SetIsDirectionReversed: usize,
+    IsThumbToolTipEnabled: usize,
+    SetIsThumbToolTipEnabled: usize,
+    ThumbToolTipValueConverter: usize,
+    SetThumbToolTipValueConverter: usize,
+    Header: usize,
+    pub SetHeader: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
@@ -12970,9 +12946,9 @@ impl windows_core::RuntimeType for ISolidColorBrush {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl ISolidColorBrush {
-    pub(crate) fn put_Color(&self, value: Color) -> windows_core::Result<()> {
+    pub(crate) fn SetColor(&self, value: Color) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Color)(
+            (windows_core::Interface::vtable(self).SetColor)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
@@ -12983,9 +12959,8 @@ impl ISolidColorBrush {
 #[repr(C)]
 pub struct ISolidColorBrush_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_Color: usize,
-    pub put_Color:
-        unsafe extern "system" fn(*mut core::ffi::c_void, Color) -> windows_core::HRESULT,
+    Color: usize,
+    pub SetColor: unsafe extern "system" fn(*mut core::ffi::c_void, Color) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
     ISplitButton,
@@ -13014,7 +12989,7 @@ impl ISplitButton {
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
-            let token__ = (windows_core::Interface::vtable(self).add_Click)(
+            let token__ = (windows_core::Interface::vtable(self).Click)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Interface::as_raw(&handler),
                 &mut result__,
@@ -13023,7 +12998,7 @@ impl ISplitButton {
             Ok(windows_core::EventRevoker::new(
                 self.clone(),
                 token__,
-                windows_core::Interface::vtable(self).remove_Click,
+                windows_core::Interface::vtable(self).RemoveClick,
             ))
         }
     }
@@ -13031,18 +13006,18 @@ impl ISplitButton {
 #[repr(C)]
 pub struct ISplitButton_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_Flyout: usize,
-    put_Flyout: usize,
-    get_Command: usize,
-    put_Command: usize,
-    get_CommandParameter: usize,
-    put_CommandParameter: usize,
-    pub add_Click: unsafe extern "system" fn(
+    Flyout: usize,
+    SetFlyout: usize,
+    Command: usize,
+    SetCommand: usize,
+    CommandParameter: usize,
+    SetCommandParameter: usize,
+    pub Click: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         *mut i64,
     ) -> windows_core::HRESULT,
-    pub remove_Click:
+    pub RemoveClick:
         unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
@@ -13087,60 +13062,60 @@ impl windows_core::RuntimeType for ISplitView {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl ISplitView {
-    pub(crate) fn put_Content<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetContent<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<UIElement>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Content)(
+            (windows_core::Interface::vtable(self).SetContent)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
             .ok()
         }
     }
-    pub(crate) fn put_Pane<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetPane<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<UIElement>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Pane)(
+            (windows_core::Interface::vtable(self).SetPane)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
             .ok()
         }
     }
-    pub(crate) fn put_IsPaneOpen(&self, value: bool) -> windows_core::Result<()> {
+    pub(crate) fn SetIsPaneOpen(&self, value: bool) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_IsPaneOpen)(
+            (windows_core::Interface::vtable(self).SetIsPaneOpen)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_OpenPaneLength(&self, value: f64) -> windows_core::Result<()> {
+    pub(crate) fn SetOpenPaneLength(&self, value: f64) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_OpenPaneLength)(
+            (windows_core::Interface::vtable(self).SetOpenPaneLength)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_CompactPaneLength(&self, value: f64) -> windows_core::Result<()> {
+    pub(crate) fn SetCompactPaneLength(&self, value: f64) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_CompactPaneLength)(
+            (windows_core::Interface::vtable(self).SetCompactPaneLength)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_DisplayMode(&self, value: SplitViewDisplayMode) -> windows_core::Result<()> {
+    pub(crate) fn SetDisplayMode(&self, value: SplitViewDisplayMode) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_DisplayMode)(
+            (windows_core::Interface::vtable(self).SetDisplayMode)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
@@ -13167,7 +13142,7 @@ impl ISplitView {
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
-            let token__ = (windows_core::Interface::vtable(self).add_PaneClosed)(
+            let token__ = (windows_core::Interface::vtable(self).PaneClosed)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Interface::as_raw(&handler),
                 &mut result__,
@@ -13176,7 +13151,7 @@ impl ISplitView {
             Ok(windows_core::EventRevoker::new(
                 self.clone(),
                 token__,
-                windows_core::Interface::vtable(self).remove_PaneClosed,
+                windows_core::Interface::vtable(self).RemovePaneClosed,
             ))
         }
     }
@@ -13184,45 +13159,45 @@ impl ISplitView {
 #[repr(C)]
 pub struct ISplitView_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_Content: usize,
-    pub put_Content: unsafe extern "system" fn(
+    Content: usize,
+    pub SetContent: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_Pane: usize,
-    pub put_Pane: unsafe extern "system" fn(
+    Pane: usize,
+    pub SetPane: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_IsPaneOpen: usize,
-    pub put_IsPaneOpen:
+    IsPaneOpen: usize,
+    pub SetIsPaneOpen:
         unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
-    get_OpenPaneLength: usize,
-    pub put_OpenPaneLength:
+    OpenPaneLength: usize,
+    pub SetOpenPaneLength:
         unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
-    get_CompactPaneLength: usize,
-    pub put_CompactPaneLength:
+    CompactPaneLength: usize,
+    pub SetCompactPaneLength:
         unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
-    get_PanePlacement: usize,
-    put_PanePlacement: usize,
-    get_DisplayMode: usize,
-    pub put_DisplayMode: unsafe extern "system" fn(
+    PanePlacement: usize,
+    SetPanePlacement: usize,
+    DisplayMode: usize,
+    pub SetDisplayMode: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         SplitViewDisplayMode,
     ) -> windows_core::HRESULT,
-    get_TemplateSettings: usize,
-    get_PaneBackground: usize,
-    put_PaneBackground: usize,
-    get_LightDismissOverlayMode: usize,
-    put_LightDismissOverlayMode: usize,
-    add_PaneClosing: usize,
-    remove_PaneClosing: usize,
-    pub add_PaneClosed: unsafe extern "system" fn(
+    TemplateSettings: usize,
+    PaneBackground: usize,
+    SetPaneBackground: usize,
+    LightDismissOverlayMode: usize,
+    SetLightDismissOverlayMode: usize,
+    PaneClosing: usize,
+    RemovePaneClosing: usize,
+    pub PaneClosed: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         *mut i64,
     ) -> windows_core::HRESULT,
-    pub remove_PaneClosed:
+    pub RemovePaneClosed:
         unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
@@ -13254,18 +13229,18 @@ impl windows_core::RuntimeType for IStackPanel {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IStackPanel {
-    pub(crate) fn put_Orientation(&self, value: Orientation) -> windows_core::Result<()> {
+    pub(crate) fn SetOrientation(&self, value: Orientation) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Orientation)(
+            (windows_core::Interface::vtable(self).SetOrientation)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_Spacing(&self, value: f64) -> windows_core::Result<()> {
+    pub(crate) fn SetSpacing(&self, value: f64) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Spacing)(
+            (windows_core::Interface::vtable(self).SetSpacing)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
@@ -13276,24 +13251,23 @@ impl IStackPanel {
 #[repr(C)]
 pub struct IStackPanel_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_AreScrollSnapPointsRegular: usize,
-    put_AreScrollSnapPointsRegular: usize,
-    get_Orientation: usize,
-    pub put_Orientation:
+    AreScrollSnapPointsRegular: usize,
+    SetAreScrollSnapPointsRegular: usize,
+    Orientation: usize,
+    pub SetOrientation:
         unsafe extern "system" fn(*mut core::ffi::c_void, Orientation) -> windows_core::HRESULT,
-    get_BackgroundSizing: usize,
-    put_BackgroundSizing: usize,
-    get_BorderBrush: usize,
-    put_BorderBrush: usize,
-    get_BorderThickness: usize,
-    put_BorderThickness: usize,
-    get_CornerRadius: usize,
-    put_CornerRadius: usize,
-    get_Padding: usize,
-    put_Padding: usize,
-    get_Spacing: usize,
-    pub put_Spacing:
-        unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
+    BackgroundSizing: usize,
+    SetBackgroundSizing: usize,
+    BorderBrush: usize,
+    SetBorderBrush: usize,
+    BorderThickness: usize,
+    SetBorderThickness: usize,
+    CornerRadius: usize,
+    SetCornerRadius: usize,
+    Padding: usize,
+    SetPadding: usize,
+    Spacing: usize,
+    pub SetSpacing: unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
     IStackPanelFactory,
@@ -13329,10 +13303,10 @@ windows_core::imp::interface_hierarchy!(
     windows_core::IInspectable
 );
 impl IStorageItem {
-    pub(crate) fn get_Name(&self) -> windows_core::Result<String> {
+    pub(crate) fn Name(&self) -> windows_core::Result<String> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_Name)(
+            (windows_core::Interface::vtable(self).Name)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
@@ -13342,10 +13316,10 @@ impl IStorageItem {
             })
         }
     }
-    pub(crate) fn get_Path(&self) -> windows_core::Result<String> {
+    pub(crate) fn Path(&self) -> windows_core::Result<String> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_Path)(
+            (windows_core::Interface::vtable(self).Path)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
@@ -13355,10 +13329,10 @@ impl IStorageItem {
             })
         }
     }
-    pub(crate) fn get_Attributes(&self) -> windows_core::Result<FileAttributes> {
+    pub(crate) fn Attributes(&self) -> windows_core::Result<FileAttributes> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_Attributes)(
+            (windows_core::Interface::vtable(self).Attributes)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
@@ -13374,15 +13348,15 @@ pub struct IStorageItem_Vtbl {
     DeleteAsyncOverloadDefaultOptions: usize,
     DeleteAsync: usize,
     GetBasicPropertiesAsync: usize,
-    pub get_Name: unsafe extern "system" fn(
+    pub Name: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    pub get_Path: unsafe extern "system" fn(
+    pub Path: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    pub get_Attributes: unsafe extern "system" fn(
+    pub Attributes: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut FileAttributes,
     ) -> windows_core::HRESULT,
@@ -13518,20 +13492,20 @@ impl windows_core::RuntimeType for ISwapChainPanel {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl ISwapChainPanel {
-    pub(crate) fn get_CompositionScaleX(&self) -> windows_core::Result<f32> {
+    pub(crate) fn CompositionScaleX(&self) -> windows_core::Result<f32> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_CompositionScaleX)(
+            (windows_core::Interface::vtable(self).CompositionScaleX)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
             .map(|| result__)
         }
     }
-    pub(crate) fn get_CompositionScaleY(&self) -> windows_core::Result<f32> {
+    pub(crate) fn CompositionScaleY(&self) -> windows_core::Result<f32> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_CompositionScaleY)(
+            (windows_core::Interface::vtable(self).CompositionScaleY)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
@@ -13558,7 +13532,7 @@ impl ISwapChainPanel {
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
-            let token__ = (windows_core::Interface::vtable(self).add_CompositionScaleChanged)(
+            let token__ = (windows_core::Interface::vtable(self).CompositionScaleChanged)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Interface::as_raw(&handler),
                 &mut result__,
@@ -13567,7 +13541,7 @@ impl ISwapChainPanel {
             Ok(windows_core::EventRevoker::new(
                 self.clone(),
                 token__,
-                windows_core::Interface::vtable(self).remove_CompositionScaleChanged,
+                windows_core::Interface::vtable(self).RemoveCompositionScaleChanged,
             ))
         }
     }
@@ -13575,16 +13549,16 @@ impl ISwapChainPanel {
 #[repr(C)]
 pub struct ISwapChainPanel_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    pub get_CompositionScaleX:
+    pub CompositionScaleX:
         unsafe extern "system" fn(*mut core::ffi::c_void, *mut f32) -> windows_core::HRESULT,
-    pub get_CompositionScaleY:
+    pub CompositionScaleY:
         unsafe extern "system" fn(*mut core::ffi::c_void, *mut f32) -> windows_core::HRESULT,
-    pub add_CompositionScaleChanged: unsafe extern "system" fn(
+    pub CompositionScaleChanged: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         *mut i64,
     ) -> windows_core::HRESULT,
-    pub remove_CompositionScaleChanged:
+    pub RemoveCompositionScaleChanged:
         unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
@@ -13688,9 +13662,9 @@ impl windows_core::RuntimeType for ITabView {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl ITabView {
-    pub(crate) fn put_IsAddTabButtonVisible(&self, value: bool) -> windows_core::Result<()> {
+    pub(crate) fn SetIsAddTabButtonVisible(&self, value: bool) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_IsAddTabButtonVisible)(
+            (windows_core::Interface::vtable(self).SetIsAddTabButtonVisible)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
@@ -13717,7 +13691,7 @@ impl ITabView {
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
-            let token__ = (windows_core::Interface::vtable(self).add_TabCloseRequested)(
+            let token__ = (windows_core::Interface::vtable(self).TabCloseRequested)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Interface::as_raw(&handler),
                 &mut result__,
@@ -13726,7 +13700,7 @@ impl ITabView {
             Ok(windows_core::EventRevoker::new(
                 self.clone(),
                 token__,
-                windows_core::Interface::vtable(self).remove_TabCloseRequested,
+                windows_core::Interface::vtable(self).RemoveTabCloseRequested,
             ))
         }
     }
@@ -13749,7 +13723,7 @@ impl ITabView {
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
-            let token__ = (windows_core::Interface::vtable(self).add_AddTabButtonClick)(
+            let token__ = (windows_core::Interface::vtable(self).AddTabButtonClick)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Interface::as_raw(&handler),
                 &mut result__,
@@ -13758,44 +13732,44 @@ impl ITabView {
             Ok(windows_core::EventRevoker::new(
                 self.clone(),
                 token__,
-                windows_core::Interface::vtable(self).remove_AddTabButtonClick,
+                windows_core::Interface::vtable(self).RemoveAddTabButtonClick,
             ))
         }
     }
-    pub(crate) fn get_TabItems(
+    pub(crate) fn TabItems(
         &self,
     ) -> windows_core::Result<windows_collections::IVector<windows_core::IInspectable>> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_TabItems)(
+            (windows_core::Interface::vtable(self).TabItems)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
             .and_then(|| windows_core::Type::from_abi(result__))
         }
     }
-    pub(crate) fn put_CanReorderTabs(&self, value: bool) -> windows_core::Result<()> {
+    pub(crate) fn SetCanReorderTabs(&self, value: bool) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_CanReorderTabs)(
+            (windows_core::Interface::vtable(self).SetCanReorderTabs)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn get_SelectedIndex(&self) -> windows_core::Result<i32> {
+    pub(crate) fn SelectedIndex(&self) -> windows_core::Result<i32> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_SelectedIndex)(
+            (windows_core::Interface::vtable(self).SelectedIndex)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
             .map(|| result__)
         }
     }
-    pub(crate) fn put_SelectedIndex(&self, value: i32) -> windows_core::Result<()> {
+    pub(crate) fn SetSelectedIndex(&self, value: i32) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_SelectedIndex)(
+            (windows_core::Interface::vtable(self).SetSelectedIndex)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
@@ -13821,7 +13795,7 @@ impl ITabView {
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
-            let token__ = (windows_core::Interface::vtable(self).add_SelectionChanged)(
+            let token__ = (windows_core::Interface::vtable(self).SelectionChanged)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Interface::as_raw(&handler),
                 &mut result__,
@@ -13830,7 +13804,7 @@ impl ITabView {
             Ok(windows_core::EventRevoker::new(
                 self.clone(),
                 token__,
-                windows_core::Interface::vtable(self).remove_SelectionChanged,
+                windows_core::Interface::vtable(self).RemoveSelectionChanged,
             ))
         }
     }
@@ -13838,74 +13812,74 @@ impl ITabView {
 #[repr(C)]
 pub struct ITabView_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_TabWidthMode: usize,
-    put_TabWidthMode: usize,
-    get_CloseButtonOverlayMode: usize,
-    put_CloseButtonOverlayMode: usize,
-    get_TabStripHeader: usize,
-    put_TabStripHeader: usize,
-    get_TabStripHeaderTemplate: usize,
-    put_TabStripHeaderTemplate: usize,
-    get_TabStripFooter: usize,
-    put_TabStripFooter: usize,
-    get_TabStripFooterTemplate: usize,
-    put_TabStripFooterTemplate: usize,
-    get_IsAddTabButtonVisible: usize,
-    pub put_IsAddTabButtonVisible:
+    TabWidthMode: usize,
+    SetTabWidthMode: usize,
+    CloseButtonOverlayMode: usize,
+    SetCloseButtonOverlayMode: usize,
+    TabStripHeader: usize,
+    SetTabStripHeader: usize,
+    TabStripHeaderTemplate: usize,
+    SetTabStripHeaderTemplate: usize,
+    TabStripFooter: usize,
+    SetTabStripFooter: usize,
+    TabStripFooterTemplate: usize,
+    SetTabStripFooterTemplate: usize,
+    IsAddTabButtonVisible: usize,
+    pub SetIsAddTabButtonVisible:
         unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
-    get_AddTabButtonCommand: usize,
-    put_AddTabButtonCommand: usize,
-    get_AddTabButtonCommandParameter: usize,
-    put_AddTabButtonCommandParameter: usize,
-    pub add_TabCloseRequested: unsafe extern "system" fn(
+    AddTabButtonCommand: usize,
+    SetAddTabButtonCommand: usize,
+    AddTabButtonCommandParameter: usize,
+    SetAddTabButtonCommandParameter: usize,
+    pub TabCloseRequested: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         *mut i64,
     ) -> windows_core::HRESULT,
-    pub remove_TabCloseRequested:
+    pub RemoveTabCloseRequested:
         unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
-    add_TabDroppedOutside: usize,
-    remove_TabDroppedOutside: usize,
-    pub add_AddTabButtonClick: unsafe extern "system" fn(
+    TabDroppedOutside: usize,
+    RemoveTabDroppedOutside: usize,
+    pub AddTabButtonClick: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         *mut i64,
     ) -> windows_core::HRESULT,
-    pub remove_AddTabButtonClick:
+    pub RemoveAddTabButtonClick:
         unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
-    add_TabItemsChanged: usize,
-    remove_TabItemsChanged: usize,
-    get_TabItemsSource: usize,
-    put_TabItemsSource: usize,
-    pub get_TabItems: unsafe extern "system" fn(
+    TabItemsChanged: usize,
+    RemoveTabItemsChanged: usize,
+    TabItemsSource: usize,
+    SetTabItemsSource: usize,
+    pub TabItems: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_TabItemTemplate: usize,
-    put_TabItemTemplate: usize,
-    get_TabItemTemplateSelector: usize,
-    put_TabItemTemplateSelector: usize,
-    get_CanDragTabs: usize,
-    put_CanDragTabs: usize,
-    get_CanReorderTabs: usize,
-    pub put_CanReorderTabs:
+    TabItemTemplate: usize,
+    SetTabItemTemplate: usize,
+    TabItemTemplateSelector: usize,
+    SetTabItemTemplateSelector: usize,
+    CanDragTabs: usize,
+    SetCanDragTabs: usize,
+    CanReorderTabs: usize,
+    pub SetCanReorderTabs:
         unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
-    get_AllowDropTabs: usize,
-    put_AllowDropTabs: usize,
-    pub get_SelectedIndex:
+    AllowDropTabs: usize,
+    SetAllowDropTabs: usize,
+    pub SelectedIndex:
         unsafe extern "system" fn(*mut core::ffi::c_void, *mut i32) -> windows_core::HRESULT,
-    pub put_SelectedIndex:
+    pub SetSelectedIndex:
         unsafe extern "system" fn(*mut core::ffi::c_void, i32) -> windows_core::HRESULT,
-    get_SelectedItem: usize,
-    put_SelectedItem: usize,
+    SelectedItem: usize,
+    SetSelectedItem: usize,
     ContainerFromItem: usize,
     ContainerFromIndex: usize,
-    pub add_SelectionChanged: unsafe extern "system" fn(
+    pub SelectionChanged: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         *mut i64,
     ) -> windows_core::HRESULT,
-    pub remove_SelectionChanged:
+    pub RemoveSelectionChanged:
         unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
@@ -13937,21 +13911,21 @@ impl windows_core::RuntimeType for ITabViewItem {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl ITabViewItem {
-    pub(crate) fn put_Header<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetHeader<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<windows_core::IInspectable>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Header)(
+            (windows_core::Interface::vtable(self).SetHeader)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
             .ok()
         }
     }
-    pub(crate) fn put_IsClosable(&self, value: bool) -> windows_core::Result<()> {
+    pub(crate) fn SetIsClosable(&self, value: bool) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_IsClosable)(
+            (windows_core::Interface::vtable(self).SetIsClosable)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
@@ -13962,17 +13936,17 @@ impl ITabViewItem {
 #[repr(C)]
 pub struct ITabViewItem_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_Header: usize,
-    pub put_Header: unsafe extern "system" fn(
+    Header: usize,
+    pub SetHeader: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_HeaderTemplate: usize,
-    put_HeaderTemplate: usize,
-    get_IconSource: usize,
-    put_IconSource: usize,
-    get_IsClosable: usize,
-    pub put_IsClosable:
+    HeaderTemplate: usize,
+    SetHeaderTemplate: usize,
+    IconSource: usize,
+    SetIconSource: usize,
+    IsClosable: usize,
+    pub SetIsClosable:
         unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
@@ -14004,10 +13978,10 @@ impl windows_core::RuntimeType for ITabViewTabCloseRequestedEventArgs {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl ITabViewTabCloseRequestedEventArgs {
-    pub(crate) fn get_Tab(&self) -> windows_core::Result<TabViewItem> {
+    pub(crate) fn Tab(&self) -> windows_core::Result<TabViewItem> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_Tab)(
+            (windows_core::Interface::vtable(self).Tab)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
@@ -14018,8 +13992,8 @@ impl ITabViewTabCloseRequestedEventArgs {
 #[repr(C)]
 pub struct ITabViewTabCloseRequestedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_Item: usize,
-    pub get_Tab: unsafe extern "system" fn(
+    Item: usize,
+    pub Tab: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
@@ -14047,72 +14021,72 @@ impl windows_core::RuntimeType for ITeachingTip {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl ITeachingTip {
-    pub(crate) fn put_Title(&self, value: &str) -> windows_core::Result<()> {
+    pub(crate) fn SetTitle(&self, value: &str) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Title)(
+            (windows_core::Interface::vtable(self).SetTitle)(
                 windows_core::Interface::as_raw(self),
                 core::mem::transmute_copy(&windows_core::HSTRING::from(value)),
             )
             .ok()
         }
     }
-    pub(crate) fn put_Subtitle(&self, value: &str) -> windows_core::Result<()> {
+    pub(crate) fn SetSubtitle(&self, value: &str) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Subtitle)(
+            (windows_core::Interface::vtable(self).SetSubtitle)(
                 windows_core::Interface::as_raw(self),
                 core::mem::transmute_copy(&windows_core::HSTRING::from(value)),
             )
             .ok()
         }
     }
-    pub(crate) fn put_IsOpen(&self, value: bool) -> windows_core::Result<()> {
+    pub(crate) fn SetIsOpen(&self, value: bool) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_IsOpen)(
+            (windows_core::Interface::vtable(self).SetIsOpen)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_ActionButtonContent<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetActionButtonContent<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<windows_core::IInspectable>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_ActionButtonContent)(
+            (windows_core::Interface::vtable(self).SetActionButtonContent)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
             .ok()
         }
     }
-    pub(crate) fn put_CloseButtonContent<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetCloseButtonContent<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<windows_core::IInspectable>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_CloseButtonContent)(
+            (windows_core::Interface::vtable(self).SetCloseButtonContent)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
             .ok()
         }
     }
-    pub(crate) fn put_IsLightDismissEnabled(&self, value: bool) -> windows_core::Result<()> {
+    pub(crate) fn SetIsLightDismissEnabled(&self, value: bool) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_IsLightDismissEnabled)(
+            (windows_core::Interface::vtable(self).SetIsLightDismissEnabled)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_PreferredPlacement(
+    pub(crate) fn SetPreferredPlacement(
         &self,
         value: TeachingTipPlacementMode,
     ) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_PreferredPlacement)(
+            (windows_core::Interface::vtable(self).SetPreferredPlacement)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
@@ -14139,7 +14113,7 @@ impl ITeachingTip {
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
-            let token__ = (windows_core::Interface::vtable(self).add_ActionButtonClick)(
+            let token__ = (windows_core::Interface::vtable(self).ActionButtonClick)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Interface::as_raw(&handler),
                 &mut result__,
@@ -14148,7 +14122,7 @@ impl ITeachingTip {
             Ok(windows_core::EventRevoker::new(
                 self.clone(),
                 token__,
-                windows_core::Interface::vtable(self).remove_ActionButtonClick,
+                windows_core::Interface::vtable(self).RemoveActionButtonClick,
             ))
         }
     }
@@ -14169,7 +14143,7 @@ impl ITeachingTip {
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
-            let token__ = (windows_core::Interface::vtable(self).add_Closed)(
+            let token__ = (windows_core::Interface::vtable(self).Closed)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Interface::as_raw(&handler),
                 &mut result__,
@@ -14178,7 +14152,7 @@ impl ITeachingTip {
             Ok(windows_core::EventRevoker::new(
                 self.clone(),
                 token__,
-                windows_core::Interface::vtable(self).remove_Closed,
+                windows_core::Interface::vtable(self).RemoveClosed,
             ))
         }
     }
@@ -14186,81 +14160,80 @@ impl ITeachingTip {
 #[repr(C)]
 pub struct ITeachingTip_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_Title: usize,
-    pub put_Title: unsafe extern "system" fn(
+    Title: usize,
+    pub SetTitle: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_Subtitle: usize,
-    pub put_Subtitle: unsafe extern "system" fn(
+    Subtitle: usize,
+    pub SetSubtitle: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_IsOpen: usize,
-    pub put_IsOpen:
+    IsOpen: usize,
+    pub SetIsOpen: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
+    Target: usize,
+    SetTarget: usize,
+    TailVisibility: usize,
+    SetTailVisibility: usize,
+    ActionButtonContent: usize,
+    pub SetActionButtonContent: unsafe extern "system" fn(
+        *mut core::ffi::c_void,
+        *mut core::ffi::c_void,
+    ) -> windows_core::HRESULT,
+    ActionButtonStyle: usize,
+    SetActionButtonStyle: usize,
+    ActionButtonCommand: usize,
+    SetActionButtonCommand: usize,
+    ActionButtonCommandParameter: usize,
+    SetActionButtonCommandParameter: usize,
+    CloseButtonContent: usize,
+    pub SetCloseButtonContent: unsafe extern "system" fn(
+        *mut core::ffi::c_void,
+        *mut core::ffi::c_void,
+    ) -> windows_core::HRESULT,
+    CloseButtonStyle: usize,
+    SetCloseButtonStyle: usize,
+    CloseButtonCommand: usize,
+    SetCloseButtonCommand: usize,
+    CloseButtonCommandParameter: usize,
+    SetCloseButtonCommandParameter: usize,
+    PlacementMargin: usize,
+    SetPlacementMargin: usize,
+    ShouldConstrainToRootBounds: usize,
+    SetShouldConstrainToRootBounds: usize,
+    IsLightDismissEnabled: usize,
+    pub SetIsLightDismissEnabled:
         unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
-    get_Target: usize,
-    put_Target: usize,
-    get_TailVisibility: usize,
-    put_TailVisibility: usize,
-    get_ActionButtonContent: usize,
-    pub put_ActionButtonContent: unsafe extern "system" fn(
-        *mut core::ffi::c_void,
-        *mut core::ffi::c_void,
-    ) -> windows_core::HRESULT,
-    get_ActionButtonStyle: usize,
-    put_ActionButtonStyle: usize,
-    get_ActionButtonCommand: usize,
-    put_ActionButtonCommand: usize,
-    get_ActionButtonCommandParameter: usize,
-    put_ActionButtonCommandParameter: usize,
-    get_CloseButtonContent: usize,
-    pub put_CloseButtonContent: unsafe extern "system" fn(
-        *mut core::ffi::c_void,
-        *mut core::ffi::c_void,
-    ) -> windows_core::HRESULT,
-    get_CloseButtonStyle: usize,
-    put_CloseButtonStyle: usize,
-    get_CloseButtonCommand: usize,
-    put_CloseButtonCommand: usize,
-    get_CloseButtonCommandParameter: usize,
-    put_CloseButtonCommandParameter: usize,
-    get_PlacementMargin: usize,
-    put_PlacementMargin: usize,
-    get_ShouldConstrainToRootBounds: usize,
-    put_ShouldConstrainToRootBounds: usize,
-    get_IsLightDismissEnabled: usize,
-    pub put_IsLightDismissEnabled:
-        unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
-    get_PreferredPlacement: usize,
-    pub put_PreferredPlacement: unsafe extern "system" fn(
+    PreferredPlacement: usize,
+    pub SetPreferredPlacement: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         TeachingTipPlacementMode,
     ) -> windows_core::HRESULT,
-    get_HeroContentPlacement: usize,
-    put_HeroContentPlacement: usize,
-    get_HeroContent: usize,
-    put_HeroContent: usize,
-    get_IconSource: usize,
-    put_IconSource: usize,
-    get_TemplateSettings: usize,
-    pub add_ActionButtonClick: unsafe extern "system" fn(
+    HeroContentPlacement: usize,
+    SetHeroContentPlacement: usize,
+    HeroContent: usize,
+    SetHeroContent: usize,
+    IconSource: usize,
+    SetIconSource: usize,
+    TemplateSettings: usize,
+    pub ActionButtonClick: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         *mut i64,
     ) -> windows_core::HRESULT,
-    pub remove_ActionButtonClick:
+    pub RemoveActionButtonClick:
         unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
-    add_CloseButtonClick: usize,
-    remove_CloseButtonClick: usize,
-    add_Closing: usize,
-    remove_Closing: usize,
-    pub add_Closed: unsafe extern "system" fn(
+    CloseButtonClick: usize,
+    RemoveCloseButtonClick: usize,
+    Closing: usize,
+    RemoveClosing: usize,
+    pub Closed: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         *mut i64,
     ) -> windows_core::HRESULT,
-    pub remove_Closed:
+    pub RemoveClosed:
         unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
@@ -14305,61 +14278,61 @@ impl windows_core::RuntimeType for ITextBlock {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl ITextBlock {
-    pub(crate) fn put_FontSize(&self, value: f64) -> windows_core::Result<()> {
+    pub(crate) fn SetFontSize(&self, value: f64) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_FontSize)(
+            (windows_core::Interface::vtable(self).SetFontSize)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_FontFamily<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetFontFamily<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<FontFamily>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_FontFamily)(
+            (windows_core::Interface::vtable(self).SetFontFamily)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
             .ok()
         }
     }
-    pub(crate) fn put_FontWeight(&self, value: FontWeight) -> windows_core::Result<()> {
+    pub(crate) fn SetFontWeight(&self, value: FontWeight) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_FontWeight)(
+            (windows_core::Interface::vtable(self).SetFontWeight)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_Foreground<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetForeground<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<Brush>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Foreground)(
+            (windows_core::Interface::vtable(self).SetForeground)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
             .ok()
         }
     }
-    pub(crate) fn put_TextWrapping(&self, value: TextWrapping) -> windows_core::Result<()> {
+    pub(crate) fn SetTextWrapping(&self, value: TextWrapping) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_TextWrapping)(
+            (windows_core::Interface::vtable(self).SetTextWrapping)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn get_Text(&self) -> windows_core::Result<String> {
+    pub(crate) fn Text(&self) -> windows_core::Result<String> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_Text)(
+            (windows_core::Interface::vtable(self).Text)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
@@ -14369,18 +14342,18 @@ impl ITextBlock {
             })
         }
     }
-    pub(crate) fn put_Text(&self, value: &str) -> windows_core::Result<()> {
+    pub(crate) fn SetText(&self, value: &str) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Text)(
+            (windows_core::Interface::vtable(self).SetText)(
                 windows_core::Interface::as_raw(self),
                 core::mem::transmute_copy(&windows_core::HSTRING::from(value)),
             )
             .ok()
         }
     }
-    pub(crate) fn put_IsTextSelectionEnabled(&self, value: bool) -> windows_core::Result<()> {
+    pub(crate) fn SetIsTextSelectionEnabled(&self, value: bool) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_IsTextSelectionEnabled)(
+            (windows_core::Interface::vtable(self).SetIsTextSelectionEnabled)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
@@ -14391,52 +14364,52 @@ impl ITextBlock {
 #[repr(C)]
 pub struct ITextBlock_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_FontSize: usize,
-    pub put_FontSize:
+    FontSize: usize,
+    pub SetFontSize:
         unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
-    get_FontFamily: usize,
-    pub put_FontFamily: unsafe extern "system" fn(
+    FontFamily: usize,
+    pub SetFontFamily: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_FontWeight: usize,
-    pub put_FontWeight:
+    FontWeight: usize,
+    pub SetFontWeight:
         unsafe extern "system" fn(*mut core::ffi::c_void, FontWeight) -> windows_core::HRESULT,
-    get_FontStyle: usize,
-    put_FontStyle: usize,
-    get_FontStretch: usize,
-    put_FontStretch: usize,
-    get_CharacterSpacing: usize,
-    put_CharacterSpacing: usize,
-    get_Foreground: usize,
-    pub put_Foreground: unsafe extern "system" fn(
+    FontStyle: usize,
+    SetFontStyle: usize,
+    FontStretch: usize,
+    SetFontStretch: usize,
+    CharacterSpacing: usize,
+    SetCharacterSpacing: usize,
+    Foreground: usize,
+    pub SetForeground: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_TextWrapping: usize,
-    pub put_TextWrapping:
+    TextWrapping: usize,
+    pub SetTextWrapping:
         unsafe extern "system" fn(*mut core::ffi::c_void, TextWrapping) -> windows_core::HRESULT,
-    get_TextTrimming: usize,
-    put_TextTrimming: usize,
-    get_TextAlignment: usize,
-    put_TextAlignment: usize,
-    pub get_Text: unsafe extern "system" fn(
+    TextTrimming: usize,
+    SetTextTrimming: usize,
+    TextAlignment: usize,
+    SetTextAlignment: usize,
+    pub Text: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    pub put_Text: unsafe extern "system" fn(
+    pub SetText: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_Inlines: usize,
-    get_Padding: usize,
-    put_Padding: usize,
-    get_LineHeight: usize,
-    put_LineHeight: usize,
-    get_LineStackingStrategy: usize,
-    put_LineStackingStrategy: usize,
-    get_IsTextSelectionEnabled: usize,
-    pub put_IsTextSelectionEnabled:
+    Inlines: usize,
+    Padding: usize,
+    SetPadding: usize,
+    LineHeight: usize,
+    SetLineHeight: usize,
+    LineStackingStrategy: usize,
+    SetLineStackingStrategy: usize,
+    IsTextSelectionEnabled: usize,
+    pub SetIsTextSelectionEnabled:
         unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
@@ -14449,10 +14422,10 @@ impl windows_core::RuntimeType for ITextBox {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl ITextBox {
-    pub(crate) fn get_Text(&self) -> windows_core::Result<String> {
+    pub(crate) fn Text(&self) -> windows_core::Result<String> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_Text)(
+            (windows_core::Interface::vtable(self).Text)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
@@ -14462,48 +14435,48 @@ impl ITextBox {
             })
         }
     }
-    pub(crate) fn put_Text(&self, value: &str) -> windows_core::Result<()> {
+    pub(crate) fn SetText(&self, value: &str) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Text)(
+            (windows_core::Interface::vtable(self).SetText)(
                 windows_core::Interface::as_raw(self),
                 core::mem::transmute_copy(&windows_core::HSTRING::from(value)),
             )
             .ok()
         }
     }
-    pub(crate) fn put_AcceptsReturn(&self, value: bool) -> windows_core::Result<()> {
+    pub(crate) fn SetAcceptsReturn(&self, value: bool) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_AcceptsReturn)(
+            (windows_core::Interface::vtable(self).SetAcceptsReturn)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_TextWrapping(&self, value: TextWrapping) -> windows_core::Result<()> {
+    pub(crate) fn SetTextWrapping(&self, value: TextWrapping) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_TextWrapping)(
+            (windows_core::Interface::vtable(self).SetTextWrapping)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_Header<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetHeader<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<windows_core::IInspectable>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Header)(
+            (windows_core::Interface::vtable(self).SetHeader)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
             .ok()
         }
     }
-    pub(crate) fn put_PlaceholderText(&self, value: &str) -> windows_core::Result<()> {
+    pub(crate) fn SetPlaceholderText(&self, value: &str) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_PlaceholderText)(
+            (windows_core::Interface::vtable(self).SetPlaceholderText)(
                 windows_core::Interface::as_raw(self),
                 core::mem::transmute_copy(&windows_core::HSTRING::from(value)),
             )
@@ -14529,7 +14502,7 @@ impl ITextBox {
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
-            let token__ = (windows_core::Interface::vtable(self).add_TextChanged)(
+            let token__ = (windows_core::Interface::vtable(self).TextChanged)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Interface::as_raw(&handler),
                 &mut result__,
@@ -14538,7 +14511,7 @@ impl ITextBox {
             Ok(windows_core::EventRevoker::new(
                 self.clone(),
                 token__,
-                windows_core::Interface::vtable(self).remove_TextChanged,
+                windows_core::Interface::vtable(self).RemoveTextChanged,
             ))
         }
     }
@@ -14546,78 +14519,78 @@ impl ITextBox {
 #[repr(C)]
 pub struct ITextBox_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    pub get_Text: unsafe extern "system" fn(
+    pub Text: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    pub put_Text: unsafe extern "system" fn(
+    pub SetText: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_SelectedText: usize,
-    put_SelectedText: usize,
-    get_SelectionLength: usize,
-    put_SelectionLength: usize,
-    get_SelectionStart: usize,
-    put_SelectionStart: usize,
-    get_MaxLength: usize,
-    put_MaxLength: usize,
-    get_IsReadOnly: usize,
-    put_IsReadOnly: usize,
-    get_AcceptsReturn: usize,
-    pub put_AcceptsReturn:
+    SelectedText: usize,
+    SetSelectedText: usize,
+    SelectionLength: usize,
+    SetSelectionLength: usize,
+    SelectionStart: usize,
+    SetSelectionStart: usize,
+    MaxLength: usize,
+    SetMaxLength: usize,
+    IsReadOnly: usize,
+    SetIsReadOnly: usize,
+    AcceptsReturn: usize,
+    pub SetAcceptsReturn:
         unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
-    get_TextAlignment: usize,
-    put_TextAlignment: usize,
-    get_TextWrapping: usize,
-    pub put_TextWrapping:
+    TextAlignment: usize,
+    SetTextAlignment: usize,
+    TextWrapping: usize,
+    pub SetTextWrapping:
         unsafe extern "system" fn(*mut core::ffi::c_void, TextWrapping) -> windows_core::HRESULT,
-    get_IsSpellCheckEnabled: usize,
-    put_IsSpellCheckEnabled: usize,
-    get_IsTextPredictionEnabled: usize,
-    put_IsTextPredictionEnabled: usize,
-    get_InputScope: usize,
-    put_InputScope: usize,
-    get_Header: usize,
-    pub put_Header: unsafe extern "system" fn(
+    IsSpellCheckEnabled: usize,
+    SetIsSpellCheckEnabled: usize,
+    IsTextPredictionEnabled: usize,
+    SetIsTextPredictionEnabled: usize,
+    InputScope: usize,
+    SetInputScope: usize,
+    Header: usize,
+    pub SetHeader: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_HeaderTemplate: usize,
-    put_HeaderTemplate: usize,
-    get_PlaceholderText: usize,
-    pub put_PlaceholderText: unsafe extern "system" fn(
+    HeaderTemplate: usize,
+    SetHeaderTemplate: usize,
+    PlaceholderText: usize,
+    pub SetPlaceholderText: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_SelectionHighlightColor: usize,
-    put_SelectionHighlightColor: usize,
-    get_PreventKeyboardDisplayOnProgrammaticFocus: usize,
-    put_PreventKeyboardDisplayOnProgrammaticFocus: usize,
-    get_IsColorFontEnabled: usize,
-    put_IsColorFontEnabled: usize,
-    get_SelectionHighlightColorWhenNotFocused: usize,
-    put_SelectionHighlightColorWhenNotFocused: usize,
-    get_HorizontalTextAlignment: usize,
-    put_HorizontalTextAlignment: usize,
-    get_CharacterCasing: usize,
-    put_CharacterCasing: usize,
-    get_PlaceholderForeground: usize,
-    put_PlaceholderForeground: usize,
-    get_CanPasteClipboardContent: usize,
-    get_CanUndo: usize,
-    get_CanRedo: usize,
-    get_SelectionFlyout: usize,
-    put_SelectionFlyout: usize,
-    get_ProofingMenuFlyout: usize,
-    get_Description: usize,
-    put_Description: usize,
-    pub add_TextChanged: unsafe extern "system" fn(
+    SelectionHighlightColor: usize,
+    SetSelectionHighlightColor: usize,
+    PreventKeyboardDisplayOnProgrammaticFocus: usize,
+    SetPreventKeyboardDisplayOnProgrammaticFocus: usize,
+    IsColorFontEnabled: usize,
+    SetIsColorFontEnabled: usize,
+    SelectionHighlightColorWhenNotFocused: usize,
+    SetSelectionHighlightColorWhenNotFocused: usize,
+    HorizontalTextAlignment: usize,
+    SetHorizontalTextAlignment: usize,
+    CharacterCasing: usize,
+    SetCharacterCasing: usize,
+    PlaceholderForeground: usize,
+    SetPlaceholderForeground: usize,
+    CanPasteClipboardContent: usize,
+    CanUndo: usize,
+    CanRedo: usize,
+    SelectionFlyout: usize,
+    SetSelectionFlyout: usize,
+    ProofingMenuFlyout: usize,
+    Description: usize,
+    SetDescription: usize,
+    pub TextChanged: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         *mut i64,
     ) -> windows_core::HRESULT,
-    pub remove_TextChanged:
+    pub RemoveTextChanged:
         unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
@@ -14690,13 +14663,13 @@ impl ITextDocument {
 #[repr(C)]
 pub struct ITextDocument_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_CaretType: usize,
-    put_CaretType: usize,
-    get_DefaultTabStop: usize,
-    put_DefaultTabStop: usize,
-    get_Selection: usize,
-    get_UndoLimit: usize,
-    put_UndoLimit: usize,
+    CaretType: usize,
+    SetCaretType: usize,
+    DefaultTabStop: usize,
+    SetDefaultTabStop: usize,
+    Selection: usize,
+    UndoLimit: usize,
+    SetUndoLimit: usize,
     CanCopy: usize,
     CanPaste: usize,
     CanRedo: usize,
@@ -14735,9 +14708,9 @@ impl windows_core::RuntimeType for ITextElement {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl ITextElement {
-    pub(crate) fn put_FontWeight(&self, value: FontWeight) -> windows_core::Result<()> {
+    pub(crate) fn SetFontWeight(&self, value: FontWeight) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_FontWeight)(
+            (windows_core::Interface::vtable(self).SetFontWeight)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
@@ -14748,13 +14721,13 @@ impl ITextElement {
 #[repr(C)]
 pub struct ITextElement_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_Name: usize,
-    get_FontSize: usize,
-    put_FontSize: usize,
-    get_FontFamily: usize,
-    put_FontFamily: usize,
-    get_FontWeight: usize,
-    pub put_FontWeight:
+    Name: usize,
+    FontSize: usize,
+    SetFontSize: usize,
+    FontFamily: usize,
+    SetFontFamily: usize,
+    FontWeight: usize,
+    pub SetFontWeight:
         unsafe extern "system" fn(*mut core::ffi::c_void, FontWeight) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
@@ -14767,30 +14740,30 @@ impl windows_core::RuntimeType for ITimePicker {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl ITimePicker {
-    pub(crate) fn put_Header<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetHeader<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<windows_core::IInspectable>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Header)(
+            (windows_core::Interface::vtable(self).SetHeader)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
             .ok()
         }
     }
-    pub(crate) fn put_ClockIdentifier(&self, value: &str) -> windows_core::Result<()> {
+    pub(crate) fn SetClockIdentifier(&self, value: &str) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_ClockIdentifier)(
+            (windows_core::Interface::vtable(self).SetClockIdentifier)(
                 windows_core::Interface::as_raw(self),
                 core::mem::transmute_copy(&windows_core::HSTRING::from(value)),
             )
             .ok()
         }
     }
-    pub(crate) fn put_MinuteIncrement(&self, value: i32) -> windows_core::Result<()> {
+    pub(crate) fn SetMinuteIncrement(&self, value: i32) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_MinuteIncrement)(
+            (windows_core::Interface::vtable(self).SetMinuteIncrement)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
@@ -14813,7 +14786,7 @@ impl ITimePicker {
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
-            let token__ = (windows_core::Interface::vtable(self).add_SelectedTimeChanged)(
+            let token__ = (windows_core::Interface::vtable(self).SelectedTimeChanged)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Interface::as_raw(&handler),
                 &mut result__,
@@ -14822,7 +14795,7 @@ impl ITimePicker {
             Ok(windows_core::EventRevoker::new(
                 self.clone(),
                 token__,
-                windows_core::Interface::vtable(self).remove_SelectedTimeChanged,
+                windows_core::Interface::vtable(self).RemoveSelectedTimeChanged,
             ))
         }
     }
@@ -14830,35 +14803,35 @@ impl ITimePicker {
 #[repr(C)]
 pub struct ITimePicker_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_Header: usize,
-    pub put_Header: unsafe extern "system" fn(
+    Header: usize,
+    pub SetHeader: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_HeaderTemplate: usize,
-    put_HeaderTemplate: usize,
-    get_ClockIdentifier: usize,
-    pub put_ClockIdentifier: unsafe extern "system" fn(
+    HeaderTemplate: usize,
+    SetHeaderTemplate: usize,
+    ClockIdentifier: usize,
+    pub SetClockIdentifier: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_MinuteIncrement: usize,
-    pub put_MinuteIncrement:
+    MinuteIncrement: usize,
+    pub SetMinuteIncrement:
         unsafe extern "system" fn(*mut core::ffi::c_void, i32) -> windows_core::HRESULT,
-    get_Time: usize,
-    put_Time: usize,
-    get_LightDismissOverlayMode: usize,
-    put_LightDismissOverlayMode: usize,
-    get_SelectedTime: usize,
-    put_SelectedTime: usize,
-    add_TimeChanged: usize,
-    remove_TimeChanged: usize,
-    pub add_SelectedTimeChanged: unsafe extern "system" fn(
+    Time: usize,
+    SetTime: usize,
+    LightDismissOverlayMode: usize,
+    SetLightDismissOverlayMode: usize,
+    SelectedTime: usize,
+    SetSelectedTime: usize,
+    TimeChanged: usize,
+    RemoveTimeChanged: usize,
+    pub SelectedTimeChanged: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         *mut i64,
     ) -> windows_core::HRESULT,
-    pub remove_SelectedTimeChanged:
+    pub RemoveSelectedTimeChanged:
         unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
@@ -14890,10 +14863,10 @@ impl windows_core::RuntimeType for ITimePickerSelectedValueChangedEventArgs {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl ITimePickerSelectedValueChangedEventArgs {
-    pub(crate) fn get_NewTime(&self) -> windows_core::Result<windows_time::TimeSpan> {
+    pub(crate) fn NewTime(&self) -> windows_core::Result<windows_time::TimeSpan> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_NewTime)(
+            (windows_core::Interface::vtable(self).NewTime)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
@@ -14905,8 +14878,8 @@ impl ITimePickerSelectedValueChangedEventArgs {
 #[repr(C)]
 pub struct ITimePickerSelectedValueChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_OldTime: usize,
-    pub get_NewTime: unsafe extern "system" fn(
+    OldTime: usize,
+    pub NewTime: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
@@ -14921,69 +14894,69 @@ impl windows_core::RuntimeType for ITitleBar {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl ITitleBar {
-    pub(crate) fn put_Title(&self, value: &str) -> windows_core::Result<()> {
+    pub(crate) fn SetTitle(&self, value: &str) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Title)(
+            (windows_core::Interface::vtable(self).SetTitle)(
                 windows_core::Interface::as_raw(self),
                 core::mem::transmute_copy(&windows_core::HSTRING::from(value)),
             )
             .ok()
         }
     }
-    pub(crate) fn put_Subtitle(&self, value: &str) -> windows_core::Result<()> {
+    pub(crate) fn SetSubtitle(&self, value: &str) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Subtitle)(
+            (windows_core::Interface::vtable(self).SetSubtitle)(
                 windows_core::Interface::as_raw(self),
                 core::mem::transmute_copy(&windows_core::HSTRING::from(value)),
             )
             .ok()
         }
     }
-    pub(crate) fn put_Content<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetContent<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<UIElement>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Content)(
+            (windows_core::Interface::vtable(self).SetContent)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
             .ok()
         }
     }
-    pub(crate) fn put_RightHeader<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetRightHeader<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<UIElement>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_RightHeader)(
+            (windows_core::Interface::vtable(self).SetRightHeader)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
             .ok()
         }
     }
-    pub(crate) fn put_IsBackButtonVisible(&self, value: bool) -> windows_core::Result<()> {
+    pub(crate) fn SetIsBackButtonVisible(&self, value: bool) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_IsBackButtonVisible)(
+            (windows_core::Interface::vtable(self).SetIsBackButtonVisible)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_IsBackButtonEnabled(&self, value: bool) -> windows_core::Result<()> {
+    pub(crate) fn SetIsBackButtonEnabled(&self, value: bool) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_IsBackButtonEnabled)(
+            (windows_core::Interface::vtable(self).SetIsBackButtonEnabled)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_IsPaneToggleButtonVisible(&self, value: bool) -> windows_core::Result<()> {
+    pub(crate) fn SetIsPaneToggleButtonVisible(&self, value: bool) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_IsPaneToggleButtonVisible)(
+            (windows_core::Interface::vtable(self).SetIsPaneToggleButtonVisible)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
@@ -15009,7 +14982,7 @@ impl ITitleBar {
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
-            let token__ = (windows_core::Interface::vtable(self).add_BackRequested)(
+            let token__ = (windows_core::Interface::vtable(self).BackRequested)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Interface::as_raw(&handler),
                 &mut result__,
@@ -15018,7 +14991,7 @@ impl ITitleBar {
             Ok(windows_core::EventRevoker::new(
                 self.clone(),
                 token__,
-                windows_core::Interface::vtable(self).remove_BackRequested,
+                windows_core::Interface::vtable(self).RemoveBackRequested,
             ))
         }
     }
@@ -15041,7 +15014,7 @@ impl ITitleBar {
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
-            let token__ = (windows_core::Interface::vtable(self).add_PaneToggleRequested)(
+            let token__ = (windows_core::Interface::vtable(self).PaneToggleRequested)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Interface::as_raw(&handler),
                 &mut result__,
@@ -15050,7 +15023,7 @@ impl ITitleBar {
             Ok(windows_core::EventRevoker::new(
                 self.clone(),
                 token__,
-                windows_core::Interface::vtable(self).remove_PaneToggleRequested,
+                windows_core::Interface::vtable(self).RemovePaneToggleRequested,
             ))
         }
     }
@@ -15058,53 +15031,53 @@ impl ITitleBar {
 #[repr(C)]
 pub struct ITitleBar_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_Title: usize,
-    pub put_Title: unsafe extern "system" fn(
+    Title: usize,
+    pub SetTitle: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_Subtitle: usize,
-    pub put_Subtitle: unsafe extern "system" fn(
+    Subtitle: usize,
+    pub SetSubtitle: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_IconSource: usize,
-    put_IconSource: usize,
-    get_LeftHeader: usize,
-    put_LeftHeader: usize,
-    get_Content: usize,
-    pub put_Content: unsafe extern "system" fn(
+    IconSource: usize,
+    SetIconSource: usize,
+    LeftHeader: usize,
+    SetLeftHeader: usize,
+    Content: usize,
+    pub SetContent: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_RightHeader: usize,
-    pub put_RightHeader: unsafe extern "system" fn(
+    RightHeader: usize,
+    pub SetRightHeader: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_IsBackButtonVisible: usize,
-    pub put_IsBackButtonVisible:
+    IsBackButtonVisible: usize,
+    pub SetIsBackButtonVisible:
         unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
-    get_IsBackButtonEnabled: usize,
-    pub put_IsBackButtonEnabled:
+    IsBackButtonEnabled: usize,
+    pub SetIsBackButtonEnabled:
         unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
-    get_IsPaneToggleButtonVisible: usize,
-    pub put_IsPaneToggleButtonVisible:
+    IsPaneToggleButtonVisible: usize,
+    pub SetIsPaneToggleButtonVisible:
         unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
-    get_TemplateSettings: usize,
-    pub add_BackRequested: unsafe extern "system" fn(
+    TemplateSettings: usize,
+    pub BackRequested: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         *mut i64,
     ) -> windows_core::HRESULT,
-    pub remove_BackRequested:
+    pub RemoveBackRequested:
         unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
-    pub add_PaneToggleRequested: unsafe extern "system" fn(
+    pub PaneToggleRequested: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         *mut i64,
     ) -> windows_core::HRESULT,
-    pub remove_PaneToggleRequested:
+    pub RemovePaneToggleRequested:
         unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
@@ -15136,10 +15109,10 @@ impl windows_core::RuntimeType for IToggleButton {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IToggleButton {
-    pub(crate) fn put_IsChecked(&self, value: Option<bool>) -> windows_core::Result<()> {
+    pub(crate) fn SetIsChecked(&self, value: Option<bool>) -> windows_core::Result<()> {
         let value__ = value.map(<windows_reference::IReference<bool> as From<_>>::from);
         unsafe {
-            (windows_core::Interface::vtable(self).put_IsChecked)(
+            (windows_core::Interface::vtable(self).SetIsChecked)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Param::param(value__.as_ref()).abi(),
             )
@@ -15160,7 +15133,7 @@ impl IToggleButton {
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
-            let token__ = (windows_core::Interface::vtable(self).add_Checked)(
+            let token__ = (windows_core::Interface::vtable(self).Checked)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Interface::as_raw(&handler),
                 &mut result__,
@@ -15169,7 +15142,7 @@ impl IToggleButton {
             Ok(windows_core::EventRevoker::new(
                 self.clone(),
                 token__,
-                windows_core::Interface::vtable(self).remove_Checked,
+                windows_core::Interface::vtable(self).RemoveChecked,
             ))
         }
     }
@@ -15190,7 +15163,7 @@ impl IToggleButton {
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
-            let token__ = (windows_core::Interface::vtable(self).add_Unchecked)(
+            let token__ = (windows_core::Interface::vtable(self).Unchecked)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Interface::as_raw(&handler),
                 &mut result__,
@@ -15199,7 +15172,7 @@ impl IToggleButton {
             Ok(windows_core::EventRevoker::new(
                 self.clone(),
                 token__,
-                windows_core::Interface::vtable(self).remove_Unchecked,
+                windows_core::Interface::vtable(self).RemoveUnchecked,
             ))
         }
     }
@@ -15207,26 +15180,26 @@ impl IToggleButton {
 #[repr(C)]
 pub struct IToggleButton_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_IsChecked: usize,
-    pub put_IsChecked: unsafe extern "system" fn(
+    IsChecked: usize,
+    pub SetIsChecked: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_IsThreeState: usize,
-    put_IsThreeState: usize,
-    pub add_Checked: unsafe extern "system" fn(
+    IsThreeState: usize,
+    SetIsThreeState: usize,
+    pub Checked: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         *mut i64,
     ) -> windows_core::HRESULT,
-    pub remove_Checked:
+    pub RemoveChecked:
         unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
-    pub add_Unchecked: unsafe extern "system" fn(
+    pub Unchecked: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         *mut i64,
     ) -> windows_core::HRESULT,
-    pub remove_Unchecked:
+    pub RemoveUnchecked:
         unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
@@ -15258,55 +15231,55 @@ impl windows_core::RuntimeType for IToggleSwitch {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IToggleSwitch {
-    pub(crate) fn get_IsOn(&self) -> windows_core::Result<bool> {
+    pub(crate) fn IsOn(&self) -> windows_core::Result<bool> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_IsOn)(
+            (windows_core::Interface::vtable(self).IsOn)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
             .map(|| result__)
         }
     }
-    pub(crate) fn put_IsOn(&self, value: bool) -> windows_core::Result<()> {
+    pub(crate) fn SetIsOn(&self, value: bool) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_IsOn)(
+            (windows_core::Interface::vtable(self).SetIsOn)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_Header<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetHeader<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<windows_core::IInspectable>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Header)(
+            (windows_core::Interface::vtable(self).SetHeader)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
             .ok()
         }
     }
-    pub(crate) fn put_OnContent<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetOnContent<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<windows_core::IInspectable>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_OnContent)(
+            (windows_core::Interface::vtable(self).SetOnContent)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
             .ok()
         }
     }
-    pub(crate) fn put_OffContent<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetOffContent<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<windows_core::IInspectable>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_OffContent)(
+            (windows_core::Interface::vtable(self).SetOffContent)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
@@ -15327,7 +15300,7 @@ impl IToggleSwitch {
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
-            let token__ = (windows_core::Interface::vtable(self).add_Toggled)(
+            let token__ = (windows_core::Interface::vtable(self).Toggled)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Interface::as_raw(&handler),
                 &mut result__,
@@ -15336,7 +15309,7 @@ impl IToggleSwitch {
             Ok(windows_core::EventRevoker::new(
                 self.clone(),
                 token__,
-                windows_core::Interface::vtable(self).remove_Toggled,
+                windows_core::Interface::vtable(self).RemoveToggled,
             ))
         }
     }
@@ -15344,37 +15317,36 @@ impl IToggleSwitch {
 #[repr(C)]
 pub struct IToggleSwitch_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    pub get_IsOn:
-        unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
-    pub put_IsOn: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
-    get_Header: usize,
-    pub put_Header: unsafe extern "system" fn(
+    pub IsOn: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
+    pub SetIsOn: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
+    Header: usize,
+    pub SetHeader: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_HeaderTemplate: usize,
-    put_HeaderTemplate: usize,
-    get_OnContent: usize,
-    pub put_OnContent: unsafe extern "system" fn(
+    HeaderTemplate: usize,
+    SetHeaderTemplate: usize,
+    OnContent: usize,
+    pub SetOnContent: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_OnContentTemplate: usize,
-    put_OnContentTemplate: usize,
-    get_OffContent: usize,
-    pub put_OffContent: unsafe extern "system" fn(
+    OnContentTemplate: usize,
+    SetOnContentTemplate: usize,
+    OffContent: usize,
+    pub SetOffContent: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_OffContentTemplate: usize,
-    put_OffContentTemplate: usize,
-    get_TemplateSettings: usize,
-    pub add_Toggled: unsafe extern "system" fn(
+    OffContentTemplate: usize,
+    SetOffContentTemplate: usize,
+    TemplateSettings: usize,
+    pub Toggled: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         *mut i64,
     ) -> windows_core::HRESULT,
-    pub remove_Toggled:
+    pub RemoveToggled:
         unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
@@ -15434,17 +15406,17 @@ impl windows_core::RuntimeType for IToolTipServiceStatics {
 #[repr(C)]
 pub struct IToolTipServiceStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_PlacementProperty: usize,
+    PlacementProperty: usize,
     GetPlacement: usize,
     pub SetPlacement: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         PlacementMode,
     ) -> windows_core::HRESULT,
-    get_PlacementTargetProperty: usize,
+    PlacementTargetProperty: usize,
     GetPlacementTarget: usize,
     SetPlacementTarget: usize,
-    get_ToolTipProperty: usize,
+    ToolTipProperty: usize,
     GetToolTip: usize,
     pub SetToolTip: unsafe extern "system" fn(
         *mut core::ffi::c_void,
@@ -15462,24 +15434,24 @@ impl windows_core::RuntimeType for ITreeView {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl ITreeView {
-    pub(crate) fn get_RootNodes(
+    pub(crate) fn RootNodes(
         &self,
     ) -> windows_core::Result<windows_collections::IVector<TreeViewNode>> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_RootNodes)(
+            (windows_core::Interface::vtable(self).RootNodes)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
             .and_then(|| windows_core::Type::from_abi(result__))
         }
     }
-    pub(crate) fn put_SelectionMode(
+    pub(crate) fn SetSelectionMode(
         &self,
         value: TreeViewSelectionMode,
     ) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_SelectionMode)(
+            (windows_core::Interface::vtable(self).SetSelectionMode)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
@@ -15506,7 +15478,7 @@ impl ITreeView {
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
-            let token__ = (windows_core::Interface::vtable(self).add_ItemInvoked)(
+            let token__ = (windows_core::Interface::vtable(self).ItemInvoked)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Interface::as_raw(&handler),
                 &mut result__,
@@ -15515,7 +15487,7 @@ impl ITreeView {
             Ok(windows_core::EventRevoker::new(
                 self.clone(),
                 token__,
-                windows_core::Interface::vtable(self).remove_ItemInvoked,
+                windows_core::Interface::vtable(self).RemoveItemInvoked,
             ))
         }
     }
@@ -15523,25 +15495,25 @@ impl ITreeView {
 #[repr(C)]
 pub struct ITreeView_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    pub get_RootNodes: unsafe extern "system" fn(
+    pub RootNodes: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_SelectionMode: usize,
-    pub put_SelectionMode: unsafe extern "system" fn(
+    SelectionMode: usize,
+    pub SetSelectionMode: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         TreeViewSelectionMode,
     ) -> windows_core::HRESULT,
-    get_SelectedNodes: usize,
+    SelectedNodes: usize,
     Expand: usize,
     Collapse: usize,
     SelectAll: usize,
-    pub add_ItemInvoked: unsafe extern "system" fn(
+    pub ItemInvoked: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         *mut i64,
     ) -> windows_core::HRESULT,
-    pub remove_ItemInvoked:
+    pub RemoveItemInvoked:
         unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
@@ -15573,10 +15545,10 @@ impl windows_core::RuntimeType for ITreeViewItemInvokedEventArgs {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl ITreeViewItemInvokedEventArgs {
-    pub(crate) fn get_InvokedItem(&self) -> windows_core::Result<windows_core::IInspectable> {
+    pub(crate) fn InvokedItem(&self) -> windows_core::Result<windows_core::IInspectable> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_InvokedItem)(
+            (windows_core::Interface::vtable(self).InvokedItem)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
@@ -15587,7 +15559,7 @@ impl ITreeViewItemInvokedEventArgs {
 #[repr(C)]
 pub struct ITreeViewItemInvokedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    pub get_InvokedItem: unsafe extern "system" fn(
+    pub InvokedItem: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
@@ -15602,43 +15574,43 @@ impl windows_core::RuntimeType for ITreeViewNode {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl ITreeViewNode {
-    pub(crate) fn get_Content(&self) -> windows_core::Result<windows_core::IInspectable> {
+    pub(crate) fn Content(&self) -> windows_core::Result<windows_core::IInspectable> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_Content)(
+            (windows_core::Interface::vtable(self).Content)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
             .and_then(|| windows_core::Type::from_abi(result__))
         }
     }
-    pub(crate) fn put_Content<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetContent<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<windows_core::IInspectable>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Content)(
+            (windows_core::Interface::vtable(self).SetContent)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
             .ok()
         }
     }
-    pub(crate) fn put_IsExpanded(&self, value: bool) -> windows_core::Result<()> {
+    pub(crate) fn SetIsExpanded(&self, value: bool) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_IsExpanded)(
+            (windows_core::Interface::vtable(self).SetIsExpanded)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn get_Children(
+    pub(crate) fn Children(
         &self,
     ) -> windows_core::Result<windows_collections::IVector<TreeViewNode>> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_Children)(
+            (windows_core::Interface::vtable(self).Children)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
@@ -15649,23 +15621,23 @@ impl ITreeViewNode {
 #[repr(C)]
 pub struct ITreeViewNode_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    pub get_Content: unsafe extern "system" fn(
+    pub Content: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    pub put_Content: unsafe extern "system" fn(
+    pub SetContent: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_Parent: usize,
-    get_IsExpanded: usize,
-    pub put_IsExpanded:
+    Parent: usize,
+    IsExpanded: usize,
+    pub SetIsExpanded:
         unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
-    get_HasChildren: usize,
-    get_Depth: usize,
-    get_HasUnrealizedChildren: usize,
-    put_HasUnrealizedChildren: usize,
-    pub get_Children: unsafe extern "system" fn(
+    HasChildren: usize,
+    Depth: usize,
+    HasUnrealizedChildren: usize,
+    SetHasUnrealizedChildren: usize,
+    pub Children: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
@@ -15712,64 +15684,64 @@ impl windows_core::RuntimeType for IUIElement {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IUIElement {
-    pub(crate) fn put_AllowDrop(&self, value: bool) -> windows_core::Result<()> {
+    pub(crate) fn SetAllowDrop(&self, value: bool) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_AllowDrop)(
+            (windows_core::Interface::vtable(self).SetAllowDrop)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_Opacity(&self, value: f64) -> windows_core::Result<()> {
+    pub(crate) fn SetOpacity(&self, value: f64) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Opacity)(
+            (windows_core::Interface::vtable(self).SetOpacity)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn get_KeyboardAccelerators(
+    pub(crate) fn KeyboardAccelerators(
         &self,
     ) -> windows_core::Result<windows_collections::IVector<KeyboardAccelerator>> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_KeyboardAccelerators)(
+            (windows_core::Interface::vtable(self).KeyboardAccelerators)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
             .and_then(|| windows_core::Type::from_abi(result__))
         }
     }
-    pub(crate) fn put_KeyboardAcceleratorPlacementMode(
+    pub(crate) fn SetKeyboardAcceleratorPlacementMode(
         &self,
         value: KeyboardAcceleratorPlacementMode,
     ) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_KeyboardAcceleratorPlacementMode)(
+            (windows_core::Interface::vtable(self).SetKeyboardAcceleratorPlacementMode)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn get_XamlRoot(&self) -> windows_core::Result<XamlRoot> {
+    pub(crate) fn XamlRoot(&self) -> windows_core::Result<XamlRoot> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_XamlRoot)(
+            (windows_core::Interface::vtable(self).XamlRoot)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
             .and_then(|| windows_core::Type::from_abi(result__))
         }
     }
-    pub(crate) fn put_XamlRoot<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetXamlRoot<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<XamlRoot>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_XamlRoot)(
+            (windows_core::Interface::vtable(self).SetXamlRoot)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
@@ -15793,7 +15765,7 @@ impl IUIElement {
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
-            let token__ = (windows_core::Interface::vtable(self).add_DragEnter)(
+            let token__ = (windows_core::Interface::vtable(self).DragEnter)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Interface::as_raw(&handler),
                 &mut result__,
@@ -15802,7 +15774,7 @@ impl IUIElement {
             Ok(windows_core::EventRevoker::new(
                 self.clone(),
                 token__,
-                windows_core::Interface::vtable(self).remove_DragEnter,
+                windows_core::Interface::vtable(self).RemoveDragEnter,
             ))
         }
     }
@@ -15823,7 +15795,7 @@ impl IUIElement {
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
-            let token__ = (windows_core::Interface::vtable(self).add_DragLeave)(
+            let token__ = (windows_core::Interface::vtable(self).DragLeave)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Interface::as_raw(&handler),
                 &mut result__,
@@ -15832,7 +15804,7 @@ impl IUIElement {
             Ok(windows_core::EventRevoker::new(
                 self.clone(),
                 token__,
-                windows_core::Interface::vtable(self).remove_DragLeave,
+                windows_core::Interface::vtable(self).RemoveDragLeave,
             ))
         }
     }
@@ -15850,7 +15822,7 @@ impl IUIElement {
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
-            let token__ = (windows_core::Interface::vtable(self).add_DragOver)(
+            let token__ = (windows_core::Interface::vtable(self).DragOver)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Interface::as_raw(&handler),
                 &mut result__,
@@ -15859,7 +15831,7 @@ impl IUIElement {
             Ok(windows_core::EventRevoker::new(
                 self.clone(),
                 token__,
-                windows_core::Interface::vtable(self).remove_DragOver,
+                windows_core::Interface::vtable(self).RemoveDragOver,
             ))
         }
     }
@@ -15877,7 +15849,7 @@ impl IUIElement {
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
-            let token__ = (windows_core::Interface::vtable(self).add_Drop)(
+            let token__ = (windows_core::Interface::vtable(self).Drop)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Interface::as_raw(&handler),
                 &mut result__,
@@ -15886,7 +15858,7 @@ impl IUIElement {
             Ok(windows_core::EventRevoker::new(
                 self.clone(),
                 token__,
-                windows_core::Interface::vtable(self).remove_Drop,
+                windows_core::Interface::vtable(self).RemoveDrop,
             ))
         }
     }
@@ -15909,7 +15881,7 @@ impl IUIElement {
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
-            let token__ = (windows_core::Interface::vtable(self).add_PointerPressed)(
+            let token__ = (windows_core::Interface::vtable(self).PointerPressed)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Interface::as_raw(&handler),
                 &mut result__,
@@ -15918,7 +15890,7 @@ impl IUIElement {
             Ok(windows_core::EventRevoker::new(
                 self.clone(),
                 token__,
-                windows_core::Interface::vtable(self).remove_PointerPressed,
+                windows_core::Interface::vtable(self).RemovePointerPressed,
             ))
         }
     }
@@ -15941,7 +15913,7 @@ impl IUIElement {
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
-            let token__ = (windows_core::Interface::vtable(self).add_PointerReleased)(
+            let token__ = (windows_core::Interface::vtable(self).PointerReleased)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Interface::as_raw(&handler),
                 &mut result__,
@@ -15950,7 +15922,7 @@ impl IUIElement {
             Ok(windows_core::EventRevoker::new(
                 self.clone(),
                 token__,
-                windows_core::Interface::vtable(self).remove_PointerReleased,
+                windows_core::Interface::vtable(self).RemovePointerReleased,
             ))
         }
     }
@@ -15973,7 +15945,7 @@ impl IUIElement {
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
-            let token__ = (windows_core::Interface::vtable(self).add_PointerExited)(
+            let token__ = (windows_core::Interface::vtable(self).PointerExited)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Interface::as_raw(&handler),
                 &mut result__,
@@ -15982,7 +15954,7 @@ impl IUIElement {
             Ok(windows_core::EventRevoker::new(
                 self.clone(),
                 token__,
-                windows_core::Interface::vtable(self).remove_PointerExited,
+                windows_core::Interface::vtable(self).RemovePointerExited,
             ))
         }
     }
@@ -16002,7 +15974,7 @@ impl IUIElement {
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
-            let token__ = (windows_core::Interface::vtable(self).add_Tapped)(
+            let token__ = (windows_core::Interface::vtable(self).Tapped)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Interface::as_raw(&handler),
                 &mut result__,
@@ -16011,7 +15983,7 @@ impl IUIElement {
             Ok(windows_core::EventRevoker::new(
                 self.clone(),
                 token__,
-                windows_core::Interface::vtable(self).remove_Tapped,
+                windows_core::Interface::vtable(self).RemoveTapped,
             ))
         }
     }
@@ -16034,7 +16006,7 @@ impl IUIElement {
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
-            let token__ = (windows_core::Interface::vtable(self).add_RightTapped)(
+            let token__ = (windows_core::Interface::vtable(self).RightTapped)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Interface::as_raw(&handler),
                 &mut result__,
@@ -16043,7 +16015,7 @@ impl IUIElement {
             Ok(windows_core::EventRevoker::new(
                 self.clone(),
                 token__,
-                windows_core::Interface::vtable(self).remove_RightTapped,
+                windows_core::Interface::vtable(self).RemoveRightTapped,
             ))
         }
     }
@@ -16051,239 +16023,237 @@ impl IUIElement {
 #[repr(C)]
 pub struct IUIElement_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_DesiredSize: usize,
-    get_AllowDrop: usize,
-    pub put_AllowDrop:
+    DesiredSize: usize,
+    AllowDrop: usize,
+    pub SetAllowDrop:
         unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
-    get_Opacity: usize,
-    pub put_Opacity:
-        unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
-    get_Clip: usize,
-    put_Clip: usize,
-    get_RenderTransform: usize,
-    put_RenderTransform: usize,
-    get_Projection: usize,
-    put_Projection: usize,
-    get_Transform3D: usize,
-    put_Transform3D: usize,
-    get_RenderTransformOrigin: usize,
-    put_RenderTransformOrigin: usize,
-    get_IsHitTestVisible: usize,
-    put_IsHitTestVisible: usize,
-    get_Visibility: usize,
-    put_Visibility: usize,
-    get_RenderSize: usize,
-    get_UseLayoutRounding: usize,
-    put_UseLayoutRounding: usize,
-    get_Transitions: usize,
-    put_Transitions: usize,
-    get_CacheMode: usize,
-    put_CacheMode: usize,
-    get_IsTapEnabled: usize,
-    put_IsTapEnabled: usize,
-    get_IsDoubleTapEnabled: usize,
-    put_IsDoubleTapEnabled: usize,
-    get_CanDrag: usize,
-    put_CanDrag: usize,
-    get_IsRightTapEnabled: usize,
-    put_IsRightTapEnabled: usize,
-    get_IsHoldingEnabled: usize,
-    put_IsHoldingEnabled: usize,
-    get_ManipulationMode: usize,
-    put_ManipulationMode: usize,
-    get_PointerCaptures: usize,
-    get_ContextFlyout: usize,
-    put_ContextFlyout: usize,
-    get_CompositeMode: usize,
-    put_CompositeMode: usize,
-    get_Lights: usize,
-    get_CanBeScrollAnchor: usize,
-    put_CanBeScrollAnchor: usize,
-    get_ExitDisplayModeOnAccessKeyInvoked: usize,
-    put_ExitDisplayModeOnAccessKeyInvoked: usize,
-    get_IsAccessKeyScope: usize,
-    put_IsAccessKeyScope: usize,
-    get_AccessKeyScopeOwner: usize,
-    put_AccessKeyScopeOwner: usize,
-    get_AccessKey: usize,
-    put_AccessKey: usize,
-    get_KeyTipPlacementMode: usize,
-    put_KeyTipPlacementMode: usize,
-    get_KeyTipHorizontalOffset: usize,
-    put_KeyTipHorizontalOffset: usize,
-    get_KeyTipVerticalOffset: usize,
-    put_KeyTipVerticalOffset: usize,
-    get_KeyTipTarget: usize,
-    put_KeyTipTarget: usize,
-    get_XYFocusKeyboardNavigation: usize,
-    put_XYFocusKeyboardNavigation: usize,
-    get_XYFocusUpNavigationStrategy: usize,
-    put_XYFocusUpNavigationStrategy: usize,
-    get_XYFocusDownNavigationStrategy: usize,
-    put_XYFocusDownNavigationStrategy: usize,
-    get_XYFocusLeftNavigationStrategy: usize,
-    put_XYFocusLeftNavigationStrategy: usize,
-    get_XYFocusRightNavigationStrategy: usize,
-    put_XYFocusRightNavigationStrategy: usize,
-    pub get_KeyboardAccelerators: unsafe extern "system" fn(
+    Opacity: usize,
+    pub SetOpacity: unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
+    Clip: usize,
+    SetClip: usize,
+    RenderTransform: usize,
+    SetRenderTransform: usize,
+    Projection: usize,
+    SetProjection: usize,
+    Transform3D: usize,
+    SetTransform3D: usize,
+    RenderTransformOrigin: usize,
+    SetRenderTransformOrigin: usize,
+    IsHitTestVisible: usize,
+    SetIsHitTestVisible: usize,
+    Visibility: usize,
+    SetVisibility: usize,
+    RenderSize: usize,
+    UseLayoutRounding: usize,
+    SetUseLayoutRounding: usize,
+    Transitions: usize,
+    SetTransitions: usize,
+    CacheMode: usize,
+    SetCacheMode: usize,
+    IsTapEnabled: usize,
+    SetIsTapEnabled: usize,
+    IsDoubleTapEnabled: usize,
+    SetIsDoubleTapEnabled: usize,
+    CanDrag: usize,
+    SetCanDrag: usize,
+    IsRightTapEnabled: usize,
+    SetIsRightTapEnabled: usize,
+    IsHoldingEnabled: usize,
+    SetIsHoldingEnabled: usize,
+    ManipulationMode: usize,
+    SetManipulationMode: usize,
+    PointerCaptures: usize,
+    ContextFlyout: usize,
+    SetContextFlyout: usize,
+    CompositeMode: usize,
+    SetCompositeMode: usize,
+    Lights: usize,
+    CanBeScrollAnchor: usize,
+    SetCanBeScrollAnchor: usize,
+    ExitDisplayModeOnAccessKeyInvoked: usize,
+    SetExitDisplayModeOnAccessKeyInvoked: usize,
+    IsAccessKeyScope: usize,
+    SetIsAccessKeyScope: usize,
+    AccessKeyScopeOwner: usize,
+    SetAccessKeyScopeOwner: usize,
+    AccessKey: usize,
+    SetAccessKey: usize,
+    KeyTipPlacementMode: usize,
+    SetKeyTipPlacementMode: usize,
+    KeyTipHorizontalOffset: usize,
+    SetKeyTipHorizontalOffset: usize,
+    KeyTipVerticalOffset: usize,
+    SetKeyTipVerticalOffset: usize,
+    KeyTipTarget: usize,
+    SetKeyTipTarget: usize,
+    XYFocusKeyboardNavigation: usize,
+    SetXYFocusKeyboardNavigation: usize,
+    XYFocusUpNavigationStrategy: usize,
+    SetXYFocusUpNavigationStrategy: usize,
+    XYFocusDownNavigationStrategy: usize,
+    SetXYFocusDownNavigationStrategy: usize,
+    XYFocusLeftNavigationStrategy: usize,
+    SetXYFocusLeftNavigationStrategy: usize,
+    XYFocusRightNavigationStrategy: usize,
+    SetXYFocusRightNavigationStrategy: usize,
+    pub KeyboardAccelerators: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_KeyboardAcceleratorPlacementTarget: usize,
-    put_KeyboardAcceleratorPlacementTarget: usize,
-    get_KeyboardAcceleratorPlacementMode: usize,
-    pub put_KeyboardAcceleratorPlacementMode: unsafe extern "system" fn(
+    KeyboardAcceleratorPlacementTarget: usize,
+    SetKeyboardAcceleratorPlacementTarget: usize,
+    KeyboardAcceleratorPlacementMode: usize,
+    pub SetKeyboardAcceleratorPlacementMode: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         KeyboardAcceleratorPlacementMode,
     )
         -> windows_core::HRESULT,
-    get_HighContrastAdjustment: usize,
-    put_HighContrastAdjustment: usize,
-    get_TabFocusNavigation: usize,
-    put_TabFocusNavigation: usize,
-    get_OpacityTransition: usize,
-    put_OpacityTransition: usize,
-    get_Translation: usize,
-    put_Translation: usize,
-    get_TranslationTransition: usize,
-    put_TranslationTransition: usize,
-    get_Rotation: usize,
-    put_Rotation: usize,
-    get_RotationTransition: usize,
-    put_RotationTransition: usize,
-    get_Scale: usize,
-    put_Scale: usize,
-    get_ScaleTransition: usize,
-    put_ScaleTransition: usize,
-    get_TransformMatrix: usize,
-    put_TransformMatrix: usize,
-    get_CenterPoint: usize,
-    put_CenterPoint: usize,
-    get_RotationAxis: usize,
-    put_RotationAxis: usize,
-    get_ActualOffset: usize,
-    get_ActualSize: usize,
-    pub get_XamlRoot: unsafe extern "system" fn(
+    HighContrastAdjustment: usize,
+    SetHighContrastAdjustment: usize,
+    TabFocusNavigation: usize,
+    SetTabFocusNavigation: usize,
+    OpacityTransition: usize,
+    SetOpacityTransition: usize,
+    Translation: usize,
+    SetTranslation: usize,
+    TranslationTransition: usize,
+    SetTranslationTransition: usize,
+    Rotation: usize,
+    SetRotation: usize,
+    RotationTransition: usize,
+    SetRotationTransition: usize,
+    Scale: usize,
+    SetScale: usize,
+    ScaleTransition: usize,
+    SetScaleTransition: usize,
+    TransformMatrix: usize,
+    SetTransformMatrix: usize,
+    CenterPoint: usize,
+    SetCenterPoint: usize,
+    RotationAxis: usize,
+    SetRotationAxis: usize,
+    ActualOffset: usize,
+    ActualSize: usize,
+    pub XamlRoot: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    pub put_XamlRoot: unsafe extern "system" fn(
+    pub SetXamlRoot: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_Shadow: usize,
-    put_Shadow: usize,
-    get_RasterizationScale: usize,
-    put_RasterizationScale: usize,
-    get_FocusState: usize,
-    get_UseSystemFocusVisuals: usize,
-    put_UseSystemFocusVisuals: usize,
-    get_XYFocusLeft: usize,
-    put_XYFocusLeft: usize,
-    get_XYFocusRight: usize,
-    put_XYFocusRight: usize,
-    get_XYFocusUp: usize,
-    put_XYFocusUp: usize,
-    get_XYFocusDown: usize,
-    put_XYFocusDown: usize,
-    get_IsTabStop: usize,
-    put_IsTabStop: usize,
-    get_TabIndex: usize,
-    put_TabIndex: usize,
-    add_KeyUp: usize,
-    remove_KeyUp: usize,
-    add_KeyDown: usize,
-    remove_KeyDown: usize,
-    add_GotFocus: usize,
-    remove_GotFocus: usize,
-    add_LostFocus: usize,
-    remove_LostFocus: usize,
-    add_DragStarting: usize,
-    remove_DragStarting: usize,
-    add_DropCompleted: usize,
-    remove_DropCompleted: usize,
-    add_CharacterReceived: usize,
-    remove_CharacterReceived: usize,
-    pub add_DragEnter: unsafe extern "system" fn(
+    Shadow: usize,
+    SetShadow: usize,
+    RasterizationScale: usize,
+    SetRasterizationScale: usize,
+    FocusState: usize,
+    UseSystemFocusVisuals: usize,
+    SetUseSystemFocusVisuals: usize,
+    XYFocusLeft: usize,
+    SetXYFocusLeft: usize,
+    XYFocusRight: usize,
+    SetXYFocusRight: usize,
+    XYFocusUp: usize,
+    SetXYFocusUp: usize,
+    XYFocusDown: usize,
+    SetXYFocusDown: usize,
+    IsTabStop: usize,
+    SetIsTabStop: usize,
+    TabIndex: usize,
+    SetTabIndex: usize,
+    KeyUp: usize,
+    RemoveKeyUp: usize,
+    KeyDown: usize,
+    RemoveKeyDown: usize,
+    GotFocus: usize,
+    RemoveGotFocus: usize,
+    LostFocus: usize,
+    RemoveLostFocus: usize,
+    DragStarting: usize,
+    RemoveDragStarting: usize,
+    DropCompleted: usize,
+    RemoveDropCompleted: usize,
+    CharacterReceived: usize,
+    RemoveCharacterReceived: usize,
+    pub DragEnter: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         *mut i64,
     ) -> windows_core::HRESULT,
-    pub remove_DragEnter:
+    pub RemoveDragEnter:
         unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
-    pub add_DragLeave: unsafe extern "system" fn(
+    pub DragLeave: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         *mut i64,
     ) -> windows_core::HRESULT,
-    pub remove_DragLeave:
+    pub RemoveDragLeave:
         unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
-    pub add_DragOver: unsafe extern "system" fn(
+    pub DragOver: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         *mut i64,
     ) -> windows_core::HRESULT,
-    pub remove_DragOver:
+    pub RemoveDragOver:
         unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
-    pub add_Drop: unsafe extern "system" fn(
+    pub Drop: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         *mut i64,
     ) -> windows_core::HRESULT,
-    pub remove_Drop:
+    pub RemoveDrop: unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
+    pub PointerPressed: unsafe extern "system" fn(
+        *mut core::ffi::c_void,
+        *mut core::ffi::c_void,
+        *mut i64,
+    ) -> windows_core::HRESULT,
+    pub RemovePointerPressed:
         unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
-    pub add_PointerPressed: unsafe extern "system" fn(
+    PointerMoved: usize,
+    RemovePointerMoved: usize,
+    pub PointerReleased: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         *mut i64,
     ) -> windows_core::HRESULT,
-    pub remove_PointerPressed:
+    pub RemovePointerReleased:
         unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
-    add_PointerMoved: usize,
-    remove_PointerMoved: usize,
-    pub add_PointerReleased: unsafe extern "system" fn(
+    PointerEntered: usize,
+    RemovePointerEntered: usize,
+    pub PointerExited: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         *mut i64,
     ) -> windows_core::HRESULT,
-    pub remove_PointerReleased:
+    pub RemovePointerExited:
         unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
-    add_PointerEntered: usize,
-    remove_PointerEntered: usize,
-    pub add_PointerExited: unsafe extern "system" fn(
+    PointerCaptureLost: usize,
+    RemovePointerCaptureLost: usize,
+    PointerCanceled: usize,
+    RemovePointerCanceled: usize,
+    PointerWheelChanged: usize,
+    RemovePointerWheelChanged: usize,
+    pub Tapped: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         *mut i64,
     ) -> windows_core::HRESULT,
-    pub remove_PointerExited:
+    pub RemoveTapped:
         unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
-    add_PointerCaptureLost: usize,
-    remove_PointerCaptureLost: usize,
-    add_PointerCanceled: usize,
-    remove_PointerCanceled: usize,
-    add_PointerWheelChanged: usize,
-    remove_PointerWheelChanged: usize,
-    pub add_Tapped: unsafe extern "system" fn(
+    DoubleTapped: usize,
+    RemoveDoubleTapped: usize,
+    Holding: usize,
+    RemoveHolding: usize,
+    ContextRequested: usize,
+    RemoveContextRequested: usize,
+    ContextCanceled: usize,
+    RemoveContextCanceled: usize,
+    pub RightTapped: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         *mut i64,
     ) -> windows_core::HRESULT,
-    pub remove_Tapped:
-        unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
-    add_DoubleTapped: usize,
-    remove_DoubleTapped: usize,
-    add_Holding: usize,
-    remove_Holding: usize,
-    add_ContextRequested: usize,
-    remove_ContextRequested: usize,
-    add_ContextCanceled: usize,
-    remove_ContextCanceled: usize,
-    pub add_RightTapped: unsafe extern "system" fn(
-        *mut core::ffi::c_void,
-        *mut core::ffi::c_void,
-        *mut i64,
-    ) -> windows_core::HRESULT,
-    pub remove_RightTapped:
+    pub RemoveRightTapped:
         unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
@@ -16368,21 +16338,21 @@ impl windows_core::RuntimeType for IViewbox {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IViewbox {
-    pub(crate) fn put_Child<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetChild<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<UIElement>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Child)(
+            (windows_core::Interface::vtable(self).SetChild)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
             .ok()
         }
     }
-    pub(crate) fn put_Stretch(&self, value: Stretch) -> windows_core::Result<()> {
+    pub(crate) fn SetStretch(&self, value: Stretch) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Stretch)(
+            (windows_core::Interface::vtable(self).SetStretch)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
@@ -16393,13 +16363,13 @@ impl IViewbox {
 #[repr(C)]
 pub struct IViewbox_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_Child: usize,
-    pub put_Child: unsafe extern "system" fn(
+    Child: usize,
+    pub SetChild: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_Stretch: usize,
-    pub put_Stretch:
+    Stretch: usize,
+    pub SetStretch:
         unsafe extern "system" fn(*mut core::ffi::c_void, Stretch) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
@@ -16412,22 +16382,22 @@ impl windows_core::RuntimeType for IVisual {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IVisual {
-    pub(crate) fn put_CenterPoint(
+    pub(crate) fn SetCenterPoint(
         &self,
         value: windows_numerics::Vector3,
     ) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_CenterPoint)(
+            (windows_core::Interface::vtable(self).SetCenterPoint)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn get_Scale(&self) -> windows_core::Result<windows_numerics::Vector3> {
+    pub(crate) fn Scale(&self) -> windows_core::Result<windows_numerics::Vector3> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_Scale)(
+            (windows_core::Interface::vtable(self).Scale)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
@@ -16438,37 +16408,37 @@ impl IVisual {
 #[repr(C)]
 pub struct IVisual_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_AnchorPoint: usize,
-    put_AnchorPoint: usize,
-    get_BackfaceVisibility: usize,
-    put_BackfaceVisibility: usize,
-    get_BorderMode: usize,
-    put_BorderMode: usize,
-    get_CenterPoint: usize,
-    pub put_CenterPoint: unsafe extern "system" fn(
+    AnchorPoint: usize,
+    SetAnchorPoint: usize,
+    BackfaceVisibility: usize,
+    SetBackfaceVisibility: usize,
+    BorderMode: usize,
+    SetBorderMode: usize,
+    CenterPoint: usize,
+    pub SetCenterPoint: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         windows_numerics::Vector3,
     ) -> windows_core::HRESULT,
-    get_Clip: usize,
-    put_Clip: usize,
-    get_CompositeMode: usize,
-    put_CompositeMode: usize,
-    get_IsVisible: usize,
-    put_IsVisible: usize,
-    get_Offset: usize,
-    put_Offset: usize,
-    get_Opacity: usize,
-    put_Opacity: usize,
-    get_Orientation: usize,
-    put_Orientation: usize,
-    get_Parent: usize,
-    get_RotationAngle: usize,
-    put_RotationAngle: usize,
-    get_RotationAngleInDegrees: usize,
-    put_RotationAngleInDegrees: usize,
-    get_RotationAxis: usize,
-    put_RotationAxis: usize,
-    pub get_Scale: unsafe extern "system" fn(
+    Clip: usize,
+    SetClip: usize,
+    CompositeMode: usize,
+    SetCompositeMode: usize,
+    IsVisible: usize,
+    SetIsVisible: usize,
+    Offset: usize,
+    SetOffset: usize,
+    Opacity: usize,
+    SetOpacity: usize,
+    Orientation: usize,
+    SetOrientation: usize,
+    Parent: usize,
+    RotationAngle: usize,
+    SetRotationAngle: usize,
+    RotationAngleInDegrees: usize,
+    SetRotationAngleInDegrees: usize,
+    RotationAxis: usize,
+    SetRotationAxis: usize,
+    pub Scale: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut windows_numerics::Vector3,
     ) -> windows_core::HRESULT,
@@ -16483,30 +16453,30 @@ impl windows_core::RuntimeType for IWindow {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IWindow {
-    pub(crate) fn put_Content<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetContent<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<UIElement>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Content)(
+            (windows_core::Interface::vtable(self).SetContent)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
             .ok()
         }
     }
-    pub(crate) fn put_Title(&self, value: &str) -> windows_core::Result<()> {
+    pub(crate) fn SetTitle(&self, value: &str) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Title)(
+            (windows_core::Interface::vtable(self).SetTitle)(
                 windows_core::Interface::as_raw(self),
                 core::mem::transmute_copy(&windows_core::HSTRING::from(value)),
             )
             .ok()
         }
     }
-    pub(crate) fn put_ExtendsContentIntoTitleBar(&self, value: bool) -> windows_core::Result<()> {
+    pub(crate) fn SetExtendsContentIntoTitleBar(&self, value: bool) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_ExtendsContentIntoTitleBar)(
+            (windows_core::Interface::vtable(self).SetExtendsContentIntoTitleBar)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
@@ -16530,7 +16500,7 @@ impl IWindow {
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
-            let token__ = (windows_core::Interface::vtable(self).add_Closed)(
+            let token__ = (windows_core::Interface::vtable(self).Closed)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Interface::as_raw(&handler),
                 &mut result__,
@@ -16539,7 +16509,7 @@ impl IWindow {
             Ok(windows_core::EventRevoker::new(
                 self.clone(),
                 token__,
-                windows_core::Interface::vtable(self).remove_Closed,
+                windows_core::Interface::vtable(self).RemoveClosed,
             ))
         }
     }
@@ -16565,38 +16535,38 @@ impl IWindow {
 #[repr(C)]
 pub struct IWindow_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_Bounds: usize,
-    get_Visible: usize,
-    get_Content: usize,
-    pub put_Content: unsafe extern "system" fn(
+    Bounds: usize,
+    Visible: usize,
+    Content: usize,
+    pub SetContent: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_CoreWindow: usize,
-    get_Compositor: usize,
-    get_Dispatcher: usize,
-    get_DispatcherQueue: usize,
-    get_Title: usize,
-    pub put_Title: unsafe extern "system" fn(
+    CoreWindow: usize,
+    Compositor: usize,
+    Dispatcher: usize,
+    DispatcherQueue: usize,
+    Title: usize,
+    pub SetTitle: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_ExtendsContentIntoTitleBar: usize,
-    pub put_ExtendsContentIntoTitleBar:
+    ExtendsContentIntoTitleBar: usize,
+    pub SetExtendsContentIntoTitleBar:
         unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
-    add_Activated: usize,
-    remove_Activated: usize,
-    pub add_Closed: unsafe extern "system" fn(
+    Activated: usize,
+    RemoveActivated: usize,
+    pub Closed: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         *mut i64,
     ) -> windows_core::HRESULT,
-    pub remove_Closed:
+    pub RemoveClosed:
         unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
-    add_SizeChanged: usize,
-    remove_SizeChanged: usize,
-    add_VisibilityChanged: usize,
-    remove_VisibilityChanged: usize,
+    SizeChanged: usize,
+    RemoveSizeChanged: usize,
+    VisibilityChanged: usize,
+    RemoveVisibilityChanged: usize,
     pub Activate: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
     Close: usize,
     pub SetTitleBar: unsafe extern "system" fn(
@@ -16614,22 +16584,22 @@ impl windows_core::RuntimeType for IWindow2 {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IWindow2 {
-    pub(crate) fn put_SystemBackdrop<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetSystemBackdrop<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<SystemBackdrop>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_SystemBackdrop)(
+            (windows_core::Interface::vtable(self).SetSystemBackdrop)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
             .ok()
         }
     }
-    pub(crate) fn get_AppWindow(&self) -> windows_core::Result<AppWindow> {
+    pub(crate) fn AppWindow(&self) -> windows_core::Result<AppWindow> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_AppWindow)(
+            (windows_core::Interface::vtable(self).AppWindow)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
@@ -16640,12 +16610,12 @@ impl IWindow2 {
 #[repr(C)]
 pub struct IWindow2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_SystemBackdrop: usize,
-    pub put_SystemBackdrop: unsafe extern "system" fn(
+    SystemBackdrop: usize,
+    pub SetSystemBackdrop: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    pub get_AppWindow: unsafe extern "system" fn(
+    pub AppWindow: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
@@ -16689,12 +16659,12 @@ windows_core::imp::define_interface!(
 );
 windows_core::imp::interface_hierarchy!(IWindowNative, windows_core::IUnknown);
 impl IWindowNative {
-    pub(crate) unsafe fn get_WindowHandle(
+    pub(crate) unsafe fn WindowHandle(
         &self,
         hwnd: *mut *mut core::ffi::c_void,
     ) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).get_WindowHandle)(
+            (windows_core::Interface::vtable(self).WindowHandle)(
                 windows_core::Interface::as_raw(self),
                 hwnd as _,
             )
@@ -16705,7 +16675,7 @@ impl IWindowNative {
 #[repr(C)]
 pub struct IWindowNative_Vtbl {
     pub base__: windows_core::IUnknown_Vtbl,
-    pub get_WindowHandle: unsafe extern "system" fn(
+    pub WindowHandle: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,

--- a/crates/libs/reactor/src/hooks.rs
+++ b/crates/libs/reactor/src/hooks.rs
@@ -30,8 +30,8 @@ impl DispatcherTimer {
     {
         let queue = DispatcherQueue::GetForCurrentThread()?;
         let timer = queue.CreateTimer()?;
-        timer.put_Interval(duration_to_timespan(interval))?;
-        timer.put_IsRepeating(repeating)?;
+        timer.SetInterval(duration_to_timespan(interval))?;
+        timer.SetIsRepeating(repeating)?;
 
         let tick_revoker = timer.Tick(move |_, _| {
             f();

--- a/crates/libs/reactor/src/host.rs
+++ b/crates/libs/reactor/src/host.rs
@@ -35,7 +35,7 @@ pub fn set_requested_theme(theme: RequestedTheme) {
 
     ROOT_FRAMEWORK_ELEMENT.with(|cell| {
         if let Some(ife) = cell.borrow().as_ref() {
-            let _ = ife.put_RequestedTheme(element_theme);
+            let _ = ife.SetRequestedTheme(element_theme);
             update_titlebar_theme();
         } else {
             PENDING_THEME.with(|p| p.set(Some(element_theme)));
@@ -46,7 +46,7 @@ pub fn set_requested_theme(theme: RequestedTheme) {
 fn update_titlebar_theme() {
     ROOT_FRAMEWORK_ELEMENT.with(|cell| {
         if let Some(ife) = cell.borrow().as_ref()
-            && let Ok(theme) = ife.get_ActualTheme()
+            && let Ok(theme) = ife.ActualTheme()
         {
             let titlebar_theme = match theme {
                 ElementTheme::Dark => TitleBarTheme::Dark,
@@ -57,13 +57,13 @@ fn update_titlebar_theme() {
             let _ = ROOT_WINDOW.with(|wcell| -> Option<()> {
                 let window = wcell.borrow();
                 let window_2 = window.as_ref()?.cast::<IWindow2>().ok()?;
-                let app_window = window_2.get_AppWindow().ok()?;
+                let app_window = window_2.AppWindow().ok()?;
                 let titlebar = app_window
-                    .get_TitleBar()
+                    .TitleBar()
                     .ok()?
                     .cast::<IAppWindowTitleBar3>()
                     .ok()?;
-                titlebar.put_PreferredTheme(titlebar_theme).ok()
+                titlebar.SetPreferredTheme(titlebar_theme).ok()
             });
         }
     });
@@ -73,9 +73,9 @@ pub fn set_titlebar_height(tall: bool) {
     let applied = ROOT_WINDOW.with(|wcell| -> Option<()> {
         let window = wcell.borrow();
         let window_2 = window.as_ref()?.cast::<IWindow2>().ok()?;
-        let app_window = window_2.get_AppWindow().ok()?;
+        let app_window = window_2.AppWindow().ok()?;
         let titlebar = app_window
-            .get_TitleBar()
+            .TitleBar()
             .ok()?
             .cast::<IAppWindowTitleBar2>()
             .ok()?;
@@ -84,7 +84,7 @@ pub fn set_titlebar_height(tall: bool) {
         } else {
             TitleBarHeightOption::Standard
         };
-        titlebar.put_PreferredHeightOption(option).ok()
+        titlebar.SetPreferredHeightOption(option).ok()
     });
     if applied.is_none() {
         PENDING_TALL.with(|p| p.set(Some(tall)));
@@ -99,7 +99,7 @@ pub fn set_backdrop(backdrop: Option<Backdrop>) {
                 let _ = b.apply_to(window);
             } else {
                 if let Ok(w2) = window.cast::<IWindow2>() {
-                    let _ = w2.put_SystemBackdrop(None);
+                    let _ = w2.SetSystemBackdrop(None);
                 }
             }
         }
@@ -146,14 +146,14 @@ impl Backdrop {
             Backdrop::Mica => MicaBackdrop::new()?.cast()?,
             Backdrop::MicaAlt => {
                 let mica = MicaBackdrop::new()?;
-                mica.put_Kind(MicaKind::BaseAlt)?;
+                mica.SetKind(MicaKind::BaseAlt)?;
                 mica.cast()?
             }
             Backdrop::Acrylic => DesktopAcrylicBackdrop::new()?.cast()?,
         };
         window
             .cast::<IWindow2>()?
-            .put_SystemBackdrop(&system_backdrop)
+            .SetSystemBackdrop(&system_backdrop)
     }
 }
 
@@ -217,7 +217,7 @@ impl ReactorHost {
                 Some(rid) => {
                     if let Some(ui) = state.render_host.with_backend(|b| b.get_ui_element(rid)) {
                         let ui_element: UIElement = ui.cast().unwrap();
-                        let _ = state.window.put_Content(&ui_element);
+                        let _ = state.window.SetContent(&ui_element);
                         last_attached_for_hook.set(Some(rid));
 
                         if !subscribed.get() {
@@ -242,7 +242,7 @@ impl ReactorHost {
                                 // root element existed (e.g. from a first-mount
                                 // use_effect).
                                 if let Some(theme) = PENDING_THEME.with(|p| p.take()) {
-                                    let _ = fe.put_RequestedTheme(theme);
+                                    let _ = fe.SetRequestedTheme(theme);
                                     update_titlebar_theme();
                                 }
                             }
@@ -250,7 +250,7 @@ impl ReactorHost {
 
                         // Wire TitleBar to window on every root change (mirrors C# mount behavior).
                         if let Some(tb) = state.render_host.with_backend(|b| b.find_titlebar()) {
-                            let _ = state.window.put_ExtendsContentIntoTitleBar(true);
+                            let _ = state.window.SetExtendsContentIntoTitleBar(true);
                             if let Ok(tb_ui) = tb.cast::<UIElement>() {
                                 let _ = state.window.SetTitleBar(&tb_ui);
                             }
@@ -298,11 +298,11 @@ impl ReactorHost {
             let _ = (|| -> Result<()> {
                 let mut hwnd: HWND = HWND::default();
                 if let Ok(native) = window.cast::<IWindowNative>() {
-                    let _ = unsafe { native.get_WindowHandle(&mut hwnd) };
+                    let _ = unsafe { native.WindowHandle(&mut hwnd) };
                 }
 
                 if let Some(native_kind) = presenter.to_native()
-                    && let Ok(app_window) = window.cast::<IWindow2>()?.get_AppWindow()
+                    && let Ok(app_window) = window.cast::<IWindow2>()?.AppWindow()
                 {
                     let _ = app_window.SetPresenterByKind(native_kind);
                 }
@@ -419,12 +419,12 @@ fn subscribe_size_and_dpi(
 ) {
     let mut hwnd: HWND = HWND::default();
     if let Ok(native) = window.cast::<IWindowNative>() {
-        let _ = unsafe { native.get_WindowHandle(&mut hwnd) };
+        let _ = unsafe { native.WindowHandle(&mut hwnd) };
     }
 
     let _ = fe
         .SizeChanged(move |_sender, args| {
-            let size = args.unwrap().get_NewSize().unwrap();
+            let size = args.unwrap().NewSize().unwrap();
             let new_dpi = unsafe { GetDpiForWindow(hwnd) };
             if new_dpi > 0 {
                 render_host.set_dpi(new_dpi);
@@ -448,14 +448,12 @@ fn create_window(
 
     let mut hwnd = HWND::default();
     unsafe {
-        window
-            .cast::<IWindowNative>()?
-            .get_WindowHandle(&mut hwnd)?;
+        window.cast::<IWindowNative>()?.WindowHandle(&mut hwnd)?;
     }
     let dpi = unsafe { GetDpiForWindow(hwnd) };
     let dpi = if dpi == 0 { 96 } else { dpi };
 
-    window.put_Title(title.as_ref())?;
+    window.SetTitle(title.as_ref())?;
 
     let dip_size = match size {
         Some(s) => s,
@@ -465,7 +463,7 @@ fn create_window(
     let dip_to_px = |dips: f64| (dips * dpi as f64 / 96.0).round() as i32;
 
     let window_2 = window.cast::<IWindow2>()?;
-    let app_window = window_2.get_AppWindow()?;
+    let app_window = window_2.AppWindow()?;
     let app_window_2 = app_window.cast::<IAppWindow2>()?;
     app_window_2.ResizeClient(SizeInt32 {
         width: dip_to_px(dip_size.width),
@@ -475,30 +473,28 @@ fn create_window(
     app_window.SetPresenterByKind(AppWindowPresenterKind::Overlapped)?;
     set_requested_theme(RequestedTheme::Default);
 
-    let outer_size = app_window.get_Size()?;
-    let inner_size = app_window_2.get_ClientSize()?;
+    let outer_size = app_window.Size()?;
+    let inner_size = app_window_2.ClientSize()?;
     let nc_width_px = outer_size.width.saturating_sub(inner_size.width);
     let nc_height_px = outer_size.height.saturating_sub(inner_size.height);
 
-    let overlapped = app_window
-        .get_Presenter()?
-        .cast::<IOverlappedPresenter3>()?;
+    let overlapped = app_window.Presenter()?.cast::<IOverlappedPresenter3>()?;
     if let Some(min_w) = constraints.min_width {
-        overlapped.put_PreferredMinimumWidth(Some(dip_to_px(min_w).saturating_add(nc_width_px)))?;
+        overlapped.SetPreferredMinimumWidth(Some(dip_to_px(min_w).saturating_add(nc_width_px)))?;
     }
     if let Some(min_h) = constraints.min_height {
         overlapped
-            .put_PreferredMinimumHeight(Some(dip_to_px(min_h).saturating_add(nc_height_px)))?;
+            .SetPreferredMinimumHeight(Some(dip_to_px(min_h).saturating_add(nc_height_px)))?;
     }
     if let Some(max_w) = constraints.max_width {
-        overlapped.put_PreferredMaximumWidth(Some(dip_to_px(max_w).saturating_add(nc_width_px)))?;
+        overlapped.SetPreferredMaximumWidth(Some(dip_to_px(max_w).saturating_add(nc_width_px)))?;
     }
     if let Some(max_h) = constraints.max_height {
         overlapped
-            .put_PreferredMaximumHeight(Some(dip_to_px(max_h).saturating_add(nc_height_px)))?;
+            .SetPreferredMaximumHeight(Some(dip_to_px(max_h).saturating_add(nc_height_px)))?;
     }
 
-    let actual_client_px = app_window_2.get_ClientSize()?;
+    let actual_client_px = app_window_2.ClientSize()?;
     let actual_dip_size = WindowSize {
         width: actual_client_px.width as f64 * 96.0 / dpi as f64,
         height: actual_client_px.height as f64 * 96.0 / dpi as f64,
@@ -525,31 +521,27 @@ fn apply_constraints_for_window(
     let dip_scale = dpi as f64 / 96.0;
     let dip_to_px = |dips: f64| (dips * dip_scale).round() as i32;
 
-    let app_window = window.cast::<IWindow2>()?.get_AppWindow()?;
+    let app_window = window.cast::<IWindow2>()?.AppWindow()?;
     let app_window_2 = app_window.cast::<IAppWindow2>()?;
 
-    let outer_size = app_window.get_Size()?;
-    let inner_size = app_window_2.get_ClientSize()?;
+    let outer_size = app_window.Size()?;
+    let inner_size = app_window_2.ClientSize()?;
     let nc_width_px = outer_size.width.saturating_sub(inner_size.width);
     let nc_height_px = outer_size.height.saturating_sub(inner_size.height);
 
-    let presenter = app_window
-        .get_Presenter()?
-        .cast::<IOverlappedPresenter3>()?;
+    let presenter = app_window.Presenter()?.cast::<IOverlappedPresenter3>()?;
 
     if let Some(min_w) = constraints.min_width {
-        presenter.put_PreferredMinimumWidth(Some(dip_to_px(min_w).saturating_add(nc_width_px)))?;
+        presenter.SetPreferredMinimumWidth(Some(dip_to_px(min_w).saturating_add(nc_width_px)))?;
     }
     if let Some(min_h) = constraints.min_height {
-        presenter
-            .put_PreferredMinimumHeight(Some(dip_to_px(min_h).saturating_add(nc_height_px)))?;
+        presenter.SetPreferredMinimumHeight(Some(dip_to_px(min_h).saturating_add(nc_height_px)))?;
     }
     if let Some(max_w) = constraints.max_width {
-        presenter.put_PreferredMaximumWidth(Some(dip_to_px(max_w).saturating_add(nc_width_px)))?;
+        presenter.SetPreferredMaximumWidth(Some(dip_to_px(max_w).saturating_add(nc_width_px)))?;
     }
     if let Some(max_h) = constraints.max_height {
-        presenter
-            .put_PreferredMaximumHeight(Some(dip_to_px(max_h).saturating_add(nc_height_px)))?;
+        presenter.SetPreferredMaximumHeight(Some(dip_to_px(max_h).saturating_add(nc_height_px)))?;
     }
     Ok(())
 }
@@ -580,7 +572,7 @@ fn subscribe_actual_theme_changed(
 }
 
 fn update_color_scheme_from(fe: &FrameworkElement) {
-    if let Ok(theme) = fe.get_ActualTheme() {
+    if let Ok(theme) = fe.ActualTheme() {
         let scheme = match theme {
             ElementTheme::Dark => ColorScheme::Dark,
             _ => ColorScheme::Light,

--- a/crates/libs/reactor/src/widgets/swap_chain_panel.rs
+++ b/crates/libs/reactor/src/widgets/swap_chain_panel.rs
@@ -25,8 +25,8 @@ impl SwapChainPanelHandle {
     /// Typically both values are equal (e.g., 1.5 at 150% display scaling).
     pub fn composition_scale(&self) -> Result<(f32, f32)> {
         let panel: bindings::ISwapChainPanel = self.0.cast()?;
-        let x = panel.get_CompositionScaleX()?;
-        let y = panel.get_CompositionScaleY()?;
+        let x = panel.CompositionScaleX()?;
+        let y = panel.CompositionScaleY()?;
         Ok((x, y))
     }
 
@@ -41,8 +41,8 @@ impl SwapChainPanelHandle {
         panel.CompositionScaleChanged(move |sender, _| {
             if let Some(sender) = sender.as_ref() {
                 let scp: &bindings::ISwapChainPanel = sender;
-                let x = scp.get_CompositionScaleX().unwrap_or(1.0);
-                let y = scp.get_CompositionScaleY().unwrap_or(1.0);
+                let x = scp.CompositionScaleX().unwrap_or(1.0);
+                let y = scp.CompositionScaleY().unwrap_or(1.0);
                 f(x, y);
             }
         })
@@ -124,7 +124,7 @@ impl SwapChainPanel {
                     Rc::new(RefCell::new(None));
                 let r = fe.SizeChanged(move |_sender, args| {
                     if let Some(args) = args.as_ref()
-                        && let Ok(s) = args.get_NewSize()
+                        && let Ok(s) = args.NewSize()
                     {
                         f(s.width as f64, s.height as f64);
                     }

--- a/crates/tests/libs/bindgen/data/bindgen/auto_events/expected.rs
+++ b/crates/tests/libs/bindgen/data/bindgen/auto_events/expected.rs
@@ -128,7 +128,7 @@ pub mod Test {
             };
             unsafe {
                 let mut result__ = core::mem::zeroed();
-                let token__ = (windows_core::Interface::vtable(self).add_Click)(
+                let token__ = (windows_core::Interface::vtable(self).Click)(
                     windows_core::Interface::as_raw(self),
                     windows_core::Interface::as_raw(&handler),
                     &mut result__,
@@ -137,7 +137,7 @@ pub mod Test {
                 Ok(windows_core::EventRevoker::new(
                     self.clone(),
                     token__,
-                    windows_core::Interface::vtable(self).remove_Click,
+                    windows_core::Interface::vtable(self).RemoveClick,
                 ))
             }
         }
@@ -159,8 +159,8 @@ pub mod Test {
     }
     pub trait IFoo_Impl: windows_core::IUnknownImpl {
         fn Bar(&self) -> windows_core::Result<i32>;
-        fn add_Click(&self, handler: windows_core::Ref<Handler>) -> windows_core::Result<i64>;
-        fn remove_Click(&self, token: i64) -> windows_core::Result<()>;
+        fn Click(&self, handler: windows_core::Ref<Handler>) -> windows_core::Result<i64>;
+        fn RemoveClick(&self, token: i64) -> windows_core::Result<()>;
         fn SetCompleted(
             &self,
             callback: windows_core::Ref<CompletedCallback>,
@@ -184,7 +184,7 @@ pub mod Test {
                     }
                 }
             }
-            unsafe extern "system" fn add_Click<Identity: IFoo_Impl, const OFFSET: isize>(
+            unsafe extern "system" fn Click<Identity: IFoo_Impl, const OFFSET: isize>(
                 this: *mut core::ffi::c_void,
                 handler: *mut core::ffi::c_void,
                 result__: *mut i64,
@@ -192,7 +192,7 @@ pub mod Test {
                 unsafe {
                     let this: &Identity =
                         &*((this as *const *const ()).offset(OFFSET) as *const Identity);
-                    match IFoo_Impl::add_Click(this, core::mem::transmute_copy(&handler)) {
+                    match IFoo_Impl::Click(this, core::mem::transmute_copy(&handler)) {
                         Ok(ok__) => {
                             result__.write(ok__);
                             windows_core::HRESULT(0)
@@ -201,14 +201,14 @@ pub mod Test {
                     }
                 }
             }
-            unsafe extern "system" fn remove_Click<Identity: IFoo_Impl, const OFFSET: isize>(
+            unsafe extern "system" fn RemoveClick<Identity: IFoo_Impl, const OFFSET: isize>(
                 this: *mut core::ffi::c_void,
                 token: i64,
             ) -> windows_core::HRESULT {
                 unsafe {
                     let this: &Identity =
                         &*((this as *const *const ()).offset(OFFSET) as *const Identity);
-                    IFoo_Impl::remove_Click(this, token).into()
+                    IFoo_Impl::RemoveClick(this, token).into()
                 }
             }
             unsafe extern "system" fn SetCompleted<Identity: IFoo_Impl, const OFFSET: isize>(
@@ -224,8 +224,8 @@ pub mod Test {
             Self {
                 base__: windows_core::IInspectable_Vtbl::new::<Identity, IFoo, OFFSET>(),
                 Bar: Bar::<Identity, OFFSET>,
-                add_Click: add_Click::<Identity, OFFSET>,
-                remove_Click: remove_Click::<Identity, OFFSET>,
+                Click: Click::<Identity, OFFSET>,
+                RemoveClick: RemoveClick::<Identity, OFFSET>,
                 SetCompleted: SetCompleted::<Identity, OFFSET>,
             }
         }
@@ -238,12 +238,12 @@ pub mod Test {
         pub base__: windows_core::IInspectable_Vtbl,
         pub Bar:
             unsafe extern "system" fn(*mut core::ffi::c_void, *mut i32) -> windows_core::HRESULT,
-        pub add_Click: unsafe extern "system" fn(
+        pub Click: unsafe extern "system" fn(
             *mut core::ffi::c_void,
             *mut core::ffi::c_void,
             *mut i64,
         ) -> windows_core::HRESULT,
-        pub remove_Click:
+        pub RemoveClick:
             unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
         pub SetCompleted: unsafe extern "system" fn(
             *mut core::ffi::c_void,

--- a/crates/tests/libs/bindgen/data/bindgen/minimal/expected.rs
+++ b/crates/tests/libs/bindgen/data/bindgen/minimal/expected.rs
@@ -19,10 +19,10 @@ pub mod Test {
                 .map(|| result__)
             }
         }
-        pub(crate) fn get_Name(&self) -> windows_core::Result<String> {
+        pub(crate) fn Name(&self) -> windows_core::Result<String> {
             unsafe {
                 let mut result__ = core::mem::zeroed();
-                (windows_core::Interface::vtable(self).get_Name)(
+                (windows_core::Interface::vtable(self).Name)(
                     windows_core::Interface::as_raw(self),
                     &mut result__,
                 )
@@ -32,9 +32,9 @@ pub mod Test {
                 })
             }
         }
-        pub(crate) fn put_Name(&self, value: &str) -> windows_core::Result<()> {
+        pub(crate) fn SetName(&self, value: &str) -> windows_core::Result<()> {
             unsafe {
-                (windows_core::Interface::vtable(self).put_Name)(
+                (windows_core::Interface::vtable(self).SetName)(
                     windows_core::Interface::as_raw(self),
                     core::mem::transmute_copy(&windows_core::HSTRING::from(value)),
                 )
@@ -47,11 +47,11 @@ pub mod Test {
         pub base__: windows_core::IInspectable_Vtbl,
         pub Direct:
             unsafe extern "system" fn(*mut core::ffi::c_void, *mut i32) -> windows_core::HRESULT,
-        pub get_Name: unsafe extern "system" fn(
+        pub Name: unsafe extern "system" fn(
             *mut core::ffi::c_void,
             *mut *mut core::ffi::c_void,
         ) -> windows_core::HRESULT,
-        pub put_Name: unsafe extern "system" fn(
+        pub SetName: unsafe extern "system" fn(
             *mut core::ffi::c_void,
             *mut core::ffi::c_void,
         ) -> windows_core::HRESULT,

--- a/crates/tests/libs/reactor_selftest/src/bindings.rs
+++ b/crates/tests/libs/reactor_selftest/src/bindings.rs
@@ -338,10 +338,10 @@ impl Application {
             .and_then(|| windows_core::Type::from_abi(result__))
         })
     }
-    pub(crate) fn get_Current() -> windows_core::Result<Application> {
+    pub(crate) fn Current() -> windows_core::Result<Application> {
         Self::IApplicationStatics(|this| unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(this).get_Current)(
+            (windows_core::Interface::vtable(this).Current)(
                 windows_core::Interface::as_raw(this),
                 &mut result__,
             )
@@ -2389,7 +2389,7 @@ impl CompositionTarget {
         };
         Self::ICompositionTargetStatics(|this| unsafe {
             let mut result__ = core::mem::zeroed();
-            let token__ = (windows_core::Interface::vtable(this).add_Rendering)(
+            let token__ = (windows_core::Interface::vtable(this).Rendering)(
                 windows_core::Interface::as_raw(this),
                 windows_core::Interface::as_raw(&handler),
                 &mut result__,
@@ -2398,7 +2398,7 @@ impl CompositionTarget {
             Ok(windows_core::EventRevoker::new(
                 this.clone(),
                 token__,
-                windows_core::Interface::vtable(this).remove_Rendering,
+                windows_core::Interface::vtable(this).RemoveRendering,
             ))
         })
     }
@@ -4368,10 +4368,10 @@ impl windows_core::RuntimeType for IAppBarButton {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IAppBarButton {
-    pub(crate) fn get_Label(&self) -> windows_core::Result<String> {
+    pub(crate) fn Label(&self) -> windows_core::Result<String> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_Label)(
+            (windows_core::Interface::vtable(self).Label)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
@@ -4381,21 +4381,21 @@ impl IAppBarButton {
             })
         }
     }
-    pub(crate) fn put_Label(&self, value: &str) -> windows_core::Result<()> {
+    pub(crate) fn SetLabel(&self, value: &str) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Label)(
+            (windows_core::Interface::vtable(self).SetLabel)(
                 windows_core::Interface::as_raw(self),
                 core::mem::transmute_copy(&windows_core::HSTRING::from(value)),
             )
             .ok()
         }
     }
-    pub(crate) fn put_Icon<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetIcon<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<IconElement>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Icon)(
+            (windows_core::Interface::vtable(self).SetIcon)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
@@ -4406,16 +4406,16 @@ impl IAppBarButton {
 #[repr(C)]
 pub struct IAppBarButton_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    pub get_Label: unsafe extern "system" fn(
+    pub Label: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    pub put_Label: unsafe extern "system" fn(
+    pub SetLabel: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_Icon: usize,
-    pub put_Icon: unsafe extern "system" fn(
+    Icon: usize,
+    pub SetIcon: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
@@ -4481,21 +4481,21 @@ impl windows_core::RuntimeType for IAppBarToggleButton {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IAppBarToggleButton {
-    pub(crate) fn put_Label(&self, value: &str) -> windows_core::Result<()> {
+    pub(crate) fn SetLabel(&self, value: &str) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Label)(
+            (windows_core::Interface::vtable(self).SetLabel)(
                 windows_core::Interface::as_raw(self),
                 core::mem::transmute_copy(&windows_core::HSTRING::from(value)),
             )
             .ok()
         }
     }
-    pub(crate) fn put_Icon<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetIcon<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<IconElement>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Icon)(
+            (windows_core::Interface::vtable(self).SetIcon)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
@@ -4506,13 +4506,13 @@ impl IAppBarToggleButton {
 #[repr(C)]
 pub struct IAppBarToggleButton_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_Label: usize,
-    pub put_Label: unsafe extern "system" fn(
+    Label: usize,
+    pub SetLabel: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_Icon: usize,
-    pub put_Icon: unsafe extern "system" fn(
+    Icon: usize,
+    pub SetIcon: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
@@ -4546,30 +4546,30 @@ impl windows_core::RuntimeType for IAppWindow {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IAppWindow {
-    pub(crate) fn get_Presenter(&self) -> windows_core::Result<AppWindowPresenter> {
+    pub(crate) fn Presenter(&self) -> windows_core::Result<AppWindowPresenter> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_Presenter)(
+            (windows_core::Interface::vtable(self).Presenter)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
             .and_then(|| windows_core::Type::from_abi(result__))
         }
     }
-    pub(crate) fn get_Size(&self) -> windows_core::Result<SizeInt32> {
+    pub(crate) fn Size(&self) -> windows_core::Result<SizeInt32> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_Size)(
+            (windows_core::Interface::vtable(self).Size)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
             .map(|| result__)
         }
     }
-    pub(crate) fn get_TitleBar(&self) -> windows_core::Result<AppWindowTitleBar> {
+    pub(crate) fn TitleBar(&self) -> windows_core::Result<AppWindowTitleBar> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_TitleBar)(
+            (windows_core::Interface::vtable(self).TitleBar)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
@@ -4592,21 +4592,21 @@ impl IAppWindow {
 #[repr(C)]
 pub struct IAppWindow_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_Id: usize,
-    get_IsShownInSwitchers: usize,
-    put_IsShownInSwitchers: usize,
-    get_IsVisible: usize,
-    get_OwnerWindowId: usize,
-    get_Position: usize,
-    pub get_Presenter: unsafe extern "system" fn(
+    Id: usize,
+    IsShownInSwitchers: usize,
+    SetIsShownInSwitchers: usize,
+    IsVisible: usize,
+    OwnerWindowId: usize,
+    Position: usize,
+    pub Presenter: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    pub get_Size:
+    pub Size:
         unsafe extern "system" fn(*mut core::ffi::c_void, *mut SizeInt32) -> windows_core::HRESULT,
-    get_Title: usize,
-    put_Title: usize,
-    pub get_TitleBar: unsafe extern "system" fn(
+    Title: usize,
+    SetTitle: usize,
+    pub TitleBar: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
@@ -4634,10 +4634,10 @@ impl windows_core::RuntimeType for IAppWindow2 {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IAppWindow2 {
-    pub(crate) fn get_ClientSize(&self) -> windows_core::Result<SizeInt32> {
+    pub(crate) fn ClientSize(&self) -> windows_core::Result<SizeInt32> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_ClientSize)(
+            (windows_core::Interface::vtable(self).ClientSize)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
@@ -4657,7 +4657,7 @@ impl IAppWindow2 {
 #[repr(C)]
 pub struct IAppWindow2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    pub get_ClientSize:
+    pub ClientSize:
         unsafe extern "system" fn(*mut core::ffi::c_void, *mut SizeInt32) -> windows_core::HRESULT,
     MoveInZOrderAtBottom: usize,
     MoveInZOrderAtTop: usize,
@@ -4701,12 +4701,12 @@ impl windows_core::RuntimeType for IAppWindowTitleBar2 {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IAppWindowTitleBar2 {
-    pub(crate) fn put_PreferredHeightOption(
+    pub(crate) fn SetPreferredHeightOption(
         &self,
         value: TitleBarHeightOption,
     ) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_PreferredHeightOption)(
+            (windows_core::Interface::vtable(self).SetPreferredHeightOption)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
@@ -4717,8 +4717,8 @@ impl IAppWindowTitleBar2 {
 #[repr(C)]
 pub struct IAppWindowTitleBar2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_PreferredHeightOption: usize,
-    pub put_PreferredHeightOption: unsafe extern "system" fn(
+    PreferredHeightOption: usize,
+    pub SetPreferredHeightOption: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         TitleBarHeightOption,
     ) -> windows_core::HRESULT,
@@ -4733,9 +4733,9 @@ impl windows_core::RuntimeType for IAppWindowTitleBar3 {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IAppWindowTitleBar3 {
-    pub(crate) fn put_PreferredTheme(&self, value: TitleBarTheme) -> windows_core::Result<()> {
+    pub(crate) fn SetPreferredTheme(&self, value: TitleBarTheme) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_PreferredTheme)(
+            (windows_core::Interface::vtable(self).SetPreferredTheme)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
@@ -4746,8 +4746,8 @@ impl IAppWindowTitleBar3 {
 #[repr(C)]
 pub struct IAppWindowTitleBar3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_PreferredTheme: usize,
-    pub put_PreferredTheme:
+    PreferredTheme: usize,
+    pub SetPreferredTheme:
         unsafe extern "system" fn(*mut core::ffi::c_void, TitleBarTheme) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
@@ -4760,10 +4760,10 @@ impl windows_core::RuntimeType for IApplication {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IApplication {
-    pub(crate) fn get_Resources(&self) -> windows_core::Result<ResourceDictionary> {
+    pub(crate) fn Resources(&self) -> windows_core::Result<ResourceDictionary> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_Resources)(
+            (windows_core::Interface::vtable(self).Resources)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
@@ -4774,7 +4774,7 @@ impl IApplication {
 #[repr(C)]
 pub struct IApplication_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    pub get_Resources: unsafe extern "system" fn(
+    pub Resources: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
@@ -4836,7 +4836,7 @@ impl windows_core::RuntimeType for IApplicationStatics {
 #[repr(C)]
 pub struct IApplicationStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    pub get_Current: unsafe extern "system" fn(
+    pub Current: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
@@ -4855,10 +4855,10 @@ impl windows_core::RuntimeType for IAutoSuggestBox {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IAutoSuggestBox {
-    pub(crate) fn get_Text(&self) -> windows_core::Result<String> {
+    pub(crate) fn Text(&self) -> windows_core::Result<String> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_Text)(
+            (windows_core::Interface::vtable(self).Text)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
@@ -4868,30 +4868,30 @@ impl IAutoSuggestBox {
             })
         }
     }
-    pub(crate) fn put_Text(&self, value: &str) -> windows_core::Result<()> {
+    pub(crate) fn SetText(&self, value: &str) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Text)(
+            (windows_core::Interface::vtable(self).SetText)(
                 windows_core::Interface::as_raw(self),
                 core::mem::transmute_copy(&windows_core::HSTRING::from(value)),
             )
             .ok()
         }
     }
-    pub(crate) fn put_PlaceholderText(&self, value: &str) -> windows_core::Result<()> {
+    pub(crate) fn SetPlaceholderText(&self, value: &str) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_PlaceholderText)(
+            (windows_core::Interface::vtable(self).SetPlaceholderText)(
                 windows_core::Interface::as_raw(self),
                 core::mem::transmute_copy(&windows_core::HSTRING::from(value)),
             )
             .ok()
         }
     }
-    pub(crate) fn put_Header<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetHeader<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<windows_core::IInspectable>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Header)(
+            (windows_core::Interface::vtable(self).SetHeader)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
@@ -4925,7 +4925,7 @@ impl IAutoSuggestBox {
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
-            let token__ = (windows_core::Interface::vtable(self).add_SuggestionChosen)(
+            let token__ = (windows_core::Interface::vtable(self).SuggestionChosen)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Interface::as_raw(&handler),
                 &mut result__,
@@ -4934,7 +4934,7 @@ impl IAutoSuggestBox {
             Ok(windows_core::EventRevoker::new(
                 self.clone(),
                 token__,
-                windows_core::Interface::vtable(self).remove_SuggestionChosen,
+                windows_core::Interface::vtable(self).RemoveSuggestionChosen,
             ))
         }
     }
@@ -4954,7 +4954,7 @@ impl IAutoSuggestBox {
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
-            let token__ = (windows_core::Interface::vtable(self).add_TextChanged)(
+            let token__ = (windows_core::Interface::vtable(self).TextChanged)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Interface::as_raw(&handler),
                 &mut result__,
@@ -4963,7 +4963,7 @@ impl IAutoSuggestBox {
             Ok(windows_core::EventRevoker::new(
                 self.clone(),
                 token__,
-                windows_core::Interface::vtable(self).remove_TextChanged,
+                windows_core::Interface::vtable(self).RemoveTextChanged,
             ))
         }
     }
@@ -4983,7 +4983,7 @@ impl IAutoSuggestBox {
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
-            let token__ = (windows_core::Interface::vtable(self).add_QuerySubmitted)(
+            let token__ = (windows_core::Interface::vtable(self).QuerySubmitted)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Interface::as_raw(&handler),
                 &mut result__,
@@ -4992,7 +4992,7 @@ impl IAutoSuggestBox {
             Ok(windows_core::EventRevoker::new(
                 self.clone(),
                 token__,
-                windows_core::Interface::vtable(self).remove_QuerySubmitted,
+                windows_core::Interface::vtable(self).RemoveQuerySubmitted,
             ))
         }
     }
@@ -5000,62 +5000,62 @@ impl IAutoSuggestBox {
 #[repr(C)]
 pub struct IAutoSuggestBox_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_MaxSuggestionListHeight: usize,
-    put_MaxSuggestionListHeight: usize,
-    get_IsSuggestionListOpen: usize,
-    put_IsSuggestionListOpen: usize,
-    get_TextMemberPath: usize,
-    put_TextMemberPath: usize,
-    pub get_Text: unsafe extern "system" fn(
+    MaxSuggestionListHeight: usize,
+    SetMaxSuggestionListHeight: usize,
+    IsSuggestionListOpen: usize,
+    SetIsSuggestionListOpen: usize,
+    TextMemberPath: usize,
+    SetTextMemberPath: usize,
+    pub Text: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    pub put_Text: unsafe extern "system" fn(
+    pub SetText: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_UpdateTextOnSelect: usize,
-    put_UpdateTextOnSelect: usize,
-    get_PlaceholderText: usize,
-    pub put_PlaceholderText: unsafe extern "system" fn(
+    UpdateTextOnSelect: usize,
+    SetUpdateTextOnSelect: usize,
+    PlaceholderText: usize,
+    pub SetPlaceholderText: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_Header: usize,
-    pub put_Header: unsafe extern "system" fn(
+    Header: usize,
+    pub SetHeader: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_AutoMaximizeSuggestionArea: usize,
-    put_AutoMaximizeSuggestionArea: usize,
-    get_TextBoxStyle: usize,
-    put_TextBoxStyle: usize,
-    get_QueryIcon: usize,
-    put_QueryIcon: usize,
-    get_LightDismissOverlayMode: usize,
-    put_LightDismissOverlayMode: usize,
-    get_Description: usize,
-    put_Description: usize,
-    pub add_SuggestionChosen: unsafe extern "system" fn(
+    AutoMaximizeSuggestionArea: usize,
+    SetAutoMaximizeSuggestionArea: usize,
+    TextBoxStyle: usize,
+    SetTextBoxStyle: usize,
+    QueryIcon: usize,
+    SetQueryIcon: usize,
+    LightDismissOverlayMode: usize,
+    SetLightDismissOverlayMode: usize,
+    Description: usize,
+    SetDescription: usize,
+    pub SuggestionChosen: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         *mut i64,
     ) -> windows_core::HRESULT,
-    pub remove_SuggestionChosen:
+    pub RemoveSuggestionChosen:
         unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
-    pub add_TextChanged: unsafe extern "system" fn(
+    pub TextChanged: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         *mut i64,
     ) -> windows_core::HRESULT,
-    pub remove_TextChanged:
+    pub RemoveTextChanged:
         unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
-    pub add_QuerySubmitted: unsafe extern "system" fn(
+    pub QuerySubmitted: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         *mut i64,
     ) -> windows_core::HRESULT,
-    pub remove_QuerySubmitted:
+    pub RemoveQuerySubmitted:
         unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
@@ -5068,10 +5068,10 @@ impl windows_core::RuntimeType for IAutoSuggestBoxQuerySubmittedEventArgs {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IAutoSuggestBoxQuerySubmittedEventArgs {
-    pub(crate) fn get_QueryText(&self) -> windows_core::Result<String> {
+    pub(crate) fn QueryText(&self) -> windows_core::Result<String> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_QueryText)(
+            (windows_core::Interface::vtable(self).QueryText)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
@@ -5085,7 +5085,7 @@ impl IAutoSuggestBoxQuerySubmittedEventArgs {
 #[repr(C)]
 pub struct IAutoSuggestBoxQuerySubmittedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    pub get_QueryText: unsafe extern "system" fn(
+    pub QueryText: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
@@ -5100,10 +5100,10 @@ impl windows_core::RuntimeType for IAutoSuggestBoxSuggestionChosenEventArgs {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IAutoSuggestBoxSuggestionChosenEventArgs {
-    pub(crate) fn get_SelectedItem(&self) -> windows_core::Result<windows_core::IInspectable> {
+    pub(crate) fn SelectedItem(&self) -> windows_core::Result<windows_core::IInspectable> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_SelectedItem)(
+            (windows_core::Interface::vtable(self).SelectedItem)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
@@ -5114,7 +5114,7 @@ impl IAutoSuggestBoxSuggestionChosenEventArgs {
 #[repr(C)]
 pub struct IAutoSuggestBoxSuggestionChosenEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    pub get_SelectedItem: unsafe extern "system" fn(
+    pub SelectedItem: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
@@ -5129,10 +5129,10 @@ impl windows_core::RuntimeType for IAutoSuggestBoxTextChangedEventArgs {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IAutoSuggestBoxTextChangedEventArgs {
-    pub(crate) fn get_Reason(&self) -> windows_core::Result<AutoSuggestionBoxTextChangeReason> {
+    pub(crate) fn Reason(&self) -> windows_core::Result<AutoSuggestionBoxTextChangeReason> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_Reason)(
+            (windows_core::Interface::vtable(self).Reason)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
@@ -5143,7 +5143,7 @@ impl IAutoSuggestBoxTextChangedEventArgs {
 #[repr(C)]
 pub struct IAutoSuggestBoxTextChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    pub get_Reason: unsafe extern "system" fn(
+    pub Reason: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut AutoSuggestionBoxTextChangeReason,
     ) -> windows_core::HRESULT,
@@ -5158,22 +5158,22 @@ impl windows_core::RuntimeType for IAutomationPeer {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IAutomationPeer {
-    pub(crate) fn get_EventsSource(&self) -> windows_core::Result<AutomationPeer> {
+    pub(crate) fn EventsSource(&self) -> windows_core::Result<AutomationPeer> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_EventsSource)(
+            (windows_core::Interface::vtable(self).EventsSource)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
             .and_then(|| windows_core::Type::from_abi(result__))
         }
     }
-    pub(crate) fn put_EventsSource<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetEventsSource<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<AutomationPeer>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_EventsSource)(
+            (windows_core::Interface::vtable(self).SetEventsSource)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
@@ -5785,11 +5785,11 @@ impl IAutomationPeer {
 #[repr(C)]
 pub struct IAutomationPeer_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    pub get_EventsSource: unsafe extern "system" fn(
+    pub EventsSource: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    pub put_EventsSource: unsafe extern "system" fn(
+    pub SetEventsSource: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
@@ -6761,96 +6761,96 @@ impl windows_core::RuntimeType for IAutomationPropertiesStatics {
 #[repr(C)]
 pub struct IAutomationPropertiesStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_AcceleratorKeyProperty: usize,
+    AcceleratorKeyProperty: usize,
     GetAcceleratorKey: usize,
     SetAcceleratorKey: usize,
-    get_AccessKeyProperty: usize,
+    AccessKeyProperty: usize,
     GetAccessKey: usize,
     SetAccessKey: usize,
-    get_AutomationIdProperty: usize,
+    AutomationIdProperty: usize,
     GetAutomationId: usize,
     pub SetAutomationId: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_HelpTextProperty: usize,
+    HelpTextProperty: usize,
     GetHelpText: usize,
     pub SetHelpText: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_IsRequiredForFormProperty: usize,
+    IsRequiredForFormProperty: usize,
     GetIsRequiredForForm: usize,
     SetIsRequiredForForm: usize,
-    get_ItemStatusProperty: usize,
+    ItemStatusProperty: usize,
     GetItemStatus: usize,
     SetItemStatus: usize,
-    get_ItemTypeProperty: usize,
+    ItemTypeProperty: usize,
     GetItemType: usize,
     SetItemType: usize,
-    get_LabeledByProperty: usize,
+    LabeledByProperty: usize,
     GetLabeledBy: usize,
     SetLabeledBy: usize,
-    get_NameProperty: usize,
+    NameProperty: usize,
     GetName: usize,
     pub SetName: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_LiveSettingProperty: usize,
+    LiveSettingProperty: usize,
     GetLiveSetting: usize,
     pub SetLiveSetting: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         AutomationLiveSetting,
     ) -> windows_core::HRESULT,
-    get_AccessibilityViewProperty: usize,
+    AccessibilityViewProperty: usize,
     GetAccessibilityView: usize,
     SetAccessibilityView: usize,
-    get_ControlledPeersProperty: usize,
+    ControlledPeersProperty: usize,
     GetControlledPeers: usize,
-    get_PositionInSetProperty: usize,
+    PositionInSetProperty: usize,
     GetPositionInSet: usize,
     SetPositionInSet: usize,
-    get_SizeOfSetProperty: usize,
+    SizeOfSetProperty: usize,
     GetSizeOfSet: usize,
     SetSizeOfSet: usize,
-    get_LevelProperty: usize,
+    LevelProperty: usize,
     GetLevel: usize,
     SetLevel: usize,
-    get_AnnotationsProperty: usize,
+    AnnotationsProperty: usize,
     GetAnnotations: usize,
-    get_LandmarkTypeProperty: usize,
+    LandmarkTypeProperty: usize,
     GetLandmarkType: usize,
     SetLandmarkType: usize,
-    get_LocalizedLandmarkTypeProperty: usize,
+    LocalizedLandmarkTypeProperty: usize,
     GetLocalizedLandmarkType: usize,
     SetLocalizedLandmarkType: usize,
-    get_IsPeripheralProperty: usize,
+    IsPeripheralProperty: usize,
     GetIsPeripheral: usize,
     SetIsPeripheral: usize,
-    get_IsDataValidForFormProperty: usize,
+    IsDataValidForFormProperty: usize,
     GetIsDataValidForForm: usize,
     SetIsDataValidForForm: usize,
-    get_FullDescriptionProperty: usize,
+    FullDescriptionProperty: usize,
     GetFullDescription: usize,
     SetFullDescription: usize,
-    get_LocalizedControlTypeProperty: usize,
+    LocalizedControlTypeProperty: usize,
     GetLocalizedControlType: usize,
     SetLocalizedControlType: usize,
-    get_DescribedByProperty: usize,
+    DescribedByProperty: usize,
     GetDescribedBy: usize,
-    get_FlowsToProperty: usize,
+    FlowsToProperty: usize,
     GetFlowsTo: usize,
-    get_FlowsFromProperty: usize,
+    FlowsFromProperty: usize,
     GetFlowsFrom: usize,
-    get_CultureProperty: usize,
+    CultureProperty: usize,
     GetCulture: usize,
     SetCulture: usize,
-    get_HeadingLevelProperty: usize,
+    HeadingLevelProperty: usize,
     GetHeadingLevel: usize,
     pub SetHeadingLevel: unsafe extern "system" fn(
         *mut core::ffi::c_void,
@@ -6881,12 +6881,12 @@ impl windows_core::RuntimeType for IBitmapImage {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IBitmapImage {
-    pub(crate) fn put_UriSource<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetUriSource<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<Uri>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_UriSource)(
+            (windows_core::Interface::vtable(self).SetUriSource)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
@@ -6897,10 +6897,10 @@ impl IBitmapImage {
 #[repr(C)]
 pub struct IBitmapImage_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_CreateOptions: usize,
-    put_CreateOptions: usize,
-    get_UriSource: usize,
-    pub put_UriSource: unsafe extern "system" fn(
+    CreateOptions: usize,
+    SetCreateOptions: usize,
+    UriSource: usize,
+    pub SetUriSource: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
@@ -6937,73 +6937,73 @@ impl windows_core::RuntimeType for IBorder {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IBorder {
-    pub(crate) fn put_BorderBrush<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetBorderBrush<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<Brush>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_BorderBrush)(
+            (windows_core::Interface::vtable(self).SetBorderBrush)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
             .ok()
         }
     }
-    pub(crate) fn put_BorderThickness(&self, value: Thickness) -> windows_core::Result<()> {
+    pub(crate) fn SetBorderThickness(&self, value: Thickness) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_BorderThickness)(
+            (windows_core::Interface::vtable(self).SetBorderThickness)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_Background<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetBackground<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<Brush>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Background)(
+            (windows_core::Interface::vtable(self).SetBackground)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
             .ok()
         }
     }
-    pub(crate) fn put_CornerRadius(&self, value: CornerRadius) -> windows_core::Result<()> {
+    pub(crate) fn SetCornerRadius(&self, value: CornerRadius) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_CornerRadius)(
+            (windows_core::Interface::vtable(self).SetCornerRadius)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_Padding(&self, value: Thickness) -> windows_core::Result<()> {
+    pub(crate) fn SetPadding(&self, value: Thickness) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Padding)(
+            (windows_core::Interface::vtable(self).SetPadding)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn get_Child(&self) -> windows_core::Result<UIElement> {
+    pub(crate) fn Child(&self) -> windows_core::Result<UIElement> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_Child)(
+            (windows_core::Interface::vtable(self).Child)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
             .and_then(|| windows_core::Type::from_abi(result__))
         }
     }
-    pub(crate) fn put_Child<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetChild<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<UIElement>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Child)(
+            (windows_core::Interface::vtable(self).SetChild)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
@@ -7014,32 +7014,32 @@ impl IBorder {
 #[repr(C)]
 pub struct IBorder_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_BorderBrush: usize,
-    pub put_BorderBrush: unsafe extern "system" fn(
+    BorderBrush: usize,
+    pub SetBorderBrush: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_BorderThickness: usize,
-    pub put_BorderThickness:
+    BorderThickness: usize,
+    pub SetBorderThickness:
         unsafe extern "system" fn(*mut core::ffi::c_void, Thickness) -> windows_core::HRESULT,
-    get_Background: usize,
-    pub put_Background: unsafe extern "system" fn(
+    Background: usize,
+    pub SetBackground: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_BackgroundSizing: usize,
-    put_BackgroundSizing: usize,
-    get_CornerRadius: usize,
-    pub put_CornerRadius:
+    BackgroundSizing: usize,
+    SetBackgroundSizing: usize,
+    CornerRadius: usize,
+    pub SetCornerRadius:
         unsafe extern "system" fn(*mut core::ffi::c_void, CornerRadius) -> windows_core::HRESULT,
-    get_Padding: usize,
-    pub put_Padding:
+    Padding: usize,
+    pub SetPadding:
         unsafe extern "system" fn(*mut core::ffi::c_void, Thickness) -> windows_core::HRESULT,
-    pub get_Child: unsafe extern "system" fn(
+    pub Child: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    pub put_Child: unsafe extern "system" fn(
+    pub SetChild: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
@@ -7054,12 +7054,12 @@ impl windows_core::RuntimeType for IBreadcrumbBar {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IBreadcrumbBar {
-    pub(crate) fn put_ItemsSource<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetItemsSource<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<windows_core::IInspectable>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_ItemsSource)(
+            (windows_core::Interface::vtable(self).SetItemsSource)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
@@ -7082,7 +7082,7 @@ impl IBreadcrumbBar {
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
-            let token__ = (windows_core::Interface::vtable(self).add_ItemClicked)(
+            let token__ = (windows_core::Interface::vtable(self).ItemClicked)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Interface::as_raw(&handler),
                 &mut result__,
@@ -7091,7 +7091,7 @@ impl IBreadcrumbBar {
             Ok(windows_core::EventRevoker::new(
                 self.clone(),
                 token__,
-                windows_core::Interface::vtable(self).remove_ItemClicked,
+                windows_core::Interface::vtable(self).RemoveItemClicked,
             ))
         }
     }
@@ -7099,19 +7099,19 @@ impl IBreadcrumbBar {
 #[repr(C)]
 pub struct IBreadcrumbBar_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_ItemsSource: usize,
-    pub put_ItemsSource: unsafe extern "system" fn(
+    ItemsSource: usize,
+    pub SetItemsSource: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_ItemTemplate: usize,
-    put_ItemTemplate: usize,
-    pub add_ItemClicked: unsafe extern "system" fn(
+    ItemTemplate: usize,
+    SetItemTemplate: usize,
+    pub ItemClicked: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         *mut i64,
     ) -> windows_core::HRESULT,
-    pub remove_ItemClicked:
+    pub RemoveItemClicked:
         unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
@@ -7143,10 +7143,10 @@ impl windows_core::RuntimeType for IBreadcrumbBarItemClickedEventArgs {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IBreadcrumbBarItemClickedEventArgs {
-    pub(crate) fn get_Index(&self) -> windows_core::Result<i32> {
+    pub(crate) fn Index(&self) -> windows_core::Result<i32> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_Index)(
+            (windows_core::Interface::vtable(self).Index)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
@@ -7157,8 +7157,7 @@ impl IBreadcrumbBarItemClickedEventArgs {
 #[repr(C)]
 pub struct IBreadcrumbBarItemClickedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    pub get_Index:
-        unsafe extern "system" fn(*mut core::ffi::c_void, *mut i32) -> windows_core::HRESULT,
+    pub Index: unsafe extern "system" fn(*mut core::ffi::c_void, *mut i32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBrush, IBrush_Vtbl, 0x2de3cb83_1329_5679_88f8_c822bc5442cb);
 impl windows_core::RuntimeType for IBrush {
@@ -7179,22 +7178,22 @@ impl windows_core::RuntimeType for IButton {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IButton {
-    pub(crate) fn get_Flyout(&self) -> windows_core::Result<FlyoutBase> {
+    pub(crate) fn Flyout(&self) -> windows_core::Result<FlyoutBase> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_Flyout)(
+            (windows_core::Interface::vtable(self).Flyout)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
             .and_then(|| windows_core::Type::from_abi(result__))
         }
     }
-    pub(crate) fn put_Flyout<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetFlyout<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<FlyoutBase>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Flyout)(
+            (windows_core::Interface::vtable(self).SetFlyout)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
@@ -7205,11 +7204,11 @@ impl IButton {
 #[repr(C)]
 pub struct IButton_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    pub get_Flyout: unsafe extern "system" fn(
+    pub Flyout: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    pub put_Flyout: unsafe extern "system" fn(
+    pub SetFlyout: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
@@ -7271,7 +7270,7 @@ impl IButtonBase {
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
-            let token__ = (windows_core::Interface::vtable(self).add_Click)(
+            let token__ = (windows_core::Interface::vtable(self).Click)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Interface::as_raw(&handler),
                 &mut result__,
@@ -7280,7 +7279,7 @@ impl IButtonBase {
             Ok(windows_core::EventRevoker::new(
                 self.clone(),
                 token__,
-                windows_core::Interface::vtable(self).remove_Click,
+                windows_core::Interface::vtable(self).RemoveClick,
             ))
         }
     }
@@ -7288,20 +7287,20 @@ impl IButtonBase {
 #[repr(C)]
 pub struct IButtonBase_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_ClickMode: usize,
-    put_ClickMode: usize,
-    get_IsPointerOver: usize,
-    get_IsPressed: usize,
-    get_Command: usize,
-    put_Command: usize,
-    get_CommandParameter: usize,
-    put_CommandParameter: usize,
-    pub add_Click: unsafe extern "system" fn(
+    ClickMode: usize,
+    SetClickMode: usize,
+    IsPointerOver: usize,
+    IsPressed: usize,
+    Command: usize,
+    SetCommand: usize,
+    CommandParameter: usize,
+    SetCommandParameter: usize,
+    pub Click: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         *mut i64,
     ) -> windows_core::HRESULT,
-    pub remove_Click:
+    pub RemoveClick:
         unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
@@ -7346,39 +7345,39 @@ impl windows_core::RuntimeType for ICalendarDatePicker {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl ICalendarDatePicker {
-    pub(crate) fn put_IsCalendarOpen(&self, value: bool) -> windows_core::Result<()> {
+    pub(crate) fn SetIsCalendarOpen(&self, value: bool) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_IsCalendarOpen)(
+            (windows_core::Interface::vtable(self).SetIsCalendarOpen)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_PlaceholderText(&self, value: &str) -> windows_core::Result<()> {
+    pub(crate) fn SetPlaceholderText(&self, value: &str) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_PlaceholderText)(
+            (windows_core::Interface::vtable(self).SetPlaceholderText)(
                 windows_core::Interface::as_raw(self),
                 core::mem::transmute_copy(&windows_core::HSTRING::from(value)),
             )
             .ok()
         }
     }
-    pub(crate) fn put_Header<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetHeader<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<windows_core::IInspectable>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Header)(
+            (windows_core::Interface::vtable(self).SetHeader)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
             .ok()
         }
     }
-    pub(crate) fn put_IsTodayHighlighted(&self, value: bool) -> windows_core::Result<()> {
+    pub(crate) fn SetIsTodayHighlighted(&self, value: bool) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_IsTodayHighlighted)(
+            (windows_core::Interface::vtable(self).SetIsTodayHighlighted)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
@@ -7411,7 +7410,7 @@ impl ICalendarDatePicker {
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
-            let token__ = (windows_core::Interface::vtable(self).add_DateChanged)(
+            let token__ = (windows_core::Interface::vtable(self).DateChanged)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Interface::as_raw(&handler),
                 &mut result__,
@@ -7420,7 +7419,7 @@ impl ICalendarDatePicker {
             Ok(windows_core::EventRevoker::new(
                 self.clone(),
                 token__,
-                windows_core::Interface::vtable(self).remove_DateChanged,
+                windows_core::Interface::vtable(self).RemoveDateChanged,
             ))
         }
     }
@@ -7428,58 +7427,58 @@ impl ICalendarDatePicker {
 #[repr(C)]
 pub struct ICalendarDatePicker_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_Date: usize,
-    put_Date: usize,
-    get_IsCalendarOpen: usize,
-    pub put_IsCalendarOpen:
+    Date: usize,
+    SetDate: usize,
+    IsCalendarOpen: usize,
+    pub SetIsCalendarOpen:
         unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
-    get_DateFormat: usize,
-    put_DateFormat: usize,
-    get_PlaceholderText: usize,
-    pub put_PlaceholderText: unsafe extern "system" fn(
+    DateFormat: usize,
+    SetDateFormat: usize,
+    PlaceholderText: usize,
+    pub SetPlaceholderText: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_Header: usize,
-    pub put_Header: unsafe extern "system" fn(
+    Header: usize,
+    pub SetHeader: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_HeaderTemplate: usize,
-    put_HeaderTemplate: usize,
-    get_CalendarViewStyle: usize,
-    put_CalendarViewStyle: usize,
-    get_LightDismissOverlayMode: usize,
-    put_LightDismissOverlayMode: usize,
-    get_Description: usize,
-    put_Description: usize,
-    get_MinDate: usize,
-    put_MinDate: usize,
-    get_MaxDate: usize,
-    put_MaxDate: usize,
-    get_IsTodayHighlighted: usize,
-    pub put_IsTodayHighlighted:
+    HeaderTemplate: usize,
+    SetHeaderTemplate: usize,
+    CalendarViewStyle: usize,
+    SetCalendarViewStyle: usize,
+    LightDismissOverlayMode: usize,
+    SetLightDismissOverlayMode: usize,
+    Description: usize,
+    SetDescription: usize,
+    MinDate: usize,
+    SetMinDate: usize,
+    MaxDate: usize,
+    SetMaxDate: usize,
+    IsTodayHighlighted: usize,
+    pub SetIsTodayHighlighted:
         unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
-    get_DisplayMode: usize,
-    put_DisplayMode: usize,
-    get_FirstDayOfWeek: usize,
-    put_FirstDayOfWeek: usize,
-    get_DayOfWeekFormat: usize,
-    put_DayOfWeekFormat: usize,
-    get_CalendarIdentifier: usize,
-    put_CalendarIdentifier: usize,
-    get_IsOutOfScopeEnabled: usize,
-    put_IsOutOfScopeEnabled: usize,
-    get_IsGroupLabelVisible: usize,
-    put_IsGroupLabelVisible: usize,
-    add_CalendarViewDayItemChanging: usize,
-    remove_CalendarViewDayItemChanging: usize,
-    pub add_DateChanged: unsafe extern "system" fn(
+    DisplayMode: usize,
+    SetDisplayMode: usize,
+    FirstDayOfWeek: usize,
+    SetFirstDayOfWeek: usize,
+    DayOfWeekFormat: usize,
+    SetDayOfWeekFormat: usize,
+    CalendarIdentifier: usize,
+    SetCalendarIdentifier: usize,
+    IsOutOfScopeEnabled: usize,
+    SetIsOutOfScopeEnabled: usize,
+    IsGroupLabelVisible: usize,
+    SetIsGroupLabelVisible: usize,
+    CalendarViewDayItemChanging: usize,
+    RemoveCalendarViewDayItemChanging: usize,
+    pub DateChanged: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         *mut i64,
     ) -> windows_core::HRESULT,
-    pub remove_DateChanged:
+    pub RemoveDateChanged:
         unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
@@ -7492,10 +7491,10 @@ impl windows_core::RuntimeType for ICalendarDatePickerDateChangedEventArgs {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl ICalendarDatePickerDateChangedEventArgs {
-    pub(crate) fn get_NewDate(&self) -> windows_core::Result<windows_time::DateTime> {
+    pub(crate) fn NewDate(&self) -> windows_core::Result<windows_time::DateTime> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_NewDate)(
+            (windows_core::Interface::vtable(self).NewDate)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
@@ -7507,7 +7506,7 @@ impl ICalendarDatePickerDateChangedEventArgs {
 #[repr(C)]
 pub struct ICalendarDatePickerDateChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    pub get_NewDate: unsafe extern "system" fn(
+    pub NewDate: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
@@ -7541,18 +7540,18 @@ impl windows_core::RuntimeType for ICalendarView {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl ICalendarView {
-    pub(crate) fn put_IsGroupLabelVisible(&self, value: bool) -> windows_core::Result<()> {
+    pub(crate) fn SetIsGroupLabelVisible(&self, value: bool) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_IsGroupLabelVisible)(
+            (windows_core::Interface::vtable(self).SetIsGroupLabelVisible)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_IsTodayHighlighted(&self, value: bool) -> windows_core::Result<()> {
+    pub(crate) fn SetIsTodayHighlighted(&self, value: bool) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_IsTodayHighlighted)(
+            (windows_core::Interface::vtable(self).SetIsTodayHighlighted)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
@@ -7586,7 +7585,7 @@ impl ICalendarView {
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
-            let token__ = (windows_core::Interface::vtable(self).add_SelectedDatesChanged)(
+            let token__ = (windows_core::Interface::vtable(self).SelectedDatesChanged)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Interface::as_raw(&handler),
                 &mut result__,
@@ -7595,7 +7594,7 @@ impl ICalendarView {
             Ok(windows_core::EventRevoker::new(
                 self.clone(),
                 token__,
-                windows_core::Interface::vtable(self).remove_SelectedDatesChanged,
+                windows_core::Interface::vtable(self).RemoveSelectedDatesChanged,
             ))
         }
     }
@@ -7603,164 +7602,164 @@ impl ICalendarView {
 #[repr(C)]
 pub struct ICalendarView_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_CalendarIdentifier: usize,
-    put_CalendarIdentifier: usize,
-    get_DayOfWeekFormat: usize,
-    put_DayOfWeekFormat: usize,
-    get_IsGroupLabelVisible: usize,
-    pub put_IsGroupLabelVisible:
+    CalendarIdentifier: usize,
+    SetCalendarIdentifier: usize,
+    DayOfWeekFormat: usize,
+    SetDayOfWeekFormat: usize,
+    IsGroupLabelVisible: usize,
+    pub SetIsGroupLabelVisible:
         unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
-    get_DisplayMode: usize,
-    put_DisplayMode: usize,
-    get_FirstDayOfWeek: usize,
-    put_FirstDayOfWeek: usize,
-    get_IsOutOfScopeEnabled: usize,
-    put_IsOutOfScopeEnabled: usize,
-    get_IsTodayHighlighted: usize,
-    pub put_IsTodayHighlighted:
+    DisplayMode: usize,
+    SetDisplayMode: usize,
+    FirstDayOfWeek: usize,
+    SetFirstDayOfWeek: usize,
+    IsOutOfScopeEnabled: usize,
+    SetIsOutOfScopeEnabled: usize,
+    IsTodayHighlighted: usize,
+    pub SetIsTodayHighlighted:
         unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
-    get_MaxDate: usize,
-    put_MaxDate: usize,
-    get_MinDate: usize,
-    put_MinDate: usize,
-    get_NumberOfWeeksInView: usize,
-    put_NumberOfWeeksInView: usize,
-    get_SelectedDates: usize,
-    get_SelectionMode: usize,
-    put_SelectionMode: usize,
-    get_TemplateSettings: usize,
-    get_FocusBorderBrush: usize,
-    put_FocusBorderBrush: usize,
-    get_SelectedHoverBorderBrush: usize,
-    put_SelectedHoverBorderBrush: usize,
-    get_SelectedPressedBorderBrush: usize,
-    put_SelectedPressedBorderBrush: usize,
-    get_SelectedDisabledBorderBrush: usize,
-    put_SelectedDisabledBorderBrush: usize,
-    get_SelectedBorderBrush: usize,
-    put_SelectedBorderBrush: usize,
-    get_HoverBorderBrush: usize,
-    put_HoverBorderBrush: usize,
-    get_PressedBorderBrush: usize,
-    put_PressedBorderBrush: usize,
-    get_TodaySelectedInnerBorderBrush: usize,
-    put_TodaySelectedInnerBorderBrush: usize,
-    get_BlackoutStrikethroughBrush: usize,
-    put_BlackoutStrikethroughBrush: usize,
-    get_CalendarItemBorderBrush: usize,
-    put_CalendarItemBorderBrush: usize,
-    get_BlackoutBackground: usize,
-    put_BlackoutBackground: usize,
-    get_OutOfScopeBackground: usize,
-    put_OutOfScopeBackground: usize,
-    get_CalendarItemBackground: usize,
-    put_CalendarItemBackground: usize,
-    get_CalendarItemHoverBackground: usize,
-    put_CalendarItemHoverBackground: usize,
-    get_CalendarItemPressedBackground: usize,
-    put_CalendarItemPressedBackground: usize,
-    get_CalendarItemDisabledBackground: usize,
-    put_CalendarItemDisabledBackground: usize,
-    get_TodayBackground: usize,
-    put_TodayBackground: usize,
-    get_TodayBlackoutBackground: usize,
-    put_TodayBlackoutBackground: usize,
-    get_TodayHoverBackground: usize,
-    put_TodayHoverBackground: usize,
-    get_TodayPressedBackground: usize,
-    put_TodayPressedBackground: usize,
-    get_TodayDisabledBackground: usize,
-    put_TodayDisabledBackground: usize,
-    get_PressedForeground: usize,
-    put_PressedForeground: usize,
-    get_TodayForeground: usize,
-    put_TodayForeground: usize,
-    get_BlackoutForeground: usize,
-    put_BlackoutForeground: usize,
-    get_TodayBlackoutForeground: usize,
-    put_TodayBlackoutForeground: usize,
-    get_SelectedForeground: usize,
-    put_SelectedForeground: usize,
-    get_SelectedHoverForeground: usize,
-    put_SelectedHoverForeground: usize,
-    get_SelectedPressedForeground: usize,
-    put_SelectedPressedForeground: usize,
-    get_SelectedDisabledForeground: usize,
-    put_SelectedDisabledForeground: usize,
-    get_OutOfScopeForeground: usize,
-    put_OutOfScopeForeground: usize,
-    get_OutOfScopeHoverForeground: usize,
-    put_OutOfScopeHoverForeground: usize,
-    get_OutOfScopePressedForeground: usize,
-    put_OutOfScopePressedForeground: usize,
-    get_CalendarItemForeground: usize,
-    put_CalendarItemForeground: usize,
-    get_DisabledForeground: usize,
-    put_DisabledForeground: usize,
-    get_DayItemFontFamily: usize,
-    put_DayItemFontFamily: usize,
-    get_DayItemFontSize: usize,
-    put_DayItemFontSize: usize,
-    get_DayItemFontStyle: usize,
-    put_DayItemFontStyle: usize,
-    get_DayItemFontWeight: usize,
-    put_DayItemFontWeight: usize,
-    get_TodayFontWeight: usize,
-    put_TodayFontWeight: usize,
-    get_FirstOfMonthLabelFontFamily: usize,
-    put_FirstOfMonthLabelFontFamily: usize,
-    get_FirstOfMonthLabelFontSize: usize,
-    put_FirstOfMonthLabelFontSize: usize,
-    get_FirstOfMonthLabelFontStyle: usize,
-    put_FirstOfMonthLabelFontStyle: usize,
-    get_FirstOfMonthLabelFontWeight: usize,
-    put_FirstOfMonthLabelFontWeight: usize,
-    get_MonthYearItemFontFamily: usize,
-    put_MonthYearItemFontFamily: usize,
-    get_MonthYearItemFontSize: usize,
-    put_MonthYearItemFontSize: usize,
-    get_MonthYearItemFontStyle: usize,
-    put_MonthYearItemFontStyle: usize,
-    get_MonthYearItemFontWeight: usize,
-    put_MonthYearItemFontWeight: usize,
-    get_FirstOfYearDecadeLabelFontFamily: usize,
-    put_FirstOfYearDecadeLabelFontFamily: usize,
-    get_FirstOfYearDecadeLabelFontSize: usize,
-    put_FirstOfYearDecadeLabelFontSize: usize,
-    get_FirstOfYearDecadeLabelFontStyle: usize,
-    put_FirstOfYearDecadeLabelFontStyle: usize,
-    get_FirstOfYearDecadeLabelFontWeight: usize,
-    put_FirstOfYearDecadeLabelFontWeight: usize,
-    get_DayItemMargin: usize,
-    put_DayItemMargin: usize,
-    get_MonthYearItemMargin: usize,
-    put_MonthYearItemMargin: usize,
-    get_FirstOfMonthLabelMargin: usize,
-    put_FirstOfMonthLabelMargin: usize,
-    get_FirstOfYearDecadeLabelMargin: usize,
-    put_FirstOfYearDecadeLabelMargin: usize,
-    get_HorizontalDayItemAlignment: usize,
-    put_HorizontalDayItemAlignment: usize,
-    get_VerticalDayItemAlignment: usize,
-    put_VerticalDayItemAlignment: usize,
-    get_HorizontalFirstOfMonthLabelAlignment: usize,
-    put_HorizontalFirstOfMonthLabelAlignment: usize,
-    get_VerticalFirstOfMonthLabelAlignment: usize,
-    put_VerticalFirstOfMonthLabelAlignment: usize,
-    get_CalendarItemBorderThickness: usize,
-    put_CalendarItemBorderThickness: usize,
-    get_CalendarViewDayItemStyle: usize,
-    put_CalendarViewDayItemStyle: usize,
-    get_CalendarItemCornerRadius: usize,
-    put_CalendarItemCornerRadius: usize,
-    add_CalendarViewDayItemChanging: usize,
-    remove_CalendarViewDayItemChanging: usize,
-    pub add_SelectedDatesChanged: unsafe extern "system" fn(
+    MaxDate: usize,
+    SetMaxDate: usize,
+    MinDate: usize,
+    SetMinDate: usize,
+    NumberOfWeeksInView: usize,
+    SetNumberOfWeeksInView: usize,
+    SelectedDates: usize,
+    SelectionMode: usize,
+    SetSelectionMode: usize,
+    TemplateSettings: usize,
+    FocusBorderBrush: usize,
+    SetFocusBorderBrush: usize,
+    SelectedHoverBorderBrush: usize,
+    SetSelectedHoverBorderBrush: usize,
+    SelectedPressedBorderBrush: usize,
+    SetSelectedPressedBorderBrush: usize,
+    SelectedDisabledBorderBrush: usize,
+    SetSelectedDisabledBorderBrush: usize,
+    SelectedBorderBrush: usize,
+    SetSelectedBorderBrush: usize,
+    HoverBorderBrush: usize,
+    SetHoverBorderBrush: usize,
+    PressedBorderBrush: usize,
+    SetPressedBorderBrush: usize,
+    TodaySelectedInnerBorderBrush: usize,
+    SetTodaySelectedInnerBorderBrush: usize,
+    BlackoutStrikethroughBrush: usize,
+    SetBlackoutStrikethroughBrush: usize,
+    CalendarItemBorderBrush: usize,
+    SetCalendarItemBorderBrush: usize,
+    BlackoutBackground: usize,
+    SetBlackoutBackground: usize,
+    OutOfScopeBackground: usize,
+    SetOutOfScopeBackground: usize,
+    CalendarItemBackground: usize,
+    SetCalendarItemBackground: usize,
+    CalendarItemHoverBackground: usize,
+    SetCalendarItemHoverBackground: usize,
+    CalendarItemPressedBackground: usize,
+    SetCalendarItemPressedBackground: usize,
+    CalendarItemDisabledBackground: usize,
+    SetCalendarItemDisabledBackground: usize,
+    TodayBackground: usize,
+    SetTodayBackground: usize,
+    TodayBlackoutBackground: usize,
+    SetTodayBlackoutBackground: usize,
+    TodayHoverBackground: usize,
+    SetTodayHoverBackground: usize,
+    TodayPressedBackground: usize,
+    SetTodayPressedBackground: usize,
+    TodayDisabledBackground: usize,
+    SetTodayDisabledBackground: usize,
+    PressedForeground: usize,
+    SetPressedForeground: usize,
+    TodayForeground: usize,
+    SetTodayForeground: usize,
+    BlackoutForeground: usize,
+    SetBlackoutForeground: usize,
+    TodayBlackoutForeground: usize,
+    SetTodayBlackoutForeground: usize,
+    SelectedForeground: usize,
+    SetSelectedForeground: usize,
+    SelectedHoverForeground: usize,
+    SetSelectedHoverForeground: usize,
+    SelectedPressedForeground: usize,
+    SetSelectedPressedForeground: usize,
+    SelectedDisabledForeground: usize,
+    SetSelectedDisabledForeground: usize,
+    OutOfScopeForeground: usize,
+    SetOutOfScopeForeground: usize,
+    OutOfScopeHoverForeground: usize,
+    SetOutOfScopeHoverForeground: usize,
+    OutOfScopePressedForeground: usize,
+    SetOutOfScopePressedForeground: usize,
+    CalendarItemForeground: usize,
+    SetCalendarItemForeground: usize,
+    DisabledForeground: usize,
+    SetDisabledForeground: usize,
+    DayItemFontFamily: usize,
+    SetDayItemFontFamily: usize,
+    DayItemFontSize: usize,
+    SetDayItemFontSize: usize,
+    DayItemFontStyle: usize,
+    SetDayItemFontStyle: usize,
+    DayItemFontWeight: usize,
+    SetDayItemFontWeight: usize,
+    TodayFontWeight: usize,
+    SetTodayFontWeight: usize,
+    FirstOfMonthLabelFontFamily: usize,
+    SetFirstOfMonthLabelFontFamily: usize,
+    FirstOfMonthLabelFontSize: usize,
+    SetFirstOfMonthLabelFontSize: usize,
+    FirstOfMonthLabelFontStyle: usize,
+    SetFirstOfMonthLabelFontStyle: usize,
+    FirstOfMonthLabelFontWeight: usize,
+    SetFirstOfMonthLabelFontWeight: usize,
+    MonthYearItemFontFamily: usize,
+    SetMonthYearItemFontFamily: usize,
+    MonthYearItemFontSize: usize,
+    SetMonthYearItemFontSize: usize,
+    MonthYearItemFontStyle: usize,
+    SetMonthYearItemFontStyle: usize,
+    MonthYearItemFontWeight: usize,
+    SetMonthYearItemFontWeight: usize,
+    FirstOfYearDecadeLabelFontFamily: usize,
+    SetFirstOfYearDecadeLabelFontFamily: usize,
+    FirstOfYearDecadeLabelFontSize: usize,
+    SetFirstOfYearDecadeLabelFontSize: usize,
+    FirstOfYearDecadeLabelFontStyle: usize,
+    SetFirstOfYearDecadeLabelFontStyle: usize,
+    FirstOfYearDecadeLabelFontWeight: usize,
+    SetFirstOfYearDecadeLabelFontWeight: usize,
+    DayItemMargin: usize,
+    SetDayItemMargin: usize,
+    MonthYearItemMargin: usize,
+    SetMonthYearItemMargin: usize,
+    FirstOfMonthLabelMargin: usize,
+    SetFirstOfMonthLabelMargin: usize,
+    FirstOfYearDecadeLabelMargin: usize,
+    SetFirstOfYearDecadeLabelMargin: usize,
+    HorizontalDayItemAlignment: usize,
+    SetHorizontalDayItemAlignment: usize,
+    VerticalDayItemAlignment: usize,
+    SetVerticalDayItemAlignment: usize,
+    HorizontalFirstOfMonthLabelAlignment: usize,
+    SetHorizontalFirstOfMonthLabelAlignment: usize,
+    VerticalFirstOfMonthLabelAlignment: usize,
+    SetVerticalFirstOfMonthLabelAlignment: usize,
+    CalendarItemBorderThickness: usize,
+    SetCalendarItemBorderThickness: usize,
+    CalendarViewDayItemStyle: usize,
+    SetCalendarViewDayItemStyle: usize,
+    CalendarItemCornerRadius: usize,
+    SetCalendarItemCornerRadius: usize,
+    CalendarViewDayItemChanging: usize,
+    RemoveCalendarViewDayItemChanging: usize,
+    pub SelectedDatesChanged: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         *mut i64,
     ) -> windows_core::HRESULT,
-    pub remove_SelectedDatesChanged:
+    pub RemoveSelectedDatesChanged:
         unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
@@ -7839,7 +7838,7 @@ impl windows_core::RuntimeType for ICanvasStatics {
 #[repr(C)]
 pub struct ICanvasStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_LeftProperty: usize,
+    LeftProperty: usize,
     pub GetLeft: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
@@ -7850,7 +7849,7 @@ pub struct ICanvasStatics_Vtbl {
         *mut core::ffi::c_void,
         f64,
     ) -> windows_core::HRESULT,
-    get_TopProperty: usize,
+    TopProperty: usize,
     pub GetTop: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
@@ -7861,7 +7860,7 @@ pub struct ICanvasStatics_Vtbl {
         *mut core::ffi::c_void,
         f64,
     ) -> windows_core::HRESULT,
-    get_ZIndexProperty: usize,
+    ZIndexProperty: usize,
     GetZIndex: usize,
     pub SetZIndex: unsafe extern "system" fn(
         *mut core::ffi::c_void,
@@ -7911,10 +7910,10 @@ impl windows_core::RuntimeType for IColorChangedEventArgs {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IColorChangedEventArgs {
-    pub(crate) fn get_NewColor(&self) -> windows_core::Result<Color> {
+    pub(crate) fn NewColor(&self) -> windows_core::Result<Color> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_NewColor)(
+            (windows_core::Interface::vtable(self).NewColor)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
@@ -7925,8 +7924,8 @@ impl IColorChangedEventArgs {
 #[repr(C)]
 pub struct IColorChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_OldColor: usize,
-    pub get_NewColor:
+    OldColor: usize,
+    pub NewColor:
         unsafe extern "system" fn(*mut core::ffi::c_void, *mut Color) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
@@ -7939,48 +7938,48 @@ impl windows_core::RuntimeType for IColorPicker {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IColorPicker {
-    pub(crate) fn put_Color(&self, value: Color) -> windows_core::Result<()> {
+    pub(crate) fn SetColor(&self, value: Color) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Color)(
+            (windows_core::Interface::vtable(self).SetColor)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_IsAlphaEnabled(&self, value: bool) -> windows_core::Result<()> {
+    pub(crate) fn SetIsAlphaEnabled(&self, value: bool) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_IsAlphaEnabled)(
+            (windows_core::Interface::vtable(self).SetIsAlphaEnabled)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_IsColorSliderVisible(&self, value: bool) -> windows_core::Result<()> {
+    pub(crate) fn SetIsColorSliderVisible(&self, value: bool) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_IsColorSliderVisible)(
+            (windows_core::Interface::vtable(self).SetIsColorSliderVisible)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_IsColorChannelTextInputVisible(
+    pub(crate) fn SetIsColorChannelTextInputVisible(
         &self,
         value: bool,
     ) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_IsColorChannelTextInputVisible)(
+            (windows_core::Interface::vtable(self).SetIsColorChannelTextInputVisible)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_IsHexInputVisible(&self, value: bool) -> windows_core::Result<()> {
+    pub(crate) fn SetIsHexInputVisible(&self, value: bool) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_IsHexInputVisible)(
+            (windows_core::Interface::vtable(self).SetIsHexInputVisible)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
@@ -8006,7 +8005,7 @@ impl IColorPicker {
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
-            let token__ = (windows_core::Interface::vtable(self).add_ColorChanged)(
+            let token__ = (windows_core::Interface::vtable(self).ColorChanged)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Interface::as_raw(&handler),
                 &mut result__,
@@ -8015,7 +8014,7 @@ impl IColorPicker {
             Ok(windows_core::EventRevoker::new(
                 self.clone(),
                 token__,
-                windows_core::Interface::vtable(self).remove_ColorChanged,
+                windows_core::Interface::vtable(self).RemoveColorChanged,
             ))
         }
     }
@@ -8023,55 +8022,54 @@ impl IColorPicker {
 #[repr(C)]
 pub struct IColorPicker_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_Color: usize,
-    pub put_Color:
-        unsafe extern "system" fn(*mut core::ffi::c_void, Color) -> windows_core::HRESULT,
-    get_PreviousColor: usize,
-    put_PreviousColor: usize,
-    get_IsAlphaEnabled: usize,
-    pub put_IsAlphaEnabled:
+    Color: usize,
+    pub SetColor: unsafe extern "system" fn(*mut core::ffi::c_void, Color) -> windows_core::HRESULT,
+    PreviousColor: usize,
+    SetPreviousColor: usize,
+    IsAlphaEnabled: usize,
+    pub SetIsAlphaEnabled:
         unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
-    get_IsColorSpectrumVisible: usize,
-    put_IsColorSpectrumVisible: usize,
-    get_IsColorPreviewVisible: usize,
-    put_IsColorPreviewVisible: usize,
-    get_IsColorSliderVisible: usize,
-    pub put_IsColorSliderVisible:
+    IsColorSpectrumVisible: usize,
+    SetIsColorSpectrumVisible: usize,
+    IsColorPreviewVisible: usize,
+    SetIsColorPreviewVisible: usize,
+    IsColorSliderVisible: usize,
+    pub SetIsColorSliderVisible:
         unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
-    get_IsAlphaSliderVisible: usize,
-    put_IsAlphaSliderVisible: usize,
-    get_IsMoreButtonVisible: usize,
-    put_IsMoreButtonVisible: usize,
-    get_IsColorChannelTextInputVisible: usize,
-    pub put_IsColorChannelTextInputVisible:
+    IsAlphaSliderVisible: usize,
+    SetIsAlphaSliderVisible: usize,
+    IsMoreButtonVisible: usize,
+    SetIsMoreButtonVisible: usize,
+    IsColorChannelTextInputVisible: usize,
+    pub SetIsColorChannelTextInputVisible:
         unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
-    get_IsAlphaTextInputVisible: usize,
-    put_IsAlphaTextInputVisible: usize,
-    get_IsHexInputVisible: usize,
-    pub put_IsHexInputVisible:
+    IsAlphaTextInputVisible: usize,
+    SetIsAlphaTextInputVisible: usize,
+    IsHexInputVisible: usize,
+    pub SetIsHexInputVisible:
         unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
-    get_MinHue: usize,
-    put_MinHue: usize,
-    get_MaxHue: usize,
-    put_MaxHue: usize,
-    get_MinSaturation: usize,
-    put_MinSaturation: usize,
-    get_MaxSaturation: usize,
-    put_MaxSaturation: usize,
-    get_MinValue: usize,
-    put_MinValue: usize,
-    get_MaxValue: usize,
-    put_MaxValue: usize,
-    get_ColorSpectrumShape: usize,
-    put_ColorSpectrumShape: usize,
-    get_ColorSpectrumComponents: usize,
-    put_ColorSpectrumComponents: usize,
-    pub add_ColorChanged: unsafe extern "system" fn(
+    MinHue: usize,
+    SetMinHue: usize,
+    MaxHue: usize,
+    SetMaxHue: usize,
+    MinSaturation: usize,
+    SetMinSaturation: usize,
+    MaxSaturation: usize,
+    SetMaxSaturation: usize,
+    MinValue: usize,
+    SetMinValue: usize,
+    MaxValue: usize,
+    SetMaxValue: usize,
+    ColorSpectrumShape: usize,
+    SetColorSpectrumShape: usize,
+    ColorSpectrumComponents: usize,
+    SetColorSpectrumComponents: usize,
+    pub ColorChanged: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         *mut i64,
     ) -> windows_core::HRESULT,
-    pub remove_ColorChanged:
+    pub RemoveColorChanged:
         unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
@@ -8103,9 +8101,9 @@ impl windows_core::RuntimeType for IColumnDefinition {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IColumnDefinition {
-    pub(crate) fn put_Width(&self, value: GridLength) -> windows_core::Result<()> {
+    pub(crate) fn SetWidth(&self, value: GridLength) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Width)(
+            (windows_core::Interface::vtable(self).SetWidth)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
@@ -8116,8 +8114,8 @@ impl IColumnDefinition {
 #[repr(C)]
 pub struct IColumnDefinition_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_Width: usize,
-    pub put_Width:
+    Width: usize,
+    pub SetWidth:
         unsafe extern "system" fn(*mut core::ffi::c_void, GridLength) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
@@ -8130,30 +8128,30 @@ impl windows_core::RuntimeType for IComboBox {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IComboBox {
-    pub(crate) fn put_IsEditable(&self, value: bool) -> windows_core::Result<()> {
+    pub(crate) fn SetIsEditable(&self, value: bool) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_IsEditable)(
+            (windows_core::Interface::vtable(self).SetIsEditable)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_Header<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetHeader<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<windows_core::IInspectable>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Header)(
+            (windows_core::Interface::vtable(self).SetHeader)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
             .ok()
         }
     }
-    pub(crate) fn put_PlaceholderText(&self, value: &str) -> windows_core::Result<()> {
+    pub(crate) fn SetPlaceholderText(&self, value: &str) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_PlaceholderText)(
+            (windows_core::Interface::vtable(self).SetPlaceholderText)(
                 windows_core::Interface::as_raw(self),
                 core::mem::transmute_copy(&windows_core::HSTRING::from(value)),
             )
@@ -8164,26 +8162,26 @@ impl IComboBox {
 #[repr(C)]
 pub struct IComboBox_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_IsDropDownOpen: usize,
-    put_IsDropDownOpen: usize,
-    get_IsEditable: usize,
-    pub put_IsEditable:
+    IsDropDownOpen: usize,
+    SetIsDropDownOpen: usize,
+    IsEditable: usize,
+    pub SetIsEditable:
         unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
-    get_IsSelectionBoxHighlighted: usize,
-    get_MaxDropDownHeight: usize,
-    put_MaxDropDownHeight: usize,
-    get_SelectionBoxItem: usize,
-    get_SelectionBoxItemTemplate: usize,
-    get_TemplateSettings: usize,
-    get_Header: usize,
-    pub put_Header: unsafe extern "system" fn(
+    IsSelectionBoxHighlighted: usize,
+    MaxDropDownHeight: usize,
+    SetMaxDropDownHeight: usize,
+    SelectionBoxItem: usize,
+    SelectionBoxItemTemplate: usize,
+    TemplateSettings: usize,
+    Header: usize,
+    pub SetHeader: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_HeaderTemplate: usize,
-    put_HeaderTemplate: usize,
-    get_PlaceholderText: usize,
-    pub put_PlaceholderText: unsafe extern "system" fn(
+    HeaderTemplate: usize,
+    SetHeaderTemplate: usize,
+    PlaceholderText: usize,
+    pub SetPlaceholderText: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
@@ -8217,36 +8215,36 @@ impl windows_core::RuntimeType for ICommandBar {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl ICommandBar {
-    pub(crate) fn get_PrimaryCommands(
+    pub(crate) fn PrimaryCommands(
         &self,
     ) -> windows_core::Result<windows_collections::IObservableVector<ICommandBarElement>> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_PrimaryCommands)(
+            (windows_core::Interface::vtable(self).PrimaryCommands)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
             .and_then(|| windows_core::Type::from_abi(result__))
         }
     }
-    pub(crate) fn get_SecondaryCommands(
+    pub(crate) fn SecondaryCommands(
         &self,
     ) -> windows_core::Result<windows_collections::IObservableVector<ICommandBarElement>> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_SecondaryCommands)(
+            (windows_core::Interface::vtable(self).SecondaryCommands)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
             .and_then(|| windows_core::Type::from_abi(result__))
         }
     }
-    pub(crate) fn put_DefaultLabelPosition(
+    pub(crate) fn SetDefaultLabelPosition(
         &self,
         value: CommandBarDefaultLabelPosition,
     ) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_DefaultLabelPosition)(
+            (windows_core::Interface::vtable(self).SetDefaultLabelPosition)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
@@ -8257,19 +8255,19 @@ impl ICommandBar {
 #[repr(C)]
 pub struct ICommandBar_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    pub get_PrimaryCommands: unsafe extern "system" fn(
+    pub PrimaryCommands: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    pub get_SecondaryCommands: unsafe extern "system" fn(
+    pub SecondaryCommands: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_CommandBarOverflowPresenterStyle: usize,
-    put_CommandBarOverflowPresenterStyle: usize,
-    get_CommandBarTemplateSettings: usize,
-    get_DefaultLabelPosition: usize,
-    pub put_DefaultLabelPosition: unsafe extern "system" fn(
+    CommandBarOverflowPresenterStyle: usize,
+    SetCommandBarOverflowPresenterStyle: usize,
+    CommandBarTemplateSettings: usize,
+    DefaultLabelPosition: usize,
+    pub SetDefaultLabelPosition: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         CommandBarDefaultLabelPosition,
     ) -> windows_core::HRESULT,
@@ -8324,24 +8322,24 @@ impl windows_core::RuntimeType for ICommandBarFlyout {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl ICommandBarFlyout {
-    pub(crate) fn get_PrimaryCommands(
+    pub(crate) fn PrimaryCommands(
         &self,
     ) -> windows_core::Result<windows_collections::IObservableVector<ICommandBarElement>> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_PrimaryCommands)(
+            (windows_core::Interface::vtable(self).PrimaryCommands)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
             .and_then(|| windows_core::Type::from_abi(result__))
         }
     }
-    pub(crate) fn get_SecondaryCommands(
+    pub(crate) fn SecondaryCommands(
         &self,
     ) -> windows_core::Result<windows_collections::IObservableVector<ICommandBarElement>> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_SecondaryCommands)(
+            (windows_core::Interface::vtable(self).SecondaryCommands)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
@@ -8352,11 +8350,11 @@ impl ICommandBarFlyout {
 #[repr(C)]
 pub struct ICommandBarFlyout_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    pub get_PrimaryCommands: unsafe extern "system" fn(
+    pub PrimaryCommands: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    pub get_SecondaryCommands: unsafe extern "system" fn(
+    pub SecondaryCommands: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
@@ -8403,9 +8401,9 @@ impl windows_core::RuntimeType for ICompositionAnimation2 {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl ICompositionAnimation2 {
-    pub(crate) fn put_Target(&self, value: &str) -> windows_core::Result<()> {
+    pub(crate) fn SetTarget(&self, value: &str) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Target)(
+            (windows_core::Interface::vtable(self).SetTarget)(
                 windows_core::Interface::as_raw(self),
                 core::mem::transmute_copy(&windows_core::HSTRING::from(value)),
             )
@@ -8417,8 +8415,8 @@ impl ICompositionAnimation2 {
 pub struct ICompositionAnimation2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     SetBooleanParameter: usize,
-    get_Target: usize,
-    pub put_Target: unsafe extern "system" fn(
+    Target: usize,
+    pub SetTarget: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
@@ -8482,10 +8480,10 @@ impl windows_core::RuntimeType for ICompositionObject {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl ICompositionObject {
-    pub(crate) fn get_Compositor(&self) -> windows_core::Result<Compositor> {
+    pub(crate) fn Compositor(&self) -> windows_core::Result<Compositor> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_Compositor)(
+            (windows_core::Interface::vtable(self).Compositor)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
@@ -8513,11 +8511,11 @@ impl ICompositionObject {
 #[repr(C)]
 pub struct ICompositionObject_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    pub get_Compositor: unsafe extern "system" fn(
+    pub Compositor: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_Properties: usize,
+    Properties: usize,
     pub StartAnimation: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
@@ -8534,12 +8532,12 @@ impl windows_core::RuntimeType for ICompositionObject2 {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl ICompositionObject2 {
-    pub(crate) fn put_ImplicitAnimations<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetImplicitAnimations<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<ImplicitAnimationCollection>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_ImplicitAnimations)(
+            (windows_core::Interface::vtable(self).SetImplicitAnimations)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
@@ -8550,10 +8548,10 @@ impl ICompositionObject2 {
 #[repr(C)]
 pub struct ICompositionObject2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_Comment: usize,
-    put_Comment: usize,
-    get_ImplicitAnimations: usize,
-    pub put_ImplicitAnimations: unsafe extern "system" fn(
+    Comment: usize,
+    SetComment: usize,
+    ImplicitAnimations: usize,
+    pub SetImplicitAnimations: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
@@ -8583,12 +8581,12 @@ impl windows_core::RuntimeType for ICompositionTargetStatics {
 #[repr(C)]
 pub struct ICompositionTargetStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    pub add_Rendering: unsafe extern "system" fn(
+    pub Rendering: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         *mut i64,
     ) -> windows_core::HRESULT,
-    pub remove_Rendering:
+    pub RemoveRendering:
         unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
@@ -8737,22 +8735,22 @@ impl windows_core::RuntimeType for IContentControl {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IContentControl {
-    pub(crate) fn get_Content(&self) -> windows_core::Result<windows_core::IInspectable> {
+    pub(crate) fn Content(&self) -> windows_core::Result<windows_core::IInspectable> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_Content)(
+            (windows_core::Interface::vtable(self).Content)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
             .and_then(|| windows_core::Type::from_abi(result__))
         }
     }
-    pub(crate) fn put_Content<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetContent<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<windows_core::IInspectable>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Content)(
+            (windows_core::Interface::vtable(self).SetContent)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
@@ -8763,11 +8761,11 @@ impl IContentControl {
 #[repr(C)]
 pub struct IContentControl_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    pub get_Content: unsafe extern "system" fn(
+    pub Content: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    pub put_Content: unsafe extern "system" fn(
+    pub SetContent: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
@@ -8782,57 +8780,57 @@ impl windows_core::RuntimeType for IContentDialog {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IContentDialog {
-    pub(crate) fn put_Title<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetTitle<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<windows_core::IInspectable>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Title)(
+            (windows_core::Interface::vtable(self).SetTitle)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
             .ok()
         }
     }
-    pub(crate) fn put_PrimaryButtonText(&self, value: &str) -> windows_core::Result<()> {
+    pub(crate) fn SetPrimaryButtonText(&self, value: &str) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_PrimaryButtonText)(
+            (windows_core::Interface::vtable(self).SetPrimaryButtonText)(
                 windows_core::Interface::as_raw(self),
                 core::mem::transmute_copy(&windows_core::HSTRING::from(value)),
             )
             .ok()
         }
     }
-    pub(crate) fn put_SecondaryButtonText(&self, value: &str) -> windows_core::Result<()> {
+    pub(crate) fn SetSecondaryButtonText(&self, value: &str) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_SecondaryButtonText)(
+            (windows_core::Interface::vtable(self).SetSecondaryButtonText)(
                 windows_core::Interface::as_raw(self),
                 core::mem::transmute_copy(&windows_core::HSTRING::from(value)),
             )
             .ok()
         }
     }
-    pub(crate) fn put_CloseButtonText(&self, value: &str) -> windows_core::Result<()> {
+    pub(crate) fn SetCloseButtonText(&self, value: &str) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_CloseButtonText)(
+            (windows_core::Interface::vtable(self).SetCloseButtonText)(
                 windows_core::Interface::as_raw(self),
                 core::mem::transmute_copy(&windows_core::HSTRING::from(value)),
             )
             .ok()
         }
     }
-    pub(crate) fn put_IsPrimaryButtonEnabled(&self, value: bool) -> windows_core::Result<()> {
+    pub(crate) fn SetIsPrimaryButtonEnabled(&self, value: bool) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_IsPrimaryButtonEnabled)(
+            (windows_core::Interface::vtable(self).SetIsPrimaryButtonEnabled)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_IsSecondaryButtonEnabled(&self, value: bool) -> windows_core::Result<()> {
+    pub(crate) fn SetIsSecondaryButtonEnabled(&self, value: bool) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_IsSecondaryButtonEnabled)(
+            (windows_core::Interface::vtable(self).SetIsSecondaryButtonEnabled)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
@@ -8856,7 +8854,7 @@ impl IContentDialog {
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
-            let token__ = (windows_core::Interface::vtable(self).add_Closed)(
+            let token__ = (windows_core::Interface::vtable(self).Closed)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Interface::as_raw(&handler),
                 &mut result__,
@@ -8865,7 +8863,7 @@ impl IContentDialog {
             Ok(windows_core::EventRevoker::new(
                 self.clone(),
                 token__,
-                windows_core::Interface::vtable(self).remove_Closed,
+                windows_core::Interface::vtable(self).RemoveClosed,
             ))
         }
     }
@@ -8890,73 +8888,73 @@ impl IContentDialog {
 #[repr(C)]
 pub struct IContentDialog_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_Title: usize,
-    pub put_Title: unsafe extern "system" fn(
+    Title: usize,
+    pub SetTitle: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_TitleTemplate: usize,
-    put_TitleTemplate: usize,
-    get_FullSizeDesired: usize,
-    put_FullSizeDesired: usize,
-    get_PrimaryButtonText: usize,
-    pub put_PrimaryButtonText: unsafe extern "system" fn(
+    TitleTemplate: usize,
+    SetTitleTemplate: usize,
+    FullSizeDesired: usize,
+    SetFullSizeDesired: usize,
+    PrimaryButtonText: usize,
+    pub SetPrimaryButtonText: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_SecondaryButtonText: usize,
-    pub put_SecondaryButtonText: unsafe extern "system" fn(
+    SecondaryButtonText: usize,
+    pub SetSecondaryButtonText: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_CloseButtonText: usize,
-    pub put_CloseButtonText: unsafe extern "system" fn(
+    CloseButtonText: usize,
+    pub SetCloseButtonText: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_PrimaryButtonCommand: usize,
-    put_PrimaryButtonCommand: usize,
-    get_SecondaryButtonCommand: usize,
-    put_SecondaryButtonCommand: usize,
-    get_CloseButtonCommand: usize,
-    put_CloseButtonCommand: usize,
-    get_PrimaryButtonCommandParameter: usize,
-    put_PrimaryButtonCommandParameter: usize,
-    get_SecondaryButtonCommandParameter: usize,
-    put_SecondaryButtonCommandParameter: usize,
-    get_CloseButtonCommandParameter: usize,
-    put_CloseButtonCommandParameter: usize,
-    get_IsPrimaryButtonEnabled: usize,
-    pub put_IsPrimaryButtonEnabled:
+    PrimaryButtonCommand: usize,
+    SetPrimaryButtonCommand: usize,
+    SecondaryButtonCommand: usize,
+    SetSecondaryButtonCommand: usize,
+    CloseButtonCommand: usize,
+    SetCloseButtonCommand: usize,
+    PrimaryButtonCommandParameter: usize,
+    SetPrimaryButtonCommandParameter: usize,
+    SecondaryButtonCommandParameter: usize,
+    SetSecondaryButtonCommandParameter: usize,
+    CloseButtonCommandParameter: usize,
+    SetCloseButtonCommandParameter: usize,
+    IsPrimaryButtonEnabled: usize,
+    pub SetIsPrimaryButtonEnabled:
         unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
-    get_IsSecondaryButtonEnabled: usize,
-    pub put_IsSecondaryButtonEnabled:
+    IsSecondaryButtonEnabled: usize,
+    pub SetIsSecondaryButtonEnabled:
         unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
-    get_PrimaryButtonStyle: usize,
-    put_PrimaryButtonStyle: usize,
-    get_SecondaryButtonStyle: usize,
-    put_SecondaryButtonStyle: usize,
-    get_CloseButtonStyle: usize,
-    put_CloseButtonStyle: usize,
-    get_DefaultButton: usize,
-    put_DefaultButton: usize,
-    add_Closing: usize,
-    remove_Closing: usize,
-    pub add_Closed: unsafe extern "system" fn(
+    PrimaryButtonStyle: usize,
+    SetPrimaryButtonStyle: usize,
+    SecondaryButtonStyle: usize,
+    SetSecondaryButtonStyle: usize,
+    CloseButtonStyle: usize,
+    SetCloseButtonStyle: usize,
+    DefaultButton: usize,
+    SetDefaultButton: usize,
+    Closing: usize,
+    RemoveClosing: usize,
+    pub Closed: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         *mut i64,
     ) -> windows_core::HRESULT,
-    pub remove_Closed:
+    pub RemoveClosed:
         unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
-    add_Opened: usize,
-    remove_Opened: usize,
-    add_PrimaryButtonClick: usize,
-    remove_PrimaryButtonClick: usize,
-    add_SecondaryButtonClick: usize,
-    remove_SecondaryButtonClick: usize,
-    add_CloseButtonClick: usize,
-    remove_CloseButtonClick: usize,
+    Opened: usize,
+    RemoveOpened: usize,
+    PrimaryButtonClick: usize,
+    RemovePrimaryButtonClick: usize,
+    SecondaryButtonClick: usize,
+    RemoveSecondaryButtonClick: usize,
+    CloseButtonClick: usize,
+    RemoveCloseButtonClick: usize,
     pub Hide: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
     pub ShowAsync: unsafe extern "system" fn(
         *mut core::ffi::c_void,
@@ -8973,10 +8971,10 @@ impl windows_core::RuntimeType for IContentDialogClosedEventArgs {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IContentDialogClosedEventArgs {
-    pub(crate) fn get_Result(&self) -> windows_core::Result<ContentDialogResult> {
+    pub(crate) fn Result(&self) -> windows_core::Result<ContentDialogResult> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_Result)(
+            (windows_core::Interface::vtable(self).Result)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
@@ -8987,7 +8985,7 @@ impl IContentDialogClosedEventArgs {
 #[repr(C)]
 pub struct IContentDialogClosedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    pub get_Result: unsafe extern "system" fn(
+    pub Result: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut ContentDialogResult,
     ) -> windows_core::HRESULT,
@@ -9021,82 +9019,82 @@ impl windows_core::RuntimeType for IControl {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IControl {
-    pub(crate) fn put_FontSize(&self, value: f64) -> windows_core::Result<()> {
+    pub(crate) fn SetFontSize(&self, value: f64) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_FontSize)(
+            (windows_core::Interface::vtable(self).SetFontSize)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_FontFamily<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetFontFamily<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<FontFamily>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_FontFamily)(
+            (windows_core::Interface::vtable(self).SetFontFamily)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
             .ok()
         }
     }
-    pub(crate) fn put_FontWeight(&self, value: FontWeight) -> windows_core::Result<()> {
+    pub(crate) fn SetFontWeight(&self, value: FontWeight) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_FontWeight)(
+            (windows_core::Interface::vtable(self).SetFontWeight)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_Foreground<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetForeground<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<Brush>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Foreground)(
+            (windows_core::Interface::vtable(self).SetForeground)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
             .ok()
         }
     }
-    pub(crate) fn get_IsEnabled(&self) -> windows_core::Result<bool> {
+    pub(crate) fn IsEnabled(&self) -> windows_core::Result<bool> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_IsEnabled)(
+            (windows_core::Interface::vtable(self).IsEnabled)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
             .map(|| result__)
         }
     }
-    pub(crate) fn put_IsEnabled(&self, value: bool) -> windows_core::Result<()> {
+    pub(crate) fn SetIsEnabled(&self, value: bool) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_IsEnabled)(
+            (windows_core::Interface::vtable(self).SetIsEnabled)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_Padding(&self, value: Thickness) -> windows_core::Result<()> {
+    pub(crate) fn SetPadding(&self, value: Thickness) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Padding)(
+            (windows_core::Interface::vtable(self).SetPadding)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_Background<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetBackground<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<Brush>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Background)(
+            (windows_core::Interface::vtable(self).SetBackground)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
@@ -9107,53 +9105,53 @@ impl IControl {
 #[repr(C)]
 pub struct IControl_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_IsFocusEngagementEnabled: usize,
-    put_IsFocusEngagementEnabled: usize,
-    get_IsFocusEngaged: usize,
-    put_IsFocusEngaged: usize,
-    get_RequiresPointer: usize,
-    put_RequiresPointer: usize,
-    get_FontSize: usize,
-    pub put_FontSize:
+    IsFocusEngagementEnabled: usize,
+    SetIsFocusEngagementEnabled: usize,
+    IsFocusEngaged: usize,
+    SetIsFocusEngaged: usize,
+    RequiresPointer: usize,
+    SetRequiresPointer: usize,
+    FontSize: usize,
+    pub SetFontSize:
         unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
-    get_FontFamily: usize,
-    pub put_FontFamily: unsafe extern "system" fn(
+    FontFamily: usize,
+    pub SetFontFamily: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_FontWeight: usize,
-    pub put_FontWeight:
+    FontWeight: usize,
+    pub SetFontWeight:
         unsafe extern "system" fn(*mut core::ffi::c_void, FontWeight) -> windows_core::HRESULT,
-    get_FontStyle: usize,
-    put_FontStyle: usize,
-    get_FontStretch: usize,
-    put_FontStretch: usize,
-    get_CharacterSpacing: usize,
-    put_CharacterSpacing: usize,
-    get_Foreground: usize,
-    pub put_Foreground: unsafe extern "system" fn(
+    FontStyle: usize,
+    SetFontStyle: usize,
+    FontStretch: usize,
+    SetFontStretch: usize,
+    CharacterSpacing: usize,
+    SetCharacterSpacing: usize,
+    Foreground: usize,
+    pub SetForeground: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_IsTextScaleFactorEnabled: usize,
-    put_IsTextScaleFactorEnabled: usize,
-    pub get_IsEnabled:
+    IsTextScaleFactorEnabled: usize,
+    SetIsTextScaleFactorEnabled: usize,
+    pub IsEnabled:
         unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
-    pub put_IsEnabled:
+    pub SetIsEnabled:
         unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
-    get_TabNavigation: usize,
-    put_TabNavigation: usize,
-    get_Template: usize,
-    put_Template: usize,
-    get_Padding: usize,
-    pub put_Padding:
+    TabNavigation: usize,
+    SetTabNavigation: usize,
+    Template: usize,
+    SetTemplate: usize,
+    Padding: usize,
+    pub SetPadding:
         unsafe extern "system" fn(*mut core::ffi::c_void, Thickness) -> windows_core::HRESULT,
-    get_HorizontalContentAlignment: usize,
-    put_HorizontalContentAlignment: usize,
-    get_VerticalContentAlignment: usize,
-    put_VerticalContentAlignment: usize,
-    get_Background: usize,
-    pub put_Background: unsafe extern "system" fn(
+    HorizontalContentAlignment: usize,
+    SetHorizontalContentAlignment: usize,
+    VerticalContentAlignment: usize,
+    SetVerticalContentAlignment: usize,
+    Background: usize,
+    pub SetBackground: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
@@ -9194,12 +9192,12 @@ impl windows_core::RuntimeType for IDataPackageView {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IDataPackageView {
-    pub(crate) fn get_AvailableFormats(
+    pub(crate) fn AvailableFormats(
         &self,
     ) -> windows_core::Result<windows_collections::IVectorView<windows_core::HSTRING>> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_AvailableFormats)(
+            (windows_core::Interface::vtable(self).AvailableFormats)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
@@ -9236,10 +9234,10 @@ impl IDataPackageView {
 #[repr(C)]
 pub struct IDataPackageView_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_Properties: usize,
-    get_RequestedOperation: usize,
+    Properties: usize,
+    RequestedOperation: usize,
     ReportOperationCompleted: usize,
-    pub get_AvailableFormats: unsafe extern "system" fn(
+    pub AvailableFormats: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
@@ -9270,39 +9268,39 @@ impl windows_core::RuntimeType for IDatePicker {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IDatePicker {
-    pub(crate) fn put_Header<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetHeader<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<windows_core::IInspectable>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Header)(
+            (windows_core::Interface::vtable(self).SetHeader)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
             .ok()
         }
     }
-    pub(crate) fn put_DayVisible(&self, value: bool) -> windows_core::Result<()> {
+    pub(crate) fn SetDayVisible(&self, value: bool) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_DayVisible)(
+            (windows_core::Interface::vtable(self).SetDayVisible)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_MonthVisible(&self, value: bool) -> windows_core::Result<()> {
+    pub(crate) fn SetMonthVisible(&self, value: bool) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_MonthVisible)(
+            (windows_core::Interface::vtable(self).SetMonthVisible)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_YearVisible(&self, value: bool) -> windows_core::Result<()> {
+    pub(crate) fn SetYearVisible(&self, value: bool) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_YearVisible)(
+            (windows_core::Interface::vtable(self).SetYearVisible)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
@@ -9325,7 +9323,7 @@ impl IDatePicker {
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
-            let token__ = (windows_core::Interface::vtable(self).add_SelectedDateChanged)(
+            let token__ = (windows_core::Interface::vtable(self).SelectedDateChanged)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Interface::as_raw(&handler),
                 &mut result__,
@@ -9334,7 +9332,7 @@ impl IDatePicker {
             Ok(windows_core::EventRevoker::new(
                 self.clone(),
                 token__,
-                windows_core::Interface::vtable(self).remove_SelectedDateChanged,
+                windows_core::Interface::vtable(self).RemoveSelectedDateChanged,
             ))
         }
     }
@@ -9342,50 +9340,50 @@ impl IDatePicker {
 #[repr(C)]
 pub struct IDatePicker_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_Header: usize,
-    pub put_Header: unsafe extern "system" fn(
+    Header: usize,
+    pub SetHeader: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_HeaderTemplate: usize,
-    put_HeaderTemplate: usize,
-    get_CalendarIdentifier: usize,
-    put_CalendarIdentifier: usize,
-    get_Date: usize,
-    put_Date: usize,
-    get_DayVisible: usize,
-    pub put_DayVisible:
+    HeaderTemplate: usize,
+    SetHeaderTemplate: usize,
+    CalendarIdentifier: usize,
+    SetCalendarIdentifier: usize,
+    Date: usize,
+    SetDate: usize,
+    DayVisible: usize,
+    pub SetDayVisible:
         unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
-    get_MonthVisible: usize,
-    pub put_MonthVisible:
+    MonthVisible: usize,
+    pub SetMonthVisible:
         unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
-    get_YearVisible: usize,
-    pub put_YearVisible:
+    YearVisible: usize,
+    pub SetYearVisible:
         unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
-    get_DayFormat: usize,
-    put_DayFormat: usize,
-    get_MonthFormat: usize,
-    put_MonthFormat: usize,
-    get_YearFormat: usize,
-    put_YearFormat: usize,
-    get_MinYear: usize,
-    put_MinYear: usize,
-    get_MaxYear: usize,
-    put_MaxYear: usize,
-    get_Orientation: usize,
-    put_Orientation: usize,
-    get_LightDismissOverlayMode: usize,
-    put_LightDismissOverlayMode: usize,
-    get_SelectedDate: usize,
-    put_SelectedDate: usize,
-    add_DateChanged: usize,
-    remove_DateChanged: usize,
-    pub add_SelectedDateChanged: unsafe extern "system" fn(
+    DayFormat: usize,
+    SetDayFormat: usize,
+    MonthFormat: usize,
+    SetMonthFormat: usize,
+    YearFormat: usize,
+    SetYearFormat: usize,
+    MinYear: usize,
+    SetMinYear: usize,
+    MaxYear: usize,
+    SetMaxYear: usize,
+    Orientation: usize,
+    SetOrientation: usize,
+    LightDismissOverlayMode: usize,
+    SetLightDismissOverlayMode: usize,
+    SelectedDate: usize,
+    SetSelectedDate: usize,
+    DateChanged: usize,
+    RemoveDateChanged: usize,
+    pub SelectedDateChanged: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         *mut i64,
     ) -> windows_core::HRESULT,
-    pub remove_SelectedDateChanged:
+    pub RemoveSelectedDateChanged:
         unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
@@ -9417,10 +9415,10 @@ impl windows_core::RuntimeType for IDatePickerSelectedValueChangedEventArgs {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IDatePickerSelectedValueChangedEventArgs {
-    pub(crate) fn get_NewDate(&self) -> windows_core::Result<windows_time::DateTime> {
+    pub(crate) fn NewDate(&self) -> windows_core::Result<windows_time::DateTime> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_NewDate)(
+            (windows_core::Interface::vtable(self).NewDate)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
@@ -9432,8 +9430,8 @@ impl IDatePickerSelectedValueChangedEventArgs {
 #[repr(C)]
 pub struct IDatePickerSelectedValueChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_OldDate: usize,
-    pub get_NewDate: unsafe extern "system" fn(
+    OldDate: usize,
+    pub NewDate: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
@@ -9559,20 +9557,20 @@ impl IDependencyObject {
             .ok()
         }
     }
-    pub(crate) fn get_Dispatcher(&self) -> windows_core::Result<CoreDispatcher> {
+    pub(crate) fn Dispatcher(&self) -> windows_core::Result<CoreDispatcher> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_Dispatcher)(
+            (windows_core::Interface::vtable(self).Dispatcher)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
             .and_then(|| windows_core::Type::from_abi(result__))
         }
     }
-    pub(crate) fn get_DispatcherQueue(&self) -> windows_core::Result<DispatcherQueue> {
+    pub(crate) fn DispatcherQueue(&self) -> windows_core::Result<DispatcherQueue> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_DispatcherQueue)(
+            (windows_core::Interface::vtable(self).DispatcherQueue)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
@@ -9618,11 +9616,11 @@ pub struct IDependencyObject_Vtbl {
         *mut core::ffi::c_void,
         i64,
     ) -> windows_core::HRESULT,
-    pub get_Dispatcher: unsafe extern "system" fn(
+    pub Dispatcher: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    pub get_DispatcherQueue: unsafe extern "system" fn(
+    pub DispatcherQueue: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
@@ -9772,18 +9770,18 @@ impl windows_core::RuntimeType for IDispatcherQueueTimer {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IDispatcherQueueTimer {
-    pub(crate) fn put_Interval(&self, value: windows_time::TimeSpan) -> windows_core::Result<()> {
+    pub(crate) fn SetInterval(&self, value: windows_time::TimeSpan) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Interval)(
+            (windows_core::Interface::vtable(self).SetInterval)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_IsRepeating(&self, value: bool) -> windows_core::Result<()> {
+    pub(crate) fn SetIsRepeating(&self, value: bool) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_IsRepeating)(
+            (windows_core::Interface::vtable(self).SetIsRepeating)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
@@ -9814,7 +9812,7 @@ impl IDispatcherQueueTimer {
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
-            let token__ = (windows_core::Interface::vtable(self).add_Tick)(
+            let token__ = (windows_core::Interface::vtable(self).Tick)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Interface::as_raw(&handler),
                 &mut result__,
@@ -9823,7 +9821,7 @@ impl IDispatcherQueueTimer {
             Ok(windows_core::EventRevoker::new(
                 self.clone(),
                 token__,
-                windows_core::Interface::vtable(self).remove_Tick,
+                windows_core::Interface::vtable(self).RemoveTick,
             ))
         }
     }
@@ -9831,24 +9829,23 @@ impl IDispatcherQueueTimer {
 #[repr(C)]
 pub struct IDispatcherQueueTimer_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_Interval: usize,
-    pub put_Interval: unsafe extern "system" fn(
+    Interval: usize,
+    pub SetInterval: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         windows_time::TimeSpan,
     ) -> windows_core::HRESULT,
-    get_IsRunning: usize,
-    get_IsRepeating: usize,
-    pub put_IsRepeating:
+    IsRunning: usize,
+    IsRepeating: usize,
+    pub SetIsRepeating:
         unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
     pub Start: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
     pub Stop: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
-    pub add_Tick: unsafe extern "system" fn(
+    pub Tick: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         *mut i64,
     ) -> windows_core::HRESULT,
-    pub remove_Tick:
-        unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
+    pub RemoveTick: unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
     IDragEventArgs,
@@ -9860,32 +9857,32 @@ impl windows_core::RuntimeType for IDragEventArgs {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IDragEventArgs {
-    pub(crate) fn get_DataView(&self) -> windows_core::Result<DataPackageView> {
+    pub(crate) fn DataView(&self) -> windows_core::Result<DataPackageView> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_DataView)(
+            (windows_core::Interface::vtable(self).DataView)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
             .and_then(|| windows_core::Type::from_abi(result__))
         }
     }
-    pub(crate) fn get_DragUIOverride(&self) -> windows_core::Result<DragUIOverride> {
+    pub(crate) fn DragUIOverride(&self) -> windows_core::Result<DragUIOverride> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_DragUIOverride)(
+            (windows_core::Interface::vtable(self).DragUIOverride)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
             .and_then(|| windows_core::Type::from_abi(result__))
         }
     }
-    pub(crate) fn put_AcceptedOperation(
+    pub(crate) fn SetAcceptedOperation(
         &self,
         value: DataPackageOperation,
     ) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_AcceptedOperation)(
+            (windows_core::Interface::vtable(self).SetAcceptedOperation)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
@@ -9906,25 +9903,25 @@ impl IDragEventArgs {
 #[repr(C)]
 pub struct IDragEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_Handled: usize,
-    put_Handled: usize,
-    get_Data: usize,
-    put_Data: usize,
-    pub get_DataView: unsafe extern "system" fn(
+    Handled: usize,
+    SetHandled: usize,
+    Data: usize,
+    SetData: usize,
+    pub DataView: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    pub get_DragUIOverride: unsafe extern "system" fn(
+    pub DragUIOverride: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_Modifiers: usize,
-    get_AcceptedOperation: usize,
-    pub put_AcceptedOperation: unsafe extern "system" fn(
+    Modifiers: usize,
+    AcceptedOperation: usize,
+    pub SetAcceptedOperation: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         DataPackageOperation,
     ) -> windows_core::HRESULT,
-    get_AllowedOperations: usize,
+    AllowedOperations: usize,
     pub GetDeferral: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
@@ -9962,27 +9959,27 @@ impl windows_core::RuntimeType for IDragUIOverride {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IDragUIOverride {
-    pub(crate) fn put_Caption(&self, value: &str) -> windows_core::Result<()> {
+    pub(crate) fn SetCaption(&self, value: &str) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Caption)(
+            (windows_core::Interface::vtable(self).SetCaption)(
                 windows_core::Interface::as_raw(self),
                 core::mem::transmute_copy(&windows_core::HSTRING::from(value)),
             )
             .ok()
         }
     }
-    pub(crate) fn put_IsContentVisible(&self, value: bool) -> windows_core::Result<()> {
+    pub(crate) fn SetIsContentVisible(&self, value: bool) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_IsContentVisible)(
+            (windows_core::Interface::vtable(self).SetIsContentVisible)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_IsGlyphVisible(&self, value: bool) -> windows_core::Result<()> {
+    pub(crate) fn SetIsGlyphVisible(&self, value: bool) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_IsGlyphVisible)(
+            (windows_core::Interface::vtable(self).SetIsGlyphVisible)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
@@ -9993,18 +9990,18 @@ impl IDragUIOverride {
 #[repr(C)]
 pub struct IDragUIOverride_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_Caption: usize,
-    pub put_Caption: unsafe extern "system" fn(
+    Caption: usize,
+    pub SetCaption: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_IsContentVisible: usize,
-    pub put_IsContentVisible:
+    IsContentVisible: usize,
+    pub SetIsContentVisible:
         unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
-    get_IsCaptionVisible: usize,
-    put_IsCaptionVisible: usize,
-    get_IsGlyphVisible: usize,
-    pub put_IsGlyphVisible:
+    IsCaptionVisible: usize,
+    SetIsCaptionVisible: usize,
+    IsGlyphVisible: usize,
+    pub SetIsGlyphVisible:
         unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
@@ -10093,21 +10090,21 @@ impl windows_core::RuntimeType for IExpander {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IExpander {
-    pub(crate) fn put_Header<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetHeader<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<windows_core::IInspectable>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Header)(
+            (windows_core::Interface::vtable(self).SetHeader)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
             .ok()
         }
     }
-    pub(crate) fn put_IsExpanded(&self, value: bool) -> windows_core::Result<()> {
+    pub(crate) fn SetIsExpanded(&self, value: bool) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_IsExpanded)(
+            (windows_core::Interface::vtable(self).SetIsExpanded)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
@@ -10133,7 +10130,7 @@ impl IExpander {
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
-            let token__ = (windows_core::Interface::vtable(self).add_Expanding)(
+            let token__ = (windows_core::Interface::vtable(self).Expanding)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Interface::as_raw(&handler),
                 &mut result__,
@@ -10142,7 +10139,7 @@ impl IExpander {
             Ok(windows_core::EventRevoker::new(
                 self.clone(),
                 token__,
-                windows_core::Interface::vtable(self).remove_Expanding,
+                windows_core::Interface::vtable(self).RemoveExpanding,
             ))
         }
     }
@@ -10165,7 +10162,7 @@ impl IExpander {
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
-            let token__ = (windows_core::Interface::vtable(self).add_Collapsed)(
+            let token__ = (windows_core::Interface::vtable(self).Collapsed)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Interface::as_raw(&handler),
                 &mut result__,
@@ -10174,7 +10171,7 @@ impl IExpander {
             Ok(windows_core::EventRevoker::new(
                 self.clone(),
                 token__,
-                windows_core::Interface::vtable(self).remove_Collapsed,
+                windows_core::Interface::vtable(self).RemoveCollapsed,
             ))
         }
     }
@@ -10182,33 +10179,33 @@ impl IExpander {
 #[repr(C)]
 pub struct IExpander_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_Header: usize,
-    pub put_Header: unsafe extern "system" fn(
+    Header: usize,
+    pub SetHeader: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_HeaderTemplate: usize,
-    put_HeaderTemplate: usize,
-    get_HeaderTemplateSelector: usize,
-    put_HeaderTemplateSelector: usize,
-    get_IsExpanded: usize,
-    pub put_IsExpanded:
+    HeaderTemplate: usize,
+    SetHeaderTemplate: usize,
+    HeaderTemplateSelector: usize,
+    SetHeaderTemplateSelector: usize,
+    IsExpanded: usize,
+    pub SetIsExpanded:
         unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
-    get_ExpandDirection: usize,
-    put_ExpandDirection: usize,
-    pub add_Expanding: unsafe extern "system" fn(
+    ExpandDirection: usize,
+    SetExpandDirection: usize,
+    pub Expanding: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         *mut i64,
     ) -> windows_core::HRESULT,
-    pub remove_Expanding:
+    pub RemoveExpanding:
         unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
-    pub add_Collapsed: unsafe extern "system" fn(
+    pub Collapsed: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         *mut i64,
     ) -> windows_core::HRESULT,
-    pub remove_Collapsed:
+    pub RemoveCollapsed:
         unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
@@ -10298,12 +10295,12 @@ impl windows_core::RuntimeType for IFlyout {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IFlyout {
-    pub(crate) fn put_Content<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetContent<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<UIElement>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Content)(
+            (windows_core::Interface::vtable(self).SetContent)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
@@ -10314,8 +10311,8 @@ impl IFlyout {
 #[repr(C)]
 pub struct IFlyout_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_Content: usize,
-    pub put_Content: unsafe extern "system" fn(
+    Content: usize,
+    pub SetContent: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
@@ -10330,9 +10327,9 @@ impl windows_core::RuntimeType for IFlyoutBase {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IFlyoutBase {
-    pub(crate) fn put_Placement(&self, value: FlyoutPlacementMode) -> windows_core::Result<()> {
+    pub(crate) fn SetPlacement(&self, value: FlyoutPlacementMode) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Placement)(
+            (windows_core::Interface::vtable(self).SetPlacement)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
@@ -10343,8 +10340,8 @@ impl IFlyoutBase {
 #[repr(C)]
 pub struct IFlyoutBase_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_Placement: usize,
-    pub put_Placement: unsafe extern "system" fn(
+    Placement: usize,
+    pub SetPlacement: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         FlyoutPlacementMode,
     ) -> windows_core::HRESULT,
@@ -10411,170 +10408,170 @@ impl windows_core::RuntimeType for IFrameworkElement {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IFrameworkElement {
-    pub(crate) fn get_Resources(&self) -> windows_core::Result<ResourceDictionary> {
+    pub(crate) fn Resources(&self) -> windows_core::Result<ResourceDictionary> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_Resources)(
+            (windows_core::Interface::vtable(self).Resources)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
             .and_then(|| windows_core::Type::from_abi(result__))
         }
     }
-    pub(crate) fn get_Tag(&self) -> windows_core::Result<windows_core::IInspectable> {
+    pub(crate) fn Tag(&self) -> windows_core::Result<windows_core::IInspectable> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_Tag)(
+            (windows_core::Interface::vtable(self).Tag)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
             .and_then(|| windows_core::Type::from_abi(result__))
         }
     }
-    pub(crate) fn put_Tag<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetTag<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<windows_core::IInspectable>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Tag)(
+            (windows_core::Interface::vtable(self).SetTag)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
             .ok()
         }
     }
-    pub(crate) fn get_ActualWidth(&self) -> windows_core::Result<f64> {
+    pub(crate) fn ActualWidth(&self) -> windows_core::Result<f64> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_ActualWidth)(
+            (windows_core::Interface::vtable(self).ActualWidth)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
             .map(|| result__)
         }
     }
-    pub(crate) fn get_ActualHeight(&self) -> windows_core::Result<f64> {
+    pub(crate) fn ActualHeight(&self) -> windows_core::Result<f64> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_ActualHeight)(
+            (windows_core::Interface::vtable(self).ActualHeight)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
             .map(|| result__)
         }
     }
-    pub(crate) fn put_Width(&self, value: f64) -> windows_core::Result<()> {
+    pub(crate) fn SetWidth(&self, value: f64) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Width)(
+            (windows_core::Interface::vtable(self).SetWidth)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_Height(&self, value: f64) -> windows_core::Result<()> {
+    pub(crate) fn SetHeight(&self, value: f64) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Height)(
+            (windows_core::Interface::vtable(self).SetHeight)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_MinWidth(&self, value: f64) -> windows_core::Result<()> {
+    pub(crate) fn SetMinWidth(&self, value: f64) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_MinWidth)(
+            (windows_core::Interface::vtable(self).SetMinWidth)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_MaxWidth(&self, value: f64) -> windows_core::Result<()> {
+    pub(crate) fn SetMaxWidth(&self, value: f64) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_MaxWidth)(
+            (windows_core::Interface::vtable(self).SetMaxWidth)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_MinHeight(&self, value: f64) -> windows_core::Result<()> {
+    pub(crate) fn SetMinHeight(&self, value: f64) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_MinHeight)(
+            (windows_core::Interface::vtable(self).SetMinHeight)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_MaxHeight(&self, value: f64) -> windows_core::Result<()> {
+    pub(crate) fn SetMaxHeight(&self, value: f64) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_MaxHeight)(
+            (windows_core::Interface::vtable(self).SetMaxHeight)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_HorizontalAlignment(
+    pub(crate) fn SetHorizontalAlignment(
         &self,
         value: HorizontalAlignment,
     ) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_HorizontalAlignment)(
+            (windows_core::Interface::vtable(self).SetHorizontalAlignment)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_VerticalAlignment(
+    pub(crate) fn SetVerticalAlignment(
         &self,
         value: VerticalAlignment,
     ) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_VerticalAlignment)(
+            (windows_core::Interface::vtable(self).SetVerticalAlignment)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_Margin(&self, value: Thickness) -> windows_core::Result<()> {
+    pub(crate) fn SetMargin(&self, value: Thickness) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Margin)(
+            (windows_core::Interface::vtable(self).SetMargin)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_Style<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetStyle<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<Style>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Style)(
+            (windows_core::Interface::vtable(self).SetStyle)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
             .ok()
         }
     }
-    pub(crate) fn put_RequestedTheme(&self, value: ElementTheme) -> windows_core::Result<()> {
+    pub(crate) fn SetRequestedTheme(&self, value: ElementTheme) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_RequestedTheme)(
+            (windows_core::Interface::vtable(self).SetRequestedTheme)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn get_ActualTheme(&self) -> windows_core::Result<ElementTheme> {
+    pub(crate) fn ActualTheme(&self) -> windows_core::Result<ElementTheme> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_ActualTheme)(
+            (windows_core::Interface::vtable(self).ActualTheme)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
@@ -10600,7 +10597,7 @@ impl IFrameworkElement {
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
-            let token__ = (windows_core::Interface::vtable(self).add_SizeChanged)(
+            let token__ = (windows_core::Interface::vtable(self).SizeChanged)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Interface::as_raw(&handler),
                 &mut result__,
@@ -10609,7 +10606,7 @@ impl IFrameworkElement {
             Ok(windows_core::EventRevoker::new(
                 self.clone(),
                 token__,
-                windows_core::Interface::vtable(self).remove_SizeChanged,
+                windows_core::Interface::vtable(self).RemoveSizeChanged,
             ))
         }
     }
@@ -10633,7 +10630,7 @@ impl IFrameworkElement {
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
-            let token__ = (windows_core::Interface::vtable(self).add_ActualThemeChanged)(
+            let token__ = (windows_core::Interface::vtable(self).ActualThemeChanged)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Interface::as_raw(&handler),
                 &mut result__,
@@ -10642,7 +10639,7 @@ impl IFrameworkElement {
             Ok(windows_core::EventRevoker::new(
                 self.clone(),
                 token__,
-                windows_core::Interface::vtable(self).remove_ActualThemeChanged,
+                windows_core::Interface::vtable(self).RemoveActualThemeChanged,
             ))
         }
     }
@@ -10650,113 +10647,113 @@ impl IFrameworkElement {
 #[repr(C)]
 pub struct IFrameworkElement_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_Triggers: usize,
-    pub get_Resources: unsafe extern "system" fn(
+    Triggers: usize,
+    pub Resources: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    put_Resources: usize,
-    pub get_Tag: unsafe extern "system" fn(
+    SetResources: usize,
+    pub Tag: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    pub put_Tag: unsafe extern "system" fn(
+    pub SetTag: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_Language: usize,
-    put_Language: usize,
-    pub get_ActualWidth:
+    Language: usize,
+    SetLanguage: usize,
+    pub ActualWidth:
         unsafe extern "system" fn(*mut core::ffi::c_void, *mut f64) -> windows_core::HRESULT,
-    pub get_ActualHeight:
+    pub ActualHeight:
         unsafe extern "system" fn(*mut core::ffi::c_void, *mut f64) -> windows_core::HRESULT,
-    get_Width: usize,
-    pub put_Width: unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
-    get_Height: usize,
-    pub put_Height: unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
-    get_MinWidth: usize,
-    pub put_MinWidth:
+    Width: usize,
+    pub SetWidth: unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
+    Height: usize,
+    pub SetHeight: unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
+    MinWidth: usize,
+    pub SetMinWidth:
         unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
-    get_MaxWidth: usize,
-    pub put_MaxWidth:
+    MaxWidth: usize,
+    pub SetMaxWidth:
         unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
-    get_MinHeight: usize,
-    pub put_MinHeight:
+    MinHeight: usize,
+    pub SetMinHeight:
         unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
-    get_MaxHeight: usize,
-    pub put_MaxHeight:
+    MaxHeight: usize,
+    pub SetMaxHeight:
         unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
-    get_HorizontalAlignment: usize,
-    pub put_HorizontalAlignment: unsafe extern "system" fn(
+    HorizontalAlignment: usize,
+    pub SetHorizontalAlignment: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         HorizontalAlignment,
     ) -> windows_core::HRESULT,
-    get_VerticalAlignment: usize,
-    pub put_VerticalAlignment: unsafe extern "system" fn(
+    VerticalAlignment: usize,
+    pub SetVerticalAlignment: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         VerticalAlignment,
     ) -> windows_core::HRESULT,
-    get_Margin: usize,
-    pub put_Margin:
+    Margin: usize,
+    pub SetMargin:
         unsafe extern "system" fn(*mut core::ffi::c_void, Thickness) -> windows_core::HRESULT,
-    get_Name: usize,
-    put_Name: usize,
-    get_BaseUri: usize,
-    get_DataContext: usize,
-    put_DataContext: usize,
-    get_AllowFocusOnInteraction: usize,
-    put_AllowFocusOnInteraction: usize,
-    get_FocusVisualMargin: usize,
-    put_FocusVisualMargin: usize,
-    get_FocusVisualSecondaryThickness: usize,
-    put_FocusVisualSecondaryThickness: usize,
-    get_FocusVisualPrimaryThickness: usize,
-    put_FocusVisualPrimaryThickness: usize,
-    get_FocusVisualSecondaryBrush: usize,
-    put_FocusVisualSecondaryBrush: usize,
-    get_FocusVisualPrimaryBrush: usize,
-    put_FocusVisualPrimaryBrush: usize,
-    get_AllowFocusWhenDisabled: usize,
-    put_AllowFocusWhenDisabled: usize,
-    get_Style: usize,
-    pub put_Style: unsafe extern "system" fn(
+    Name: usize,
+    SetName: usize,
+    BaseUri: usize,
+    DataContext: usize,
+    SetDataContext: usize,
+    AllowFocusOnInteraction: usize,
+    SetAllowFocusOnInteraction: usize,
+    FocusVisualMargin: usize,
+    SetFocusVisualMargin: usize,
+    FocusVisualSecondaryThickness: usize,
+    SetFocusVisualSecondaryThickness: usize,
+    FocusVisualPrimaryThickness: usize,
+    SetFocusVisualPrimaryThickness: usize,
+    FocusVisualSecondaryBrush: usize,
+    SetFocusVisualSecondaryBrush: usize,
+    FocusVisualPrimaryBrush: usize,
+    SetFocusVisualPrimaryBrush: usize,
+    AllowFocusWhenDisabled: usize,
+    SetAllowFocusWhenDisabled: usize,
+    Style: usize,
+    pub SetStyle: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_Parent: usize,
-    get_FlowDirection: usize,
-    put_FlowDirection: usize,
-    get_RequestedTheme: usize,
-    pub put_RequestedTheme:
+    Parent: usize,
+    FlowDirection: usize,
+    SetFlowDirection: usize,
+    RequestedTheme: usize,
+    pub SetRequestedTheme:
         unsafe extern "system" fn(*mut core::ffi::c_void, ElementTheme) -> windows_core::HRESULT,
-    get_IsLoaded: usize,
-    pub get_ActualTheme: unsafe extern "system" fn(
+    IsLoaded: usize,
+    pub ActualTheme: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut ElementTheme,
     ) -> windows_core::HRESULT,
-    add_Loaded: usize,
-    remove_Loaded: usize,
-    add_Unloaded: usize,
-    remove_Unloaded: usize,
-    add_DataContextChanged: usize,
-    remove_DataContextChanged: usize,
-    pub add_SizeChanged: unsafe extern "system" fn(
+    Loaded: usize,
+    RemoveLoaded: usize,
+    Unloaded: usize,
+    RemoveUnloaded: usize,
+    DataContextChanged: usize,
+    RemoveDataContextChanged: usize,
+    pub SizeChanged: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         *mut i64,
     ) -> windows_core::HRESULT,
-    pub remove_SizeChanged:
+    pub RemoveSizeChanged:
         unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
-    add_LayoutUpdated: usize,
-    remove_LayoutUpdated: usize,
-    add_Loading: usize,
-    remove_Loading: usize,
-    pub add_ActualThemeChanged: unsafe extern "system" fn(
+    LayoutUpdated: usize,
+    RemoveLayoutUpdated: usize,
+    Loading: usize,
+    RemoveLoading: usize,
+    pub ActualThemeChanged: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         *mut i64,
     ) -> windows_core::HRESULT,
-    pub remove_ActualThemeChanged:
+    pub RemoveActualThemeChanged:
         unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
@@ -10769,10 +10766,10 @@ impl windows_core::RuntimeType for IFrameworkElementAutomationPeer {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IFrameworkElementAutomationPeer {
-    pub(crate) fn get_Owner(&self) -> windows_core::Result<UIElement> {
+    pub(crate) fn Owner(&self) -> windows_core::Result<UIElement> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_Owner)(
+            (windows_core::Interface::vtable(self).Owner)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
@@ -10783,7 +10780,7 @@ impl IFrameworkElementAutomationPeer {
 #[repr(C)]
 pub struct IFrameworkElementAutomationPeer_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    pub get_Owner: unsafe extern "system" fn(
+    pub Owner: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
@@ -10837,38 +10834,38 @@ impl windows_core::RuntimeType for IGrid {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IGrid {
-    pub(crate) fn get_RowDefinitions(&self) -> windows_core::Result<RowDefinitionCollection> {
+    pub(crate) fn RowDefinitions(&self) -> windows_core::Result<RowDefinitionCollection> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_RowDefinitions)(
+            (windows_core::Interface::vtable(self).RowDefinitions)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
             .and_then(|| windows_core::Type::from_abi(result__))
         }
     }
-    pub(crate) fn get_ColumnDefinitions(&self) -> windows_core::Result<ColumnDefinitionCollection> {
+    pub(crate) fn ColumnDefinitions(&self) -> windows_core::Result<ColumnDefinitionCollection> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_ColumnDefinitions)(
+            (windows_core::Interface::vtable(self).ColumnDefinitions)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
             .and_then(|| windows_core::Type::from_abi(result__))
         }
     }
-    pub(crate) fn put_RowSpacing(&self, value: f64) -> windows_core::Result<()> {
+    pub(crate) fn SetRowSpacing(&self, value: f64) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_RowSpacing)(
+            (windows_core::Interface::vtable(self).SetRowSpacing)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_ColumnSpacing(&self, value: f64) -> windows_core::Result<()> {
+    pub(crate) fn SetColumnSpacing(&self, value: f64) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_ColumnSpacing)(
+            (windows_core::Interface::vtable(self).SetColumnSpacing)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
@@ -10879,29 +10876,29 @@ impl IGrid {
 #[repr(C)]
 pub struct IGrid_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    pub get_RowDefinitions: unsafe extern "system" fn(
+    pub RowDefinitions: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    pub get_ColumnDefinitions: unsafe extern "system" fn(
+    pub ColumnDefinitions: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_BackgroundSizing: usize,
-    put_BackgroundSizing: usize,
-    get_BorderBrush: usize,
-    put_BorderBrush: usize,
-    get_BorderThickness: usize,
-    put_BorderThickness: usize,
-    get_CornerRadius: usize,
-    put_CornerRadius: usize,
-    get_Padding: usize,
-    put_Padding: usize,
-    get_RowSpacing: usize,
-    pub put_RowSpacing:
+    BackgroundSizing: usize,
+    SetBackgroundSizing: usize,
+    BorderBrush: usize,
+    SetBorderBrush: usize,
+    BorderThickness: usize,
+    SetBorderThickness: usize,
+    CornerRadius: usize,
+    SetCornerRadius: usize,
+    Padding: usize,
+    SetPadding: usize,
+    RowSpacing: usize,
+    pub SetRowSpacing:
         unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
-    get_ColumnSpacing: usize,
-    pub put_ColumnSpacing:
+    ColumnSpacing: usize,
+    pub SetColumnSpacing:
         unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
@@ -10935,14 +10932,14 @@ impl windows_core::RuntimeType for IGridStatics {
 #[repr(C)]
 pub struct IGridStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_BackgroundSizingProperty: usize,
-    get_BorderBrushProperty: usize,
-    get_BorderThicknessProperty: usize,
-    get_CornerRadiusProperty: usize,
-    get_PaddingProperty: usize,
-    get_RowSpacingProperty: usize,
-    get_ColumnSpacingProperty: usize,
-    get_RowProperty: usize,
+    BackgroundSizingProperty: usize,
+    BorderBrushProperty: usize,
+    BorderThicknessProperty: usize,
+    CornerRadiusProperty: usize,
+    PaddingProperty: usize,
+    RowSpacingProperty: usize,
+    ColumnSpacingProperty: usize,
+    RowProperty: usize,
     pub GetRow: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
@@ -10953,21 +10950,21 @@ pub struct IGridStatics_Vtbl {
         *mut core::ffi::c_void,
         i32,
     ) -> windows_core::HRESULT,
-    get_ColumnProperty: usize,
+    ColumnProperty: usize,
     GetColumn: usize,
     pub SetColumn: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         i32,
     ) -> windows_core::HRESULT,
-    get_RowSpanProperty: usize,
+    RowSpanProperty: usize,
     GetRowSpan: usize,
     pub SetRowSpan: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         i32,
     ) -> windows_core::HRESULT,
-    get_ColumnSpanProperty: usize,
+    ColumnSpanProperty: usize,
     GetColumnSpan: usize,
     pub SetColumnSpan: unsafe extern "system" fn(
         *mut core::ffi::c_void,
@@ -11017,12 +11014,12 @@ impl windows_core::RuntimeType for IHyperlinkButton {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IHyperlinkButton {
-    pub(crate) fn put_NavigateUri<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetNavigateUri<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<Uri>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_NavigateUri)(
+            (windows_core::Interface::vtable(self).SetNavigateUri)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
@@ -11033,8 +11030,8 @@ impl IHyperlinkButton {
 #[repr(C)]
 pub struct IHyperlinkButton_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_NavigateUri: usize,
-    pub put_NavigateUri: unsafe extern "system" fn(
+    NavigateUri: usize,
+    pub SetNavigateUri: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
@@ -11090,21 +11087,21 @@ impl windows_core::RuntimeType for IImage {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IImage {
-    pub(crate) fn put_Source<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetSource<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<ImageSource>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Source)(
+            (windows_core::Interface::vtable(self).SetSource)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
             .ok()
         }
     }
-    pub(crate) fn put_Stretch(&self, value: Stretch) -> windows_core::Result<()> {
+    pub(crate) fn SetStretch(&self, value: Stretch) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Stretch)(
+            (windows_core::Interface::vtable(self).SetStretch)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
@@ -11115,13 +11112,13 @@ impl IImage {
 #[repr(C)]
 pub struct IImage_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_Source: usize,
-    pub put_Source: unsafe extern "system" fn(
+    Source: usize,
+    pub SetSource: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_Stretch: usize,
-    pub put_Stretch:
+    Stretch: usize,
+    pub SetStretch:
         unsafe extern "system" fn(*mut core::ffi::c_void, Stretch) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
@@ -11160,9 +11157,9 @@ impl windows_core::RuntimeType for IInfoBadge {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IInfoBadge {
-    pub(crate) fn put_Value(&self, value: i32) -> windows_core::Result<()> {
+    pub(crate) fn SetValue(&self, value: i32) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Value)(
+            (windows_core::Interface::vtable(self).SetValue)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
@@ -11173,8 +11170,8 @@ impl IInfoBadge {
 #[repr(C)]
 pub struct IInfoBadge_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_Value: usize,
-    pub put_Value: unsafe extern "system" fn(*mut core::ffi::c_void, i32) -> windows_core::HRESULT,
+    Value: usize,
+    pub SetValue: unsafe extern "system" fn(*mut core::ffi::c_void, i32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
     IInfoBadgeFactory,
@@ -11205,45 +11202,45 @@ impl windows_core::RuntimeType for IInfoBar {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IInfoBar {
-    pub(crate) fn put_IsOpen(&self, value: bool) -> windows_core::Result<()> {
+    pub(crate) fn SetIsOpen(&self, value: bool) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_IsOpen)(
+            (windows_core::Interface::vtable(self).SetIsOpen)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_Title(&self, value: &str) -> windows_core::Result<()> {
+    pub(crate) fn SetTitle(&self, value: &str) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Title)(
+            (windows_core::Interface::vtable(self).SetTitle)(
                 windows_core::Interface::as_raw(self),
                 core::mem::transmute_copy(&windows_core::HSTRING::from(value)),
             )
             .ok()
         }
     }
-    pub(crate) fn put_Message(&self, value: &str) -> windows_core::Result<()> {
+    pub(crate) fn SetMessage(&self, value: &str) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Message)(
+            (windows_core::Interface::vtable(self).SetMessage)(
                 windows_core::Interface::as_raw(self),
                 core::mem::transmute_copy(&windows_core::HSTRING::from(value)),
             )
             .ok()
         }
     }
-    pub(crate) fn put_Severity(&self, value: InfoBarSeverity) -> windows_core::Result<()> {
+    pub(crate) fn SetSeverity(&self, value: InfoBarSeverity) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Severity)(
+            (windows_core::Interface::vtable(self).SetSeverity)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_IsClosable(&self, value: bool) -> windows_core::Result<()> {
+    pub(crate) fn SetIsClosable(&self, value: bool) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_IsClosable)(
+            (windows_core::Interface::vtable(self).SetIsClosable)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
@@ -11266,7 +11263,7 @@ impl IInfoBar {
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
-            let token__ = (windows_core::Interface::vtable(self).add_Closed)(
+            let token__ = (windows_core::Interface::vtable(self).Closed)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Interface::as_raw(&handler),
                 &mut result__,
@@ -11275,7 +11272,7 @@ impl IInfoBar {
             Ok(windows_core::EventRevoker::new(
                 self.clone(),
                 token__,
-                windows_core::Interface::vtable(self).remove_Closed,
+                windows_core::Interface::vtable(self).RemoveClosed,
             ))
         }
     }
@@ -11283,52 +11280,51 @@ impl IInfoBar {
 #[repr(C)]
 pub struct IInfoBar_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_IsOpen: usize,
-    pub put_IsOpen:
-        unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
-    get_Title: usize,
-    pub put_Title: unsafe extern "system" fn(
+    IsOpen: usize,
+    pub SetIsOpen: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
+    Title: usize,
+    pub SetTitle: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_Message: usize,
-    pub put_Message: unsafe extern "system" fn(
+    Message: usize,
+    pub SetMessage: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_Severity: usize,
-    pub put_Severity:
+    Severity: usize,
+    pub SetSeverity:
         unsafe extern "system" fn(*mut core::ffi::c_void, InfoBarSeverity) -> windows_core::HRESULT,
-    get_IconSource: usize,
-    put_IconSource: usize,
-    get_IsIconVisible: usize,
-    put_IsIconVisible: usize,
-    get_IsClosable: usize,
-    pub put_IsClosable:
+    IconSource: usize,
+    SetIconSource: usize,
+    IsIconVisible: usize,
+    SetIsIconVisible: usize,
+    IsClosable: usize,
+    pub SetIsClosable:
         unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
-    get_CloseButtonStyle: usize,
-    put_CloseButtonStyle: usize,
-    get_CloseButtonCommand: usize,
-    put_CloseButtonCommand: usize,
-    get_CloseButtonCommandParameter: usize,
-    put_CloseButtonCommandParameter: usize,
-    get_ActionButton: usize,
-    put_ActionButton: usize,
-    get_Content: usize,
-    put_Content: usize,
-    get_ContentTemplate: usize,
-    put_ContentTemplate: usize,
-    get_TemplateSettings: usize,
-    add_CloseButtonClick: usize,
-    remove_CloseButtonClick: usize,
-    add_Closing: usize,
-    remove_Closing: usize,
-    pub add_Closed: unsafe extern "system" fn(
+    CloseButtonStyle: usize,
+    SetCloseButtonStyle: usize,
+    CloseButtonCommand: usize,
+    SetCloseButtonCommand: usize,
+    CloseButtonCommandParameter: usize,
+    SetCloseButtonCommandParameter: usize,
+    ActionButton: usize,
+    SetActionButton: usize,
+    Content: usize,
+    SetContent: usize,
+    ContentTemplate: usize,
+    SetContentTemplate: usize,
+    TemplateSettings: usize,
+    CloseButtonClick: usize,
+    RemoveCloseButtonClick: usize,
+    Closing: usize,
+    RemoveClosing: usize,
+    pub Closed: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         *mut i64,
     ) -> windows_core::HRESULT,
-    pub remove_Closed:
+    pub RemoveClosed:
         unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
@@ -11452,22 +11448,22 @@ impl windows_core::RuntimeType for IItemsControl {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IItemsControl {
-    pub(crate) fn put_ItemsSource<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetItemsSource<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<windows_core::IInspectable>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_ItemsSource)(
+            (windows_core::Interface::vtable(self).SetItemsSource)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
             .ok()
         }
     }
-    pub(crate) fn get_Items(&self) -> windows_core::Result<ItemCollection> {
+    pub(crate) fn Items(&self) -> windows_core::Result<ItemCollection> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_Items)(
+            (windows_core::Interface::vtable(self).Items)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
@@ -11478,12 +11474,12 @@ impl IItemsControl {
 #[repr(C)]
 pub struct IItemsControl_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_ItemsSource: usize,
-    pub put_ItemsSource: unsafe extern "system" fn(
+    ItemsSource: usize,
+    pub SetItemsSource: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    pub get_Items: unsafe extern "system" fn(
+    pub Items: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
@@ -11498,9 +11494,9 @@ impl windows_core::RuntimeType for IKeyFrameAnimation {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IKeyFrameAnimation {
-    pub(crate) fn put_Duration(&self, value: windows_time::TimeSpan) -> windows_core::Result<()> {
+    pub(crate) fn SetDuration(&self, value: windows_time::TimeSpan) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Duration)(
+            (windows_core::Interface::vtable(self).SetDuration)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
@@ -11530,20 +11526,20 @@ impl IKeyFrameAnimation {
 #[repr(C)]
 pub struct IKeyFrameAnimation_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_DelayTime: usize,
-    put_DelayTime: usize,
-    get_Duration: usize,
-    pub put_Duration: unsafe extern "system" fn(
+    DelayTime: usize,
+    SetDelayTime: usize,
+    Duration: usize,
+    pub SetDuration: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         windows_time::TimeSpan,
     ) -> windows_core::HRESULT,
-    get_IterationBehavior: usize,
-    put_IterationBehavior: usize,
-    get_IterationCount: usize,
-    put_IterationCount: usize,
-    get_KeyFrameCount: usize,
-    get_StopBehavior: usize,
-    put_StopBehavior: usize,
+    IterationBehavior: usize,
+    SetIterationBehavior: usize,
+    IterationCount: usize,
+    SetIterationCount: usize,
+    KeyFrameCount: usize,
+    StopBehavior: usize,
+    SetStopBehavior: usize,
     InsertExpressionKeyFrame: usize,
     pub InsertExpressionKeyFrameWithEasingFunction:
         unsafe extern "system" fn(
@@ -11563,18 +11559,18 @@ impl windows_core::RuntimeType for IKeyboardAccelerator {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IKeyboardAccelerator {
-    pub(crate) fn put_Key(&self, value: VirtualKey) -> windows_core::Result<()> {
+    pub(crate) fn SetKey(&self, value: VirtualKey) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Key)(
+            (windows_core::Interface::vtable(self).SetKey)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_Modifiers(&self, value: VirtualKeyModifiers) -> windows_core::Result<()> {
+    pub(crate) fn SetModifiers(&self, value: VirtualKeyModifiers) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Modifiers)(
+            (windows_core::Interface::vtable(self).SetModifiers)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
@@ -11605,7 +11601,7 @@ impl IKeyboardAccelerator {
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
-            let token__ = (windows_core::Interface::vtable(self).add_Invoked)(
+            let token__ = (windows_core::Interface::vtable(self).Invoked)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Interface::as_raw(&handler),
                 &mut result__,
@@ -11614,7 +11610,7 @@ impl IKeyboardAccelerator {
             Ok(windows_core::EventRevoker::new(
                 self.clone(),
                 token__,
-                windows_core::Interface::vtable(self).remove_Invoked,
+                windows_core::Interface::vtable(self).RemoveInvoked,
             ))
         }
     }
@@ -11622,24 +11618,24 @@ impl IKeyboardAccelerator {
 #[repr(C)]
 pub struct IKeyboardAccelerator_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_Key: usize,
-    pub put_Key:
+    Key: usize,
+    pub SetKey:
         unsafe extern "system" fn(*mut core::ffi::c_void, VirtualKey) -> windows_core::HRESULT,
-    get_Modifiers: usize,
-    pub put_Modifiers: unsafe extern "system" fn(
+    Modifiers: usize,
+    pub SetModifiers: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         VirtualKeyModifiers,
     ) -> windows_core::HRESULT,
-    get_IsEnabled: usize,
-    put_IsEnabled: usize,
-    get_ScopeOwner: usize,
-    put_ScopeOwner: usize,
-    pub add_Invoked: unsafe extern "system" fn(
+    IsEnabled: usize,
+    SetIsEnabled: usize,
+    ScopeOwner: usize,
+    SetScopeOwner: usize,
+    pub Invoked: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         *mut i64,
     ) -> windows_core::HRESULT,
-    pub remove_Invoked:
+    pub RemoveInvoked:
         unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
@@ -11671,9 +11667,9 @@ impl windows_core::RuntimeType for IKeyboardAcceleratorInvokedEventArgs {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IKeyboardAcceleratorInvokedEventArgs {
-    pub(crate) fn put_Handled(&self, value: bool) -> windows_core::Result<()> {
+    pub(crate) fn SetHandled(&self, value: bool) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Handled)(
+            (windows_core::Interface::vtable(self).SetHandled)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
@@ -11684,8 +11680,8 @@ impl IKeyboardAcceleratorInvokedEventArgs {
 #[repr(C)]
 pub struct IKeyboardAcceleratorInvokedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_Handled: usize,
-    pub put_Handled:
+    Handled: usize,
+    pub SetHandled:
         unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
@@ -11707,36 +11703,36 @@ impl windows_core::RuntimeType for ILine {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl ILine {
-    pub(crate) fn put_X1(&self, value: f64) -> windows_core::Result<()> {
+    pub(crate) fn SetX1(&self, value: f64) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_X1)(
+            (windows_core::Interface::vtable(self).SetX1)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_Y1(&self, value: f64) -> windows_core::Result<()> {
+    pub(crate) fn SetY1(&self, value: f64) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Y1)(
+            (windows_core::Interface::vtable(self).SetY1)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_X2(&self, value: f64) -> windows_core::Result<()> {
+    pub(crate) fn SetX2(&self, value: f64) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_X2)(
+            (windows_core::Interface::vtable(self).SetX2)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_Y2(&self, value: f64) -> windows_core::Result<()> {
+    pub(crate) fn SetY2(&self, value: f64) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Y2)(
+            (windows_core::Interface::vtable(self).SetY2)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
@@ -11747,14 +11743,14 @@ impl ILine {
 #[repr(C)]
 pub struct ILine_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_X1: usize,
-    pub put_X1: unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
-    get_Y1: usize,
-    pub put_Y1: unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
-    get_X2: usize,
-    pub put_X2: unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
-    get_Y2: usize,
-    pub put_Y2: unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
+    X1: usize,
+    pub SetX1: unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
+    Y1: usize,
+    pub SetY1: unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
+    X2: usize,
+    pub SetX2: unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
+    Y2: usize,
+    pub SetY2: unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
     ILinearEasingFunction,
@@ -11824,50 +11820,50 @@ impl windows_core::RuntimeType for IListViewBase {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IListViewBase {
-    pub(crate) fn put_SelectionMode(
+    pub(crate) fn SetSelectionMode(
         &self,
         value: ListViewSelectionMode,
     ) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_SelectionMode)(
+            (windows_core::Interface::vtable(self).SetSelectionMode)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn get_CanDragItems(&self) -> windows_core::Result<bool> {
+    pub(crate) fn CanDragItems(&self) -> windows_core::Result<bool> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_CanDragItems)(
+            (windows_core::Interface::vtable(self).CanDragItems)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
             .map(|| result__)
         }
     }
-    pub(crate) fn put_CanDragItems(&self, value: bool) -> windows_core::Result<()> {
+    pub(crate) fn SetCanDragItems(&self, value: bool) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_CanDragItems)(
+            (windows_core::Interface::vtable(self).SetCanDragItems)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn get_CanReorderItems(&self) -> windows_core::Result<bool> {
+    pub(crate) fn CanReorderItems(&self) -> windows_core::Result<bool> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_CanReorderItems)(
+            (windows_core::Interface::vtable(self).CanReorderItems)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
             .map(|| result__)
         }
     }
-    pub(crate) fn put_CanReorderItems(&self, value: bool) -> windows_core::Result<()> {
+    pub(crate) fn SetCanReorderItems(&self, value: bool) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_CanReorderItems)(
+            (windows_core::Interface::vtable(self).SetCanReorderItems)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
@@ -11890,51 +11886,51 @@ impl IListViewBase {
 #[repr(C)]
 pub struct IListViewBase_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_SelectedItems: usize,
-    get_SelectionMode: usize,
-    pub put_SelectionMode: unsafe extern "system" fn(
+    SelectedItems: usize,
+    SelectionMode: usize,
+    pub SetSelectionMode: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         ListViewSelectionMode,
     ) -> windows_core::HRESULT,
-    get_IsSwipeEnabled: usize,
-    put_IsSwipeEnabled: usize,
-    pub get_CanDragItems:
+    IsSwipeEnabled: usize,
+    SetIsSwipeEnabled: usize,
+    pub CanDragItems:
         unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
-    pub put_CanDragItems:
+    pub SetCanDragItems:
         unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
-    pub get_CanReorderItems:
+    pub CanReorderItems:
         unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
-    pub put_CanReorderItems:
+    pub SetCanReorderItems:
         unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
-    get_IsItemClickEnabled: usize,
-    put_IsItemClickEnabled: usize,
-    get_DataFetchSize: usize,
-    put_DataFetchSize: usize,
-    get_IncrementalLoadingThreshold: usize,
-    put_IncrementalLoadingThreshold: usize,
-    get_IncrementalLoadingTrigger: usize,
-    put_IncrementalLoadingTrigger: usize,
-    get_ShowsScrollingPlaceholders: usize,
-    put_ShowsScrollingPlaceholders: usize,
-    get_ReorderMode: usize,
-    put_ReorderMode: usize,
-    get_SelectedRanges: usize,
-    get_IsMultiSelectCheckBoxEnabled: usize,
-    put_IsMultiSelectCheckBoxEnabled: usize,
-    get_SingleSelectionFollowsFocus: usize,
-    put_SingleSelectionFollowsFocus: usize,
-    add_ItemClick: usize,
-    remove_ItemClick: usize,
-    add_DragItemsStarting: usize,
-    remove_DragItemsStarting: usize,
-    add_DragItemsCompleted: usize,
-    remove_DragItemsCompleted: usize,
-    add_ContainerContentChanging: usize,
-    remove_ContainerContentChanging: usize,
-    add_ChoosingItemContainer: usize,
-    remove_ChoosingItemContainer: usize,
-    add_ChoosingGroupHeaderContainer: usize,
-    remove_ChoosingGroupHeaderContainer: usize,
+    IsItemClickEnabled: usize,
+    SetIsItemClickEnabled: usize,
+    DataFetchSize: usize,
+    SetDataFetchSize: usize,
+    IncrementalLoadingThreshold: usize,
+    SetIncrementalLoadingThreshold: usize,
+    IncrementalLoadingTrigger: usize,
+    SetIncrementalLoadingTrigger: usize,
+    ShowsScrollingPlaceholders: usize,
+    SetShowsScrollingPlaceholders: usize,
+    ReorderMode: usize,
+    SetReorderMode: usize,
+    SelectedRanges: usize,
+    IsMultiSelectCheckBoxEnabled: usize,
+    SetIsMultiSelectCheckBoxEnabled: usize,
+    SingleSelectionFollowsFocus: usize,
+    SetSingleSelectionFollowsFocus: usize,
+    ItemClick: usize,
+    RemoveItemClick: usize,
+    DragItemsStarting: usize,
+    RemoveDragItemsStarting: usize,
+    DragItemsCompleted: usize,
+    RemoveDragItemsCompleted: usize,
+    ContainerContentChanging: usize,
+    RemoveContainerContentChanging: usize,
+    ChoosingItemContainer: usize,
+    RemoveChoosingItemContainer: usize,
+    ChoosingGroupHeaderContainer: usize,
+    RemoveChoosingGroupHeaderContainer: usize,
     pub ScrollIntoView: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
@@ -11982,12 +11978,10 @@ impl windows_core::RuntimeType for IMenuBar {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IMenuBar {
-    pub(crate) fn get_Items(
-        &self,
-    ) -> windows_core::Result<windows_collections::IVector<MenuBarItem>> {
+    pub(crate) fn Items(&self) -> windows_core::Result<windows_collections::IVector<MenuBarItem>> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_Items)(
+            (windows_core::Interface::vtable(self).Items)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
@@ -11998,7 +11992,7 @@ impl IMenuBar {
 #[repr(C)]
 pub struct IMenuBar_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    pub get_Items: unsafe extern "system" fn(
+    pub Items: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
@@ -12032,21 +12026,21 @@ impl windows_core::RuntimeType for IMenuBarItem {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IMenuBarItem {
-    pub(crate) fn put_Title(&self, value: &str) -> windows_core::Result<()> {
+    pub(crate) fn SetTitle(&self, value: &str) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Title)(
+            (windows_core::Interface::vtable(self).SetTitle)(
                 windows_core::Interface::as_raw(self),
                 core::mem::transmute_copy(&windows_core::HSTRING::from(value)),
             )
             .ok()
         }
     }
-    pub(crate) fn get_Items(
+    pub(crate) fn Items(
         &self,
     ) -> windows_core::Result<windows_collections::IVector<MenuFlyoutItemBase>> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_Items)(
+            (windows_core::Interface::vtable(self).Items)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
@@ -12057,12 +12051,12 @@ impl IMenuBarItem {
 #[repr(C)]
 pub struct IMenuBarItem_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_Title: usize,
-    pub put_Title: unsafe extern "system" fn(
+    Title: usize,
+    pub SetTitle: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    pub get_Items: unsafe extern "system" fn(
+    pub Items: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
@@ -12096,12 +12090,12 @@ impl windows_core::RuntimeType for IMenuFlyout {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IMenuFlyout {
-    pub(crate) fn get_Items(
+    pub(crate) fn Items(
         &self,
     ) -> windows_core::Result<windows_collections::IVector<MenuFlyoutItemBase>> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_Items)(
+            (windows_core::Interface::vtable(self).Items)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
@@ -12112,7 +12106,7 @@ impl IMenuFlyout {
 #[repr(C)]
 pub struct IMenuFlyout_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    pub get_Items: unsafe extern "system" fn(
+    pub Items: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
@@ -12146,10 +12140,10 @@ impl windows_core::RuntimeType for IMenuFlyoutItem {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IMenuFlyoutItem {
-    pub(crate) fn get_Text(&self) -> windows_core::Result<String> {
+    pub(crate) fn Text(&self) -> windows_core::Result<String> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_Text)(
+            (windows_core::Interface::vtable(self).Text)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
@@ -12159,9 +12153,9 @@ impl IMenuFlyoutItem {
             })
         }
     }
-    pub(crate) fn put_Text(&self, value: &str) -> windows_core::Result<()> {
+    pub(crate) fn SetText(&self, value: &str) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Text)(
+            (windows_core::Interface::vtable(self).SetText)(
                 windows_core::Interface::as_raw(self),
                 core::mem::transmute_copy(&windows_core::HSTRING::from(value)),
             )
@@ -12182,7 +12176,7 @@ impl IMenuFlyoutItem {
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
-            let token__ = (windows_core::Interface::vtable(self).add_Click)(
+            let token__ = (windows_core::Interface::vtable(self).Click)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Interface::as_raw(&handler),
                 &mut result__,
@@ -12191,7 +12185,7 @@ impl IMenuFlyoutItem {
             Ok(windows_core::EventRevoker::new(
                 self.clone(),
                 token__,
-                windows_core::Interface::vtable(self).remove_Click,
+                windows_core::Interface::vtable(self).RemoveClick,
             ))
         }
     }
@@ -12199,29 +12193,29 @@ impl IMenuFlyoutItem {
 #[repr(C)]
 pub struct IMenuFlyoutItem_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    pub get_Text: unsafe extern "system" fn(
+    pub Text: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    pub put_Text: unsafe extern "system" fn(
+    pub SetText: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_Command: usize,
-    put_Command: usize,
-    get_CommandParameter: usize,
-    put_CommandParameter: usize,
-    get_Icon: usize,
-    put_Icon: usize,
-    get_KeyboardAcceleratorTextOverride: usize,
-    put_KeyboardAcceleratorTextOverride: usize,
-    get_TemplateSettings: usize,
-    pub add_Click: unsafe extern "system" fn(
+    Command: usize,
+    SetCommand: usize,
+    CommandParameter: usize,
+    SetCommandParameter: usize,
+    Icon: usize,
+    SetIcon: usize,
+    KeyboardAcceleratorTextOverride: usize,
+    SetKeyboardAcceleratorTextOverride: usize,
+    TemplateSettings: usize,
+    pub Click: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         *mut i64,
     ) -> windows_core::HRESULT,
-    pub remove_Click:
+    pub RemoveClick:
         unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
@@ -12298,21 +12292,21 @@ impl windows_core::RuntimeType for IMenuFlyoutSubItem {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IMenuFlyoutSubItem {
-    pub(crate) fn get_Items(
+    pub(crate) fn Items(
         &self,
     ) -> windows_core::Result<windows_collections::IVector<MenuFlyoutItemBase>> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_Items)(
+            (windows_core::Interface::vtable(self).Items)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
             .and_then(|| windows_core::Type::from_abi(result__))
         }
     }
-    pub(crate) fn put_Text(&self, value: &str) -> windows_core::Result<()> {
+    pub(crate) fn SetText(&self, value: &str) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Text)(
+            (windows_core::Interface::vtable(self).SetText)(
                 windows_core::Interface::as_raw(self),
                 core::mem::transmute_copy(&windows_core::HSTRING::from(value)),
             )
@@ -12323,12 +12317,12 @@ impl IMenuFlyoutSubItem {
 #[repr(C)]
 pub struct IMenuFlyoutSubItem_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    pub get_Items: unsafe extern "system" fn(
+    pub Items: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_Text: usize,
-    pub put_Text: unsafe extern "system" fn(
+    Text: usize,
+    pub SetText: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
@@ -12343,9 +12337,9 @@ impl windows_core::RuntimeType for IMicaBackdrop {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IMicaBackdrop {
-    pub(crate) fn put_Kind(&self, value: MicaKind) -> windows_core::Result<()> {
+    pub(crate) fn SetKind(&self, value: MicaKind) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Kind)(
+            (windows_core::Interface::vtable(self).SetKind)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
@@ -12356,8 +12350,8 @@ impl IMicaBackdrop {
 #[repr(C)]
 pub struct IMicaBackdrop_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_Kind: usize,
-    pub put_Kind:
+    Kind: usize,
+    pub SetKind:
         unsafe extern "system" fn(*mut core::ffi::c_void, MicaKind) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
@@ -12389,85 +12383,85 @@ impl windows_core::RuntimeType for INavigationView {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl INavigationView {
-    pub(crate) fn put_IsPaneOpen(&self, value: bool) -> windows_core::Result<()> {
+    pub(crate) fn SetIsPaneOpen(&self, value: bool) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_IsPaneOpen)(
+            (windows_core::Interface::vtable(self).SetIsPaneOpen)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_Header<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetHeader<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<windows_core::IInspectable>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Header)(
+            (windows_core::Interface::vtable(self).SetHeader)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
             .ok()
         }
     }
-    pub(crate) fn put_IsSettingsVisible(&self, value: bool) -> windows_core::Result<()> {
+    pub(crate) fn SetIsSettingsVisible(&self, value: bool) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_IsSettingsVisible)(
+            (windows_core::Interface::vtable(self).SetIsSettingsVisible)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_IsPaneToggleButtonVisible(&self, value: bool) -> windows_core::Result<()> {
+    pub(crate) fn SetIsPaneToggleButtonVisible(&self, value: bool) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_IsPaneToggleButtonVisible)(
+            (windows_core::Interface::vtable(self).SetIsPaneToggleButtonVisible)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_SelectedItem<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetSelectedItem<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<windows_core::IInspectable>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_SelectedItem)(
+            (windows_core::Interface::vtable(self).SetSelectedItem)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
             .ok()
         }
     }
-    pub(crate) fn get_MenuItems(
+    pub(crate) fn MenuItems(
         &self,
     ) -> windows_core::Result<windows_collections::IVector<windows_core::IInspectable>> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_MenuItems)(
+            (windows_core::Interface::vtable(self).MenuItems)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
             .and_then(|| windows_core::Type::from_abi(result__))
         }
     }
-    pub(crate) fn get_AutoSuggestBox(&self) -> windows_core::Result<AutoSuggestBox> {
+    pub(crate) fn AutoSuggestBox(&self) -> windows_core::Result<AutoSuggestBox> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_AutoSuggestBox)(
+            (windows_core::Interface::vtable(self).AutoSuggestBox)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
             .and_then(|| windows_core::Type::from_abi(result__))
         }
     }
-    pub(crate) fn put_AutoSuggestBox<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetAutoSuggestBox<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<AutoSuggestBox>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_AutoSuggestBox)(
+            (windows_core::Interface::vtable(self).SetAutoSuggestBox)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
@@ -12501,7 +12495,7 @@ impl INavigationView {
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
-            let token__ = (windows_core::Interface::vtable(self).add_SelectionChanged)(
+            let token__ = (windows_core::Interface::vtable(self).SelectionChanged)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Interface::as_raw(&handler),
                 &mut result__,
@@ -12510,7 +12504,7 @@ impl INavigationView {
             Ok(windows_core::EventRevoker::new(
                 self.clone(),
                 token__,
-                windows_core::Interface::vtable(self).remove_SelectionChanged,
+                windows_core::Interface::vtable(self).RemoveSelectionChanged,
             ))
         }
     }
@@ -12518,76 +12512,76 @@ impl INavigationView {
 #[repr(C)]
 pub struct INavigationView_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_IsPaneOpen: usize,
-    pub put_IsPaneOpen:
+    IsPaneOpen: usize,
+    pub SetIsPaneOpen:
         unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
-    get_CompactModeThresholdWidth: usize,
-    put_CompactModeThresholdWidth: usize,
-    get_ExpandedModeThresholdWidth: usize,
-    put_ExpandedModeThresholdWidth: usize,
-    get_FooterMenuItems: usize,
-    get_FooterMenuItemsSource: usize,
-    put_FooterMenuItemsSource: usize,
-    get_PaneFooter: usize,
-    put_PaneFooter: usize,
-    get_Header: usize,
-    pub put_Header: unsafe extern "system" fn(
+    CompactModeThresholdWidth: usize,
+    SetCompactModeThresholdWidth: usize,
+    ExpandedModeThresholdWidth: usize,
+    SetExpandedModeThresholdWidth: usize,
+    FooterMenuItems: usize,
+    FooterMenuItemsSource: usize,
+    SetFooterMenuItemsSource: usize,
+    PaneFooter: usize,
+    SetPaneFooter: usize,
+    Header: usize,
+    pub SetHeader: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_HeaderTemplate: usize,
-    put_HeaderTemplate: usize,
-    get_DisplayMode: usize,
-    get_IsSettingsVisible: usize,
-    pub put_IsSettingsVisible:
+    HeaderTemplate: usize,
+    SetHeaderTemplate: usize,
+    DisplayMode: usize,
+    IsSettingsVisible: usize,
+    pub SetIsSettingsVisible:
         unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
-    get_IsPaneToggleButtonVisible: usize,
-    pub put_IsPaneToggleButtonVisible:
+    IsPaneToggleButtonVisible: usize,
+    pub SetIsPaneToggleButtonVisible:
         unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
-    get_AlwaysShowHeader: usize,
-    put_AlwaysShowHeader: usize,
-    get_CompactPaneLength: usize,
-    put_CompactPaneLength: usize,
-    get_OpenPaneLength: usize,
-    put_OpenPaneLength: usize,
-    get_PaneToggleButtonStyle: usize,
-    put_PaneToggleButtonStyle: usize,
-    get_SelectedItem: usize,
-    pub put_SelectedItem: unsafe extern "system" fn(
+    AlwaysShowHeader: usize,
+    SetAlwaysShowHeader: usize,
+    CompactPaneLength: usize,
+    SetCompactPaneLength: usize,
+    OpenPaneLength: usize,
+    SetOpenPaneLength: usize,
+    PaneToggleButtonStyle: usize,
+    SetPaneToggleButtonStyle: usize,
+    SelectedItem: usize,
+    pub SetSelectedItem: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    pub get_MenuItems: unsafe extern "system" fn(
+    pub MenuItems: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_MenuItemsSource: usize,
-    put_MenuItemsSource: usize,
-    get_SettingsItem: usize,
-    pub get_AutoSuggestBox: unsafe extern "system" fn(
+    MenuItemsSource: usize,
+    SetMenuItemsSource: usize,
+    SettingsItem: usize,
+    pub AutoSuggestBox: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    pub put_AutoSuggestBox: unsafe extern "system" fn(
+    pub SetAutoSuggestBox: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_MenuItemTemplate: usize,
-    put_MenuItemTemplate: usize,
-    get_MenuItemTemplateSelector: usize,
-    put_MenuItemTemplateSelector: usize,
-    get_MenuItemContainerStyle: usize,
-    put_MenuItemContainerStyle: usize,
-    get_MenuItemContainerStyleSelector: usize,
-    put_MenuItemContainerStyleSelector: usize,
+    MenuItemTemplate: usize,
+    SetMenuItemTemplate: usize,
+    MenuItemTemplateSelector: usize,
+    SetMenuItemTemplateSelector: usize,
+    MenuItemContainerStyle: usize,
+    SetMenuItemContainerStyle: usize,
+    MenuItemContainerStyleSelector: usize,
+    SetMenuItemContainerStyleSelector: usize,
     MenuItemFromContainer: usize,
     ContainerFromMenuItem: usize,
-    pub add_SelectionChanged: unsafe extern "system" fn(
+    pub SelectionChanged: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         *mut i64,
     ) -> windows_core::HRESULT,
-    pub remove_SelectionChanged:
+    pub RemoveSelectionChanged:
         unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
@@ -12600,30 +12594,30 @@ impl windows_core::RuntimeType for INavigationView2 {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl INavigationView2 {
-    pub(crate) fn put_IsBackButtonVisible(
+    pub(crate) fn SetIsBackButtonVisible(
         &self,
         value: NavigationViewBackButtonVisible,
     ) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_IsBackButtonVisible)(
+            (windows_core::Interface::vtable(self).SetIsBackButtonVisible)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_IsBackEnabled(&self, value: bool) -> windows_core::Result<()> {
+    pub(crate) fn SetIsBackEnabled(&self, value: bool) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_IsBackEnabled)(
+            (windows_core::Interface::vtable(self).SetIsBackEnabled)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_PaneTitle(&self, value: &str) -> windows_core::Result<()> {
+    pub(crate) fn SetPaneTitle(&self, value: &str) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_PaneTitle)(
+            (windows_core::Interface::vtable(self).SetPaneTitle)(
                 windows_core::Interface::as_raw(self),
                 core::mem::transmute_copy(&windows_core::HSTRING::from(value)),
             )
@@ -12646,7 +12640,7 @@ impl INavigationView2 {
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
-            let token__ = (windows_core::Interface::vtable(self).add_BackRequested)(
+            let token__ = (windows_core::Interface::vtable(self).BackRequested)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Interface::as_raw(&handler),
                 &mut result__,
@@ -12655,16 +12649,16 @@ impl INavigationView2 {
             Ok(windows_core::EventRevoker::new(
                 self.clone(),
                 token__,
-                windows_core::Interface::vtable(self).remove_BackRequested,
+                windows_core::Interface::vtable(self).RemoveBackRequested,
             ))
         }
     }
-    pub(crate) fn put_PaneDisplayMode(
+    pub(crate) fn SetPaneDisplayMode(
         &self,
         value: NavigationViewPaneDisplayMode,
     ) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_PaneDisplayMode)(
+            (windows_core::Interface::vtable(self).SetPaneDisplayMode)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
@@ -12675,36 +12669,36 @@ impl INavigationView2 {
 #[repr(C)]
 pub struct INavigationView2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_IsBackButtonVisible: usize,
-    pub put_IsBackButtonVisible: unsafe extern "system" fn(
+    IsBackButtonVisible: usize,
+    pub SetIsBackButtonVisible: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         NavigationViewBackButtonVisible,
     ) -> windows_core::HRESULT,
-    get_IsBackEnabled: usize,
-    pub put_IsBackEnabled:
+    IsBackEnabled: usize,
+    pub SetIsBackEnabled:
         unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
-    get_PaneTitle: usize,
-    pub put_PaneTitle: unsafe extern "system" fn(
+    PaneTitle: usize,
+    pub SetPaneTitle: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    pub add_BackRequested: unsafe extern "system" fn(
+    pub BackRequested: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         *mut i64,
     ) -> windows_core::HRESULT,
-    pub remove_BackRequested:
+    pub RemoveBackRequested:
         unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
-    add_PaneClosed: usize,
-    remove_PaneClosed: usize,
-    add_PaneClosing: usize,
-    remove_PaneClosing: usize,
-    add_PaneOpened: usize,
-    remove_PaneOpened: usize,
-    add_PaneOpening: usize,
-    remove_PaneOpening: usize,
-    get_PaneDisplayMode: usize,
-    pub put_PaneDisplayMode: unsafe extern "system" fn(
+    PaneClosed: usize,
+    RemovePaneClosed: usize,
+    PaneClosing: usize,
+    RemovePaneClosing: usize,
+    PaneOpened: usize,
+    RemovePaneOpened: usize,
+    PaneOpening: usize,
+    RemovePaneOpening: usize,
+    PaneDisplayMode: usize,
+    pub SetPaneDisplayMode: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         NavigationViewPaneDisplayMode,
     ) -> windows_core::HRESULT,
@@ -12751,12 +12745,12 @@ impl windows_core::RuntimeType for INavigationViewItem {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl INavigationViewItem {
-    pub(crate) fn put_Icon<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetIcon<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<IconElement>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Icon)(
+            (windows_core::Interface::vtable(self).SetIcon)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
@@ -12767,8 +12761,8 @@ impl INavigationViewItem {
 #[repr(C)]
 pub struct INavigationViewItem_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_Icon: usize,
-    pub put_Icon: unsafe extern "system" fn(
+    Icon: usize,
+    pub SetIcon: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
@@ -12783,12 +12777,12 @@ impl windows_core::RuntimeType for INavigationViewItem2 {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl INavigationViewItem2 {
-    pub(crate) fn get_MenuItems(
+    pub(crate) fn MenuItems(
         &self,
     ) -> windows_core::Result<windows_collections::IVector<windows_core::IInspectable>> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_MenuItems)(
+            (windows_core::Interface::vtable(self).MenuItems)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
@@ -12799,15 +12793,15 @@ impl INavigationViewItem2 {
 #[repr(C)]
 pub struct INavigationViewItem2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_SelectsOnInvoked: usize,
-    put_SelectsOnInvoked: usize,
-    get_IsExpanded: usize,
-    put_IsExpanded: usize,
-    get_HasUnrealizedChildren: usize,
-    put_HasUnrealizedChildren: usize,
-    get_IsChildSelected: usize,
-    put_IsChildSelected: usize,
-    pub get_MenuItems: unsafe extern "system" fn(
+    SelectsOnInvoked: usize,
+    SetSelectsOnInvoked: usize,
+    IsExpanded: usize,
+    SetIsExpanded: usize,
+    HasUnrealizedChildren: usize,
+    SetHasUnrealizedChildren: usize,
+    IsChildSelected: usize,
+    SetIsChildSelected: usize,
+    pub MenuItems: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
@@ -12886,10 +12880,10 @@ impl windows_core::RuntimeType for INavigationViewSelectionChangedEventArgs {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl INavigationViewSelectionChangedEventArgs {
-    pub(crate) fn get_SelectedItem(&self) -> windows_core::Result<windows_core::IInspectable> {
+    pub(crate) fn SelectedItem(&self) -> windows_core::Result<windows_core::IInspectable> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_SelectedItem)(
+            (windows_core::Interface::vtable(self).SelectedItem)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
@@ -12900,7 +12894,7 @@ impl INavigationViewSelectionChangedEventArgs {
 #[repr(C)]
 pub struct INavigationViewSelectionChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    pub get_SelectedItem: unsafe extern "system" fn(
+    pub SelectedItem: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
@@ -12915,39 +12909,39 @@ impl windows_core::RuntimeType for INumberBox {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl INumberBox {
-    pub(crate) fn put_Minimum(&self, value: f64) -> windows_core::Result<()> {
+    pub(crate) fn SetMinimum(&self, value: f64) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Minimum)(
+            (windows_core::Interface::vtable(self).SetMinimum)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_Maximum(&self, value: f64) -> windows_core::Result<()> {
+    pub(crate) fn SetMaximum(&self, value: f64) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Maximum)(
+            (windows_core::Interface::vtable(self).SetMaximum)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_Value(&self, value: f64) -> windows_core::Result<()> {
+    pub(crate) fn SetValue(&self, value: f64) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Value)(
+            (windows_core::Interface::vtable(self).SetValue)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_Header<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetHeader<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<windows_core::IInspectable>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Header)(
+            (windows_core::Interface::vtable(self).SetHeader)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
@@ -12974,7 +12968,7 @@ impl INumberBox {
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
-            let token__ = (windows_core::Interface::vtable(self).add_ValueChanged)(
+            let token__ = (windows_core::Interface::vtable(self).ValueChanged)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Interface::as_raw(&handler),
                 &mut result__,
@@ -12983,7 +12977,7 @@ impl INumberBox {
             Ok(windows_core::EventRevoker::new(
                 self.clone(),
                 token__,
-                windows_core::Interface::vtable(self).remove_ValueChanged,
+                windows_core::Interface::vtable(self).RemoveValueChanged,
             ))
         }
     }
@@ -12991,55 +12985,53 @@ impl INumberBox {
 #[repr(C)]
 pub struct INumberBox_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_Minimum: usize,
-    pub put_Minimum:
-        unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
-    get_Maximum: usize,
-    pub put_Maximum:
-        unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
-    get_Value: usize,
-    pub put_Value: unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
-    get_SmallChange: usize,
-    put_SmallChange: usize,
-    get_LargeChange: usize,
-    put_LargeChange: usize,
-    get_Text: usize,
-    put_Text: usize,
-    get_Header: usize,
-    pub put_Header: unsafe extern "system" fn(
+    Minimum: usize,
+    pub SetMinimum: unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
+    Maximum: usize,
+    pub SetMaximum: unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
+    Value: usize,
+    pub SetValue: unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
+    SmallChange: usize,
+    SetSmallChange: usize,
+    LargeChange: usize,
+    SetLargeChange: usize,
+    Text: usize,
+    SetText: usize,
+    Header: usize,
+    pub SetHeader: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_HeaderTemplate: usize,
-    put_HeaderTemplate: usize,
-    get_PlaceholderText: usize,
-    put_PlaceholderText: usize,
-    get_SelectionFlyout: usize,
-    put_SelectionFlyout: usize,
-    get_SelectionHighlightColor: usize,
-    put_SelectionHighlightColor: usize,
-    get_TextReadingOrder: usize,
-    put_TextReadingOrder: usize,
-    get_PreventKeyboardDisplayOnProgrammaticFocus: usize,
-    put_PreventKeyboardDisplayOnProgrammaticFocus: usize,
-    get_Description: usize,
-    put_Description: usize,
-    get_ValidationMode: usize,
-    put_ValidationMode: usize,
-    get_SpinButtonPlacementMode: usize,
-    put_SpinButtonPlacementMode: usize,
-    get_IsWrapEnabled: usize,
-    put_IsWrapEnabled: usize,
-    get_AcceptsExpression: usize,
-    put_AcceptsExpression: usize,
-    get_NumberFormatter: usize,
-    put_NumberFormatter: usize,
-    pub add_ValueChanged: unsafe extern "system" fn(
+    HeaderTemplate: usize,
+    SetHeaderTemplate: usize,
+    PlaceholderText: usize,
+    SetPlaceholderText: usize,
+    SelectionFlyout: usize,
+    SetSelectionFlyout: usize,
+    SelectionHighlightColor: usize,
+    SetSelectionHighlightColor: usize,
+    TextReadingOrder: usize,
+    SetTextReadingOrder: usize,
+    PreventKeyboardDisplayOnProgrammaticFocus: usize,
+    SetPreventKeyboardDisplayOnProgrammaticFocus: usize,
+    Description: usize,
+    SetDescription: usize,
+    ValidationMode: usize,
+    SetValidationMode: usize,
+    SpinButtonPlacementMode: usize,
+    SetSpinButtonPlacementMode: usize,
+    IsWrapEnabled: usize,
+    SetIsWrapEnabled: usize,
+    AcceptsExpression: usize,
+    SetAcceptsExpression: usize,
+    NumberFormatter: usize,
+    SetNumberFormatter: usize,
+    pub ValueChanged: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         *mut i64,
     ) -> windows_core::HRESULT,
-    pub remove_ValueChanged:
+    pub RemoveValueChanged:
         unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
@@ -13071,10 +13063,10 @@ impl windows_core::RuntimeType for INumberBoxValueChangedEventArgs {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl INumberBoxValueChangedEventArgs {
-    pub(crate) fn get_NewValue(&self) -> windows_core::Result<f64> {
+    pub(crate) fn NewValue(&self) -> windows_core::Result<f64> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_NewValue)(
+            (windows_core::Interface::vtable(self).NewValue)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
@@ -13085,8 +13077,8 @@ impl INumberBoxValueChangedEventArgs {
 #[repr(C)]
 pub struct INumberBoxValueChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_OldValue: usize,
-    pub get_NewValue:
+    OldValue: usize,
+    pub NewValue:
         unsafe extern "system" fn(*mut core::ffi::c_void, *mut f64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
@@ -13099,46 +13091,40 @@ impl windows_core::RuntimeType for IOverlappedPresenter3 {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IOverlappedPresenter3 {
-    pub(crate) fn put_PreferredMinimumHeight(
-        &self,
-        value: Option<i32>,
-    ) -> windows_core::Result<()> {
+    pub(crate) fn SetPreferredMinimumHeight(&self, value: Option<i32>) -> windows_core::Result<()> {
         let value__ = value.map(<windows_reference::IReference<i32> as From<_>>::from);
         unsafe {
-            (windows_core::Interface::vtable(self).put_PreferredMinimumHeight)(
+            (windows_core::Interface::vtable(self).SetPreferredMinimumHeight)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Param::param(value__.as_ref()).abi(),
             )
             .ok()
         }
     }
-    pub(crate) fn put_PreferredMinimumWidth(&self, value: Option<i32>) -> windows_core::Result<()> {
+    pub(crate) fn SetPreferredMinimumWidth(&self, value: Option<i32>) -> windows_core::Result<()> {
         let value__ = value.map(<windows_reference::IReference<i32> as From<_>>::from);
         unsafe {
-            (windows_core::Interface::vtable(self).put_PreferredMinimumWidth)(
+            (windows_core::Interface::vtable(self).SetPreferredMinimumWidth)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Param::param(value__.as_ref()).abi(),
             )
             .ok()
         }
     }
-    pub(crate) fn put_PreferredMaximumWidth(&self, value: Option<i32>) -> windows_core::Result<()> {
+    pub(crate) fn SetPreferredMaximumWidth(&self, value: Option<i32>) -> windows_core::Result<()> {
         let value__ = value.map(<windows_reference::IReference<i32> as From<_>>::from);
         unsafe {
-            (windows_core::Interface::vtable(self).put_PreferredMaximumWidth)(
+            (windows_core::Interface::vtable(self).SetPreferredMaximumWidth)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Param::param(value__.as_ref()).abi(),
             )
             .ok()
         }
     }
-    pub(crate) fn put_PreferredMaximumHeight(
-        &self,
-        value: Option<i32>,
-    ) -> windows_core::Result<()> {
+    pub(crate) fn SetPreferredMaximumHeight(&self, value: Option<i32>) -> windows_core::Result<()> {
         let value__ = value.map(<windows_reference::IReference<i32> as From<_>>::from);
         unsafe {
-            (windows_core::Interface::vtable(self).put_PreferredMaximumHeight)(
+            (windows_core::Interface::vtable(self).SetPreferredMaximumHeight)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Param::param(value__.as_ref()).abi(),
             )
@@ -13149,23 +13135,23 @@ impl IOverlappedPresenter3 {
 #[repr(C)]
 pub struct IOverlappedPresenter3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_PreferredMinimumHeight: usize,
-    pub put_PreferredMinimumHeight: unsafe extern "system" fn(
+    PreferredMinimumHeight: usize,
+    pub SetPreferredMinimumHeight: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_PreferredMinimumWidth: usize,
-    pub put_PreferredMinimumWidth: unsafe extern "system" fn(
+    PreferredMinimumWidth: usize,
+    pub SetPreferredMinimumWidth: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_PreferredMaximumWidth: usize,
-    pub put_PreferredMaximumWidth: unsafe extern "system" fn(
+    PreferredMaximumWidth: usize,
+    pub SetPreferredMaximumWidth: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_PreferredMaximumHeight: usize,
-    pub put_PreferredMaximumHeight: unsafe extern "system" fn(
+    PreferredMaximumHeight: usize,
+    pub SetPreferredMaximumHeight: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
@@ -13176,22 +13162,22 @@ impl windows_core::RuntimeType for IPanel {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IPanel {
-    pub(crate) fn get_Children(&self) -> windows_core::Result<UIElementCollection> {
+    pub(crate) fn Children(&self) -> windows_core::Result<UIElementCollection> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_Children)(
+            (windows_core::Interface::vtable(self).Children)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
             .and_then(|| windows_core::Type::from_abi(result__))
         }
     }
-    pub(crate) fn put_Background<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetBackground<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<Brush>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Background)(
+            (windows_core::Interface::vtable(self).SetBackground)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
@@ -13202,12 +13188,12 @@ impl IPanel {
 #[repr(C)]
 pub struct IPanel_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    pub get_Children: unsafe extern "system" fn(
+    pub Children: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_Background: usize,
-    pub put_Background: unsafe extern "system" fn(
+    Background: usize,
+    pub SetBackground: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
@@ -13222,10 +13208,10 @@ impl windows_core::RuntimeType for IParagraph {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IParagraph {
-    pub(crate) fn get_Inlines(&self) -> windows_core::Result<InlineCollection> {
+    pub(crate) fn Inlines(&self) -> windows_core::Result<InlineCollection> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_Inlines)(
+            (windows_core::Interface::vtable(self).Inlines)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
@@ -13236,7 +13222,7 @@ impl IParagraph {
 #[repr(C)]
 pub struct IParagraph_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    pub get_Inlines: unsafe extern "system" fn(
+    pub Inlines: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
@@ -13251,10 +13237,10 @@ impl windows_core::RuntimeType for IPasswordBox {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IPasswordBox {
-    pub(crate) fn get_Password(&self) -> windows_core::Result<String> {
+    pub(crate) fn Password(&self) -> windows_core::Result<String> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_Password)(
+            (windows_core::Interface::vtable(self).Password)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
@@ -13264,54 +13250,51 @@ impl IPasswordBox {
             })
         }
     }
-    pub(crate) fn put_Password(&self, value: &str) -> windows_core::Result<()> {
+    pub(crate) fn SetPassword(&self, value: &str) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Password)(
+            (windows_core::Interface::vtable(self).SetPassword)(
                 windows_core::Interface::as_raw(self),
                 core::mem::transmute_copy(&windows_core::HSTRING::from(value)),
             )
             .ok()
         }
     }
-    pub(crate) fn put_IsPasswordRevealButtonEnabled(
-        &self,
-        value: bool,
-    ) -> windows_core::Result<()> {
+    pub(crate) fn SetIsPasswordRevealButtonEnabled(&self, value: bool) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_IsPasswordRevealButtonEnabled)(
+            (windows_core::Interface::vtable(self).SetIsPasswordRevealButtonEnabled)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_Header<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetHeader<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<windows_core::IInspectable>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Header)(
+            (windows_core::Interface::vtable(self).SetHeader)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
             .ok()
         }
     }
-    pub(crate) fn put_PlaceholderText(&self, value: &str) -> windows_core::Result<()> {
+    pub(crate) fn SetPlaceholderText(&self, value: &str) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_PlaceholderText)(
+            (windows_core::Interface::vtable(self).SetPlaceholderText)(
                 windows_core::Interface::as_raw(self),
                 core::mem::transmute_copy(&windows_core::HSTRING::from(value)),
             )
             .ok()
         }
     }
-    pub(crate) fn put_PasswordRevealMode(
+    pub(crate) fn SetPasswordRevealMode(
         &self,
         value: PasswordRevealMode,
     ) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_PasswordRevealMode)(
+            (windows_core::Interface::vtable(self).SetPasswordRevealMode)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
@@ -13335,7 +13318,7 @@ impl IPasswordBox {
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
-            let token__ = (windows_core::Interface::vtable(self).add_PasswordChanged)(
+            let token__ = (windows_core::Interface::vtable(self).PasswordChanged)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Interface::as_raw(&handler),
                 &mut result__,
@@ -13344,7 +13327,7 @@ impl IPasswordBox {
             Ok(windows_core::EventRevoker::new(
                 self.clone(),
                 token__,
-                windows_core::Interface::vtable(self).remove_PasswordChanged,
+                windows_core::Interface::vtable(self).RemovePasswordChanged,
             ))
         }
     }
@@ -13352,57 +13335,57 @@ impl IPasswordBox {
 #[repr(C)]
 pub struct IPasswordBox_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    pub get_Password: unsafe extern "system" fn(
+    pub Password: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    pub put_Password: unsafe extern "system" fn(
+    pub SetPassword: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_PasswordChar: usize,
-    put_PasswordChar: usize,
-    get_IsPasswordRevealButtonEnabled: usize,
-    pub put_IsPasswordRevealButtonEnabled:
+    PasswordChar: usize,
+    SetPasswordChar: usize,
+    IsPasswordRevealButtonEnabled: usize,
+    pub SetIsPasswordRevealButtonEnabled:
         unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
-    get_MaxLength: usize,
-    put_MaxLength: usize,
-    get_Header: usize,
-    pub put_Header: unsafe extern "system" fn(
+    MaxLength: usize,
+    SetMaxLength: usize,
+    Header: usize,
+    pub SetHeader: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_HeaderTemplate: usize,
-    put_HeaderTemplate: usize,
-    get_PlaceholderText: usize,
-    pub put_PlaceholderText: unsafe extern "system" fn(
+    HeaderTemplate: usize,
+    SetHeaderTemplate: usize,
+    PlaceholderText: usize,
+    pub SetPlaceholderText: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_SelectionHighlightColor: usize,
-    put_SelectionHighlightColor: usize,
-    get_PreventKeyboardDisplayOnProgrammaticFocus: usize,
-    put_PreventKeyboardDisplayOnProgrammaticFocus: usize,
-    get_PasswordRevealMode: usize,
-    pub put_PasswordRevealMode: unsafe extern "system" fn(
+    SelectionHighlightColor: usize,
+    SetSelectionHighlightColor: usize,
+    PreventKeyboardDisplayOnProgrammaticFocus: usize,
+    SetPreventKeyboardDisplayOnProgrammaticFocus: usize,
+    PasswordRevealMode: usize,
+    pub SetPasswordRevealMode: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         PasswordRevealMode,
     ) -> windows_core::HRESULT,
-    get_TextReadingOrder: usize,
-    put_TextReadingOrder: usize,
-    get_InputScope: usize,
-    put_InputScope: usize,
-    get_CanPasteClipboardContent: usize,
-    get_SelectionFlyout: usize,
-    put_SelectionFlyout: usize,
-    get_Description: usize,
-    put_Description: usize,
-    pub add_PasswordChanged: unsafe extern "system" fn(
+    TextReadingOrder: usize,
+    SetTextReadingOrder: usize,
+    InputScope: usize,
+    SetInputScope: usize,
+    CanPasteClipboardContent: usize,
+    SelectionFlyout: usize,
+    SetSelectionFlyout: usize,
+    Description: usize,
+    SetDescription: usize,
+    pub PasswordChanged: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         *mut i64,
     ) -> windows_core::HRESULT,
-    pub remove_PasswordChanged:
+    pub RemovePasswordChanged:
         unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
@@ -13415,18 +13398,18 @@ impl windows_core::RuntimeType for IPersonPicture {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IPersonPicture {
-    pub(crate) fn put_DisplayName(&self, value: &str) -> windows_core::Result<()> {
+    pub(crate) fn SetDisplayName(&self, value: &str) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_DisplayName)(
+            (windows_core::Interface::vtable(self).SetDisplayName)(
                 windows_core::Interface::as_raw(self),
                 core::mem::transmute_copy(&windows_core::HSTRING::from(value)),
             )
             .ok()
         }
     }
-    pub(crate) fn put_Initials(&self, value: &str) -> windows_core::Result<()> {
+    pub(crate) fn SetInitials(&self, value: &str) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Initials)(
+            (windows_core::Interface::vtable(self).SetInitials)(
                 windows_core::Interface::as_raw(self),
                 core::mem::transmute_copy(&windows_core::HSTRING::from(value)),
             )
@@ -13437,25 +13420,25 @@ impl IPersonPicture {
 #[repr(C)]
 pub struct IPersonPicture_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_BadgeNumber: usize,
-    put_BadgeNumber: usize,
-    get_BadgeGlyph: usize,
-    put_BadgeGlyph: usize,
-    get_BadgeImageSource: usize,
-    put_BadgeImageSource: usize,
-    get_BadgeText: usize,
-    put_BadgeText: usize,
-    get_IsGroup: usize,
-    put_IsGroup: usize,
-    get_Contact: usize,
-    put_Contact: usize,
-    get_DisplayName: usize,
-    pub put_DisplayName: unsafe extern "system" fn(
+    BadgeNumber: usize,
+    SetBadgeNumber: usize,
+    BadgeGlyph: usize,
+    SetBadgeGlyph: usize,
+    BadgeImageSource: usize,
+    SetBadgeImageSource: usize,
+    BadgeText: usize,
+    SetBadgeText: usize,
+    IsGroup: usize,
+    SetIsGroup: usize,
+    Contact: usize,
+    SetContact: usize,
+    DisplayName: usize,
+    pub SetDisplayName: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_Initials: usize,
-    pub put_Initials: unsafe extern "system" fn(
+    Initials: usize,
+    pub SetInitials: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
@@ -13485,21 +13468,21 @@ impl windows_core::RuntimeType for IPivot {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IPivot {
-    pub(crate) fn put_Title<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetTitle<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<windows_core::IInspectable>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Title)(
+            (windows_core::Interface::vtable(self).SetTitle)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
             .ok()
         }
     }
-    pub(crate) fn put_SelectedIndex(&self, value: i32) -> windows_core::Result<()> {
+    pub(crate) fn SetSelectedIndex(&self, value: i32) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_SelectedIndex)(
+            (windows_core::Interface::vtable(self).SetSelectedIndex)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
@@ -13525,7 +13508,7 @@ impl IPivot {
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
-            let token__ = (windows_core::Interface::vtable(self).add_SelectionChanged)(
+            let token__ = (windows_core::Interface::vtable(self).SelectionChanged)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Interface::as_raw(&handler),
                 &mut result__,
@@ -13534,7 +13517,7 @@ impl IPivot {
             Ok(windows_core::EventRevoker::new(
                 self.clone(),
                 token__,
-                windows_core::Interface::vtable(self).remove_SelectionChanged,
+                windows_core::Interface::vtable(self).RemoveSelectionChanged,
             ))
         }
     }
@@ -13542,40 +13525,40 @@ impl IPivot {
 #[repr(C)]
 pub struct IPivot_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_Title: usize,
-    pub put_Title: unsafe extern "system" fn(
+    Title: usize,
+    pub SetTitle: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_TitleTemplate: usize,
-    put_TitleTemplate: usize,
-    get_LeftHeader: usize,
-    put_LeftHeader: usize,
-    get_LeftHeaderTemplate: usize,
-    put_LeftHeaderTemplate: usize,
-    get_RightHeader: usize,
-    put_RightHeader: usize,
-    get_RightHeaderTemplate: usize,
-    put_RightHeaderTemplate: usize,
-    get_HeaderTemplate: usize,
-    put_HeaderTemplate: usize,
-    get_SelectedIndex: usize,
-    pub put_SelectedIndex:
+    TitleTemplate: usize,
+    SetTitleTemplate: usize,
+    LeftHeader: usize,
+    SetLeftHeader: usize,
+    LeftHeaderTemplate: usize,
+    SetLeftHeaderTemplate: usize,
+    RightHeader: usize,
+    SetRightHeader: usize,
+    RightHeaderTemplate: usize,
+    SetRightHeaderTemplate: usize,
+    HeaderTemplate: usize,
+    SetHeaderTemplate: usize,
+    SelectedIndex: usize,
+    pub SetSelectedIndex:
         unsafe extern "system" fn(*mut core::ffi::c_void, i32) -> windows_core::HRESULT,
-    get_SelectedItem: usize,
-    put_SelectedItem: usize,
-    get_IsLocked: usize,
-    put_IsLocked: usize,
-    get_HeaderFocusVisualPlacement: usize,
-    put_HeaderFocusVisualPlacement: usize,
-    get_IsHeaderItemsCarouselEnabled: usize,
-    put_IsHeaderItemsCarouselEnabled: usize,
-    pub add_SelectionChanged: unsafe extern "system" fn(
+    SelectedItem: usize,
+    SetSelectedItem: usize,
+    IsLocked: usize,
+    SetIsLocked: usize,
+    HeaderFocusVisualPlacement: usize,
+    SetHeaderFocusVisualPlacement: usize,
+    IsHeaderItemsCarouselEnabled: usize,
+    SetIsHeaderItemsCarouselEnabled: usize,
+    pub SelectionChanged: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         *mut i64,
     ) -> windows_core::HRESULT,
-    pub remove_SelectionChanged:
+    pub RemoveSelectionChanged:
         unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
@@ -13607,12 +13590,12 @@ impl windows_core::RuntimeType for IPivotItem {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IPivotItem {
-    pub(crate) fn put_Header<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetHeader<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<windows_core::IInspectable>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Header)(
+            (windows_core::Interface::vtable(self).SetHeader)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
@@ -13623,8 +13606,8 @@ impl IPivotItem {
 #[repr(C)]
 pub struct IPivotItem_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_Header: usize,
-    pub put_Header: unsafe extern "system" fn(
+    Header: usize,
+    pub SetHeader: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
@@ -13658,10 +13641,10 @@ impl windows_core::RuntimeType for IPointerPoint {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IPointerPoint {
-    pub(crate) fn get_Properties(&self) -> windows_core::Result<PointerPointProperties> {
+    pub(crate) fn Properties(&self) -> windows_core::Result<PointerPointProperties> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_Properties)(
+            (windows_core::Interface::vtable(self).Properties)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
@@ -13672,12 +13655,12 @@ impl IPointerPoint {
 #[repr(C)]
 pub struct IPointerPoint_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_FrameId: usize,
-    get_IsInContact: usize,
-    get_PointerDeviceType: usize,
-    get_PointerId: usize,
-    get_Position: usize,
-    pub get_Properties: unsafe extern "system" fn(
+    FrameId: usize,
+    IsInContact: usize,
+    PointerDeviceType: usize,
+    PointerId: usize,
+    Position: usize,
+    pub Properties: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
@@ -13692,30 +13675,30 @@ impl windows_core::RuntimeType for IPointerPointProperties {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IPointerPointProperties {
-    pub(crate) fn get_IsLeftButtonPressed(&self) -> windows_core::Result<bool> {
+    pub(crate) fn IsLeftButtonPressed(&self) -> windows_core::Result<bool> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_IsLeftButtonPressed)(
+            (windows_core::Interface::vtable(self).IsLeftButtonPressed)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
             .map(|| result__)
         }
     }
-    pub(crate) fn get_IsMiddleButtonPressed(&self) -> windows_core::Result<bool> {
+    pub(crate) fn IsMiddleButtonPressed(&self) -> windows_core::Result<bool> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_IsMiddleButtonPressed)(
+            (windows_core::Interface::vtable(self).IsMiddleButtonPressed)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
             .map(|| result__)
         }
     }
-    pub(crate) fn get_IsRightButtonPressed(&self) -> windows_core::Result<bool> {
+    pub(crate) fn IsRightButtonPressed(&self) -> windows_core::Result<bool> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_IsRightButtonPressed)(
+            (windows_core::Interface::vtable(self).IsRightButtonPressed)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
@@ -13726,19 +13709,19 @@ impl IPointerPointProperties {
 #[repr(C)]
 pub struct IPointerPointProperties_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_ContactRect: usize,
-    get_IsBarrelButtonPressed: usize,
-    get_IsCanceled: usize,
-    get_IsEraser: usize,
-    get_IsHorizontalMouseWheel: usize,
-    get_IsInRange: usize,
-    get_IsInverted: usize,
-    pub get_IsLeftButtonPressed:
+    ContactRect: usize,
+    IsBarrelButtonPressed: usize,
+    IsCanceled: usize,
+    IsEraser: usize,
+    IsHorizontalMouseWheel: usize,
+    IsInRange: usize,
+    IsInverted: usize,
+    pub IsLeftButtonPressed:
         unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
-    pub get_IsMiddleButtonPressed:
+    pub IsMiddleButtonPressed:
         unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
-    get_IsPrimary: usize,
-    pub get_IsRightButtonPressed:
+    IsPrimary: usize,
+    pub IsRightButtonPressed:
         unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
@@ -13769,11 +13752,11 @@ impl IPointerRoutedEventArgs {
 #[repr(C)]
 pub struct IPointerRoutedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_Pointer: usize,
-    get_KeyModifiers: usize,
-    get_Handled: usize,
-    put_Handled: usize,
-    get_IsGenerated: usize,
+    Pointer: usize,
+    KeyModifiers: usize,
+    Handled: usize,
+    SetHandled: usize,
+    IsGenerated: usize,
     pub GetCurrentPoint: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
@@ -13799,9 +13782,9 @@ impl windows_core::RuntimeType for IProgressBar {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IProgressBar {
-    pub(crate) fn put_IsIndeterminate(&self, value: bool) -> windows_core::Result<()> {
+    pub(crate) fn SetIsIndeterminate(&self, value: bool) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_IsIndeterminate)(
+            (windows_core::Interface::vtable(self).SetIsIndeterminate)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
@@ -13812,8 +13795,8 @@ impl IProgressBar {
 #[repr(C)]
 pub struct IProgressBar_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_IsIndeterminate: usize,
-    pub put_IsIndeterminate:
+    IsIndeterminate: usize,
+    pub SetIsIndeterminate:
         unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
@@ -13845,45 +13828,45 @@ impl windows_core::RuntimeType for IProgressRing {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IProgressRing {
-    pub(crate) fn put_IsActive(&self, value: bool) -> windows_core::Result<()> {
+    pub(crate) fn SetIsActive(&self, value: bool) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_IsActive)(
+            (windows_core::Interface::vtable(self).SetIsActive)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_IsIndeterminate(&self, value: bool) -> windows_core::Result<()> {
+    pub(crate) fn SetIsIndeterminate(&self, value: bool) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_IsIndeterminate)(
+            (windows_core::Interface::vtable(self).SetIsIndeterminate)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_Value(&self, value: f64) -> windows_core::Result<()> {
+    pub(crate) fn SetValue(&self, value: f64) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Value)(
+            (windows_core::Interface::vtable(self).SetValue)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_Minimum(&self, value: f64) -> windows_core::Result<()> {
+    pub(crate) fn SetMinimum(&self, value: f64) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Minimum)(
+            (windows_core::Interface::vtable(self).SetMinimum)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_Maximum(&self, value: f64) -> windows_core::Result<()> {
+    pub(crate) fn SetMaximum(&self, value: f64) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Maximum)(
+            (windows_core::Interface::vtable(self).SetMaximum)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
@@ -13894,21 +13877,19 @@ impl IProgressRing {
 #[repr(C)]
 pub struct IProgressRing_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_IsActive: usize,
-    pub put_IsActive:
+    IsActive: usize,
+    pub SetIsActive:
         unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
-    get_IsIndeterminate: usize,
-    pub put_IsIndeterminate:
+    IsIndeterminate: usize,
+    pub SetIsIndeterminate:
         unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
-    get_TemplateSettings: usize,
-    get_Value: usize,
-    pub put_Value: unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
-    get_Minimum: usize,
-    pub put_Minimum:
-        unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
-    get_Maximum: usize,
-    pub put_Maximum:
-        unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
+    TemplateSettings: usize,
+    Value: usize,
+    pub SetValue: unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
+    Minimum: usize,
+    pub SetMinimum: unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
+    Maximum: usize,
+    pub SetMaximum: unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
     IProgressRingFactory,
@@ -13939,9 +13920,9 @@ impl windows_core::RuntimeType for IRadioButton {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IRadioButton {
-    pub(crate) fn put_GroupName(&self, value: &str) -> windows_core::Result<()> {
+    pub(crate) fn SetGroupName(&self, value: &str) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_GroupName)(
+            (windows_core::Interface::vtable(self).SetGroupName)(
                 windows_core::Interface::as_raw(self),
                 core::mem::transmute_copy(&windows_core::HSTRING::from(value)),
             )
@@ -13952,8 +13933,8 @@ impl IRadioButton {
 #[repr(C)]
 pub struct IRadioButton_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_GroupName: usize,
-    pub put_GroupName: unsafe extern "system" fn(
+    GroupName: usize,
+    pub SetGroupName: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
@@ -13987,31 +13968,31 @@ impl windows_core::RuntimeType for IRadioButtons {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IRadioButtons {
-    pub(crate) fn get_Items(
+    pub(crate) fn Items(
         &self,
     ) -> windows_core::Result<windows_collections::IVector<windows_core::IInspectable>> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_Items)(
+            (windows_core::Interface::vtable(self).Items)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
             .and_then(|| windows_core::Type::from_abi(result__))
         }
     }
-    pub(crate) fn get_SelectedIndex(&self) -> windows_core::Result<i32> {
+    pub(crate) fn SelectedIndex(&self) -> windows_core::Result<i32> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_SelectedIndex)(
+            (windows_core::Interface::vtable(self).SelectedIndex)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
             .map(|| result__)
         }
     }
-    pub(crate) fn put_SelectedIndex(&self, value: i32) -> windows_core::Result<()> {
+    pub(crate) fn SetSelectedIndex(&self, value: i32) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_SelectedIndex)(
+            (windows_core::Interface::vtable(self).SetSelectedIndex)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
@@ -14037,7 +14018,7 @@ impl IRadioButtons {
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
-            let token__ = (windows_core::Interface::vtable(self).add_SelectionChanged)(
+            let token__ = (windows_core::Interface::vtable(self).SelectionChanged)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Interface::as_raw(&handler),
                 &mut result__,
@@ -14046,25 +14027,25 @@ impl IRadioButtons {
             Ok(windows_core::EventRevoker::new(
                 self.clone(),
                 token__,
-                windows_core::Interface::vtable(self).remove_SelectionChanged,
+                windows_core::Interface::vtable(self).RemoveSelectionChanged,
             ))
         }
     }
-    pub(crate) fn put_MaxColumns(&self, value: i32) -> windows_core::Result<()> {
+    pub(crate) fn SetMaxColumns(&self, value: i32) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_MaxColumns)(
+            (windows_core::Interface::vtable(self).SetMaxColumns)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_Header<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetHeader<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<windows_core::IInspectable>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Header)(
+            (windows_core::Interface::vtable(self).SetHeader)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
@@ -14075,33 +14056,33 @@ impl IRadioButtons {
 #[repr(C)]
 pub struct IRadioButtons_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_ItemsSource: usize,
-    put_ItemsSource: usize,
-    pub get_Items: unsafe extern "system" fn(
+    ItemsSource: usize,
+    SetItemsSource: usize,
+    pub Items: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_ItemTemplate: usize,
-    put_ItemTemplate: usize,
+    ItemTemplate: usize,
+    SetItemTemplate: usize,
     ContainerFromIndex: usize,
-    pub get_SelectedIndex:
+    pub SelectedIndex:
         unsafe extern "system" fn(*mut core::ffi::c_void, *mut i32) -> windows_core::HRESULT,
-    pub put_SelectedIndex:
+    pub SetSelectedIndex:
         unsafe extern "system" fn(*mut core::ffi::c_void, i32) -> windows_core::HRESULT,
-    get_SelectedItem: usize,
-    put_SelectedItem: usize,
-    pub add_SelectionChanged: unsafe extern "system" fn(
+    SelectedItem: usize,
+    SetSelectedItem: usize,
+    pub SelectionChanged: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         *mut i64,
     ) -> windows_core::HRESULT,
-    pub remove_SelectionChanged:
+    pub RemoveSelectionChanged:
         unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
-    get_MaxColumns: usize,
-    pub put_MaxColumns:
+    MaxColumns: usize,
+    pub SetMaxColumns:
         unsafe extern "system" fn(*mut core::ffi::c_void, i32) -> windows_core::HRESULT,
-    get_Header: usize,
-    pub put_Header: unsafe extern "system" fn(
+    Header: usize,
+    pub SetHeader: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
@@ -14135,46 +14116,46 @@ impl windows_core::RuntimeType for IRangeBase {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IRangeBase {
-    pub(crate) fn put_Minimum(&self, value: f64) -> windows_core::Result<()> {
+    pub(crate) fn SetMinimum(&self, value: f64) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Minimum)(
+            (windows_core::Interface::vtable(self).SetMinimum)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_Maximum(&self, value: f64) -> windows_core::Result<()> {
+    pub(crate) fn SetMaximum(&self, value: f64) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Maximum)(
+            (windows_core::Interface::vtable(self).SetMaximum)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_SmallChange(&self, value: f64) -> windows_core::Result<()> {
+    pub(crate) fn SetSmallChange(&self, value: f64) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_SmallChange)(
+            (windows_core::Interface::vtable(self).SetSmallChange)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn get_Value(&self) -> windows_core::Result<f64> {
+    pub(crate) fn Value(&self) -> windows_core::Result<f64> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_Value)(
+            (windows_core::Interface::vtable(self).Value)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
             .map(|| result__)
         }
     }
-    pub(crate) fn put_Value(&self, value: f64) -> windows_core::Result<()> {
+    pub(crate) fn SetValue(&self, value: f64) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Value)(
+            (windows_core::Interface::vtable(self).SetValue)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
@@ -14200,7 +14181,7 @@ impl IRangeBase {
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
-            let token__ = (windows_core::Interface::vtable(self).add_ValueChanged)(
+            let token__ = (windows_core::Interface::vtable(self).ValueChanged)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Interface::as_raw(&handler),
                 &mut result__,
@@ -14209,7 +14190,7 @@ impl IRangeBase {
             Ok(windows_core::EventRevoker::new(
                 self.clone(),
                 token__,
-                windows_core::Interface::vtable(self).remove_ValueChanged,
+                windows_core::Interface::vtable(self).RemoveValueChanged,
             ))
         }
     }
@@ -14217,26 +14198,23 @@ impl IRangeBase {
 #[repr(C)]
 pub struct IRangeBase_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_Minimum: usize,
-    pub put_Minimum:
+    Minimum: usize,
+    pub SetMinimum: unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
+    Maximum: usize,
+    pub SetMaximum: unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
+    SmallChange: usize,
+    pub SetSmallChange:
         unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
-    get_Maximum: usize,
-    pub put_Maximum:
-        unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
-    get_SmallChange: usize,
-    pub put_SmallChange:
-        unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
-    get_LargeChange: usize,
-    put_LargeChange: usize,
-    pub get_Value:
-        unsafe extern "system" fn(*mut core::ffi::c_void, *mut f64) -> windows_core::HRESULT,
-    pub put_Value: unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
-    pub add_ValueChanged: unsafe extern "system" fn(
+    LargeChange: usize,
+    SetLargeChange: usize,
+    pub Value: unsafe extern "system" fn(*mut core::ffi::c_void, *mut f64) -> windows_core::HRESULT,
+    pub SetValue: unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
+    pub ValueChanged: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         *mut i64,
     ) -> windows_core::HRESULT,
-    pub remove_ValueChanged:
+    pub RemoveValueChanged:
         unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
@@ -14249,10 +14227,10 @@ impl windows_core::RuntimeType for IRangeBaseValueChangedEventArgs {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IRangeBaseValueChangedEventArgs {
-    pub(crate) fn get_NewValue(&self) -> windows_core::Result<f64> {
+    pub(crate) fn NewValue(&self) -> windows_core::Result<f64> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_NewValue)(
+            (windows_core::Interface::vtable(self).NewValue)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
@@ -14263,8 +14241,8 @@ impl IRangeBaseValueChangedEventArgs {
 #[repr(C)]
 pub struct IRangeBaseValueChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_OldValue: usize,
-    pub get_NewValue:
+    OldValue: usize,
+    pub NewValue:
         unsafe extern "system" fn(*mut core::ffi::c_void, *mut f64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
@@ -14277,55 +14255,55 @@ impl windows_core::RuntimeType for IRatingControl {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IRatingControl {
-    pub(crate) fn put_Caption(&self, value: &str) -> windows_core::Result<()> {
+    pub(crate) fn SetCaption(&self, value: &str) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Caption)(
+            (windows_core::Interface::vtable(self).SetCaption)(
                 windows_core::Interface::as_raw(self),
                 core::mem::transmute_copy(&windows_core::HSTRING::from(value)),
             )
             .ok()
         }
     }
-    pub(crate) fn put_IsReadOnly(&self, value: bool) -> windows_core::Result<()> {
+    pub(crate) fn SetIsReadOnly(&self, value: bool) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_IsReadOnly)(
+            (windows_core::Interface::vtable(self).SetIsReadOnly)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_MaxRating(&self, value: i32) -> windows_core::Result<()> {
+    pub(crate) fn SetMaxRating(&self, value: i32) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_MaxRating)(
+            (windows_core::Interface::vtable(self).SetMaxRating)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_PlaceholderValue(&self, value: f64) -> windows_core::Result<()> {
+    pub(crate) fn SetPlaceholderValue(&self, value: f64) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_PlaceholderValue)(
+            (windows_core::Interface::vtable(self).SetPlaceholderValue)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn get_Value(&self) -> windows_core::Result<f64> {
+    pub(crate) fn Value(&self) -> windows_core::Result<f64> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_Value)(
+            (windows_core::Interface::vtable(self).Value)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
             .map(|| result__)
         }
     }
-    pub(crate) fn put_Value(&self, value: f64) -> windows_core::Result<()> {
+    pub(crate) fn SetValue(&self, value: f64) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Value)(
+            (windows_core::Interface::vtable(self).SetValue)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
@@ -14352,7 +14330,7 @@ impl IRatingControl {
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
-            let token__ = (windows_core::Interface::vtable(self).add_ValueChanged)(
+            let token__ = (windows_core::Interface::vtable(self).ValueChanged)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Interface::as_raw(&handler),
                 &mut result__,
@@ -14361,7 +14339,7 @@ impl IRatingControl {
             Ok(windows_core::EventRevoker::new(
                 self.clone(),
                 token__,
-                windows_core::Interface::vtable(self).remove_ValueChanged,
+                windows_core::Interface::vtable(self).RemoveValueChanged,
             ))
         }
     }
@@ -14369,35 +14347,34 @@ impl IRatingControl {
 #[repr(C)]
 pub struct IRatingControl_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_Caption: usize,
-    pub put_Caption: unsafe extern "system" fn(
+    Caption: usize,
+    pub SetCaption: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_InitialSetValue: usize,
-    put_InitialSetValue: usize,
-    get_IsClearEnabled: usize,
-    put_IsClearEnabled: usize,
-    get_IsReadOnly: usize,
-    pub put_IsReadOnly:
+    InitialSetValue: usize,
+    SetInitialSetValue: usize,
+    IsClearEnabled: usize,
+    SetIsClearEnabled: usize,
+    IsReadOnly: usize,
+    pub SetIsReadOnly:
         unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
-    get_MaxRating: usize,
-    pub put_MaxRating:
+    MaxRating: usize,
+    pub SetMaxRating:
         unsafe extern "system" fn(*mut core::ffi::c_void, i32) -> windows_core::HRESULT,
-    get_PlaceholderValue: usize,
-    pub put_PlaceholderValue:
+    PlaceholderValue: usize,
+    pub SetPlaceholderValue:
         unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
-    get_ItemInfo: usize,
-    put_ItemInfo: usize,
-    pub get_Value:
-        unsafe extern "system" fn(*mut core::ffi::c_void, *mut f64) -> windows_core::HRESULT,
-    pub put_Value: unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
-    pub add_ValueChanged: unsafe extern "system" fn(
+    ItemInfo: usize,
+    SetItemInfo: usize,
+    pub Value: unsafe extern "system" fn(*mut core::ffi::c_void, *mut f64) -> windows_core::HRESULT,
+    pub SetValue: unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
+    pub ValueChanged: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         *mut i64,
     ) -> windows_core::HRESULT,
-    pub remove_ValueChanged:
+    pub RemoveValueChanged:
         unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
@@ -14457,18 +14434,18 @@ impl windows_core::RuntimeType for IRectangle {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IRectangle {
-    pub(crate) fn put_RadiusX(&self, value: f64) -> windows_core::Result<()> {
+    pub(crate) fn SetRadiusX(&self, value: f64) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_RadiusX)(
+            (windows_core::Interface::vtable(self).SetRadiusX)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_RadiusY(&self, value: f64) -> windows_core::Result<()> {
+    pub(crate) fn SetRadiusY(&self, value: f64) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_RadiusY)(
+            (windows_core::Interface::vtable(self).SetRadiusY)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
@@ -14479,12 +14456,10 @@ impl IRectangle {
 #[repr(C)]
 pub struct IRectangle_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_RadiusX: usize,
-    pub put_RadiusX:
-        unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
-    get_RadiusY: usize,
-    pub put_RadiusY:
-        unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
+    RadiusX: usize,
+    pub SetRadiusX: unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
+    RadiusY: usize,
+    pub SetRadiusY: unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
     IRelativePanel,
@@ -14530,73 +14505,73 @@ impl windows_core::RuntimeType for IRelativePanelStatics {
 #[repr(C)]
 pub struct IRelativePanelStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_BackgroundSizingProperty: usize,
-    get_LeftOfProperty: usize,
+    BackgroundSizingProperty: usize,
+    LeftOfProperty: usize,
     GetLeftOf: usize,
     SetLeftOf: usize,
-    get_AboveProperty: usize,
+    AboveProperty: usize,
     GetAbove: usize,
     SetAbove: usize,
-    get_RightOfProperty: usize,
+    RightOfProperty: usize,
     GetRightOf: usize,
     SetRightOf: usize,
-    get_BelowProperty: usize,
+    BelowProperty: usize,
     GetBelow: usize,
     SetBelow: usize,
-    get_AlignHorizontalCenterWithProperty: usize,
+    AlignHorizontalCenterWithProperty: usize,
     GetAlignHorizontalCenterWith: usize,
     SetAlignHorizontalCenterWith: usize,
-    get_AlignVerticalCenterWithProperty: usize,
+    AlignVerticalCenterWithProperty: usize,
     GetAlignVerticalCenterWith: usize,
     SetAlignVerticalCenterWith: usize,
-    get_AlignLeftWithProperty: usize,
+    AlignLeftWithProperty: usize,
     GetAlignLeftWith: usize,
     SetAlignLeftWith: usize,
-    get_AlignTopWithProperty: usize,
+    AlignTopWithProperty: usize,
     GetAlignTopWith: usize,
     SetAlignTopWith: usize,
-    get_AlignRightWithProperty: usize,
+    AlignRightWithProperty: usize,
     GetAlignRightWith: usize,
     SetAlignRightWith: usize,
-    get_AlignBottomWithProperty: usize,
+    AlignBottomWithProperty: usize,
     GetAlignBottomWith: usize,
     SetAlignBottomWith: usize,
-    get_AlignLeftWithPanelProperty: usize,
+    AlignLeftWithPanelProperty: usize,
     GetAlignLeftWithPanel: usize,
     pub SetAlignLeftWithPanel: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         bool,
     ) -> windows_core::HRESULT,
-    get_AlignTopWithPanelProperty: usize,
+    AlignTopWithPanelProperty: usize,
     GetAlignTopWithPanel: usize,
     pub SetAlignTopWithPanel: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         bool,
     ) -> windows_core::HRESULT,
-    get_AlignRightWithPanelProperty: usize,
+    AlignRightWithPanelProperty: usize,
     GetAlignRightWithPanel: usize,
     pub SetAlignRightWithPanel: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         bool,
     ) -> windows_core::HRESULT,
-    get_AlignBottomWithPanelProperty: usize,
+    AlignBottomWithPanelProperty: usize,
     GetAlignBottomWithPanel: usize,
     pub SetAlignBottomWithPanel: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         bool,
     ) -> windows_core::HRESULT,
-    get_AlignHorizontalCenterWithPanelProperty: usize,
+    AlignHorizontalCenterWithPanelProperty: usize,
     GetAlignHorizontalCenterWithPanel: usize,
     pub SetAlignHorizontalCenterWithPanel: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         bool,
     ) -> windows_core::HRESULT,
-    get_AlignVerticalCenterWithPanelProperty: usize,
+    AlignVerticalCenterWithPanelProperty: usize,
     GetAlignVerticalCenterWithPanel: usize,
     pub SetAlignVerticalCenterWithPanel: unsafe extern "system" fn(
         *mut core::ffi::c_void,
@@ -14614,18 +14589,18 @@ impl windows_core::RuntimeType for IRepeatButton {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IRepeatButton {
-    pub(crate) fn put_Delay(&self, value: i32) -> windows_core::Result<()> {
+    pub(crate) fn SetDelay(&self, value: i32) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Delay)(
+            (windows_core::Interface::vtable(self).SetDelay)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_Interval(&self, value: i32) -> windows_core::Result<()> {
+    pub(crate) fn SetInterval(&self, value: i32) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Interval)(
+            (windows_core::Interface::vtable(self).SetInterval)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
@@ -14636,10 +14611,10 @@ impl IRepeatButton {
 #[repr(C)]
 pub struct IRepeatButton_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_Delay: usize,
-    pub put_Delay: unsafe extern "system" fn(*mut core::ffi::c_void, i32) -> windows_core::HRESULT,
-    get_Interval: usize,
-    pub put_Interval:
+    Delay: usize,
+    pub SetDelay: unsafe extern "system" fn(*mut core::ffi::c_void, i32) -> windows_core::HRESULT,
+    Interval: usize,
+    pub SetInterval:
         unsafe extern "system" fn(*mut core::ffi::c_void, i32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
@@ -14652,12 +14627,12 @@ impl windows_core::RuntimeType for IResourceDictionary {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IResourceDictionary {
-    pub(crate) fn get_MergedDictionaries(
+    pub(crate) fn MergedDictionaries(
         &self,
     ) -> windows_core::Result<windows_collections::IVector<ResourceDictionary>> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_MergedDictionaries)(
+            (windows_core::Interface::vtable(self).MergedDictionaries)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
@@ -14668,9 +14643,9 @@ impl IResourceDictionary {
 #[repr(C)]
 pub struct IResourceDictionary_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_Source: usize,
-    put_Source: usize,
-    pub get_MergedDictionaries: unsafe extern "system" fn(
+    Source: usize,
+    SetSource: usize,
+    pub MergedDictionaries: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
@@ -14685,40 +14660,40 @@ impl windows_core::RuntimeType for IRichEditBox {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IRichEditBox {
-    pub(crate) fn put_IsReadOnly(&self, value: bool) -> windows_core::Result<()> {
+    pub(crate) fn SetIsReadOnly(&self, value: bool) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_IsReadOnly)(
+            (windows_core::Interface::vtable(self).SetIsReadOnly)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn get_Document(&self) -> windows_core::Result<RichEditTextDocument> {
+    pub(crate) fn Document(&self) -> windows_core::Result<RichEditTextDocument> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_Document)(
+            (windows_core::Interface::vtable(self).Document)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
             .and_then(|| windows_core::Type::from_abi(result__))
         }
     }
-    pub(crate) fn put_Header<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetHeader<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<windows_core::IInspectable>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Header)(
+            (windows_core::Interface::vtable(self).SetHeader)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
             .ok()
         }
     }
-    pub(crate) fn put_PlaceholderText(&self, value: &str) -> windows_core::Result<()> {
+    pub(crate) fn SetPlaceholderText(&self, value: &str) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_PlaceholderText)(
+            (windows_core::Interface::vtable(self).SetPlaceholderText)(
                 windows_core::Interface::as_raw(self),
                 core::mem::transmute_copy(&windows_core::HSTRING::from(value)),
             )
@@ -14742,7 +14717,7 @@ impl IRichEditBox {
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
-            let token__ = (windows_core::Interface::vtable(self).add_TextChanged)(
+            let token__ = (windows_core::Interface::vtable(self).TextChanged)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Interface::as_raw(&handler),
                 &mut result__,
@@ -14751,7 +14726,7 @@ impl IRichEditBox {
             Ok(windows_core::EventRevoker::new(
                 self.clone(),
                 token__,
-                windows_core::Interface::vtable(self).remove_TextChanged,
+                windows_core::Interface::vtable(self).RemoveTextChanged,
             ))
         }
     }
@@ -14759,65 +14734,65 @@ impl IRichEditBox {
 #[repr(C)]
 pub struct IRichEditBox_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_IsReadOnly: usize,
-    pub put_IsReadOnly:
+    IsReadOnly: usize,
+    pub SetIsReadOnly:
         unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
-    get_AcceptsReturn: usize,
-    put_AcceptsReturn: usize,
-    get_TextAlignment: usize,
-    put_TextAlignment: usize,
-    get_TextWrapping: usize,
-    put_TextWrapping: usize,
-    get_IsSpellCheckEnabled: usize,
-    put_IsSpellCheckEnabled: usize,
-    get_IsTextPredictionEnabled: usize,
-    put_IsTextPredictionEnabled: usize,
-    pub get_Document: unsafe extern "system" fn(
+    AcceptsReturn: usize,
+    SetAcceptsReturn: usize,
+    TextAlignment: usize,
+    SetTextAlignment: usize,
+    TextWrapping: usize,
+    SetTextWrapping: usize,
+    IsSpellCheckEnabled: usize,
+    SetIsSpellCheckEnabled: usize,
+    IsTextPredictionEnabled: usize,
+    SetIsTextPredictionEnabled: usize,
+    pub Document: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_InputScope: usize,
-    put_InputScope: usize,
-    get_Header: usize,
-    pub put_Header: unsafe extern "system" fn(
+    InputScope: usize,
+    SetInputScope: usize,
+    Header: usize,
+    pub SetHeader: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_HeaderTemplate: usize,
-    put_HeaderTemplate: usize,
-    get_PlaceholderText: usize,
-    pub put_PlaceholderText: unsafe extern "system" fn(
+    HeaderTemplate: usize,
+    SetHeaderTemplate: usize,
+    PlaceholderText: usize,
+    pub SetPlaceholderText: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_SelectionHighlightColor: usize,
-    put_SelectionHighlightColor: usize,
-    get_PreventKeyboardDisplayOnProgrammaticFocus: usize,
-    put_PreventKeyboardDisplayOnProgrammaticFocus: usize,
-    get_IsColorFontEnabled: usize,
-    put_IsColorFontEnabled: usize,
-    get_SelectionHighlightColorWhenNotFocused: usize,
-    put_SelectionHighlightColorWhenNotFocused: usize,
-    get_MaxLength: usize,
-    put_MaxLength: usize,
-    get_HorizontalTextAlignment: usize,
-    put_HorizontalTextAlignment: usize,
-    get_CharacterCasing: usize,
-    put_CharacterCasing: usize,
-    get_DisabledFormattingAccelerators: usize,
-    put_DisabledFormattingAccelerators: usize,
-    get_TextDocument: usize,
-    get_SelectionFlyout: usize,
-    put_SelectionFlyout: usize,
-    get_ProofingMenuFlyout: usize,
-    get_Description: usize,
-    put_Description: usize,
-    pub add_TextChanged: unsafe extern "system" fn(
+    SelectionHighlightColor: usize,
+    SetSelectionHighlightColor: usize,
+    PreventKeyboardDisplayOnProgrammaticFocus: usize,
+    SetPreventKeyboardDisplayOnProgrammaticFocus: usize,
+    IsColorFontEnabled: usize,
+    SetIsColorFontEnabled: usize,
+    SelectionHighlightColorWhenNotFocused: usize,
+    SetSelectionHighlightColorWhenNotFocused: usize,
+    MaxLength: usize,
+    SetMaxLength: usize,
+    HorizontalTextAlignment: usize,
+    SetHorizontalTextAlignment: usize,
+    CharacterCasing: usize,
+    SetCharacterCasing: usize,
+    DisabledFormattingAccelerators: usize,
+    SetDisabledFormattingAccelerators: usize,
+    TextDocument: usize,
+    SelectionFlyout: usize,
+    SetSelectionFlyout: usize,
+    ProofingMenuFlyout: usize,
+    Description: usize,
+    SetDescription: usize,
+    pub TextChanged: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         *mut i64,
     ) -> windows_core::HRESULT,
-    pub remove_TextChanged:
+    pub RemoveTextChanged:
         unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
@@ -14849,61 +14824,61 @@ impl windows_core::RuntimeType for IRichTextBlock {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IRichTextBlock {
-    pub(crate) fn put_FontSize(&self, value: f64) -> windows_core::Result<()> {
+    pub(crate) fn SetFontSize(&self, value: f64) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_FontSize)(
+            (windows_core::Interface::vtable(self).SetFontSize)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_FontFamily<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetFontFamily<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<FontFamily>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_FontFamily)(
+            (windows_core::Interface::vtable(self).SetFontFamily)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
             .ok()
         }
     }
-    pub(crate) fn put_Foreground<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetForeground<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<Brush>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Foreground)(
+            (windows_core::Interface::vtable(self).SetForeground)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
             .ok()
         }
     }
-    pub(crate) fn put_TextWrapping(&self, value: TextWrapping) -> windows_core::Result<()> {
+    pub(crate) fn SetTextWrapping(&self, value: TextWrapping) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_TextWrapping)(
+            (windows_core::Interface::vtable(self).SetTextWrapping)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn get_Blocks(&self) -> windows_core::Result<BlockCollection> {
+    pub(crate) fn Blocks(&self) -> windows_core::Result<BlockCollection> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_Blocks)(
+            (windows_core::Interface::vtable(self).Blocks)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
             .and_then(|| windows_core::Type::from_abi(result__))
         }
     }
-    pub(crate) fn put_IsTextSelectionEnabled(&self, value: bool) -> windows_core::Result<()> {
+    pub(crate) fn SetIsTextSelectionEnabled(&self, value: bool) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_IsTextSelectionEnabled)(
+            (windows_core::Interface::vtable(self).SetIsTextSelectionEnabled)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
@@ -14914,48 +14889,48 @@ impl IRichTextBlock {
 #[repr(C)]
 pub struct IRichTextBlock_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_FontSize: usize,
-    pub put_FontSize:
+    FontSize: usize,
+    pub SetFontSize:
         unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
-    get_FontFamily: usize,
-    pub put_FontFamily: unsafe extern "system" fn(
+    FontFamily: usize,
+    pub SetFontFamily: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_FontWeight: usize,
-    put_FontWeight: usize,
-    get_FontStyle: usize,
-    put_FontStyle: usize,
-    get_FontStretch: usize,
-    put_FontStretch: usize,
-    get_Foreground: usize,
-    pub put_Foreground: unsafe extern "system" fn(
+    FontWeight: usize,
+    SetFontWeight: usize,
+    FontStyle: usize,
+    SetFontStyle: usize,
+    FontStretch: usize,
+    SetFontStretch: usize,
+    Foreground: usize,
+    pub SetForeground: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_TextWrapping: usize,
-    pub put_TextWrapping:
+    TextWrapping: usize,
+    pub SetTextWrapping:
         unsafe extern "system" fn(*mut core::ffi::c_void, TextWrapping) -> windows_core::HRESULT,
-    get_TextTrimming: usize,
-    put_TextTrimming: usize,
-    get_TextAlignment: usize,
-    put_TextAlignment: usize,
-    pub get_Blocks: unsafe extern "system" fn(
+    TextTrimming: usize,
+    SetTextTrimming: usize,
+    TextAlignment: usize,
+    SetTextAlignment: usize,
+    pub Blocks: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_Padding: usize,
-    put_Padding: usize,
-    get_LineHeight: usize,
-    put_LineHeight: usize,
-    get_LineStackingStrategy: usize,
-    put_LineStackingStrategy: usize,
-    get_CharacterSpacing: usize,
-    put_CharacterSpacing: usize,
-    get_OverflowContentTarget: usize,
-    put_OverflowContentTarget: usize,
-    get_IsTextSelectionEnabled: usize,
-    pub put_IsTextSelectionEnabled:
+    Padding: usize,
+    SetPadding: usize,
+    LineHeight: usize,
+    SetLineHeight: usize,
+    LineStackingStrategy: usize,
+    SetLineStackingStrategy: usize,
+    CharacterSpacing: usize,
+    SetCharacterSpacing: usize,
+    OverflowContentTarget: usize,
+    SetOverflowContentTarget: usize,
+    IsTextSelectionEnabled: usize,
+    pub SetIsTextSelectionEnabled:
         unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
@@ -14994,9 +14969,9 @@ impl windows_core::RuntimeType for IRowDefinition {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IRowDefinition {
-    pub(crate) fn put_Height(&self, value: GridLength) -> windows_core::Result<()> {
+    pub(crate) fn SetHeight(&self, value: GridLength) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Height)(
+            (windows_core::Interface::vtable(self).SetHeight)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
@@ -15007,8 +14982,8 @@ impl IRowDefinition {
 #[repr(C)]
 pub struct IRowDefinition_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_Height: usize,
-    pub put_Height:
+    Height: usize,
+    pub SetHeight:
         unsafe extern "system" fn(*mut core::ffi::c_void, GridLength) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRun, IRun_Vtbl, 0x1f905239_37cb_590b_9132_3ffb7741906e);
@@ -15017,9 +14992,9 @@ impl windows_core::RuntimeType for IRun {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IRun {
-    pub(crate) fn put_Text(&self, value: &str) -> windows_core::Result<()> {
+    pub(crate) fn SetText(&self, value: &str) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Text)(
+            (windows_core::Interface::vtable(self).SetText)(
                 windows_core::Interface::as_raw(self),
                 core::mem::transmute_copy(&windows_core::HSTRING::from(value)),
             )
@@ -15030,8 +15005,8 @@ impl IRun {
 #[repr(C)]
 pub struct IRun_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_Text: usize,
-    pub put_Text: unsafe extern "system" fn(
+    Text: usize,
+    pub SetText: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
@@ -15087,36 +15062,36 @@ impl windows_core::RuntimeType for IScrollView {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IScrollView {
-    pub(crate) fn put_Content<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetContent<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<UIElement>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Content)(
+            (windows_core::Interface::vtable(self).SetContent)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
             .ok()
         }
     }
-    pub(crate) fn put_HorizontalScrollBarVisibility(
+    pub(crate) fn SetHorizontalScrollBarVisibility(
         &self,
         value: ScrollingScrollBarVisibility,
     ) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_HorizontalScrollBarVisibility)(
+            (windows_core::Interface::vtable(self).SetHorizontalScrollBarVisibility)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_VerticalScrollBarVisibility(
+    pub(crate) fn SetVerticalScrollBarVisibility(
         &self,
         value: ScrollingScrollBarVisibility,
     ) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_VerticalScrollBarVisibility)(
+            (windows_core::Interface::vtable(self).SetVerticalScrollBarVisibility)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
@@ -15127,31 +15102,31 @@ impl IScrollView {
 #[repr(C)]
 pub struct IScrollView_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_Content: usize,
-    pub put_Content: unsafe extern "system" fn(
+    Content: usize,
+    pub SetContent: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_CurrentAnchor: usize,
-    get_ScrollPresenter: usize,
-    get_ExpressionAnimationSources: usize,
-    get_HorizontalOffset: usize,
-    get_VerticalOffset: usize,
-    get_ZoomFactor: usize,
-    get_ExtentWidth: usize,
-    get_ExtentHeight: usize,
-    get_ViewportWidth: usize,
-    get_ViewportHeight: usize,
-    get_ScrollableWidth: usize,
-    get_ScrollableHeight: usize,
-    get_State: usize,
-    get_HorizontalScrollBarVisibility: usize,
-    pub put_HorizontalScrollBarVisibility: unsafe extern "system" fn(
+    CurrentAnchor: usize,
+    ScrollPresenter: usize,
+    ExpressionAnimationSources: usize,
+    HorizontalOffset: usize,
+    VerticalOffset: usize,
+    ZoomFactor: usize,
+    ExtentWidth: usize,
+    ExtentHeight: usize,
+    ViewportWidth: usize,
+    ViewportHeight: usize,
+    ScrollableWidth: usize,
+    ScrollableHeight: usize,
+    State: usize,
+    HorizontalScrollBarVisibility: usize,
+    pub SetHorizontalScrollBarVisibility: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         ScrollingScrollBarVisibility,
     ) -> windows_core::HRESULT,
-    get_VerticalScrollBarVisibility: usize,
-    pub put_VerticalScrollBarVisibility: unsafe extern "system" fn(
+    VerticalScrollBarVisibility: usize,
+    pub SetVerticalScrollBarVisibility: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         ScrollingScrollBarVisibility,
     ) -> windows_core::HRESULT,
@@ -15185,24 +15160,24 @@ impl windows_core::RuntimeType for IScrollViewer {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IScrollViewer {
-    pub(crate) fn put_HorizontalScrollBarVisibility(
+    pub(crate) fn SetHorizontalScrollBarVisibility(
         &self,
         value: ScrollBarVisibility,
     ) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_HorizontalScrollBarVisibility)(
+            (windows_core::Interface::vtable(self).SetHorizontalScrollBarVisibility)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_VerticalScrollBarVisibility(
+    pub(crate) fn SetVerticalScrollBarVisibility(
         &self,
         value: ScrollBarVisibility,
     ) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_VerticalScrollBarVisibility)(
+            (windows_core::Interface::vtable(self).SetVerticalScrollBarVisibility)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
@@ -15213,13 +15188,13 @@ impl IScrollViewer {
 #[repr(C)]
 pub struct IScrollViewer_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_HorizontalScrollBarVisibility: usize,
-    pub put_HorizontalScrollBarVisibility: unsafe extern "system" fn(
+    HorizontalScrollBarVisibility: usize,
+    pub SetHorizontalScrollBarVisibility: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         ScrollBarVisibility,
     ) -> windows_core::HRESULT,
-    get_VerticalScrollBarVisibility: usize,
-    pub put_VerticalScrollBarVisibility: unsafe extern "system" fn(
+    VerticalScrollBarVisibility: usize,
+    pub SetVerticalScrollBarVisibility: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         ScrollBarVisibility,
     ) -> windows_core::HRESULT,
@@ -15247,19 +15222,19 @@ impl windows_core::RuntimeType for ISelector {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl ISelector {
-    pub(crate) fn get_SelectedIndex(&self) -> windows_core::Result<i32> {
+    pub(crate) fn SelectedIndex(&self) -> windows_core::Result<i32> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_SelectedIndex)(
+            (windows_core::Interface::vtable(self).SelectedIndex)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
             .map(|| result__)
         }
     }
-    pub(crate) fn put_SelectedIndex(&self, value: i32) -> windows_core::Result<()> {
+    pub(crate) fn SetSelectedIndex(&self, value: i32) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_SelectedIndex)(
+            (windows_core::Interface::vtable(self).SetSelectedIndex)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
@@ -15285,7 +15260,7 @@ impl ISelector {
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
-            let token__ = (windows_core::Interface::vtable(self).add_SelectionChanged)(
+            let token__ = (windows_core::Interface::vtable(self).SelectionChanged)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Interface::as_raw(&handler),
                 &mut result__,
@@ -15294,7 +15269,7 @@ impl ISelector {
             Ok(windows_core::EventRevoker::new(
                 self.clone(),
                 token__,
-                windows_core::Interface::vtable(self).remove_SelectionChanged,
+                windows_core::Interface::vtable(self).RemoveSelectionChanged,
             ))
         }
     }
@@ -15302,24 +15277,24 @@ impl ISelector {
 #[repr(C)]
 pub struct ISelector_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    pub get_SelectedIndex:
+    pub SelectedIndex:
         unsafe extern "system" fn(*mut core::ffi::c_void, *mut i32) -> windows_core::HRESULT,
-    pub put_SelectedIndex:
+    pub SetSelectedIndex:
         unsafe extern "system" fn(*mut core::ffi::c_void, i32) -> windows_core::HRESULT,
-    get_SelectedItem: usize,
-    put_SelectedItem: usize,
-    get_SelectedValue: usize,
-    put_SelectedValue: usize,
-    get_SelectedValuePath: usize,
-    put_SelectedValuePath: usize,
-    get_IsSynchronizedWithCurrentItem: usize,
-    put_IsSynchronizedWithCurrentItem: usize,
-    pub add_SelectionChanged: unsafe extern "system" fn(
+    SelectedItem: usize,
+    SetSelectedItem: usize,
+    SelectedValue: usize,
+    SetSelectedValue: usize,
+    SelectedValuePath: usize,
+    SetSelectedValuePath: usize,
+    IsSynchronizedWithCurrentItem: usize,
+    SetIsSynchronizedWithCurrentItem: usize,
+    pub SelectionChanged: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         *mut i64,
     ) -> windows_core::HRESULT,
-    pub remove_SelectionChanged:
+    pub RemoveSelectionChanged:
         unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
@@ -15332,22 +15307,22 @@ impl windows_core::RuntimeType for ISelectorBar {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl ISelectorBar {
-    pub(crate) fn get_Items(
+    pub(crate) fn Items(
         &self,
     ) -> windows_core::Result<windows_collections::IVector<SelectorBarItem>> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_Items)(
+            (windows_core::Interface::vtable(self).Items)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
             .and_then(|| windows_core::Type::from_abi(result__))
         }
     }
-    pub(crate) fn get_SelectedItem(&self) -> windows_core::Result<SelectorBarItem> {
+    pub(crate) fn SelectedItem(&self) -> windows_core::Result<SelectorBarItem> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_SelectedItem)(
+            (windows_core::Interface::vtable(self).SelectedItem)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
@@ -15370,7 +15345,7 @@ impl ISelectorBar {
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
-            let token__ = (windows_core::Interface::vtable(self).add_SelectionChanged)(
+            let token__ = (windows_core::Interface::vtable(self).SelectionChanged)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Interface::as_raw(&handler),
                 &mut result__,
@@ -15379,7 +15354,7 @@ impl ISelectorBar {
             Ok(windows_core::EventRevoker::new(
                 self.clone(),
                 token__,
-                windows_core::Interface::vtable(self).remove_SelectionChanged,
+                windows_core::Interface::vtable(self).RemoveSelectionChanged,
             ))
         }
     }
@@ -15387,21 +15362,21 @@ impl ISelectorBar {
 #[repr(C)]
 pub struct ISelectorBar_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    pub get_Items: unsafe extern "system" fn(
+    pub Items: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    pub get_SelectedItem: unsafe extern "system" fn(
+    pub SelectedItem: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    put_SelectedItem: usize,
-    pub add_SelectionChanged: unsafe extern "system" fn(
+    SetSelectedItem: usize,
+    pub SelectionChanged: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         *mut i64,
     ) -> windows_core::HRESULT,
-    pub remove_SelectionChanged:
+    pub RemoveSelectionChanged:
         unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
@@ -15433,10 +15408,10 @@ impl windows_core::RuntimeType for ISelectorBarItem {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl ISelectorBarItem {
-    pub(crate) fn get_Text(&self) -> windows_core::Result<String> {
+    pub(crate) fn Text(&self) -> windows_core::Result<String> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_Text)(
+            (windows_core::Interface::vtable(self).Text)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
@@ -15446,21 +15421,21 @@ impl ISelectorBarItem {
             })
         }
     }
-    pub(crate) fn put_Text(&self, value: &str) -> windows_core::Result<()> {
+    pub(crate) fn SetText(&self, value: &str) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Text)(
+            (windows_core::Interface::vtable(self).SetText)(
                 windows_core::Interface::as_raw(self),
                 core::mem::transmute_copy(&windows_core::HSTRING::from(value)),
             )
             .ok()
         }
     }
-    pub(crate) fn put_Icon<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetIcon<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<IconElement>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Icon)(
+            (windows_core::Interface::vtable(self).SetIcon)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
@@ -15471,16 +15446,16 @@ impl ISelectorBarItem {
 #[repr(C)]
 pub struct ISelectorBarItem_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    pub get_Text: unsafe extern "system" fn(
+    pub Text: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    pub put_Text: unsafe extern "system" fn(
+    pub SetText: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_Icon: usize,
-    pub put_Icon: unsafe extern "system" fn(
+    Icon: usize,
+    pub SetIcon: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
@@ -15549,33 +15524,33 @@ impl windows_core::RuntimeType for IShape {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IShape {
-    pub(crate) fn put_Fill<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetFill<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<Brush>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Fill)(
+            (windows_core::Interface::vtable(self).SetFill)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
             .ok()
         }
     }
-    pub(crate) fn put_Stroke<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetStroke<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<Brush>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Stroke)(
+            (windows_core::Interface::vtable(self).SetStroke)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
             .ok()
         }
     }
-    pub(crate) fn put_StrokeThickness(&self, value: f64) -> windows_core::Result<()> {
+    pub(crate) fn SetStrokeThickness(&self, value: f64) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_StrokeThickness)(
+            (windows_core::Interface::vtable(self).SetStrokeThickness)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
@@ -15586,20 +15561,20 @@ impl IShape {
 #[repr(C)]
 pub struct IShape_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_Fill: usize,
-    pub put_Fill: unsafe extern "system" fn(
+    Fill: usize,
+    pub SetFill: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_Stroke: usize,
-    pub put_Stroke: unsafe extern "system" fn(
+    Stroke: usize,
+    pub SetStroke: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_StrokeMiterLimit: usize,
-    put_StrokeMiterLimit: usize,
-    get_StrokeThickness: usize,
-    pub put_StrokeThickness:
+    StrokeMiterLimit: usize,
+    SetStrokeMiterLimit: usize,
+    StrokeThickness: usize,
+    pub SetStrokeThickness:
         unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
@@ -15612,10 +15587,10 @@ impl windows_core::RuntimeType for ISizeChangedEventArgs {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl ISizeChangedEventArgs {
-    pub(crate) fn get_NewSize(&self) -> windows_core::Result<Size> {
+    pub(crate) fn NewSize(&self) -> windows_core::Result<Size> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_NewSize)(
+            (windows_core::Interface::vtable(self).NewSize)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
@@ -15626,8 +15601,8 @@ impl ISizeChangedEventArgs {
 #[repr(C)]
 pub struct ISizeChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_PreviousSize: usize,
-    pub get_NewSize:
+    PreviousSize: usize,
+    pub NewSize:
         unsafe extern "system" fn(*mut core::ffi::c_void, *mut Size) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
@@ -15640,30 +15615,30 @@ impl windows_core::RuntimeType for ISlider {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl ISlider {
-    pub(crate) fn put_StepFrequency(&self, value: f64) -> windows_core::Result<()> {
+    pub(crate) fn SetStepFrequency(&self, value: f64) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_StepFrequency)(
+            (windows_core::Interface::vtable(self).SetStepFrequency)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_Orientation(&self, value: Orientation) -> windows_core::Result<()> {
+    pub(crate) fn SetOrientation(&self, value: Orientation) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Orientation)(
+            (windows_core::Interface::vtable(self).SetOrientation)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_Header<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetHeader<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<windows_core::IInspectable>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Header)(
+            (windows_core::Interface::vtable(self).SetHeader)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
@@ -15674,28 +15649,28 @@ impl ISlider {
 #[repr(C)]
 pub struct ISlider_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_IntermediateValue: usize,
-    put_IntermediateValue: usize,
-    get_StepFrequency: usize,
-    pub put_StepFrequency:
+    IntermediateValue: usize,
+    SetIntermediateValue: usize,
+    StepFrequency: usize,
+    pub SetStepFrequency:
         unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
-    get_SnapsTo: usize,
-    put_SnapsTo: usize,
-    get_TickFrequency: usize,
-    put_TickFrequency: usize,
-    get_TickPlacement: usize,
-    put_TickPlacement: usize,
-    get_Orientation: usize,
-    pub put_Orientation:
+    SnapsTo: usize,
+    SetSnapsTo: usize,
+    TickFrequency: usize,
+    SetTickFrequency: usize,
+    TickPlacement: usize,
+    SetTickPlacement: usize,
+    Orientation: usize,
+    pub SetOrientation:
         unsafe extern "system" fn(*mut core::ffi::c_void, Orientation) -> windows_core::HRESULT,
-    get_IsDirectionReversed: usize,
-    put_IsDirectionReversed: usize,
-    get_IsThumbToolTipEnabled: usize,
-    put_IsThumbToolTipEnabled: usize,
-    get_ThumbToolTipValueConverter: usize,
-    put_ThumbToolTipValueConverter: usize,
-    get_Header: usize,
-    pub put_Header: unsafe extern "system" fn(
+    IsDirectionReversed: usize,
+    SetIsDirectionReversed: usize,
+    IsThumbToolTipEnabled: usize,
+    SetIsThumbToolTipEnabled: usize,
+    ThumbToolTipValueConverter: usize,
+    SetThumbToolTipValueConverter: usize,
+    Header: usize,
+    pub SetHeader: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
@@ -15729,9 +15704,9 @@ impl windows_core::RuntimeType for ISolidColorBrush {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl ISolidColorBrush {
-    pub(crate) fn put_Color(&self, value: Color) -> windows_core::Result<()> {
+    pub(crate) fn SetColor(&self, value: Color) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Color)(
+            (windows_core::Interface::vtable(self).SetColor)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
@@ -15742,9 +15717,8 @@ impl ISolidColorBrush {
 #[repr(C)]
 pub struct ISolidColorBrush_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_Color: usize,
-    pub put_Color:
-        unsafe extern "system" fn(*mut core::ffi::c_void, Color) -> windows_core::HRESULT,
+    Color: usize,
+    pub SetColor: unsafe extern "system" fn(*mut core::ffi::c_void, Color) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
     ISplitButton,
@@ -15773,7 +15747,7 @@ impl ISplitButton {
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
-            let token__ = (windows_core::Interface::vtable(self).add_Click)(
+            let token__ = (windows_core::Interface::vtable(self).Click)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Interface::as_raw(&handler),
                 &mut result__,
@@ -15782,7 +15756,7 @@ impl ISplitButton {
             Ok(windows_core::EventRevoker::new(
                 self.clone(),
                 token__,
-                windows_core::Interface::vtable(self).remove_Click,
+                windows_core::Interface::vtable(self).RemoveClick,
             ))
         }
     }
@@ -15790,18 +15764,18 @@ impl ISplitButton {
 #[repr(C)]
 pub struct ISplitButton_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_Flyout: usize,
-    put_Flyout: usize,
-    get_Command: usize,
-    put_Command: usize,
-    get_CommandParameter: usize,
-    put_CommandParameter: usize,
-    pub add_Click: unsafe extern "system" fn(
+    Flyout: usize,
+    SetFlyout: usize,
+    Command: usize,
+    SetCommand: usize,
+    CommandParameter: usize,
+    SetCommandParameter: usize,
+    pub Click: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         *mut i64,
     ) -> windows_core::HRESULT,
-    pub remove_Click:
+    pub RemoveClick:
         unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
@@ -15846,60 +15820,60 @@ impl windows_core::RuntimeType for ISplitView {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl ISplitView {
-    pub(crate) fn put_Content<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetContent<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<UIElement>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Content)(
+            (windows_core::Interface::vtable(self).SetContent)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
             .ok()
         }
     }
-    pub(crate) fn put_Pane<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetPane<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<UIElement>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Pane)(
+            (windows_core::Interface::vtable(self).SetPane)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
             .ok()
         }
     }
-    pub(crate) fn put_IsPaneOpen(&self, value: bool) -> windows_core::Result<()> {
+    pub(crate) fn SetIsPaneOpen(&self, value: bool) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_IsPaneOpen)(
+            (windows_core::Interface::vtable(self).SetIsPaneOpen)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_OpenPaneLength(&self, value: f64) -> windows_core::Result<()> {
+    pub(crate) fn SetOpenPaneLength(&self, value: f64) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_OpenPaneLength)(
+            (windows_core::Interface::vtable(self).SetOpenPaneLength)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_CompactPaneLength(&self, value: f64) -> windows_core::Result<()> {
+    pub(crate) fn SetCompactPaneLength(&self, value: f64) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_CompactPaneLength)(
+            (windows_core::Interface::vtable(self).SetCompactPaneLength)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_DisplayMode(&self, value: SplitViewDisplayMode) -> windows_core::Result<()> {
+    pub(crate) fn SetDisplayMode(&self, value: SplitViewDisplayMode) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_DisplayMode)(
+            (windows_core::Interface::vtable(self).SetDisplayMode)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
@@ -15926,7 +15900,7 @@ impl ISplitView {
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
-            let token__ = (windows_core::Interface::vtable(self).add_PaneClosed)(
+            let token__ = (windows_core::Interface::vtable(self).PaneClosed)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Interface::as_raw(&handler),
                 &mut result__,
@@ -15935,7 +15909,7 @@ impl ISplitView {
             Ok(windows_core::EventRevoker::new(
                 self.clone(),
                 token__,
-                windows_core::Interface::vtable(self).remove_PaneClosed,
+                windows_core::Interface::vtable(self).RemovePaneClosed,
             ))
         }
     }
@@ -15943,45 +15917,45 @@ impl ISplitView {
 #[repr(C)]
 pub struct ISplitView_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_Content: usize,
-    pub put_Content: unsafe extern "system" fn(
+    Content: usize,
+    pub SetContent: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_Pane: usize,
-    pub put_Pane: unsafe extern "system" fn(
+    Pane: usize,
+    pub SetPane: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_IsPaneOpen: usize,
-    pub put_IsPaneOpen:
+    IsPaneOpen: usize,
+    pub SetIsPaneOpen:
         unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
-    get_OpenPaneLength: usize,
-    pub put_OpenPaneLength:
+    OpenPaneLength: usize,
+    pub SetOpenPaneLength:
         unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
-    get_CompactPaneLength: usize,
-    pub put_CompactPaneLength:
+    CompactPaneLength: usize,
+    pub SetCompactPaneLength:
         unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
-    get_PanePlacement: usize,
-    put_PanePlacement: usize,
-    get_DisplayMode: usize,
-    pub put_DisplayMode: unsafe extern "system" fn(
+    PanePlacement: usize,
+    SetPanePlacement: usize,
+    DisplayMode: usize,
+    pub SetDisplayMode: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         SplitViewDisplayMode,
     ) -> windows_core::HRESULT,
-    get_TemplateSettings: usize,
-    get_PaneBackground: usize,
-    put_PaneBackground: usize,
-    get_LightDismissOverlayMode: usize,
-    put_LightDismissOverlayMode: usize,
-    add_PaneClosing: usize,
-    remove_PaneClosing: usize,
-    pub add_PaneClosed: unsafe extern "system" fn(
+    TemplateSettings: usize,
+    PaneBackground: usize,
+    SetPaneBackground: usize,
+    LightDismissOverlayMode: usize,
+    SetLightDismissOverlayMode: usize,
+    PaneClosing: usize,
+    RemovePaneClosing: usize,
+    pub PaneClosed: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         *mut i64,
     ) -> windows_core::HRESULT,
-    pub remove_PaneClosed:
+    pub RemovePaneClosed:
         unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
@@ -16013,18 +15987,18 @@ impl windows_core::RuntimeType for IStackPanel {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IStackPanel {
-    pub(crate) fn put_Orientation(&self, value: Orientation) -> windows_core::Result<()> {
+    pub(crate) fn SetOrientation(&self, value: Orientation) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Orientation)(
+            (windows_core::Interface::vtable(self).SetOrientation)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_Spacing(&self, value: f64) -> windows_core::Result<()> {
+    pub(crate) fn SetSpacing(&self, value: f64) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Spacing)(
+            (windows_core::Interface::vtable(self).SetSpacing)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
@@ -16035,24 +16009,23 @@ impl IStackPanel {
 #[repr(C)]
 pub struct IStackPanel_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_AreScrollSnapPointsRegular: usize,
-    put_AreScrollSnapPointsRegular: usize,
-    get_Orientation: usize,
-    pub put_Orientation:
+    AreScrollSnapPointsRegular: usize,
+    SetAreScrollSnapPointsRegular: usize,
+    Orientation: usize,
+    pub SetOrientation:
         unsafe extern "system" fn(*mut core::ffi::c_void, Orientation) -> windows_core::HRESULT,
-    get_BackgroundSizing: usize,
-    put_BackgroundSizing: usize,
-    get_BorderBrush: usize,
-    put_BorderBrush: usize,
-    get_BorderThickness: usize,
-    put_BorderThickness: usize,
-    get_CornerRadius: usize,
-    put_CornerRadius: usize,
-    get_Padding: usize,
-    put_Padding: usize,
-    get_Spacing: usize,
-    pub put_Spacing:
-        unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
+    BackgroundSizing: usize,
+    SetBackgroundSizing: usize,
+    BorderBrush: usize,
+    SetBorderBrush: usize,
+    BorderThickness: usize,
+    SetBorderThickness: usize,
+    CornerRadius: usize,
+    SetCornerRadius: usize,
+    Padding: usize,
+    SetPadding: usize,
+    Spacing: usize,
+    pub SetSpacing: unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
     IStackPanelFactory,
@@ -16088,10 +16061,10 @@ windows_core::imp::interface_hierarchy!(
     windows_core::IInspectable
 );
 impl IStorageItem {
-    pub(crate) fn get_Name(&self) -> windows_core::Result<String> {
+    pub(crate) fn Name(&self) -> windows_core::Result<String> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_Name)(
+            (windows_core::Interface::vtable(self).Name)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
@@ -16101,10 +16074,10 @@ impl IStorageItem {
             })
         }
     }
-    pub(crate) fn get_Path(&self) -> windows_core::Result<String> {
+    pub(crate) fn Path(&self) -> windows_core::Result<String> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_Path)(
+            (windows_core::Interface::vtable(self).Path)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
@@ -16114,10 +16087,10 @@ impl IStorageItem {
             })
         }
     }
-    pub(crate) fn get_Attributes(&self) -> windows_core::Result<FileAttributes> {
+    pub(crate) fn Attributes(&self) -> windows_core::Result<FileAttributes> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_Attributes)(
+            (windows_core::Interface::vtable(self).Attributes)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
@@ -16136,15 +16109,15 @@ pub struct IStorageItem_Vtbl {
     DeleteAsyncOverloadDefaultOptions: usize,
     DeleteAsync: usize,
     GetBasicPropertiesAsync: usize,
-    pub get_Name: unsafe extern "system" fn(
+    pub Name: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    pub get_Path: unsafe extern "system" fn(
+    pub Path: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    pub get_Attributes: unsafe extern "system" fn(
+    pub Attributes: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut FileAttributes,
     ) -> windows_core::HRESULT,
@@ -16386,20 +16359,20 @@ impl windows_core::RuntimeType for ISwapChainPanel {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl ISwapChainPanel {
-    pub(crate) fn get_CompositionScaleX(&self) -> windows_core::Result<f32> {
+    pub(crate) fn CompositionScaleX(&self) -> windows_core::Result<f32> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_CompositionScaleX)(
+            (windows_core::Interface::vtable(self).CompositionScaleX)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
             .map(|| result__)
         }
     }
-    pub(crate) fn get_CompositionScaleY(&self) -> windows_core::Result<f32> {
+    pub(crate) fn CompositionScaleY(&self) -> windows_core::Result<f32> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_CompositionScaleY)(
+            (windows_core::Interface::vtable(self).CompositionScaleY)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
@@ -16426,7 +16399,7 @@ impl ISwapChainPanel {
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
-            let token__ = (windows_core::Interface::vtable(self).add_CompositionScaleChanged)(
+            let token__ = (windows_core::Interface::vtable(self).CompositionScaleChanged)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Interface::as_raw(&handler),
                 &mut result__,
@@ -16435,7 +16408,7 @@ impl ISwapChainPanel {
             Ok(windows_core::EventRevoker::new(
                 self.clone(),
                 token__,
-                windows_core::Interface::vtable(self).remove_CompositionScaleChanged,
+                windows_core::Interface::vtable(self).RemoveCompositionScaleChanged,
             ))
         }
     }
@@ -16443,16 +16416,16 @@ impl ISwapChainPanel {
 #[repr(C)]
 pub struct ISwapChainPanel_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    pub get_CompositionScaleX:
+    pub CompositionScaleX:
         unsafe extern "system" fn(*mut core::ffi::c_void, *mut f32) -> windows_core::HRESULT,
-    pub get_CompositionScaleY:
+    pub CompositionScaleY:
         unsafe extern "system" fn(*mut core::ffi::c_void, *mut f32) -> windows_core::HRESULT,
-    pub add_CompositionScaleChanged: unsafe extern "system" fn(
+    pub CompositionScaleChanged: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         *mut i64,
     ) -> windows_core::HRESULT,
-    pub remove_CompositionScaleChanged:
+    pub RemoveCompositionScaleChanged:
         unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
@@ -16544,10 +16517,10 @@ impl windows_core::RuntimeType for ISymbolIcon {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl ISymbolIcon {
-    pub(crate) fn get_Symbol(&self) -> windows_core::Result<Symbol> {
+    pub(crate) fn Symbol(&self) -> windows_core::Result<Symbol> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_Symbol)(
+            (windows_core::Interface::vtable(self).Symbol)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
@@ -16558,7 +16531,7 @@ impl ISymbolIcon {
 #[repr(C)]
 pub struct ISymbolIcon_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    pub get_Symbol:
+    pub Symbol:
         unsafe extern "system" fn(*mut core::ffi::c_void, *mut Symbol) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
@@ -16602,9 +16575,9 @@ impl windows_core::RuntimeType for ITabView {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl ITabView {
-    pub(crate) fn put_IsAddTabButtonVisible(&self, value: bool) -> windows_core::Result<()> {
+    pub(crate) fn SetIsAddTabButtonVisible(&self, value: bool) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_IsAddTabButtonVisible)(
+            (windows_core::Interface::vtable(self).SetIsAddTabButtonVisible)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
@@ -16631,7 +16604,7 @@ impl ITabView {
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
-            let token__ = (windows_core::Interface::vtable(self).add_TabCloseRequested)(
+            let token__ = (windows_core::Interface::vtable(self).TabCloseRequested)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Interface::as_raw(&handler),
                 &mut result__,
@@ -16640,7 +16613,7 @@ impl ITabView {
             Ok(windows_core::EventRevoker::new(
                 self.clone(),
                 token__,
-                windows_core::Interface::vtable(self).remove_TabCloseRequested,
+                windows_core::Interface::vtable(self).RemoveTabCloseRequested,
             ))
         }
     }
@@ -16663,7 +16636,7 @@ impl ITabView {
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
-            let token__ = (windows_core::Interface::vtable(self).add_AddTabButtonClick)(
+            let token__ = (windows_core::Interface::vtable(self).AddTabButtonClick)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Interface::as_raw(&handler),
                 &mut result__,
@@ -16672,44 +16645,44 @@ impl ITabView {
             Ok(windows_core::EventRevoker::new(
                 self.clone(),
                 token__,
-                windows_core::Interface::vtable(self).remove_AddTabButtonClick,
+                windows_core::Interface::vtable(self).RemoveAddTabButtonClick,
             ))
         }
     }
-    pub(crate) fn get_TabItems(
+    pub(crate) fn TabItems(
         &self,
     ) -> windows_core::Result<windows_collections::IVector<windows_core::IInspectable>> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_TabItems)(
+            (windows_core::Interface::vtable(self).TabItems)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
             .and_then(|| windows_core::Type::from_abi(result__))
         }
     }
-    pub(crate) fn put_CanReorderTabs(&self, value: bool) -> windows_core::Result<()> {
+    pub(crate) fn SetCanReorderTabs(&self, value: bool) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_CanReorderTabs)(
+            (windows_core::Interface::vtable(self).SetCanReorderTabs)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn get_SelectedIndex(&self) -> windows_core::Result<i32> {
+    pub(crate) fn SelectedIndex(&self) -> windows_core::Result<i32> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_SelectedIndex)(
+            (windows_core::Interface::vtable(self).SelectedIndex)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
             .map(|| result__)
         }
     }
-    pub(crate) fn put_SelectedIndex(&self, value: i32) -> windows_core::Result<()> {
+    pub(crate) fn SetSelectedIndex(&self, value: i32) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_SelectedIndex)(
+            (windows_core::Interface::vtable(self).SetSelectedIndex)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
@@ -16735,7 +16708,7 @@ impl ITabView {
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
-            let token__ = (windows_core::Interface::vtable(self).add_SelectionChanged)(
+            let token__ = (windows_core::Interface::vtable(self).SelectionChanged)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Interface::as_raw(&handler),
                 &mut result__,
@@ -16744,7 +16717,7 @@ impl ITabView {
             Ok(windows_core::EventRevoker::new(
                 self.clone(),
                 token__,
-                windows_core::Interface::vtable(self).remove_SelectionChanged,
+                windows_core::Interface::vtable(self).RemoveSelectionChanged,
             ))
         }
     }
@@ -16752,74 +16725,74 @@ impl ITabView {
 #[repr(C)]
 pub struct ITabView_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_TabWidthMode: usize,
-    put_TabWidthMode: usize,
-    get_CloseButtonOverlayMode: usize,
-    put_CloseButtonOverlayMode: usize,
-    get_TabStripHeader: usize,
-    put_TabStripHeader: usize,
-    get_TabStripHeaderTemplate: usize,
-    put_TabStripHeaderTemplate: usize,
-    get_TabStripFooter: usize,
-    put_TabStripFooter: usize,
-    get_TabStripFooterTemplate: usize,
-    put_TabStripFooterTemplate: usize,
-    get_IsAddTabButtonVisible: usize,
-    pub put_IsAddTabButtonVisible:
+    TabWidthMode: usize,
+    SetTabWidthMode: usize,
+    CloseButtonOverlayMode: usize,
+    SetCloseButtonOverlayMode: usize,
+    TabStripHeader: usize,
+    SetTabStripHeader: usize,
+    TabStripHeaderTemplate: usize,
+    SetTabStripHeaderTemplate: usize,
+    TabStripFooter: usize,
+    SetTabStripFooter: usize,
+    TabStripFooterTemplate: usize,
+    SetTabStripFooterTemplate: usize,
+    IsAddTabButtonVisible: usize,
+    pub SetIsAddTabButtonVisible:
         unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
-    get_AddTabButtonCommand: usize,
-    put_AddTabButtonCommand: usize,
-    get_AddTabButtonCommandParameter: usize,
-    put_AddTabButtonCommandParameter: usize,
-    pub add_TabCloseRequested: unsafe extern "system" fn(
+    AddTabButtonCommand: usize,
+    SetAddTabButtonCommand: usize,
+    AddTabButtonCommandParameter: usize,
+    SetAddTabButtonCommandParameter: usize,
+    pub TabCloseRequested: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         *mut i64,
     ) -> windows_core::HRESULT,
-    pub remove_TabCloseRequested:
+    pub RemoveTabCloseRequested:
         unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
-    add_TabDroppedOutside: usize,
-    remove_TabDroppedOutside: usize,
-    pub add_AddTabButtonClick: unsafe extern "system" fn(
+    TabDroppedOutside: usize,
+    RemoveTabDroppedOutside: usize,
+    pub AddTabButtonClick: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         *mut i64,
     ) -> windows_core::HRESULT,
-    pub remove_AddTabButtonClick:
+    pub RemoveAddTabButtonClick:
         unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
-    add_TabItemsChanged: usize,
-    remove_TabItemsChanged: usize,
-    get_TabItemsSource: usize,
-    put_TabItemsSource: usize,
-    pub get_TabItems: unsafe extern "system" fn(
+    TabItemsChanged: usize,
+    RemoveTabItemsChanged: usize,
+    TabItemsSource: usize,
+    SetTabItemsSource: usize,
+    pub TabItems: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_TabItemTemplate: usize,
-    put_TabItemTemplate: usize,
-    get_TabItemTemplateSelector: usize,
-    put_TabItemTemplateSelector: usize,
-    get_CanDragTabs: usize,
-    put_CanDragTabs: usize,
-    get_CanReorderTabs: usize,
-    pub put_CanReorderTabs:
+    TabItemTemplate: usize,
+    SetTabItemTemplate: usize,
+    TabItemTemplateSelector: usize,
+    SetTabItemTemplateSelector: usize,
+    CanDragTabs: usize,
+    SetCanDragTabs: usize,
+    CanReorderTabs: usize,
+    pub SetCanReorderTabs:
         unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
-    get_AllowDropTabs: usize,
-    put_AllowDropTabs: usize,
-    pub get_SelectedIndex:
+    AllowDropTabs: usize,
+    SetAllowDropTabs: usize,
+    pub SelectedIndex:
         unsafe extern "system" fn(*mut core::ffi::c_void, *mut i32) -> windows_core::HRESULT,
-    pub put_SelectedIndex:
+    pub SetSelectedIndex:
         unsafe extern "system" fn(*mut core::ffi::c_void, i32) -> windows_core::HRESULT,
-    get_SelectedItem: usize,
-    put_SelectedItem: usize,
+    SelectedItem: usize,
+    SetSelectedItem: usize,
     ContainerFromItem: usize,
     ContainerFromIndex: usize,
-    pub add_SelectionChanged: unsafe extern "system" fn(
+    pub SelectionChanged: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         *mut i64,
     ) -> windows_core::HRESULT,
-    pub remove_SelectionChanged:
+    pub RemoveSelectionChanged:
         unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
@@ -16851,21 +16824,21 @@ impl windows_core::RuntimeType for ITabViewItem {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl ITabViewItem {
-    pub(crate) fn put_Header<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetHeader<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<windows_core::IInspectable>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Header)(
+            (windows_core::Interface::vtable(self).SetHeader)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
             .ok()
         }
     }
-    pub(crate) fn put_IsClosable(&self, value: bool) -> windows_core::Result<()> {
+    pub(crate) fn SetIsClosable(&self, value: bool) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_IsClosable)(
+            (windows_core::Interface::vtable(self).SetIsClosable)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
@@ -16876,17 +16849,17 @@ impl ITabViewItem {
 #[repr(C)]
 pub struct ITabViewItem_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_Header: usize,
-    pub put_Header: unsafe extern "system" fn(
+    Header: usize,
+    pub SetHeader: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_HeaderTemplate: usize,
-    put_HeaderTemplate: usize,
-    get_IconSource: usize,
-    put_IconSource: usize,
-    get_IsClosable: usize,
-    pub put_IsClosable:
+    HeaderTemplate: usize,
+    SetHeaderTemplate: usize,
+    IconSource: usize,
+    SetIconSource: usize,
+    IsClosable: usize,
+    pub SetIsClosable:
         unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
@@ -16918,10 +16891,10 @@ impl windows_core::RuntimeType for ITabViewTabCloseRequestedEventArgs {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl ITabViewTabCloseRequestedEventArgs {
-    pub(crate) fn get_Tab(&self) -> windows_core::Result<TabViewItem> {
+    pub(crate) fn Tab(&self) -> windows_core::Result<TabViewItem> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_Tab)(
+            (windows_core::Interface::vtable(self).Tab)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
@@ -16932,8 +16905,8 @@ impl ITabViewTabCloseRequestedEventArgs {
 #[repr(C)]
 pub struct ITabViewTabCloseRequestedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_Item: usize,
-    pub get_Tab: unsafe extern "system" fn(
+    Item: usize,
+    pub Tab: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
@@ -16961,72 +16934,72 @@ impl windows_core::RuntimeType for ITeachingTip {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl ITeachingTip {
-    pub(crate) fn put_Title(&self, value: &str) -> windows_core::Result<()> {
+    pub(crate) fn SetTitle(&self, value: &str) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Title)(
+            (windows_core::Interface::vtable(self).SetTitle)(
                 windows_core::Interface::as_raw(self),
                 core::mem::transmute_copy(&windows_core::HSTRING::from(value)),
             )
             .ok()
         }
     }
-    pub(crate) fn put_Subtitle(&self, value: &str) -> windows_core::Result<()> {
+    pub(crate) fn SetSubtitle(&self, value: &str) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Subtitle)(
+            (windows_core::Interface::vtable(self).SetSubtitle)(
                 windows_core::Interface::as_raw(self),
                 core::mem::transmute_copy(&windows_core::HSTRING::from(value)),
             )
             .ok()
         }
     }
-    pub(crate) fn put_IsOpen(&self, value: bool) -> windows_core::Result<()> {
+    pub(crate) fn SetIsOpen(&self, value: bool) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_IsOpen)(
+            (windows_core::Interface::vtable(self).SetIsOpen)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_ActionButtonContent<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetActionButtonContent<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<windows_core::IInspectable>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_ActionButtonContent)(
+            (windows_core::Interface::vtable(self).SetActionButtonContent)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
             .ok()
         }
     }
-    pub(crate) fn put_CloseButtonContent<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetCloseButtonContent<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<windows_core::IInspectable>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_CloseButtonContent)(
+            (windows_core::Interface::vtable(self).SetCloseButtonContent)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
             .ok()
         }
     }
-    pub(crate) fn put_IsLightDismissEnabled(&self, value: bool) -> windows_core::Result<()> {
+    pub(crate) fn SetIsLightDismissEnabled(&self, value: bool) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_IsLightDismissEnabled)(
+            (windows_core::Interface::vtable(self).SetIsLightDismissEnabled)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_PreferredPlacement(
+    pub(crate) fn SetPreferredPlacement(
         &self,
         value: TeachingTipPlacementMode,
     ) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_PreferredPlacement)(
+            (windows_core::Interface::vtable(self).SetPreferredPlacement)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
@@ -17053,7 +17026,7 @@ impl ITeachingTip {
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
-            let token__ = (windows_core::Interface::vtable(self).add_ActionButtonClick)(
+            let token__ = (windows_core::Interface::vtable(self).ActionButtonClick)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Interface::as_raw(&handler),
                 &mut result__,
@@ -17062,7 +17035,7 @@ impl ITeachingTip {
             Ok(windows_core::EventRevoker::new(
                 self.clone(),
                 token__,
-                windows_core::Interface::vtable(self).remove_ActionButtonClick,
+                windows_core::Interface::vtable(self).RemoveActionButtonClick,
             ))
         }
     }
@@ -17083,7 +17056,7 @@ impl ITeachingTip {
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
-            let token__ = (windows_core::Interface::vtable(self).add_Closed)(
+            let token__ = (windows_core::Interface::vtable(self).Closed)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Interface::as_raw(&handler),
                 &mut result__,
@@ -17092,7 +17065,7 @@ impl ITeachingTip {
             Ok(windows_core::EventRevoker::new(
                 self.clone(),
                 token__,
-                windows_core::Interface::vtable(self).remove_Closed,
+                windows_core::Interface::vtable(self).RemoveClosed,
             ))
         }
     }
@@ -17100,81 +17073,80 @@ impl ITeachingTip {
 #[repr(C)]
 pub struct ITeachingTip_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_Title: usize,
-    pub put_Title: unsafe extern "system" fn(
+    Title: usize,
+    pub SetTitle: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_Subtitle: usize,
-    pub put_Subtitle: unsafe extern "system" fn(
+    Subtitle: usize,
+    pub SetSubtitle: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_IsOpen: usize,
-    pub put_IsOpen:
+    IsOpen: usize,
+    pub SetIsOpen: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
+    Target: usize,
+    SetTarget: usize,
+    TailVisibility: usize,
+    SetTailVisibility: usize,
+    ActionButtonContent: usize,
+    pub SetActionButtonContent: unsafe extern "system" fn(
+        *mut core::ffi::c_void,
+        *mut core::ffi::c_void,
+    ) -> windows_core::HRESULT,
+    ActionButtonStyle: usize,
+    SetActionButtonStyle: usize,
+    ActionButtonCommand: usize,
+    SetActionButtonCommand: usize,
+    ActionButtonCommandParameter: usize,
+    SetActionButtonCommandParameter: usize,
+    CloseButtonContent: usize,
+    pub SetCloseButtonContent: unsafe extern "system" fn(
+        *mut core::ffi::c_void,
+        *mut core::ffi::c_void,
+    ) -> windows_core::HRESULT,
+    CloseButtonStyle: usize,
+    SetCloseButtonStyle: usize,
+    CloseButtonCommand: usize,
+    SetCloseButtonCommand: usize,
+    CloseButtonCommandParameter: usize,
+    SetCloseButtonCommandParameter: usize,
+    PlacementMargin: usize,
+    SetPlacementMargin: usize,
+    ShouldConstrainToRootBounds: usize,
+    SetShouldConstrainToRootBounds: usize,
+    IsLightDismissEnabled: usize,
+    pub SetIsLightDismissEnabled:
         unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
-    get_Target: usize,
-    put_Target: usize,
-    get_TailVisibility: usize,
-    put_TailVisibility: usize,
-    get_ActionButtonContent: usize,
-    pub put_ActionButtonContent: unsafe extern "system" fn(
-        *mut core::ffi::c_void,
-        *mut core::ffi::c_void,
-    ) -> windows_core::HRESULT,
-    get_ActionButtonStyle: usize,
-    put_ActionButtonStyle: usize,
-    get_ActionButtonCommand: usize,
-    put_ActionButtonCommand: usize,
-    get_ActionButtonCommandParameter: usize,
-    put_ActionButtonCommandParameter: usize,
-    get_CloseButtonContent: usize,
-    pub put_CloseButtonContent: unsafe extern "system" fn(
-        *mut core::ffi::c_void,
-        *mut core::ffi::c_void,
-    ) -> windows_core::HRESULT,
-    get_CloseButtonStyle: usize,
-    put_CloseButtonStyle: usize,
-    get_CloseButtonCommand: usize,
-    put_CloseButtonCommand: usize,
-    get_CloseButtonCommandParameter: usize,
-    put_CloseButtonCommandParameter: usize,
-    get_PlacementMargin: usize,
-    put_PlacementMargin: usize,
-    get_ShouldConstrainToRootBounds: usize,
-    put_ShouldConstrainToRootBounds: usize,
-    get_IsLightDismissEnabled: usize,
-    pub put_IsLightDismissEnabled:
-        unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
-    get_PreferredPlacement: usize,
-    pub put_PreferredPlacement: unsafe extern "system" fn(
+    PreferredPlacement: usize,
+    pub SetPreferredPlacement: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         TeachingTipPlacementMode,
     ) -> windows_core::HRESULT,
-    get_HeroContentPlacement: usize,
-    put_HeroContentPlacement: usize,
-    get_HeroContent: usize,
-    put_HeroContent: usize,
-    get_IconSource: usize,
-    put_IconSource: usize,
-    get_TemplateSettings: usize,
-    pub add_ActionButtonClick: unsafe extern "system" fn(
+    HeroContentPlacement: usize,
+    SetHeroContentPlacement: usize,
+    HeroContent: usize,
+    SetHeroContent: usize,
+    IconSource: usize,
+    SetIconSource: usize,
+    TemplateSettings: usize,
+    pub ActionButtonClick: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         *mut i64,
     ) -> windows_core::HRESULT,
-    pub remove_ActionButtonClick:
+    pub RemoveActionButtonClick:
         unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
-    add_CloseButtonClick: usize,
-    remove_CloseButtonClick: usize,
-    add_Closing: usize,
-    remove_Closing: usize,
-    pub add_Closed: unsafe extern "system" fn(
+    CloseButtonClick: usize,
+    RemoveCloseButtonClick: usize,
+    Closing: usize,
+    RemoveClosing: usize,
+    pub Closed: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         *mut i64,
     ) -> windows_core::HRESULT,
-    pub remove_Closed:
+    pub RemoveClosed:
         unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
@@ -17219,61 +17191,61 @@ impl windows_core::RuntimeType for ITextBlock {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl ITextBlock {
-    pub(crate) fn put_FontSize(&self, value: f64) -> windows_core::Result<()> {
+    pub(crate) fn SetFontSize(&self, value: f64) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_FontSize)(
+            (windows_core::Interface::vtable(self).SetFontSize)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_FontFamily<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetFontFamily<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<FontFamily>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_FontFamily)(
+            (windows_core::Interface::vtable(self).SetFontFamily)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
             .ok()
         }
     }
-    pub(crate) fn put_FontWeight(&self, value: FontWeight) -> windows_core::Result<()> {
+    pub(crate) fn SetFontWeight(&self, value: FontWeight) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_FontWeight)(
+            (windows_core::Interface::vtable(self).SetFontWeight)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_Foreground<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetForeground<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<Brush>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Foreground)(
+            (windows_core::Interface::vtable(self).SetForeground)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
             .ok()
         }
     }
-    pub(crate) fn put_TextWrapping(&self, value: TextWrapping) -> windows_core::Result<()> {
+    pub(crate) fn SetTextWrapping(&self, value: TextWrapping) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_TextWrapping)(
+            (windows_core::Interface::vtable(self).SetTextWrapping)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn get_Text(&self) -> windows_core::Result<String> {
+    pub(crate) fn Text(&self) -> windows_core::Result<String> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_Text)(
+            (windows_core::Interface::vtable(self).Text)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
@@ -17283,18 +17255,18 @@ impl ITextBlock {
             })
         }
     }
-    pub(crate) fn put_Text(&self, value: &str) -> windows_core::Result<()> {
+    pub(crate) fn SetText(&self, value: &str) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Text)(
+            (windows_core::Interface::vtable(self).SetText)(
                 windows_core::Interface::as_raw(self),
                 core::mem::transmute_copy(&windows_core::HSTRING::from(value)),
             )
             .ok()
         }
     }
-    pub(crate) fn put_IsTextSelectionEnabled(&self, value: bool) -> windows_core::Result<()> {
+    pub(crate) fn SetIsTextSelectionEnabled(&self, value: bool) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_IsTextSelectionEnabled)(
+            (windows_core::Interface::vtable(self).SetIsTextSelectionEnabled)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
@@ -17305,52 +17277,52 @@ impl ITextBlock {
 #[repr(C)]
 pub struct ITextBlock_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_FontSize: usize,
-    pub put_FontSize:
+    FontSize: usize,
+    pub SetFontSize:
         unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
-    get_FontFamily: usize,
-    pub put_FontFamily: unsafe extern "system" fn(
+    FontFamily: usize,
+    pub SetFontFamily: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_FontWeight: usize,
-    pub put_FontWeight:
+    FontWeight: usize,
+    pub SetFontWeight:
         unsafe extern "system" fn(*mut core::ffi::c_void, FontWeight) -> windows_core::HRESULT,
-    get_FontStyle: usize,
-    put_FontStyle: usize,
-    get_FontStretch: usize,
-    put_FontStretch: usize,
-    get_CharacterSpacing: usize,
-    put_CharacterSpacing: usize,
-    get_Foreground: usize,
-    pub put_Foreground: unsafe extern "system" fn(
+    FontStyle: usize,
+    SetFontStyle: usize,
+    FontStretch: usize,
+    SetFontStretch: usize,
+    CharacterSpacing: usize,
+    SetCharacterSpacing: usize,
+    Foreground: usize,
+    pub SetForeground: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_TextWrapping: usize,
-    pub put_TextWrapping:
+    TextWrapping: usize,
+    pub SetTextWrapping:
         unsafe extern "system" fn(*mut core::ffi::c_void, TextWrapping) -> windows_core::HRESULT,
-    get_TextTrimming: usize,
-    put_TextTrimming: usize,
-    get_TextAlignment: usize,
-    put_TextAlignment: usize,
-    pub get_Text: unsafe extern "system" fn(
+    TextTrimming: usize,
+    SetTextTrimming: usize,
+    TextAlignment: usize,
+    SetTextAlignment: usize,
+    pub Text: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    pub put_Text: unsafe extern "system" fn(
+    pub SetText: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_Inlines: usize,
-    get_Padding: usize,
-    put_Padding: usize,
-    get_LineHeight: usize,
-    put_LineHeight: usize,
-    get_LineStackingStrategy: usize,
-    put_LineStackingStrategy: usize,
-    get_IsTextSelectionEnabled: usize,
-    pub put_IsTextSelectionEnabled:
+    Inlines: usize,
+    Padding: usize,
+    SetPadding: usize,
+    LineHeight: usize,
+    SetLineHeight: usize,
+    LineStackingStrategy: usize,
+    SetLineStackingStrategy: usize,
+    IsTextSelectionEnabled: usize,
+    pub SetIsTextSelectionEnabled:
         unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
@@ -17363,10 +17335,10 @@ impl windows_core::RuntimeType for ITextBox {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl ITextBox {
-    pub(crate) fn get_Text(&self) -> windows_core::Result<String> {
+    pub(crate) fn Text(&self) -> windows_core::Result<String> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_Text)(
+            (windows_core::Interface::vtable(self).Text)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
@@ -17376,48 +17348,48 @@ impl ITextBox {
             })
         }
     }
-    pub(crate) fn put_Text(&self, value: &str) -> windows_core::Result<()> {
+    pub(crate) fn SetText(&self, value: &str) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Text)(
+            (windows_core::Interface::vtable(self).SetText)(
                 windows_core::Interface::as_raw(self),
                 core::mem::transmute_copy(&windows_core::HSTRING::from(value)),
             )
             .ok()
         }
     }
-    pub(crate) fn put_AcceptsReturn(&self, value: bool) -> windows_core::Result<()> {
+    pub(crate) fn SetAcceptsReturn(&self, value: bool) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_AcceptsReturn)(
+            (windows_core::Interface::vtable(self).SetAcceptsReturn)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_TextWrapping(&self, value: TextWrapping) -> windows_core::Result<()> {
+    pub(crate) fn SetTextWrapping(&self, value: TextWrapping) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_TextWrapping)(
+            (windows_core::Interface::vtable(self).SetTextWrapping)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_Header<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetHeader<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<windows_core::IInspectable>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Header)(
+            (windows_core::Interface::vtable(self).SetHeader)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
             .ok()
         }
     }
-    pub(crate) fn put_PlaceholderText(&self, value: &str) -> windows_core::Result<()> {
+    pub(crate) fn SetPlaceholderText(&self, value: &str) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_PlaceholderText)(
+            (windows_core::Interface::vtable(self).SetPlaceholderText)(
                 windows_core::Interface::as_raw(self),
                 core::mem::transmute_copy(&windows_core::HSTRING::from(value)),
             )
@@ -17443,7 +17415,7 @@ impl ITextBox {
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
-            let token__ = (windows_core::Interface::vtable(self).add_TextChanged)(
+            let token__ = (windows_core::Interface::vtable(self).TextChanged)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Interface::as_raw(&handler),
                 &mut result__,
@@ -17452,7 +17424,7 @@ impl ITextBox {
             Ok(windows_core::EventRevoker::new(
                 self.clone(),
                 token__,
-                windows_core::Interface::vtable(self).remove_TextChanged,
+                windows_core::Interface::vtable(self).RemoveTextChanged,
             ))
         }
     }
@@ -17460,78 +17432,78 @@ impl ITextBox {
 #[repr(C)]
 pub struct ITextBox_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    pub get_Text: unsafe extern "system" fn(
+    pub Text: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    pub put_Text: unsafe extern "system" fn(
+    pub SetText: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_SelectedText: usize,
-    put_SelectedText: usize,
-    get_SelectionLength: usize,
-    put_SelectionLength: usize,
-    get_SelectionStart: usize,
-    put_SelectionStart: usize,
-    get_MaxLength: usize,
-    put_MaxLength: usize,
-    get_IsReadOnly: usize,
-    put_IsReadOnly: usize,
-    get_AcceptsReturn: usize,
-    pub put_AcceptsReturn:
+    SelectedText: usize,
+    SetSelectedText: usize,
+    SelectionLength: usize,
+    SetSelectionLength: usize,
+    SelectionStart: usize,
+    SetSelectionStart: usize,
+    MaxLength: usize,
+    SetMaxLength: usize,
+    IsReadOnly: usize,
+    SetIsReadOnly: usize,
+    AcceptsReturn: usize,
+    pub SetAcceptsReturn:
         unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
-    get_TextAlignment: usize,
-    put_TextAlignment: usize,
-    get_TextWrapping: usize,
-    pub put_TextWrapping:
+    TextAlignment: usize,
+    SetTextAlignment: usize,
+    TextWrapping: usize,
+    pub SetTextWrapping:
         unsafe extern "system" fn(*mut core::ffi::c_void, TextWrapping) -> windows_core::HRESULT,
-    get_IsSpellCheckEnabled: usize,
-    put_IsSpellCheckEnabled: usize,
-    get_IsTextPredictionEnabled: usize,
-    put_IsTextPredictionEnabled: usize,
-    get_InputScope: usize,
-    put_InputScope: usize,
-    get_Header: usize,
-    pub put_Header: unsafe extern "system" fn(
+    IsSpellCheckEnabled: usize,
+    SetIsSpellCheckEnabled: usize,
+    IsTextPredictionEnabled: usize,
+    SetIsTextPredictionEnabled: usize,
+    InputScope: usize,
+    SetInputScope: usize,
+    Header: usize,
+    pub SetHeader: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_HeaderTemplate: usize,
-    put_HeaderTemplate: usize,
-    get_PlaceholderText: usize,
-    pub put_PlaceholderText: unsafe extern "system" fn(
+    HeaderTemplate: usize,
+    SetHeaderTemplate: usize,
+    PlaceholderText: usize,
+    pub SetPlaceholderText: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_SelectionHighlightColor: usize,
-    put_SelectionHighlightColor: usize,
-    get_PreventKeyboardDisplayOnProgrammaticFocus: usize,
-    put_PreventKeyboardDisplayOnProgrammaticFocus: usize,
-    get_IsColorFontEnabled: usize,
-    put_IsColorFontEnabled: usize,
-    get_SelectionHighlightColorWhenNotFocused: usize,
-    put_SelectionHighlightColorWhenNotFocused: usize,
-    get_HorizontalTextAlignment: usize,
-    put_HorizontalTextAlignment: usize,
-    get_CharacterCasing: usize,
-    put_CharacterCasing: usize,
-    get_PlaceholderForeground: usize,
-    put_PlaceholderForeground: usize,
-    get_CanPasteClipboardContent: usize,
-    get_CanUndo: usize,
-    get_CanRedo: usize,
-    get_SelectionFlyout: usize,
-    put_SelectionFlyout: usize,
-    get_ProofingMenuFlyout: usize,
-    get_Description: usize,
-    put_Description: usize,
-    pub add_TextChanged: unsafe extern "system" fn(
+    SelectionHighlightColor: usize,
+    SetSelectionHighlightColor: usize,
+    PreventKeyboardDisplayOnProgrammaticFocus: usize,
+    SetPreventKeyboardDisplayOnProgrammaticFocus: usize,
+    IsColorFontEnabled: usize,
+    SetIsColorFontEnabled: usize,
+    SelectionHighlightColorWhenNotFocused: usize,
+    SetSelectionHighlightColorWhenNotFocused: usize,
+    HorizontalTextAlignment: usize,
+    SetHorizontalTextAlignment: usize,
+    CharacterCasing: usize,
+    SetCharacterCasing: usize,
+    PlaceholderForeground: usize,
+    SetPlaceholderForeground: usize,
+    CanPasteClipboardContent: usize,
+    CanUndo: usize,
+    CanRedo: usize,
+    SelectionFlyout: usize,
+    SetSelectionFlyout: usize,
+    ProofingMenuFlyout: usize,
+    Description: usize,
+    SetDescription: usize,
+    pub TextChanged: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         *mut i64,
     ) -> windows_core::HRESULT,
-    pub remove_TextChanged:
+    pub RemoveTextChanged:
         unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
@@ -17604,13 +17576,13 @@ impl ITextDocument {
 #[repr(C)]
 pub struct ITextDocument_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_CaretType: usize,
-    put_CaretType: usize,
-    get_DefaultTabStop: usize,
-    put_DefaultTabStop: usize,
-    get_Selection: usize,
-    get_UndoLimit: usize,
-    put_UndoLimit: usize,
+    CaretType: usize,
+    SetCaretType: usize,
+    DefaultTabStop: usize,
+    SetDefaultTabStop: usize,
+    Selection: usize,
+    UndoLimit: usize,
+    SetUndoLimit: usize,
     CanCopy: usize,
     CanPaste: usize,
     CanRedo: usize,
@@ -17649,9 +17621,9 @@ impl windows_core::RuntimeType for ITextElement {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl ITextElement {
-    pub(crate) fn put_FontWeight(&self, value: FontWeight) -> windows_core::Result<()> {
+    pub(crate) fn SetFontWeight(&self, value: FontWeight) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_FontWeight)(
+            (windows_core::Interface::vtable(self).SetFontWeight)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
@@ -17662,13 +17634,13 @@ impl ITextElement {
 #[repr(C)]
 pub struct ITextElement_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_Name: usize,
-    get_FontSize: usize,
-    put_FontSize: usize,
-    get_FontFamily: usize,
-    put_FontFamily: usize,
-    get_FontWeight: usize,
-    pub put_FontWeight:
+    Name: usize,
+    FontSize: usize,
+    SetFontSize: usize,
+    FontFamily: usize,
+    SetFontFamily: usize,
+    FontWeight: usize,
+    pub SetFontWeight:
         unsafe extern "system" fn(*mut core::ffi::c_void, FontWeight) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
@@ -17681,30 +17653,30 @@ impl windows_core::RuntimeType for ITimePicker {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl ITimePicker {
-    pub(crate) fn put_Header<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetHeader<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<windows_core::IInspectable>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Header)(
+            (windows_core::Interface::vtable(self).SetHeader)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
             .ok()
         }
     }
-    pub(crate) fn put_ClockIdentifier(&self, value: &str) -> windows_core::Result<()> {
+    pub(crate) fn SetClockIdentifier(&self, value: &str) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_ClockIdentifier)(
+            (windows_core::Interface::vtable(self).SetClockIdentifier)(
                 windows_core::Interface::as_raw(self),
                 core::mem::transmute_copy(&windows_core::HSTRING::from(value)),
             )
             .ok()
         }
     }
-    pub(crate) fn put_MinuteIncrement(&self, value: i32) -> windows_core::Result<()> {
+    pub(crate) fn SetMinuteIncrement(&self, value: i32) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_MinuteIncrement)(
+            (windows_core::Interface::vtable(self).SetMinuteIncrement)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
@@ -17727,7 +17699,7 @@ impl ITimePicker {
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
-            let token__ = (windows_core::Interface::vtable(self).add_SelectedTimeChanged)(
+            let token__ = (windows_core::Interface::vtable(self).SelectedTimeChanged)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Interface::as_raw(&handler),
                 &mut result__,
@@ -17736,7 +17708,7 @@ impl ITimePicker {
             Ok(windows_core::EventRevoker::new(
                 self.clone(),
                 token__,
-                windows_core::Interface::vtable(self).remove_SelectedTimeChanged,
+                windows_core::Interface::vtable(self).RemoveSelectedTimeChanged,
             ))
         }
     }
@@ -17744,35 +17716,35 @@ impl ITimePicker {
 #[repr(C)]
 pub struct ITimePicker_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_Header: usize,
-    pub put_Header: unsafe extern "system" fn(
+    Header: usize,
+    pub SetHeader: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_HeaderTemplate: usize,
-    put_HeaderTemplate: usize,
-    get_ClockIdentifier: usize,
-    pub put_ClockIdentifier: unsafe extern "system" fn(
+    HeaderTemplate: usize,
+    SetHeaderTemplate: usize,
+    ClockIdentifier: usize,
+    pub SetClockIdentifier: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_MinuteIncrement: usize,
-    pub put_MinuteIncrement:
+    MinuteIncrement: usize,
+    pub SetMinuteIncrement:
         unsafe extern "system" fn(*mut core::ffi::c_void, i32) -> windows_core::HRESULT,
-    get_Time: usize,
-    put_Time: usize,
-    get_LightDismissOverlayMode: usize,
-    put_LightDismissOverlayMode: usize,
-    get_SelectedTime: usize,
-    put_SelectedTime: usize,
-    add_TimeChanged: usize,
-    remove_TimeChanged: usize,
-    pub add_SelectedTimeChanged: unsafe extern "system" fn(
+    Time: usize,
+    SetTime: usize,
+    LightDismissOverlayMode: usize,
+    SetLightDismissOverlayMode: usize,
+    SelectedTime: usize,
+    SetSelectedTime: usize,
+    TimeChanged: usize,
+    RemoveTimeChanged: usize,
+    pub SelectedTimeChanged: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         *mut i64,
     ) -> windows_core::HRESULT,
-    pub remove_SelectedTimeChanged:
+    pub RemoveSelectedTimeChanged:
         unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
@@ -17804,10 +17776,10 @@ impl windows_core::RuntimeType for ITimePickerSelectedValueChangedEventArgs {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl ITimePickerSelectedValueChangedEventArgs {
-    pub(crate) fn get_NewTime(&self) -> windows_core::Result<windows_time::TimeSpan> {
+    pub(crate) fn NewTime(&self) -> windows_core::Result<windows_time::TimeSpan> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_NewTime)(
+            (windows_core::Interface::vtable(self).NewTime)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
@@ -17819,8 +17791,8 @@ impl ITimePickerSelectedValueChangedEventArgs {
 #[repr(C)]
 pub struct ITimePickerSelectedValueChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_OldTime: usize,
-    pub get_NewTime: unsafe extern "system" fn(
+    OldTime: usize,
+    pub NewTime: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
@@ -17835,69 +17807,69 @@ impl windows_core::RuntimeType for ITitleBar {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl ITitleBar {
-    pub(crate) fn put_Title(&self, value: &str) -> windows_core::Result<()> {
+    pub(crate) fn SetTitle(&self, value: &str) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Title)(
+            (windows_core::Interface::vtable(self).SetTitle)(
                 windows_core::Interface::as_raw(self),
                 core::mem::transmute_copy(&windows_core::HSTRING::from(value)),
             )
             .ok()
         }
     }
-    pub(crate) fn put_Subtitle(&self, value: &str) -> windows_core::Result<()> {
+    pub(crate) fn SetSubtitle(&self, value: &str) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Subtitle)(
+            (windows_core::Interface::vtable(self).SetSubtitle)(
                 windows_core::Interface::as_raw(self),
                 core::mem::transmute_copy(&windows_core::HSTRING::from(value)),
             )
             .ok()
         }
     }
-    pub(crate) fn put_Content<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetContent<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<UIElement>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Content)(
+            (windows_core::Interface::vtable(self).SetContent)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
             .ok()
         }
     }
-    pub(crate) fn put_RightHeader<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetRightHeader<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<UIElement>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_RightHeader)(
+            (windows_core::Interface::vtable(self).SetRightHeader)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
             .ok()
         }
     }
-    pub(crate) fn put_IsBackButtonVisible(&self, value: bool) -> windows_core::Result<()> {
+    pub(crate) fn SetIsBackButtonVisible(&self, value: bool) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_IsBackButtonVisible)(
+            (windows_core::Interface::vtable(self).SetIsBackButtonVisible)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_IsBackButtonEnabled(&self, value: bool) -> windows_core::Result<()> {
+    pub(crate) fn SetIsBackButtonEnabled(&self, value: bool) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_IsBackButtonEnabled)(
+            (windows_core::Interface::vtable(self).SetIsBackButtonEnabled)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_IsPaneToggleButtonVisible(&self, value: bool) -> windows_core::Result<()> {
+    pub(crate) fn SetIsPaneToggleButtonVisible(&self, value: bool) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_IsPaneToggleButtonVisible)(
+            (windows_core::Interface::vtable(self).SetIsPaneToggleButtonVisible)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
@@ -17923,7 +17895,7 @@ impl ITitleBar {
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
-            let token__ = (windows_core::Interface::vtable(self).add_BackRequested)(
+            let token__ = (windows_core::Interface::vtable(self).BackRequested)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Interface::as_raw(&handler),
                 &mut result__,
@@ -17932,7 +17904,7 @@ impl ITitleBar {
             Ok(windows_core::EventRevoker::new(
                 self.clone(),
                 token__,
-                windows_core::Interface::vtable(self).remove_BackRequested,
+                windows_core::Interface::vtable(self).RemoveBackRequested,
             ))
         }
     }
@@ -17955,7 +17927,7 @@ impl ITitleBar {
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
-            let token__ = (windows_core::Interface::vtable(self).add_PaneToggleRequested)(
+            let token__ = (windows_core::Interface::vtable(self).PaneToggleRequested)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Interface::as_raw(&handler),
                 &mut result__,
@@ -17964,7 +17936,7 @@ impl ITitleBar {
             Ok(windows_core::EventRevoker::new(
                 self.clone(),
                 token__,
-                windows_core::Interface::vtable(self).remove_PaneToggleRequested,
+                windows_core::Interface::vtable(self).RemovePaneToggleRequested,
             ))
         }
     }
@@ -17972,53 +17944,53 @@ impl ITitleBar {
 #[repr(C)]
 pub struct ITitleBar_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_Title: usize,
-    pub put_Title: unsafe extern "system" fn(
+    Title: usize,
+    pub SetTitle: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_Subtitle: usize,
-    pub put_Subtitle: unsafe extern "system" fn(
+    Subtitle: usize,
+    pub SetSubtitle: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_IconSource: usize,
-    put_IconSource: usize,
-    get_LeftHeader: usize,
-    put_LeftHeader: usize,
-    get_Content: usize,
-    pub put_Content: unsafe extern "system" fn(
+    IconSource: usize,
+    SetIconSource: usize,
+    LeftHeader: usize,
+    SetLeftHeader: usize,
+    Content: usize,
+    pub SetContent: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_RightHeader: usize,
-    pub put_RightHeader: unsafe extern "system" fn(
+    RightHeader: usize,
+    pub SetRightHeader: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_IsBackButtonVisible: usize,
-    pub put_IsBackButtonVisible:
+    IsBackButtonVisible: usize,
+    pub SetIsBackButtonVisible:
         unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
-    get_IsBackButtonEnabled: usize,
-    pub put_IsBackButtonEnabled:
+    IsBackButtonEnabled: usize,
+    pub SetIsBackButtonEnabled:
         unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
-    get_IsPaneToggleButtonVisible: usize,
-    pub put_IsPaneToggleButtonVisible:
+    IsPaneToggleButtonVisible: usize,
+    pub SetIsPaneToggleButtonVisible:
         unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
-    get_TemplateSettings: usize,
-    pub add_BackRequested: unsafe extern "system" fn(
+    TemplateSettings: usize,
+    pub BackRequested: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         *mut i64,
     ) -> windows_core::HRESULT,
-    pub remove_BackRequested:
+    pub RemoveBackRequested:
         unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
-    pub add_PaneToggleRequested: unsafe extern "system" fn(
+    pub PaneToggleRequested: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         *mut i64,
     ) -> windows_core::HRESULT,
-    pub remove_PaneToggleRequested:
+    pub RemovePaneToggleRequested:
         unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
@@ -18050,10 +18022,10 @@ impl windows_core::RuntimeType for IToggleButton {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IToggleButton {
-    pub(crate) fn get_IsChecked(&self) -> windows_core::Result<bool> {
+    pub(crate) fn IsChecked(&self) -> windows_core::Result<bool> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_IsChecked)(
+            (windows_core::Interface::vtable(self).IsChecked)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
@@ -18061,10 +18033,10 @@ impl IToggleButton {
             .and_then(|r__: windows_reference::IReference<bool>| r__.Value())
         }
     }
-    pub(crate) fn put_IsChecked(&self, value: Option<bool>) -> windows_core::Result<()> {
+    pub(crate) fn SetIsChecked(&self, value: Option<bool>) -> windows_core::Result<()> {
         let value__ = value.map(<windows_reference::IReference<bool> as From<_>>::from);
         unsafe {
-            (windows_core::Interface::vtable(self).put_IsChecked)(
+            (windows_core::Interface::vtable(self).SetIsChecked)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Param::param(value__.as_ref()).abi(),
             )
@@ -18085,7 +18057,7 @@ impl IToggleButton {
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
-            let token__ = (windows_core::Interface::vtable(self).add_Checked)(
+            let token__ = (windows_core::Interface::vtable(self).Checked)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Interface::as_raw(&handler),
                 &mut result__,
@@ -18094,7 +18066,7 @@ impl IToggleButton {
             Ok(windows_core::EventRevoker::new(
                 self.clone(),
                 token__,
-                windows_core::Interface::vtable(self).remove_Checked,
+                windows_core::Interface::vtable(self).RemoveChecked,
             ))
         }
     }
@@ -18115,7 +18087,7 @@ impl IToggleButton {
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
-            let token__ = (windows_core::Interface::vtable(self).add_Unchecked)(
+            let token__ = (windows_core::Interface::vtable(self).Unchecked)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Interface::as_raw(&handler),
                 &mut result__,
@@ -18124,7 +18096,7 @@ impl IToggleButton {
             Ok(windows_core::EventRevoker::new(
                 self.clone(),
                 token__,
-                windows_core::Interface::vtable(self).remove_Unchecked,
+                windows_core::Interface::vtable(self).RemoveUnchecked,
             ))
         }
     }
@@ -18132,29 +18104,29 @@ impl IToggleButton {
 #[repr(C)]
 pub struct IToggleButton_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    pub get_IsChecked: unsafe extern "system" fn(
+    pub IsChecked: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    pub put_IsChecked: unsafe extern "system" fn(
+    pub SetIsChecked: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_IsThreeState: usize,
-    put_IsThreeState: usize,
-    pub add_Checked: unsafe extern "system" fn(
+    IsThreeState: usize,
+    SetIsThreeState: usize,
+    pub Checked: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         *mut i64,
     ) -> windows_core::HRESULT,
-    pub remove_Checked:
+    pub RemoveChecked:
         unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
-    pub add_Unchecked: unsafe extern "system" fn(
+    pub Unchecked: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         *mut i64,
     ) -> windows_core::HRESULT,
-    pub remove_Unchecked:
+    pub RemoveUnchecked:
         unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
@@ -18186,55 +18158,55 @@ impl windows_core::RuntimeType for IToggleSwitch {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IToggleSwitch {
-    pub(crate) fn get_IsOn(&self) -> windows_core::Result<bool> {
+    pub(crate) fn IsOn(&self) -> windows_core::Result<bool> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_IsOn)(
+            (windows_core::Interface::vtable(self).IsOn)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
             .map(|| result__)
         }
     }
-    pub(crate) fn put_IsOn(&self, value: bool) -> windows_core::Result<()> {
+    pub(crate) fn SetIsOn(&self, value: bool) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_IsOn)(
+            (windows_core::Interface::vtable(self).SetIsOn)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_Header<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetHeader<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<windows_core::IInspectable>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Header)(
+            (windows_core::Interface::vtable(self).SetHeader)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
             .ok()
         }
     }
-    pub(crate) fn put_OnContent<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetOnContent<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<windows_core::IInspectable>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_OnContent)(
+            (windows_core::Interface::vtable(self).SetOnContent)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
             .ok()
         }
     }
-    pub(crate) fn put_OffContent<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetOffContent<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<windows_core::IInspectable>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_OffContent)(
+            (windows_core::Interface::vtable(self).SetOffContent)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
@@ -18255,7 +18227,7 @@ impl IToggleSwitch {
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
-            let token__ = (windows_core::Interface::vtable(self).add_Toggled)(
+            let token__ = (windows_core::Interface::vtable(self).Toggled)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Interface::as_raw(&handler),
                 &mut result__,
@@ -18264,7 +18236,7 @@ impl IToggleSwitch {
             Ok(windows_core::EventRevoker::new(
                 self.clone(),
                 token__,
-                windows_core::Interface::vtable(self).remove_Toggled,
+                windows_core::Interface::vtable(self).RemoveToggled,
             ))
         }
     }
@@ -18272,37 +18244,36 @@ impl IToggleSwitch {
 #[repr(C)]
 pub struct IToggleSwitch_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    pub get_IsOn:
-        unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
-    pub put_IsOn: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
-    get_Header: usize,
-    pub put_Header: unsafe extern "system" fn(
+    pub IsOn: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
+    pub SetIsOn: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
+    Header: usize,
+    pub SetHeader: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_HeaderTemplate: usize,
-    put_HeaderTemplate: usize,
-    get_OnContent: usize,
-    pub put_OnContent: unsafe extern "system" fn(
+    HeaderTemplate: usize,
+    SetHeaderTemplate: usize,
+    OnContent: usize,
+    pub SetOnContent: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_OnContentTemplate: usize,
-    put_OnContentTemplate: usize,
-    get_OffContent: usize,
-    pub put_OffContent: unsafe extern "system" fn(
+    OnContentTemplate: usize,
+    SetOnContentTemplate: usize,
+    OffContent: usize,
+    pub SetOffContent: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_OffContentTemplate: usize,
-    put_OffContentTemplate: usize,
-    get_TemplateSettings: usize,
-    pub add_Toggled: unsafe extern "system" fn(
+    OffContentTemplate: usize,
+    SetOffContentTemplate: usize,
+    TemplateSettings: usize,
+    pub Toggled: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         *mut i64,
     ) -> windows_core::HRESULT,
-    pub remove_Toggled:
+    pub RemoveToggled:
         unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
@@ -18362,7 +18333,7 @@ impl windows_core::RuntimeType for IToolTipServiceStatics {
 #[repr(C)]
 pub struct IToolTipServiceStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_PlacementProperty: usize,
+    PlacementProperty: usize,
     pub GetPlacement: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
@@ -18373,10 +18344,10 @@ pub struct IToolTipServiceStatics_Vtbl {
         *mut core::ffi::c_void,
         PlacementMode,
     ) -> windows_core::HRESULT,
-    get_PlacementTargetProperty: usize,
+    PlacementTargetProperty: usize,
     GetPlacementTarget: usize,
     SetPlacementTarget: usize,
-    get_ToolTipProperty: usize,
+    ToolTipProperty: usize,
     pub GetToolTip: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
@@ -18398,24 +18369,24 @@ impl windows_core::RuntimeType for ITreeView {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl ITreeView {
-    pub(crate) fn get_RootNodes(
+    pub(crate) fn RootNodes(
         &self,
     ) -> windows_core::Result<windows_collections::IVector<TreeViewNode>> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_RootNodes)(
+            (windows_core::Interface::vtable(self).RootNodes)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
             .and_then(|| windows_core::Type::from_abi(result__))
         }
     }
-    pub(crate) fn put_SelectionMode(
+    pub(crate) fn SetSelectionMode(
         &self,
         value: TreeViewSelectionMode,
     ) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_SelectionMode)(
+            (windows_core::Interface::vtable(self).SetSelectionMode)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
@@ -18442,7 +18413,7 @@ impl ITreeView {
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
-            let token__ = (windows_core::Interface::vtable(self).add_ItemInvoked)(
+            let token__ = (windows_core::Interface::vtable(self).ItemInvoked)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Interface::as_raw(&handler),
                 &mut result__,
@@ -18451,7 +18422,7 @@ impl ITreeView {
             Ok(windows_core::EventRevoker::new(
                 self.clone(),
                 token__,
-                windows_core::Interface::vtable(self).remove_ItemInvoked,
+                windows_core::Interface::vtable(self).RemoveItemInvoked,
             ))
         }
     }
@@ -18459,25 +18430,25 @@ impl ITreeView {
 #[repr(C)]
 pub struct ITreeView_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    pub get_RootNodes: unsafe extern "system" fn(
+    pub RootNodes: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_SelectionMode: usize,
-    pub put_SelectionMode: unsafe extern "system" fn(
+    SelectionMode: usize,
+    pub SetSelectionMode: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         TreeViewSelectionMode,
     ) -> windows_core::HRESULT,
-    get_SelectedNodes: usize,
+    SelectedNodes: usize,
     Expand: usize,
     Collapse: usize,
     SelectAll: usize,
-    pub add_ItemInvoked: unsafe extern "system" fn(
+    pub ItemInvoked: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         *mut i64,
     ) -> windows_core::HRESULT,
-    pub remove_ItemInvoked:
+    pub RemoveItemInvoked:
         unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
@@ -18509,10 +18480,10 @@ impl windows_core::RuntimeType for ITreeViewItemInvokedEventArgs {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl ITreeViewItemInvokedEventArgs {
-    pub(crate) fn get_InvokedItem(&self) -> windows_core::Result<windows_core::IInspectable> {
+    pub(crate) fn InvokedItem(&self) -> windows_core::Result<windows_core::IInspectable> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_InvokedItem)(
+            (windows_core::Interface::vtable(self).InvokedItem)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
@@ -18523,7 +18494,7 @@ impl ITreeViewItemInvokedEventArgs {
 #[repr(C)]
 pub struct ITreeViewItemInvokedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    pub get_InvokedItem: unsafe extern "system" fn(
+    pub InvokedItem: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
@@ -18538,43 +18509,43 @@ impl windows_core::RuntimeType for ITreeViewNode {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl ITreeViewNode {
-    pub(crate) fn get_Content(&self) -> windows_core::Result<windows_core::IInspectable> {
+    pub(crate) fn Content(&self) -> windows_core::Result<windows_core::IInspectable> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_Content)(
+            (windows_core::Interface::vtable(self).Content)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
             .and_then(|| windows_core::Type::from_abi(result__))
         }
     }
-    pub(crate) fn put_Content<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetContent<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<windows_core::IInspectable>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Content)(
+            (windows_core::Interface::vtable(self).SetContent)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
             .ok()
         }
     }
-    pub(crate) fn put_IsExpanded(&self, value: bool) -> windows_core::Result<()> {
+    pub(crate) fn SetIsExpanded(&self, value: bool) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_IsExpanded)(
+            (windows_core::Interface::vtable(self).SetIsExpanded)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn get_Children(
+    pub(crate) fn Children(
         &self,
     ) -> windows_core::Result<windows_collections::IVector<TreeViewNode>> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_Children)(
+            (windows_core::Interface::vtable(self).Children)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
@@ -18585,23 +18556,23 @@ impl ITreeViewNode {
 #[repr(C)]
 pub struct ITreeViewNode_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    pub get_Content: unsafe extern "system" fn(
+    pub Content: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    pub put_Content: unsafe extern "system" fn(
+    pub SetContent: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_Parent: usize,
-    get_IsExpanded: usize,
-    pub put_IsExpanded:
+    Parent: usize,
+    IsExpanded: usize,
+    pub SetIsExpanded:
         unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
-    get_HasChildren: usize,
-    get_Depth: usize,
-    get_HasUnrealizedChildren: usize,
-    put_HasUnrealizedChildren: usize,
-    pub get_Children: unsafe extern "system" fn(
+    HasChildren: usize,
+    Depth: usize,
+    HasUnrealizedChildren: usize,
+    SetHasUnrealizedChildren: usize,
+    pub Children: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
@@ -18648,83 +18619,83 @@ impl windows_core::RuntimeType for IUIElement {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IUIElement {
-    pub(crate) fn get_AllowDrop(&self) -> windows_core::Result<bool> {
+    pub(crate) fn AllowDrop(&self) -> windows_core::Result<bool> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_AllowDrop)(
+            (windows_core::Interface::vtable(self).AllowDrop)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
             .map(|| result__)
         }
     }
-    pub(crate) fn put_AllowDrop(&self, value: bool) -> windows_core::Result<()> {
+    pub(crate) fn SetAllowDrop(&self, value: bool) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_AllowDrop)(
+            (windows_core::Interface::vtable(self).SetAllowDrop)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_Opacity(&self, value: f64) -> windows_core::Result<()> {
+    pub(crate) fn SetOpacity(&self, value: f64) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Opacity)(
+            (windows_core::Interface::vtable(self).SetOpacity)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn put_IsHitTestVisible(&self, value: bool) -> windows_core::Result<()> {
+    pub(crate) fn SetIsHitTestVisible(&self, value: bool) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_IsHitTestVisible)(
+            (windows_core::Interface::vtable(self).SetIsHitTestVisible)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn get_KeyboardAccelerators(
+    pub(crate) fn KeyboardAccelerators(
         &self,
     ) -> windows_core::Result<windows_collections::IVector<KeyboardAccelerator>> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_KeyboardAccelerators)(
+            (windows_core::Interface::vtable(self).KeyboardAccelerators)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
             .and_then(|| windows_core::Type::from_abi(result__))
         }
     }
-    pub(crate) fn put_KeyboardAcceleratorPlacementMode(
+    pub(crate) fn SetKeyboardAcceleratorPlacementMode(
         &self,
         value: KeyboardAcceleratorPlacementMode,
     ) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_KeyboardAcceleratorPlacementMode)(
+            (windows_core::Interface::vtable(self).SetKeyboardAcceleratorPlacementMode)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn get_XamlRoot(&self) -> windows_core::Result<XamlRoot> {
+    pub(crate) fn XamlRoot(&self) -> windows_core::Result<XamlRoot> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_XamlRoot)(
+            (windows_core::Interface::vtable(self).XamlRoot)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
             .and_then(|| windows_core::Type::from_abi(result__))
         }
     }
-    pub(crate) fn put_XamlRoot<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetXamlRoot<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<XamlRoot>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_XamlRoot)(
+            (windows_core::Interface::vtable(self).SetXamlRoot)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
@@ -18748,7 +18719,7 @@ impl IUIElement {
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
-            let token__ = (windows_core::Interface::vtable(self).add_DragEnter)(
+            let token__ = (windows_core::Interface::vtable(self).DragEnter)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Interface::as_raw(&handler),
                 &mut result__,
@@ -18757,7 +18728,7 @@ impl IUIElement {
             Ok(windows_core::EventRevoker::new(
                 self.clone(),
                 token__,
-                windows_core::Interface::vtable(self).remove_DragEnter,
+                windows_core::Interface::vtable(self).RemoveDragEnter,
             ))
         }
     }
@@ -18778,7 +18749,7 @@ impl IUIElement {
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
-            let token__ = (windows_core::Interface::vtable(self).add_DragLeave)(
+            let token__ = (windows_core::Interface::vtable(self).DragLeave)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Interface::as_raw(&handler),
                 &mut result__,
@@ -18787,7 +18758,7 @@ impl IUIElement {
             Ok(windows_core::EventRevoker::new(
                 self.clone(),
                 token__,
-                windows_core::Interface::vtable(self).remove_DragLeave,
+                windows_core::Interface::vtable(self).RemoveDragLeave,
             ))
         }
     }
@@ -18805,7 +18776,7 @@ impl IUIElement {
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
-            let token__ = (windows_core::Interface::vtable(self).add_DragOver)(
+            let token__ = (windows_core::Interface::vtable(self).DragOver)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Interface::as_raw(&handler),
                 &mut result__,
@@ -18814,7 +18785,7 @@ impl IUIElement {
             Ok(windows_core::EventRevoker::new(
                 self.clone(),
                 token__,
-                windows_core::Interface::vtable(self).remove_DragOver,
+                windows_core::Interface::vtable(self).RemoveDragOver,
             ))
         }
     }
@@ -18832,7 +18803,7 @@ impl IUIElement {
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
-            let token__ = (windows_core::Interface::vtable(self).add_Drop)(
+            let token__ = (windows_core::Interface::vtable(self).Drop)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Interface::as_raw(&handler),
                 &mut result__,
@@ -18841,7 +18812,7 @@ impl IUIElement {
             Ok(windows_core::EventRevoker::new(
                 self.clone(),
                 token__,
-                windows_core::Interface::vtable(self).remove_Drop,
+                windows_core::Interface::vtable(self).RemoveDrop,
             ))
         }
     }
@@ -18864,7 +18835,7 @@ impl IUIElement {
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
-            let token__ = (windows_core::Interface::vtable(self).add_PointerPressed)(
+            let token__ = (windows_core::Interface::vtable(self).PointerPressed)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Interface::as_raw(&handler),
                 &mut result__,
@@ -18873,7 +18844,7 @@ impl IUIElement {
             Ok(windows_core::EventRevoker::new(
                 self.clone(),
                 token__,
-                windows_core::Interface::vtable(self).remove_PointerPressed,
+                windows_core::Interface::vtable(self).RemovePointerPressed,
             ))
         }
     }
@@ -18896,7 +18867,7 @@ impl IUIElement {
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
-            let token__ = (windows_core::Interface::vtable(self).add_PointerReleased)(
+            let token__ = (windows_core::Interface::vtable(self).PointerReleased)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Interface::as_raw(&handler),
                 &mut result__,
@@ -18905,7 +18876,7 @@ impl IUIElement {
             Ok(windows_core::EventRevoker::new(
                 self.clone(),
                 token__,
-                windows_core::Interface::vtable(self).remove_PointerReleased,
+                windows_core::Interface::vtable(self).RemovePointerReleased,
             ))
         }
     }
@@ -18928,7 +18899,7 @@ impl IUIElement {
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
-            let token__ = (windows_core::Interface::vtable(self).add_PointerExited)(
+            let token__ = (windows_core::Interface::vtable(self).PointerExited)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Interface::as_raw(&handler),
                 &mut result__,
@@ -18937,7 +18908,7 @@ impl IUIElement {
             Ok(windows_core::EventRevoker::new(
                 self.clone(),
                 token__,
-                windows_core::Interface::vtable(self).remove_PointerExited,
+                windows_core::Interface::vtable(self).RemovePointerExited,
             ))
         }
     }
@@ -18957,7 +18928,7 @@ impl IUIElement {
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
-            let token__ = (windows_core::Interface::vtable(self).add_Tapped)(
+            let token__ = (windows_core::Interface::vtable(self).Tapped)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Interface::as_raw(&handler),
                 &mut result__,
@@ -18966,7 +18937,7 @@ impl IUIElement {
             Ok(windows_core::EventRevoker::new(
                 self.clone(),
                 token__,
-                windows_core::Interface::vtable(self).remove_Tapped,
+                windows_core::Interface::vtable(self).RemoveTapped,
             ))
         }
     }
@@ -18989,7 +18960,7 @@ impl IUIElement {
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
-            let token__ = (windows_core::Interface::vtable(self).add_RightTapped)(
+            let token__ = (windows_core::Interface::vtable(self).RightTapped)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Interface::as_raw(&handler),
                 &mut result__,
@@ -18998,7 +18969,7 @@ impl IUIElement {
             Ok(windows_core::EventRevoker::new(
                 self.clone(),
                 token__,
-                windows_core::Interface::vtable(self).remove_RightTapped,
+                windows_core::Interface::vtable(self).RemoveRightTapped,
             ))
         }
     }
@@ -19014,272 +18985,270 @@ impl IUIElement {
 #[repr(C)]
 pub struct IUIElement_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_DesiredSize: usize,
-    pub get_AllowDrop:
+    DesiredSize: usize,
+    pub AllowDrop:
         unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
-    pub put_AllowDrop:
+    pub SetAllowDrop:
         unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
-    get_Opacity: usize,
-    pub put_Opacity:
-        unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
-    get_Clip: usize,
-    put_Clip: usize,
-    get_RenderTransform: usize,
-    put_RenderTransform: usize,
-    get_Projection: usize,
-    put_Projection: usize,
-    get_Transform3D: usize,
-    put_Transform3D: usize,
-    get_RenderTransformOrigin: usize,
-    put_RenderTransformOrigin: usize,
-    get_IsHitTestVisible: usize,
-    pub put_IsHitTestVisible:
+    Opacity: usize,
+    pub SetOpacity: unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
+    Clip: usize,
+    SetClip: usize,
+    RenderTransform: usize,
+    SetRenderTransform: usize,
+    Projection: usize,
+    SetProjection: usize,
+    Transform3D: usize,
+    SetTransform3D: usize,
+    RenderTransformOrigin: usize,
+    SetRenderTransformOrigin: usize,
+    IsHitTestVisible: usize,
+    pub SetIsHitTestVisible:
         unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
-    get_Visibility: usize,
-    put_Visibility: usize,
-    get_RenderSize: usize,
-    get_UseLayoutRounding: usize,
-    put_UseLayoutRounding: usize,
-    get_Transitions: usize,
-    put_Transitions: usize,
-    get_CacheMode: usize,
-    put_CacheMode: usize,
-    get_IsTapEnabled: usize,
-    put_IsTapEnabled: usize,
-    get_IsDoubleTapEnabled: usize,
-    put_IsDoubleTapEnabled: usize,
-    get_CanDrag: usize,
-    put_CanDrag: usize,
-    get_IsRightTapEnabled: usize,
-    put_IsRightTapEnabled: usize,
-    get_IsHoldingEnabled: usize,
-    put_IsHoldingEnabled: usize,
-    get_ManipulationMode: usize,
-    put_ManipulationMode: usize,
-    get_PointerCaptures: usize,
-    get_ContextFlyout: usize,
-    put_ContextFlyout: usize,
-    get_CompositeMode: usize,
-    put_CompositeMode: usize,
-    get_Lights: usize,
-    get_CanBeScrollAnchor: usize,
-    put_CanBeScrollAnchor: usize,
-    get_ExitDisplayModeOnAccessKeyInvoked: usize,
-    put_ExitDisplayModeOnAccessKeyInvoked: usize,
-    get_IsAccessKeyScope: usize,
-    put_IsAccessKeyScope: usize,
-    get_AccessKeyScopeOwner: usize,
-    put_AccessKeyScopeOwner: usize,
-    get_AccessKey: usize,
-    put_AccessKey: usize,
-    get_KeyTipPlacementMode: usize,
-    put_KeyTipPlacementMode: usize,
-    get_KeyTipHorizontalOffset: usize,
-    put_KeyTipHorizontalOffset: usize,
-    get_KeyTipVerticalOffset: usize,
-    put_KeyTipVerticalOffset: usize,
-    get_KeyTipTarget: usize,
-    put_KeyTipTarget: usize,
-    get_XYFocusKeyboardNavigation: usize,
-    put_XYFocusKeyboardNavigation: usize,
-    get_XYFocusUpNavigationStrategy: usize,
-    put_XYFocusUpNavigationStrategy: usize,
-    get_XYFocusDownNavigationStrategy: usize,
-    put_XYFocusDownNavigationStrategy: usize,
-    get_XYFocusLeftNavigationStrategy: usize,
-    put_XYFocusLeftNavigationStrategy: usize,
-    get_XYFocusRightNavigationStrategy: usize,
-    put_XYFocusRightNavigationStrategy: usize,
-    pub get_KeyboardAccelerators: unsafe extern "system" fn(
+    Visibility: usize,
+    SetVisibility: usize,
+    RenderSize: usize,
+    UseLayoutRounding: usize,
+    SetUseLayoutRounding: usize,
+    Transitions: usize,
+    SetTransitions: usize,
+    CacheMode: usize,
+    SetCacheMode: usize,
+    IsTapEnabled: usize,
+    SetIsTapEnabled: usize,
+    IsDoubleTapEnabled: usize,
+    SetIsDoubleTapEnabled: usize,
+    CanDrag: usize,
+    SetCanDrag: usize,
+    IsRightTapEnabled: usize,
+    SetIsRightTapEnabled: usize,
+    IsHoldingEnabled: usize,
+    SetIsHoldingEnabled: usize,
+    ManipulationMode: usize,
+    SetManipulationMode: usize,
+    PointerCaptures: usize,
+    ContextFlyout: usize,
+    SetContextFlyout: usize,
+    CompositeMode: usize,
+    SetCompositeMode: usize,
+    Lights: usize,
+    CanBeScrollAnchor: usize,
+    SetCanBeScrollAnchor: usize,
+    ExitDisplayModeOnAccessKeyInvoked: usize,
+    SetExitDisplayModeOnAccessKeyInvoked: usize,
+    IsAccessKeyScope: usize,
+    SetIsAccessKeyScope: usize,
+    AccessKeyScopeOwner: usize,
+    SetAccessKeyScopeOwner: usize,
+    AccessKey: usize,
+    SetAccessKey: usize,
+    KeyTipPlacementMode: usize,
+    SetKeyTipPlacementMode: usize,
+    KeyTipHorizontalOffset: usize,
+    SetKeyTipHorizontalOffset: usize,
+    KeyTipVerticalOffset: usize,
+    SetKeyTipVerticalOffset: usize,
+    KeyTipTarget: usize,
+    SetKeyTipTarget: usize,
+    XYFocusKeyboardNavigation: usize,
+    SetXYFocusKeyboardNavigation: usize,
+    XYFocusUpNavigationStrategy: usize,
+    SetXYFocusUpNavigationStrategy: usize,
+    XYFocusDownNavigationStrategy: usize,
+    SetXYFocusDownNavigationStrategy: usize,
+    XYFocusLeftNavigationStrategy: usize,
+    SetXYFocusLeftNavigationStrategy: usize,
+    XYFocusRightNavigationStrategy: usize,
+    SetXYFocusRightNavigationStrategy: usize,
+    pub KeyboardAccelerators: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_KeyboardAcceleratorPlacementTarget: usize,
-    put_KeyboardAcceleratorPlacementTarget: usize,
-    get_KeyboardAcceleratorPlacementMode: usize,
-    pub put_KeyboardAcceleratorPlacementMode: unsafe extern "system" fn(
+    KeyboardAcceleratorPlacementTarget: usize,
+    SetKeyboardAcceleratorPlacementTarget: usize,
+    KeyboardAcceleratorPlacementMode: usize,
+    pub SetKeyboardAcceleratorPlacementMode: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         KeyboardAcceleratorPlacementMode,
     )
         -> windows_core::HRESULT,
-    get_HighContrastAdjustment: usize,
-    put_HighContrastAdjustment: usize,
-    get_TabFocusNavigation: usize,
-    put_TabFocusNavigation: usize,
-    get_OpacityTransition: usize,
-    put_OpacityTransition: usize,
-    get_Translation: usize,
-    put_Translation: usize,
-    get_TranslationTransition: usize,
-    put_TranslationTransition: usize,
-    get_Rotation: usize,
-    put_Rotation: usize,
-    get_RotationTransition: usize,
-    put_RotationTransition: usize,
-    get_Scale: usize,
-    put_Scale: usize,
-    get_ScaleTransition: usize,
-    put_ScaleTransition: usize,
-    get_TransformMatrix: usize,
-    put_TransformMatrix: usize,
-    get_CenterPoint: usize,
-    put_CenterPoint: usize,
-    get_RotationAxis: usize,
-    put_RotationAxis: usize,
-    get_ActualOffset: usize,
-    get_ActualSize: usize,
-    pub get_XamlRoot: unsafe extern "system" fn(
+    HighContrastAdjustment: usize,
+    SetHighContrastAdjustment: usize,
+    TabFocusNavigation: usize,
+    SetTabFocusNavigation: usize,
+    OpacityTransition: usize,
+    SetOpacityTransition: usize,
+    Translation: usize,
+    SetTranslation: usize,
+    TranslationTransition: usize,
+    SetTranslationTransition: usize,
+    Rotation: usize,
+    SetRotation: usize,
+    RotationTransition: usize,
+    SetRotationTransition: usize,
+    Scale: usize,
+    SetScale: usize,
+    ScaleTransition: usize,
+    SetScaleTransition: usize,
+    TransformMatrix: usize,
+    SetTransformMatrix: usize,
+    CenterPoint: usize,
+    SetCenterPoint: usize,
+    RotationAxis: usize,
+    SetRotationAxis: usize,
+    ActualOffset: usize,
+    ActualSize: usize,
+    pub XamlRoot: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    pub put_XamlRoot: unsafe extern "system" fn(
+    pub SetXamlRoot: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_Shadow: usize,
-    put_Shadow: usize,
-    get_RasterizationScale: usize,
-    put_RasterizationScale: usize,
-    get_FocusState: usize,
-    get_UseSystemFocusVisuals: usize,
-    put_UseSystemFocusVisuals: usize,
-    get_XYFocusLeft: usize,
-    put_XYFocusLeft: usize,
-    get_XYFocusRight: usize,
-    put_XYFocusRight: usize,
-    get_XYFocusUp: usize,
-    put_XYFocusUp: usize,
-    get_XYFocusDown: usize,
-    put_XYFocusDown: usize,
-    get_IsTabStop: usize,
-    put_IsTabStop: usize,
-    get_TabIndex: usize,
-    put_TabIndex: usize,
-    add_KeyUp: usize,
-    remove_KeyUp: usize,
-    add_KeyDown: usize,
-    remove_KeyDown: usize,
-    add_GotFocus: usize,
-    remove_GotFocus: usize,
-    add_LostFocus: usize,
-    remove_LostFocus: usize,
-    add_DragStarting: usize,
-    remove_DragStarting: usize,
-    add_DropCompleted: usize,
-    remove_DropCompleted: usize,
-    add_CharacterReceived: usize,
-    remove_CharacterReceived: usize,
-    pub add_DragEnter: unsafe extern "system" fn(
+    Shadow: usize,
+    SetShadow: usize,
+    RasterizationScale: usize,
+    SetRasterizationScale: usize,
+    FocusState: usize,
+    UseSystemFocusVisuals: usize,
+    SetUseSystemFocusVisuals: usize,
+    XYFocusLeft: usize,
+    SetXYFocusLeft: usize,
+    XYFocusRight: usize,
+    SetXYFocusRight: usize,
+    XYFocusUp: usize,
+    SetXYFocusUp: usize,
+    XYFocusDown: usize,
+    SetXYFocusDown: usize,
+    IsTabStop: usize,
+    SetIsTabStop: usize,
+    TabIndex: usize,
+    SetTabIndex: usize,
+    KeyUp: usize,
+    RemoveKeyUp: usize,
+    KeyDown: usize,
+    RemoveKeyDown: usize,
+    GotFocus: usize,
+    RemoveGotFocus: usize,
+    LostFocus: usize,
+    RemoveLostFocus: usize,
+    DragStarting: usize,
+    RemoveDragStarting: usize,
+    DropCompleted: usize,
+    RemoveDropCompleted: usize,
+    CharacterReceived: usize,
+    RemoveCharacterReceived: usize,
+    pub DragEnter: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         *mut i64,
     ) -> windows_core::HRESULT,
-    pub remove_DragEnter:
+    pub RemoveDragEnter:
         unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
-    pub add_DragLeave: unsafe extern "system" fn(
+    pub DragLeave: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         *mut i64,
     ) -> windows_core::HRESULT,
-    pub remove_DragLeave:
+    pub RemoveDragLeave:
         unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
-    pub add_DragOver: unsafe extern "system" fn(
+    pub DragOver: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         *mut i64,
     ) -> windows_core::HRESULT,
-    pub remove_DragOver:
+    pub RemoveDragOver:
         unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
-    pub add_Drop: unsafe extern "system" fn(
+    pub Drop: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         *mut i64,
     ) -> windows_core::HRESULT,
-    pub remove_Drop:
-        unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
-    pub add_PointerPressed: unsafe extern "system" fn(
+    pub RemoveDrop: unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
+    pub PointerPressed: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         *mut i64,
     ) -> windows_core::HRESULT,
-    pub remove_PointerPressed:
+    pub RemovePointerPressed:
         unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
-    add_PointerMoved: usize,
-    remove_PointerMoved: usize,
-    pub add_PointerReleased: unsafe extern "system" fn(
+    PointerMoved: usize,
+    RemovePointerMoved: usize,
+    pub PointerReleased: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         *mut i64,
     ) -> windows_core::HRESULT,
-    pub remove_PointerReleased:
+    pub RemovePointerReleased:
         unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
-    add_PointerEntered: usize,
-    remove_PointerEntered: usize,
-    pub add_PointerExited: unsafe extern "system" fn(
+    PointerEntered: usize,
+    RemovePointerEntered: usize,
+    pub PointerExited: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         *mut i64,
     ) -> windows_core::HRESULT,
-    pub remove_PointerExited:
+    pub RemovePointerExited:
         unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
-    add_PointerCaptureLost: usize,
-    remove_PointerCaptureLost: usize,
-    add_PointerCanceled: usize,
-    remove_PointerCanceled: usize,
-    add_PointerWheelChanged: usize,
-    remove_PointerWheelChanged: usize,
-    pub add_Tapped: unsafe extern "system" fn(
+    PointerCaptureLost: usize,
+    RemovePointerCaptureLost: usize,
+    PointerCanceled: usize,
+    RemovePointerCanceled: usize,
+    PointerWheelChanged: usize,
+    RemovePointerWheelChanged: usize,
+    pub Tapped: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         *mut i64,
     ) -> windows_core::HRESULT,
-    pub remove_Tapped:
+    pub RemoveTapped:
         unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
-    add_DoubleTapped: usize,
-    remove_DoubleTapped: usize,
-    add_Holding: usize,
-    remove_Holding: usize,
-    add_ContextRequested: usize,
-    remove_ContextRequested: usize,
-    add_ContextCanceled: usize,
-    remove_ContextCanceled: usize,
-    pub add_RightTapped: unsafe extern "system" fn(
+    DoubleTapped: usize,
+    RemoveDoubleTapped: usize,
+    Holding: usize,
+    RemoveHolding: usize,
+    ContextRequested: usize,
+    RemoveContextRequested: usize,
+    ContextCanceled: usize,
+    RemoveContextCanceled: usize,
+    pub RightTapped: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         *mut i64,
     ) -> windows_core::HRESULT,
-    pub remove_RightTapped:
+    pub RemoveRightTapped:
         unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
-    add_ManipulationStarting: usize,
-    remove_ManipulationStarting: usize,
-    add_ManipulationInertiaStarting: usize,
-    remove_ManipulationInertiaStarting: usize,
-    add_ManipulationStarted: usize,
-    remove_ManipulationStarted: usize,
-    add_ManipulationDelta: usize,
-    remove_ManipulationDelta: usize,
-    add_ManipulationCompleted: usize,
-    remove_ManipulationCompleted: usize,
-    add_AccessKeyDisplayRequested: usize,
-    remove_AccessKeyDisplayRequested: usize,
-    add_AccessKeyDisplayDismissed: usize,
-    remove_AccessKeyDisplayDismissed: usize,
-    add_AccessKeyInvoked: usize,
-    remove_AccessKeyInvoked: usize,
-    add_ProcessKeyboardAccelerators: usize,
-    remove_ProcessKeyboardAccelerators: usize,
-    add_GettingFocus: usize,
-    remove_GettingFocus: usize,
-    add_LosingFocus: usize,
-    remove_LosingFocus: usize,
-    add_NoFocusCandidateFound: usize,
-    remove_NoFocusCandidateFound: usize,
-    add_PreviewKeyDown: usize,
-    remove_PreviewKeyDown: usize,
-    add_PreviewKeyUp: usize,
-    remove_PreviewKeyUp: usize,
-    add_BringIntoViewRequested: usize,
-    remove_BringIntoViewRequested: usize,
+    ManipulationStarting: usize,
+    RemoveManipulationStarting: usize,
+    ManipulationInertiaStarting: usize,
+    RemoveManipulationInertiaStarting: usize,
+    ManipulationStarted: usize,
+    RemoveManipulationStarted: usize,
+    ManipulationDelta: usize,
+    RemoveManipulationDelta: usize,
+    ManipulationCompleted: usize,
+    RemoveManipulationCompleted: usize,
+    AccessKeyDisplayRequested: usize,
+    RemoveAccessKeyDisplayRequested: usize,
+    AccessKeyDisplayDismissed: usize,
+    RemoveAccessKeyDisplayDismissed: usize,
+    AccessKeyInvoked: usize,
+    RemoveAccessKeyInvoked: usize,
+    ProcessKeyboardAccelerators: usize,
+    RemoveProcessKeyboardAccelerators: usize,
+    GettingFocus: usize,
+    RemoveGettingFocus: usize,
+    LosingFocus: usize,
+    RemoveLosingFocus: usize,
+    NoFocusCandidateFound: usize,
+    RemoveNoFocusCandidateFound: usize,
+    PreviewKeyDown: usize,
+    RemovePreviewKeyDown: usize,
+    PreviewKeyUp: usize,
+    RemovePreviewKeyUp: usize,
+    BringIntoViewRequested: usize,
+    RemoveBringIntoViewRequested: usize,
     Measure: usize,
     Arrange: usize,
     CapturePointer: usize,
@@ -19374,21 +19343,21 @@ impl windows_core::RuntimeType for IViewbox {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IViewbox {
-    pub(crate) fn put_Child<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetChild<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<UIElement>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Child)(
+            (windows_core::Interface::vtable(self).SetChild)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
             .ok()
         }
     }
-    pub(crate) fn put_Stretch(&self, value: Stretch) -> windows_core::Result<()> {
+    pub(crate) fn SetStretch(&self, value: Stretch) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Stretch)(
+            (windows_core::Interface::vtable(self).SetStretch)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
@@ -19399,13 +19368,13 @@ impl IViewbox {
 #[repr(C)]
 pub struct IViewbox_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_Child: usize,
-    pub put_Child: unsafe extern "system" fn(
+    Child: usize,
+    pub SetChild: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_Stretch: usize,
-    pub put_Stretch:
+    Stretch: usize,
+    pub SetStretch:
         unsafe extern "system" fn(*mut core::ffi::c_void, Stretch) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
@@ -19418,22 +19387,22 @@ impl windows_core::RuntimeType for IVisual {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IVisual {
-    pub(crate) fn put_CenterPoint(
+    pub(crate) fn SetCenterPoint(
         &self,
         value: windows_numerics::Vector3,
     ) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_CenterPoint)(
+            (windows_core::Interface::vtable(self).SetCenterPoint)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
             .ok()
         }
     }
-    pub(crate) fn get_Scale(&self) -> windows_core::Result<windows_numerics::Vector3> {
+    pub(crate) fn Scale(&self) -> windows_core::Result<windows_numerics::Vector3> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_Scale)(
+            (windows_core::Interface::vtable(self).Scale)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
@@ -19444,37 +19413,37 @@ impl IVisual {
 #[repr(C)]
 pub struct IVisual_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_AnchorPoint: usize,
-    put_AnchorPoint: usize,
-    get_BackfaceVisibility: usize,
-    put_BackfaceVisibility: usize,
-    get_BorderMode: usize,
-    put_BorderMode: usize,
-    get_CenterPoint: usize,
-    pub put_CenterPoint: unsafe extern "system" fn(
+    AnchorPoint: usize,
+    SetAnchorPoint: usize,
+    BackfaceVisibility: usize,
+    SetBackfaceVisibility: usize,
+    BorderMode: usize,
+    SetBorderMode: usize,
+    CenterPoint: usize,
+    pub SetCenterPoint: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         windows_numerics::Vector3,
     ) -> windows_core::HRESULT,
-    get_Clip: usize,
-    put_Clip: usize,
-    get_CompositeMode: usize,
-    put_CompositeMode: usize,
-    get_IsVisible: usize,
-    put_IsVisible: usize,
-    get_Offset: usize,
-    put_Offset: usize,
-    get_Opacity: usize,
-    put_Opacity: usize,
-    get_Orientation: usize,
-    put_Orientation: usize,
-    get_Parent: usize,
-    get_RotationAngle: usize,
-    put_RotationAngle: usize,
-    get_RotationAngleInDegrees: usize,
-    put_RotationAngleInDegrees: usize,
-    get_RotationAxis: usize,
-    put_RotationAxis: usize,
-    pub get_Scale: unsafe extern "system" fn(
+    Clip: usize,
+    SetClip: usize,
+    CompositeMode: usize,
+    SetCompositeMode: usize,
+    IsVisible: usize,
+    SetIsVisible: usize,
+    Offset: usize,
+    SetOffset: usize,
+    Opacity: usize,
+    SetOpacity: usize,
+    Orientation: usize,
+    SetOrientation: usize,
+    Parent: usize,
+    RotationAngle: usize,
+    SetRotationAngle: usize,
+    RotationAngleInDegrees: usize,
+    SetRotationAngleInDegrees: usize,
+    RotationAxis: usize,
+    SetRotationAxis: usize,
+    pub Scale: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut windows_numerics::Vector3,
     ) -> windows_core::HRESULT,
@@ -19573,40 +19542,40 @@ impl windows_core::RuntimeType for IWindow {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IWindow {
-    pub(crate) fn get_Content(&self) -> windows_core::Result<UIElement> {
+    pub(crate) fn Content(&self) -> windows_core::Result<UIElement> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_Content)(
+            (windows_core::Interface::vtable(self).Content)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
             .and_then(|| windows_core::Type::from_abi(result__))
         }
     }
-    pub(crate) fn put_Content<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetContent<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<UIElement>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Content)(
+            (windows_core::Interface::vtable(self).SetContent)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
             .ok()
         }
     }
-    pub(crate) fn put_Title(&self, value: &str) -> windows_core::Result<()> {
+    pub(crate) fn SetTitle(&self, value: &str) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_Title)(
+            (windows_core::Interface::vtable(self).SetTitle)(
                 windows_core::Interface::as_raw(self),
                 core::mem::transmute_copy(&windows_core::HSTRING::from(value)),
             )
             .ok()
         }
     }
-    pub(crate) fn put_ExtendsContentIntoTitleBar(&self, value: bool) -> windows_core::Result<()> {
+    pub(crate) fn SetExtendsContentIntoTitleBar(&self, value: bool) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).put_ExtendsContentIntoTitleBar)(
+            (windows_core::Interface::vtable(self).SetExtendsContentIntoTitleBar)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
@@ -19630,7 +19599,7 @@ impl IWindow {
         };
         unsafe {
             let mut result__ = core::mem::zeroed();
-            let token__ = (windows_core::Interface::vtable(self).add_Closed)(
+            let token__ = (windows_core::Interface::vtable(self).Closed)(
                 windows_core::Interface::as_raw(self),
                 windows_core::Interface::as_raw(&handler),
                 &mut result__,
@@ -19639,7 +19608,7 @@ impl IWindow {
             Ok(windows_core::EventRevoker::new(
                 self.clone(),
                 token__,
-                windows_core::Interface::vtable(self).remove_Closed,
+                windows_core::Interface::vtable(self).RemoveClosed,
             ))
         }
     }
@@ -19665,41 +19634,41 @@ impl IWindow {
 #[repr(C)]
 pub struct IWindow_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_Bounds: usize,
-    get_Visible: usize,
-    pub get_Content: unsafe extern "system" fn(
+    Bounds: usize,
+    Visible: usize,
+    pub Content: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    pub put_Content: unsafe extern "system" fn(
+    pub SetContent: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_CoreWindow: usize,
-    get_Compositor: usize,
-    get_Dispatcher: usize,
-    get_DispatcherQueue: usize,
-    get_Title: usize,
-    pub put_Title: unsafe extern "system" fn(
+    CoreWindow: usize,
+    Compositor: usize,
+    Dispatcher: usize,
+    DispatcherQueue: usize,
+    Title: usize,
+    pub SetTitle: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    get_ExtendsContentIntoTitleBar: usize,
-    pub put_ExtendsContentIntoTitleBar:
+    ExtendsContentIntoTitleBar: usize,
+    pub SetExtendsContentIntoTitleBar:
         unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
-    add_Activated: usize,
-    remove_Activated: usize,
-    pub add_Closed: unsafe extern "system" fn(
+    Activated: usize,
+    RemoveActivated: usize,
+    pub Closed: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         *mut i64,
     ) -> windows_core::HRESULT,
-    pub remove_Closed:
+    pub RemoveClosed:
         unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
-    add_SizeChanged: usize,
-    remove_SizeChanged: usize,
-    add_VisibilityChanged: usize,
-    remove_VisibilityChanged: usize,
+    SizeChanged: usize,
+    RemoveSizeChanged: usize,
+    VisibilityChanged: usize,
+    RemoveVisibilityChanged: usize,
     pub Activate: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
     Close: usize,
     pub SetTitleBar: unsafe extern "system" fn(
@@ -19717,22 +19686,22 @@ impl windows_core::RuntimeType for IWindow2 {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IWindow2 {
-    pub(crate) fn put_SystemBackdrop<P0>(&self, value: P0) -> windows_core::Result<()>
+    pub(crate) fn SetSystemBackdrop<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<SystemBackdrop>,
     {
         unsafe {
-            (windows_core::Interface::vtable(self).put_SystemBackdrop)(
+            (windows_core::Interface::vtable(self).SetSystemBackdrop)(
                 windows_core::Interface::as_raw(self),
                 value.param().abi(),
             )
             .ok()
         }
     }
-    pub(crate) fn get_AppWindow(&self) -> windows_core::Result<AppWindow> {
+    pub(crate) fn AppWindow(&self) -> windows_core::Result<AppWindow> {
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).get_AppWindow)(
+            (windows_core::Interface::vtable(self).AppWindow)(
                 windows_core::Interface::as_raw(self),
                 &mut result__,
             )
@@ -19743,12 +19712,12 @@ impl IWindow2 {
 #[repr(C)]
 pub struct IWindow2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
-    get_SystemBackdrop: usize,
-    pub put_SystemBackdrop: unsafe extern "system" fn(
+    SystemBackdrop: usize,
+    pub SetSystemBackdrop: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
-    pub get_AppWindow: unsafe extern "system" fn(
+    pub AppWindow: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
@@ -19792,12 +19761,12 @@ windows_core::imp::define_interface!(
 );
 windows_core::imp::interface_hierarchy!(IWindowNative, windows_core::IUnknown);
 impl IWindowNative {
-    pub(crate) unsafe fn get_WindowHandle(
+    pub(crate) unsafe fn WindowHandle(
         &self,
         hwnd: *mut *mut core::ffi::c_void,
     ) -> windows_core::Result<()> {
         unsafe {
-            (windows_core::Interface::vtable(self).get_WindowHandle)(
+            (windows_core::Interface::vtable(self).WindowHandle)(
                 windows_core::Interface::as_raw(self),
                 hwnd as _,
             )
@@ -19808,17 +19777,17 @@ impl IWindowNative {
 #[repr(C)]
 pub struct IWindowNative_Vtbl {
     pub base__: windows_core::IUnknown_Vtbl,
-    pub get_WindowHandle: unsafe extern "system" fn(
+    pub WindowHandle: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
 }
 pub trait IWindowNative_Impl: windows_core::IUnknownImpl {
-    fn get_WindowHandle(&self, hwnd: *mut *mut core::ffi::c_void) -> windows_core::Result<()>;
+    fn WindowHandle(&self, hwnd: *mut *mut core::ffi::c_void) -> windows_core::Result<()>;
 }
 impl IWindowNative_Vtbl {
     pub const fn new<Identity: IWindowNative_Impl, const OFFSET: isize>() -> Self {
-        unsafe extern "system" fn get_WindowHandle<
+        unsafe extern "system" fn WindowHandle<
             Identity: IWindowNative_Impl,
             const OFFSET: isize,
         >(
@@ -19828,12 +19797,12 @@ impl IWindowNative_Vtbl {
             unsafe {
                 let this: &Identity =
                     &*((this as *const *const ()).offset(OFFSET) as *const Identity);
-                IWindowNative_Impl::get_WindowHandle(this, core::mem::transmute_copy(&hwnd)).into()
+                IWindowNative_Impl::WindowHandle(this, core::mem::transmute_copy(&hwnd)).into()
             }
         }
         Self {
             base__: windows_core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
-            get_WindowHandle: get_WindowHandle::<Identity, OFFSET>,
+            WindowHandle: WindowHandle::<Identity, OFFSET>,
         }
     }
     pub fn matches(iid: &windows_core::GUID) -> bool {

--- a/crates/tests/libs/reactor_selftest/src/fixtures/controls.rs
+++ b/crates/tests/libs/reactor_selftest/src/fixtures/controls.rs
@@ -332,7 +332,7 @@ pub fn mount_rich_text(h: Harness) -> FixtureFuture {
         // Verify the RichTextBlock has paragraph content (Blocks collection non-empty).
         let has_content = !h
             .find_all::<bindings::RichTextBlock>(&|rtb| {
-                rtb.get_Blocks().is_ok_and(|b| b.Size().unwrap_or(0) > 0)
+                rtb.Blocks().is_ok_and(|b| b.Size().unwrap_or(0) > 0)
             })
             .is_empty();
         h.check("Reconciler_Mount_RichText_HasContent", has_content);
@@ -374,18 +374,18 @@ pub fn mount_reorderable_list_view(h: Harness) -> FixtureFuture {
         h.check_eq(
             "Reconciler_Mount_ReorderableListView_CanDragItems",
             true,
-            lvb.get_CanDragItems().unwrap(),
+            lvb.CanDragItems().unwrap(),
         );
         h.check_eq(
             "Reconciler_Mount_ReorderableListView_CanReorderItems",
             true,
-            lvb.get_CanReorderItems().unwrap(),
+            lvb.CanReorderItems().unwrap(),
         );
         let ui: bindings::IUIElement = lv.cast().unwrap();
         h.check_eq(
             "Reconciler_Mount_ReorderableListView_AllowDrop",
             true,
-            ui.get_AllowDrop().unwrap(),
+            ui.AllowDrop().unwrap(),
         );
     })
 }
@@ -425,18 +425,18 @@ pub fn mount_reorderable_grid_view(h: Harness) -> FixtureFuture {
         h.check_eq(
             "Reconciler_Mount_ReorderableGridView_CanDragItems",
             true,
-            lvb.get_CanDragItems().unwrap(),
+            lvb.CanDragItems().unwrap(),
         );
         h.check_eq(
             "Reconciler_Mount_ReorderableGridView_CanReorderItems",
             true,
-            lvb.get_CanReorderItems().unwrap(),
+            lvb.CanReorderItems().unwrap(),
         );
         let ui: bindings::IUIElement = gv.cast().unwrap();
         h.check_eq(
             "Reconciler_Mount_ReorderableGridView_AllowDrop",
             true,
-            ui.get_AllowDrop().unwrap(),
+            ui.AllowDrop().unwrap(),
         );
     })
 }

--- a/crates/tests/libs/reactor_selftest/src/fixtures/interactions.rs
+++ b/crates/tests/libs/reactor_selftest/src/fixtures/interactions.rs
@@ -136,7 +136,7 @@ pub fn button_disabled_to_enabled_prop_update(h: Harness) -> FixtureFuture {
             .and_then(|btn| {
                 btn.cast::<crate::bindings::IControl>()
                     .ok()
-                    .and_then(|c| c.get_IsEnabled().ok())
+                    .and_then(|c| c.IsEnabled().ok())
             })
             .unwrap_or(true);
         h.check(
@@ -152,7 +152,7 @@ pub fn button_disabled_to_enabled_prop_update(h: Harness) -> FixtureFuture {
             .and_then(|btn| {
                 btn.cast::<crate::bindings::IControl>()
                     .ok()
-                    .and_then(|c| c.get_IsEnabled().ok())
+                    .and_then(|c| c.IsEnabled().ok())
             })
             .unwrap_or(false);
         h.check("Interaction_PropUpdate_NowEnabled", now_enabled);
@@ -279,12 +279,7 @@ pub fn radio_buttons_change_selection(h: Harness) -> FixtureFuture {
 
         let initial = h
             .find_text_containing("radio-idx=")
-            .and_then(|tb| {
-                tb.cast::<crate::bindings::ITextBlock>()
-                    .ok()?
-                    .get_Text()
-                    .ok()
-            })
+            .and_then(|tb| tb.cast::<crate::bindings::ITextBlock>().ok()?.Text().ok())
             .unwrap_or_else(|| "<no radio-idx= text block found>".into());
         h.check_eq(
             "Interaction_RadioButtons_InitialZero",
@@ -313,12 +308,7 @@ pub fn radio_buttons_change_selection(h: Harness) -> FixtureFuture {
 
         let after = h
             .find_text_containing("radio-idx=")
-            .and_then(|tb| {
-                tb.cast::<crate::bindings::ITextBlock>()
-                    .ok()?
-                    .get_Text()
-                    .ok()
-            })
+            .and_then(|tb| tb.cast::<crate::bindings::ITextBlock>().ok()?.Text().ok())
             .unwrap_or_else(|| "<no radio-idx= text block found>".into());
         let h2 = h.clone();
         h.check_with(
@@ -448,7 +438,7 @@ pub fn button_icon_glyph_change_preserves_text(h: Harness) -> FixtureFuture {
         let initial_symbol = icons_before[0]
             .cast::<crate::bindings::ISymbolIcon>()
             .unwrap()
-            .get_Symbol()
+            .Symbol()
             .unwrap();
         h.check(
             "Interaction_ButtonIconGlyph_InitialIsFavorite",
@@ -485,7 +475,7 @@ pub fn button_icon_glyph_change_preserves_text(h: Harness) -> FixtureFuture {
         let new_symbol = icons_after[0]
             .cast::<crate::bindings::ISymbolIcon>()
             .unwrap()
-            .get_Symbol()
+            .Symbol()
             .unwrap();
         h.check(
             "Interaction_ButtonIconGlyph_ChangedToSave",

--- a/crates/tests/libs/reactor_selftest/src/fixtures/layout.rs
+++ b/crates/tests/libs/reactor_selftest/src/fixtures/layout.rs
@@ -39,7 +39,7 @@ pub fn grid_row_column_layout(h: Harness) -> FixtureFuture {
         let g = h.find_all::<XamlGrid>(&|g| {
             g.cast::<crate::bindings::IGrid>()
                 .unwrap()
-                .get_ColumnDefinitions()
+                .ColumnDefinitions()
                 .map_or(0, |c| {
                     c.cast::<windows_collections::IVector<crate::bindings::ColumnDefinition>>()
                         .unwrap()
@@ -49,7 +49,7 @@ pub fn grid_row_column_layout(h: Harness) -> FixtureFuture {
                 == 2
                 && g.cast::<crate::bindings::IGrid>()
                     .unwrap()
-                    .get_RowDefinitions()
+                    .RowDefinitions()
                     .map_or(0, |r| {
                         r.cast::<windows_collections::IVector<crate::bindings::RowDefinition>>()
                             .unwrap()

--- a/crates/tests/libs/reactor_selftest/src/fixtures/prop_updates.rs
+++ b/crates/tests/libs/reactor_selftest/src/fixtures/prop_updates.rs
@@ -84,7 +84,7 @@ pub fn slider_value_update(h: Harness) -> FixtureFuture {
         let winui_val = sliders
             .first()
             .and_then(|s| s.cast::<crate::bindings::IRangeBase>().ok())
-            .and_then(|rb| rb.get_Value().ok())
+            .and_then(|rb| rb.Value().ok())
             .unwrap_or(0.0);
         h.check_eq("PropUpdate_Slider_WinUIValue", 75.0, winui_val);
 
@@ -130,7 +130,7 @@ pub fn progress_bar_value_update(h: Harness) -> FixtureFuture {
         let winui_val = pbs
             .first()
             .and_then(|p| p.cast::<crate::bindings::IRangeBase>().ok())
-            .and_then(|rb| rb.get_Value().ok())
+            .and_then(|rb| rb.Value().ok())
             .unwrap_or(0.0);
         h.check_eq("PropUpdate_ProgressBar_WinUIValue", 90.0, winui_val);
 
@@ -216,7 +216,7 @@ pub fn button_enabled_update(h: Harness) -> FixtureFuture {
         let is_enabled = target
             .as_ref()
             .and_then(|b| b.cast::<crate::bindings::IControl>().ok())
-            .and_then(|c| c.get_IsEnabled().ok())
+            .and_then(|c| c.IsEnabled().ok())
             .unwrap_or(false);
         h.check("PropUpdate_ButtonEnabled_WinUIValue", is_enabled);
     })

--- a/crates/tests/libs/reactor_selftest/src/harness.rs
+++ b/crates/tests/libs/reactor_selftest/src/harness.rs
@@ -57,7 +57,7 @@ impl Harness {
         let window = Window::new()?;
         window
             .cast::<crate::bindings::IWindow>()?
-            .put_Title(window_title)?;
+            .SetTitle(window_title)?;
 
         let dispatcher = DispatcherQueue::GetForCurrentThread()?;
 
@@ -65,16 +65,16 @@ impl Harness {
         let subtitle = TextBlock::new()?;
         subtitle
             .cast::<crate::bindings::ITextBlock>()?
-            .put_FontSize(12.0)?;
+            .SetFontSize(12.0)?;
         subtitle
             .cast::<crate::bindings::ITextBlock>()?
-            .put_Foreground(&solid_brush(255, 255, 255, 255)?)?;
+            .SetForeground(&solid_brush(255, 255, 255, 255)?)?;
         subtitle
             .cast::<crate::bindings::IFrameworkElement>()?
-            .put_VerticalAlignment(VerticalAlignment::Center)?;
+            .SetVerticalAlignment(VerticalAlignment::Center)?;
         subtitle
             .cast::<crate::bindings::IUIElement>()?
-            .put_IsHitTestVisible(false)?;
+            .SetIsHitTestVisible(false)?;
 
         let inner = HarnessInner {
             window,
@@ -101,10 +101,10 @@ impl Harness {
         let segment_bar = Grid::new()?;
         segment_bar
             .cast::<crate::bindings::IUIElement>()?
-            .put_IsHitTestVisible(false)?;
+            .SetIsHitTestVisible(false)?;
         let cols = segment_bar
             .cast::<crate::bindings::IGrid>()?
-            .get_ColumnDefinitions()?;
+            .ColumnDefinitions()?;
         let star_one = GridLength {
             value: 1.0,
             grid_unit_type: GridUnitType::Star,
@@ -112,17 +112,17 @@ impl Harness {
         for i in 0..total {
             let cd = ColumnDefinition::new()?;
             cd.cast::<crate::bindings::IColumnDefinition>()?
-                .put_Width(star_one)?;
+                .SetWidth(star_one)?;
             cols.cast::<windows_collections::IVector<ColumnDefinition>>()?
                 .Append(&cd)?;
             let seg = Border::new()?;
             seg.cast::<crate::bindings::IBorder>()?
-                .put_Background(&solid_brush(30, 200, 200, 200)?)?;
+                .SetBackground(&solid_brush(30, 200, 200, 200)?)?;
             Grid::SetColumn(&seg, i as i32)?;
             let seg_ui: UIElement = seg.cast()?;
             segment_bar
                 .cast::<crate::bindings::IPanel>()?
-                .get_Children()?
+                .Children()?
                 .cast::<windows_collections::IVector<UIElement>>()?
                 .Append(&seg_ui)?;
             inner.segments.borrow_mut().push(seg);
@@ -130,8 +130,8 @@ impl Harness {
 
         let pill = Border::new()?;
         pill.cast::<crate::bindings::IBorder>()?
-            .put_Background(&solid_brush(180, 0, 0, 0)?)?;
-        pill.cast::<crate::bindings::IBorder>()?.put_CornerRadius(
+            .SetBackground(&solid_brush(180, 0, 0, 0)?)?;
+        pill.cast::<crate::bindings::IBorder>()?.SetCornerRadius(
             crate::bindings::CornerRadius {
                 top_left: 4.0,
                 top_right: 4.0,
@@ -140,76 +140,74 @@ impl Harness {
             },
         )?;
         pill.cast::<crate::bindings::IBorder>()?
-            .put_Padding(Thickness {
+            .SetPadding(Thickness {
                 left: 8.0,
                 top: 2.0,
                 right: 8.0,
                 bottom: 2.0,
             })?;
         pill.cast::<crate::bindings::IFrameworkElement>()?
-            .put_HorizontalAlignment(HorizontalAlignment::Left)?;
+            .SetHorizontalAlignment(HorizontalAlignment::Left)?;
         pill.cast::<crate::bindings::IFrameworkElement>()?
-            .put_VerticalAlignment(VerticalAlignment::Center)?;
+            .SetVerticalAlignment(VerticalAlignment::Center)?;
         pill.cast::<crate::bindings::IFrameworkElement>()?
-            .put_Margin(Thickness {
+            .SetMargin(Thickness {
                 left: 12.0,
                 top: 0.0,
                 right: 0.0,
                 bottom: 0.0,
             })?;
         pill.cast::<crate::bindings::IUIElement>()?
-            .put_IsHitTestVisible(false)?;
+            .SetIsHitTestVisible(false)?;
         let subtitle_ui: UIElement = inner.subtitle.cast()?;
         pill.cast::<crate::bindings::IBorder>()?
-            .put_Child(&subtitle_ui)?;
+            .SetChild(&subtitle_ui)?;
 
         let titlebar_area = Grid::new()?;
         titlebar_area
             .cast::<crate::bindings::IFrameworkElement>()?
-            .put_Height(48.0)?;
+            .SetHeight(48.0)?;
         let bar_ui: UIElement = segment_bar.cast()?;
         let pill_ui: UIElement = pill.cast()?;
         titlebar_area
             .cast::<crate::bindings::IPanel>()?
-            .get_Children()?
+            .Children()?
             .cast::<windows_collections::IVector<UIElement>>()?
             .Append(&bar_ui)?;
         titlebar_area
             .cast::<crate::bindings::IPanel>()?
-            .get_Children()?
+            .Children()?
             .cast::<windows_collections::IVector<UIElement>>()?
             .Append(&pill_ui)?;
 
         let root = Grid::new()?;
-        let rows = root
-            .cast::<crate::bindings::IGrid>()?
-            .get_RowDefinitions()?;
+        let rows = root.cast::<crate::bindings::IGrid>()?.RowDefinitions()?;
         let auto = GridLength {
             value: 0.0,
             grid_unit_type: GridUnitType::Auto,
         };
         let row0 = RowDefinition::new()?;
         row0.cast::<crate::bindings::IRowDefinition>()?
-            .put_Height(auto)?;
+            .SetHeight(auto)?;
         rows.cast::<windows_collections::IVector<RowDefinition>>()?
             .Append(&row0)?;
         let row1 = RowDefinition::new()?;
         row1.cast::<crate::bindings::IRowDefinition>()?
-            .put_Height(star_one)?;
+            .SetHeight(star_one)?;
         rows.cast::<windows_collections::IVector<RowDefinition>>()?
             .Append(&row1)?;
 
         let titlebar_ui: UIElement = titlebar_area.cast()?;
         Grid::SetRow(&titlebar_ui.cast::<FrameworkElement>()?, 0)?;
         root.cast::<crate::bindings::IPanel>()?
-            .get_Children()?
+            .Children()?
             .cast::<windows_collections::IVector<UIElement>>()?
             .Append(&titlebar_ui)?;
 
         let content_ui: UIElement = inner.content_area.cast()?;
         Grid::SetRow(&content_ui.cast::<FrameworkElement>()?, 1)?;
         root.cast::<crate::bindings::IPanel>()?
-            .get_Children()?
+            .Children()?
             .cast::<windows_collections::IVector<UIElement>>()?
             .Append(&content_ui)?;
 
@@ -217,11 +215,11 @@ impl Harness {
         inner
             .window
             .cast::<crate::bindings::IWindow>()?
-            .put_Content(&root_ui)?;
+            .SetContent(&root_ui)?;
         inner
             .window
             .cast::<crate::bindings::IWindow>()?
-            .put_ExtendsContentIntoTitleBar(true)?;
+            .SetExtendsContentIntoTitleBar(true)?;
 
         inner
             .window
@@ -258,7 +256,7 @@ impl Harness {
         inner
             .subtitle
             .cast::<crate::bindings::ITextBlock>()?
-            .put_Text(&label)?;
+            .SetText(&label)?;
         if let Some(tb) = inner.taskbar.borrow().as_ref() {
             unsafe {
                 let _ = tb.SetProgressValue(inner.hwnd.get(), current as u64, total as u64);
@@ -279,7 +277,7 @@ impl Harness {
             solid_brush(255, 244, 67, 54)?
         };
         seg.cast::<crate::bindings::IBorder>()?
-            .put_Background(&brush)?;
+            .SetBackground(&brush)?;
         Ok(())
     }
 
@@ -322,7 +320,7 @@ impl Harness {
                         let _ = content
                             .cast::<crate::bindings::IBorder>()
                             .unwrap()
-                            .put_Child(&ui);
+                            .SetChild(&ui);
                         last_attached.set(Some(rid));
                     }
                 }
@@ -350,7 +348,7 @@ impl Harness {
             .window
             .cast::<crate::bindings::IWindow>()
             .unwrap()
-            .get_Content()
+            .Content()
         {
             let _ = content
                 .cast::<crate::bindings::IUIElement>()
@@ -541,7 +539,7 @@ impl Harness {
             .content_area
             .cast::<crate::bindings::IBorder>()
             .unwrap()
-            .get_Child()
+            .Child()
         {
             Ok(ui) => ui.cast::<DependencyObject>().ok(),
             Err(_) => None,
@@ -552,7 +550,7 @@ impl Harness {
         self.find_first::<TextBlock>(&|tb| {
             tb.cast::<crate::bindings::ITextBlock>()
                 .unwrap()
-                .get_Text()
+                .Text()
                 .ok()
                 .is_some_and(|t| t == s)
         })
@@ -562,7 +560,7 @@ impl Harness {
         self.find_first::<TextBlock>(&|tb| {
             tb.cast::<crate::bindings::ITextBlock>()
                 .unwrap()
-                .get_Text()
+                .Text()
                 .ok()
                 .is_some_and(|t| t.contains(s))
         })
@@ -573,12 +571,12 @@ impl Harness {
             let Ok(content) = btn
                 .cast::<crate::bindings::IContentControl>()
                 .unwrap()
-                .get_Content()
+                .Content()
             else {
                 return false;
             };
             if let Ok(tb) = content.cast::<TextBlock>()
-                && let Ok(t) = tb.cast::<crate::bindings::ITextBlock>().unwrap().get_Text()
+                && let Ok(t) = tb.cast::<crate::bindings::ITextBlock>().unwrap().Text()
                 && t == label
             {
                 return true;
@@ -614,7 +612,7 @@ impl Harness {
         };
         if !btn
             .cast::<crate::bindings::IControl>()?
-            .get_IsEnabled()
+            .IsEnabled()
             .unwrap_or(false)
         {
             return Ok(());
@@ -638,7 +636,7 @@ impl Harness {
         };
         self.report_hresult("set_checkbox_value", || {
             cb.cast::<crate::bindings::IToggleButton>()?
-                .put_IsChecked(Some(checked))?;
+                .SetIsChecked(Some(checked))?;
             Ok(())
         })
     }
@@ -650,7 +648,7 @@ impl Harness {
             return Err(Error::empty());
         };
         self.report_hresult("set_toggle_switch_value", || {
-            ts.cast::<crate::bindings::IToggleSwitch>()?.put_IsOn(on)?;
+            ts.cast::<crate::bindings::IToggleSwitch>()?.SetIsOn(on)?;
             Ok(())
         })
     }
@@ -662,7 +660,7 @@ impl Harness {
             return Err(Error::empty());
         };
         self.report_hresult("set_slider_value", || {
-            s.cast::<crate::bindings::IRangeBase>()?.put_Value(value)?;
+            s.cast::<crate::bindings::IRangeBase>()?.SetValue(value)?;
             Ok(())
         })
     }
@@ -674,7 +672,7 @@ impl Harness {
             return Err(Error::empty());
         };
         self.report_hresult("set_text_field_value", || {
-            tb.cast::<crate::bindings::ITextBox>()?.put_Text(text)?;
+            tb.cast::<crate::bindings::ITextBox>()?.SetText(text)?;
             Ok(())
         })
     }
@@ -688,7 +686,7 @@ impl Harness {
         };
         self.report_hresult("set_password_box_value", || {
             pb.cast::<crate::bindings::IPasswordBox>()?
-                .put_Password(text)?;
+                .SetPassword(text)?;
             Ok(())
         })
     }
@@ -758,7 +756,7 @@ impl Harness {
         };
         self.report_hresult("set_combo_box_selected_index", || {
             c.cast::<crate::bindings::ISelector>()?
-                .put_SelectedIndex(index)?;
+                .SetSelectedIndex(index)?;
             Ok(())
         })
     }
@@ -814,21 +812,21 @@ fn dump_node(node: &DependencyObject, depth: usize, out: &mut String) {
     out.push_str(&class_name);
 
     if let Ok(tb) = node.cast::<crate::bindings::ITextBlock>()
-        && let Ok(t) = tb.get_Text()
+        && let Ok(t) = tb.Text()
     {
         out.push_str(&format!(" Text={t:?}"));
     }
     if let Ok(rb) = node.cast::<crate::bindings::IRadioButtons>() {
-        if let Ok(idx) = rb.get_SelectedIndex() {
+        if let Ok(idx) = rb.SelectedIndex() {
             out.push_str(&format!(" SelectedIndex={idx}"));
         }
     } else if let Ok(sel) = node.cast::<crate::bindings::ISelector>()
-        && let Ok(idx) = sel.get_SelectedIndex()
+        && let Ok(idx) = sel.SelectedIndex()
     {
         out.push_str(&format!(" SelectedIndex={idx}"));
     }
     if let Ok(tog) = node.cast::<crate::bindings::IToggleButton>()
-        && let Ok(v) = tog.get_IsChecked()
+        && let Ok(v) = tog.IsChecked()
     {
         out.push_str(&format!(" IsChecked={v:?}"));
     }
@@ -864,7 +862,7 @@ fn solid_brush(a: u8, r: u8, g: u8, b: u8) -> Result<SolidColorBrush> {
     let brush = SolidColorBrush::new()?;
     brush
         .cast::<crate::bindings::ISolidColorBrush>()?
-        .put_Color(Color { a, r, g, b })?;
+        .SetColor(Color { a, r, g, b })?;
     Ok(brush)
 }
 

--- a/crates/tools/reactor/src/gen_attach.rs
+++ b/crates/tools/reactor/src/gen_attach.rs
@@ -120,7 +120,7 @@ fn require_property(e: &EventDecl, handle_name: &str, pattern: &str) -> String {
             e.event()
         )
     });
-    format!("get_{prop}")
+    prop.to_string()
 }
 
 fn gen_event_arm(

--- a/crates/tools/reactor/src/gen_set_prop.rs
+++ b/crates/tools/reactor/src/gen_set_prop.rs
@@ -353,7 +353,7 @@ fn render_body(body: &Body, wildcard: bool, handle_name: Option<&str>) -> TokenS
             value_variant,
         } => {
             let cast = cast_tokens(iface, wildcard, handle_name);
-            let m = ident(method);
+            let m = ident(&method_to_rust(method));
             let arg = arg_tokens(value_variant);
             quote! { #cast.#m(#arg)?; }
         }
@@ -363,18 +363,18 @@ fn render_body(body: &Body, wildcard: bool, handle_name: Option<&str>) -> TokenS
             value_variant,
         } => {
             let cast = cast_tokens(iface, wildcard, handle_name);
-            let m = ident(method);
+            let m = ident(&method_to_rust(method));
             let arg = arg_tokens(value_variant);
             quote! { #cast.#m(Some(#arg))?; }
         }
         Body::CastNone { iface, method } => {
             let cast = cast_tokens(iface, wildcard, handle_name);
-            let m = ident(method);
+            let m = ident(&method_to_rust(method));
             quote! { #cast.#m(None)?; }
         }
         Body::IReference { iface, method } => {
             let cast = cast_tokens(iface, wildcard, handle_name);
-            let m = ident(method);
+            let m = ident(&method_to_rust(method));
             quote! {
                 let insp = windows_reference::IReference::from(v.as_str());
                 #cast.#m(&insp)?;
@@ -382,7 +382,7 @@ fn render_body(body: &Body, wildcard: bool, handle_name: Option<&str>) -> TokenS
         }
         Body::Textblock { iface, method } => {
             let cast = cast_tokens(iface, wildcard, handle_name);
-            let m = ident(method);
+            let m = ident(&method_to_rust(method));
             quote! {
                 let tb = string_as_textblock(v.as_str())?;
                 #cast.#m(&tb)?;
@@ -394,7 +394,7 @@ fn render_body(body: &Body, wildcard: bool, handle_name: Option<&str>) -> TokenS
             winui_type,
         } => {
             let cast = cast_tokens(iface, wildcard, handle_name);
-            let m = ident(method);
+            let m = ident(&method_to_rust(method));
             let wt = ident(winui_type);
             quote! {
                 #cast.#m(#wt(*v))?;

--- a/crates/tools/reactor/src/helpers.rs
+++ b/crates/tools/reactor/src/helpers.rs
@@ -6,6 +6,22 @@ pub fn ident(s: &str) -> Ident {
     Ident::new(s, Span::call_site())
 }
 
+/// Convert a metadata method name (e.g. `put_Text`, `get_Value`, `add_Click`)
+/// to its Rust binding name (`SetText`, `Value`, `Click`, `RemoveClick`).
+pub fn method_to_rust(name: &str) -> String {
+    if let Some(prop) = name.strip_prefix("get_") {
+        prop.to_string()
+    } else if let Some(prop) = name.strip_prefix("put_") {
+        format!("Set{prop}")
+    } else if let Some(event) = name.strip_prefix("add_") {
+        event.to_string()
+    } else if let Some(event) = name.strip_prefix("remove_") {
+        format!("Remove{event}")
+    } else {
+        name.to_string()
+    }
+}
+
 /// Convert `PascalCase` to `snake_case`.
 pub fn to_snake_case(s: &str) -> String {
     let mut out = String::with_capacity(s.len() + 4);

--- a/crates/tools/reactor/src/schema.rs
+++ b/crates/tools/reactor/src/schema.rs
@@ -317,12 +317,12 @@ pub struct EventDecl {
     /// How the handler is invoked. Required when `add_method` is set.
     pub invoke: Option<String>,
 
-    /// Property name on sender/args for extracting values (e.g. `"IsOn"`).
-    /// Code generation prepends `get_` to form the method name.
+    /// Rust binding method name on sender/args for extracting values (e.g. `"IsOn"`).
+    /// Used directly as the getter method identifier in generated code.
     pub property: Option<String>,
 
     /// Complement event that fires `false` for bool-dual patterns (e.g. `"Unchecked"`).
-    /// Code generation prepends `add_` to form the method name.
+    /// Used as the binding method identifier; metadata is resolved via `add_{name}`.
     pub false_event: Option<String>,
 }
 


### PR DESCRIPTION
All modes use the same name normalization across properties and events. 