### PR TITLE
Language/ABI benchmark

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 *.winmd
 obj
 bin
+aot-publish

--- a/crates/libs/strings/src/lib.rs
+++ b/crates/libs/strings/src/lib.rs
@@ -57,5 +57,5 @@ mod pwstr;
 pub use pwstr::*;
 
 unsafe extern "C" {
-    fn strlen(s: PCSTR) -> usize;
+    fn strlen(s: *const core::ffi::c_char) -> usize;
 }

--- a/crates/libs/strings/src/pcstr.rs
+++ b/crates/libs/strings/src/pcstr.rs
@@ -33,7 +33,7 @@ impl PCSTR {
     /// The `PCSTR`'s pointer needs to be valid for reads up until and including the next `\0`.
     pub unsafe fn as_bytes(&self) -> &[u8] {
         unsafe {
-            let len = strlen(*self);
+            let len = strlen(self.0.cast());
             core::slice::from_raw_parts(self.0, len)
         }
     }

--- a/crates/libs/strings/src/pstr.rs
+++ b/crates/libs/strings/src/pstr.rs
@@ -33,7 +33,7 @@ impl PSTR {
     /// The `PSTR`'s pointer needs to be valid for reads up until and including the next `\0`.
     pub unsafe fn as_bytes(&self) -> &[u8] {
         unsafe {
-            let len = strlen(PCSTR::from_raw(self.0));
+            let len = strlen(self.0.cast());
             core::slice::from_raw_parts(self.0, len)
         }
     }

--- a/crates/samples/lang_perf/component/Cargo.toml
+++ b/crates/samples/lang_perf/component/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "lang_perf_component"
+version = "0.0.0"
+edition = "2024"
+publish = false
+
+[lib]
+name = "langperf"
+crate-type = ["cdylib"]
+
+[dependencies]
+windows = { workspace = true, features = ["Win32_System_WinRT"] }
+windows-core = { workspace = true, default-features = true }
+
+[build-dependencies]
+windows-rdl = { workspace = true }
+windows-bindgen = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/samples/lang_perf/component/build.rs
+++ b/crates/samples/lang_perf/component/build.rs
@@ -1,0 +1,21 @@
+fn main() {
+    println!("cargo:rerun-if-changed=src/lang.rdl");
+
+    let reference = "../../../libs/bindgen/default";
+
+    windows_rdl::reader()
+        .input("src/lang.rdl")
+        .input(reference)
+        .output("lang.winmd")
+        .write()
+        .unwrap();
+
+    windows_bindgen::builder()
+        .input("lang.winmd")
+        .input(reference)
+        .output("src/bindings.rs")
+        .filter("LangPerf")
+        .flat()
+        .implement(std::iter::empty::<&str>())
+        .write();
+}

--- a/crates/samples/lang_perf/component/src/bindings.rs
+++ b/crates/samples/lang_perf/component/src/bindings.rs
@@ -1,0 +1,332 @@
+#[repr(transparent)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Class(windows_core::IUnknown);
+windows_core::imp::interface_hierarchy!(Class, windows_core::IUnknown, windows_core::IInspectable);
+impl Class {
+    pub fn new() -> windows_core::Result<Self> {
+        Self::IActivationFactory(|f| f.ActivateInstance::<Self>())
+    }
+    fn IActivationFactory<
+        R,
+        F: FnOnce(&windows_core::imp::IGenericFactory) -> windows_core::Result<R>,
+    >(
+        callback: F,
+    ) -> windows_core::Result<R> {
+        static SHARED: windows_core::imp::FactoryCache<Class, windows_core::imp::IGenericFactory> =
+            windows_core::imp::FactoryCache::new();
+        SHARED.call(callback)
+    }
+    pub fn Int32Property(&self) -> windows_core::Result<i32> {
+        unsafe {
+            let mut result__ = core::mem::zeroed();
+            (windows_core::Interface::vtable(self).Int32Property)(
+                windows_core::Interface::as_raw(self),
+                &mut result__,
+            )
+            .map(|| result__)
+        }
+    }
+    pub fn SetInt32Property(&self, value: i32) -> windows_core::Result<()> {
+        unsafe {
+            (windows_core::Interface::vtable(self).SetInt32Property)(
+                windows_core::Interface::as_raw(self),
+                value,
+            )
+            .ok()
+        }
+    }
+    pub fn StringProperty(&self) -> windows_core::Result<windows_core::HSTRING> {
+        unsafe {
+            let mut result__ = core::mem::zeroed();
+            (windows_core::Interface::vtable(self).StringProperty)(
+                windows_core::Interface::as_raw(self),
+                &mut result__,
+            )
+            .map(|| core::mem::transmute(result__))
+        }
+    }
+    pub fn SetStringProperty(&self, value: &windows_core::HSTRING) -> windows_core::Result<()> {
+        unsafe {
+            (windows_core::Interface::vtable(self).SetStringProperty)(
+                windows_core::Interface::as_raw(self),
+                core::mem::transmute_copy(value),
+            )
+            .ok()
+        }
+    }
+    pub fn ObjectProperty(&self) -> windows_core::Result<windows_core::IInspectable> {
+        unsafe {
+            let mut result__ = core::mem::zeroed();
+            (windows_core::Interface::vtable(self).ObjectProperty)(
+                windows_core::Interface::as_raw(self),
+                &mut result__,
+            )
+            .and_then(|| windows_core::Type::from_abi(result__))
+        }
+    }
+    pub fn SetObjectProperty<P0>(&self, value: P0) -> windows_core::Result<()>
+    where
+        P0: windows_core::Param<windows_core::IInspectable>,
+    {
+        unsafe {
+            (windows_core::Interface::vtable(self).SetObjectProperty)(
+                windows_core::Interface::as_raw(self),
+                value.param().abi(),
+            )
+            .ok()
+        }
+    }
+    pub fn NewObject(&self) -> windows_core::Result<windows_core::IInspectable> {
+        unsafe {
+            let mut result__ = core::mem::zeroed();
+            (windows_core::Interface::vtable(self).NewObject)(
+                windows_core::Interface::as_raw(self),
+                &mut result__,
+            )
+            .and_then(|| windows_core::Type::from_abi(result__))
+        }
+    }
+}
+impl windows_core::RuntimeType for Class {
+    const SIGNATURE: windows_core::imp::ConstBuffer =
+        windows_core::imp::ConstBuffer::for_class::<Self, IClass>();
+}
+unsafe impl windows_core::Interface for Class {
+    type Vtable = <IClass as windows_core::Interface>::Vtable;
+    const IID: windows_core::GUID = <IClass as windows_core::Interface>::IID;
+}
+impl windows_core::RuntimeName for Class {
+    const NAME: &'static str = "LangPerf.Class";
+}
+unsafe impl Send for Class {}
+unsafe impl Sync for Class {}
+windows_core::imp::define_interface!(IClass, IClass_Vtbl, 0xe853a9c7_689d_5bc7_a462_7b99d49ad4ff);
+impl windows_core::RuntimeType for IClass {
+    const SIGNATURE: windows_core::imp::ConstBuffer =
+        windows_core::imp::ConstBuffer::for_interface::<Self>();
+    const NAME: windows_core::imp::ConstBuffer =
+        windows_core::imp::ConstBuffer::from_slice(b"LangPerf.IClass");
+}
+impl windows_core::RuntimeName for IClass {
+    const NAME: &'static str = "LangPerf.IClass";
+}
+pub trait IClass_Impl: windows_core::IUnknownImpl {
+    fn Int32Property(&self) -> windows_core::Result<i32>;
+    fn SetInt32Property(&self, value: i32) -> windows_core::Result<()>;
+    fn StringProperty(&self) -> windows_core::Result<windows_core::HSTRING>;
+    fn SetStringProperty(&self, value: &windows_core::HSTRING) -> windows_core::Result<()>;
+    fn ObjectProperty(&self) -> windows_core::Result<windows_core::IInspectable>;
+    fn SetObjectProperty(
+        &self,
+        value: windows_core::Ref<windows_core::IInspectable>,
+    ) -> windows_core::Result<()>;
+    fn NewObject(&self) -> windows_core::Result<windows_core::IInspectable>;
+}
+impl IClass_Vtbl {
+    pub const fn new<Identity: IClass_Impl, const OFFSET: isize>() -> Self {
+        unsafe extern "system" fn Int32Property<Identity: IClass_Impl, const OFFSET: isize>(
+            this: *mut core::ffi::c_void,
+            result__: *mut i32,
+        ) -> windows_core::HRESULT {
+            unsafe {
+                let this: &Identity =
+                    &*((this as *const *const ()).offset(OFFSET) as *const Identity);
+                match IClass_Impl::Int32Property(this) {
+                    Ok(ok__) => {
+                        result__.write(ok__);
+                        windows_core::HRESULT(0)
+                    }
+                    Err(err) => err.into(),
+                }
+            }
+        }
+        unsafe extern "system" fn SetInt32Property<Identity: IClass_Impl, const OFFSET: isize>(
+            this: *mut core::ffi::c_void,
+            value: i32,
+        ) -> windows_core::HRESULT {
+            unsafe {
+                let this: &Identity =
+                    &*((this as *const *const ()).offset(OFFSET) as *const Identity);
+                IClass_Impl::SetInt32Property(this, value).into()
+            }
+        }
+        unsafe extern "system" fn StringProperty<Identity: IClass_Impl, const OFFSET: isize>(
+            this: *mut core::ffi::c_void,
+            result__: *mut *mut core::ffi::c_void,
+        ) -> windows_core::HRESULT {
+            unsafe {
+                let this: &Identity =
+                    &*((this as *const *const ()).offset(OFFSET) as *const Identity);
+                match IClass_Impl::StringProperty(this) {
+                    Ok(ok__) => {
+                        result__.write(core::mem::transmute_copy(&ok__));
+                        core::mem::forget(ok__);
+                        windows_core::HRESULT(0)
+                    }
+                    Err(err) => err.into(),
+                }
+            }
+        }
+        unsafe extern "system" fn SetStringProperty<Identity: IClass_Impl, const OFFSET: isize>(
+            this: *mut core::ffi::c_void,
+            value: *mut core::ffi::c_void,
+        ) -> windows_core::HRESULT {
+            unsafe {
+                let this: &Identity =
+                    &*((this as *const *const ()).offset(OFFSET) as *const Identity);
+                IClass_Impl::SetStringProperty(this, core::mem::transmute(&value)).into()
+            }
+        }
+        unsafe extern "system" fn ObjectProperty<Identity: IClass_Impl, const OFFSET: isize>(
+            this: *mut core::ffi::c_void,
+            result__: *mut *mut core::ffi::c_void,
+        ) -> windows_core::HRESULT {
+            unsafe {
+                let this: &Identity =
+                    &*((this as *const *const ()).offset(OFFSET) as *const Identity);
+                match IClass_Impl::ObjectProperty(this) {
+                    Ok(ok__) => {
+                        result__.write(core::mem::transmute_copy(&ok__));
+                        core::mem::forget(ok__);
+                        windows_core::HRESULT(0)
+                    }
+                    Err(err) => err.into(),
+                }
+            }
+        }
+        unsafe extern "system" fn SetObjectProperty<Identity: IClass_Impl, const OFFSET: isize>(
+            this: *mut core::ffi::c_void,
+            value: *mut core::ffi::c_void,
+        ) -> windows_core::HRESULT {
+            unsafe {
+                let this: &Identity =
+                    &*((this as *const *const ()).offset(OFFSET) as *const Identity);
+                IClass_Impl::SetObjectProperty(this, core::mem::transmute_copy(&value)).into()
+            }
+        }
+        unsafe extern "system" fn NewObject<Identity: IClass_Impl, const OFFSET: isize>(
+            this: *mut core::ffi::c_void,
+            result__: *mut *mut core::ffi::c_void,
+        ) -> windows_core::HRESULT {
+            unsafe {
+                let this: &Identity =
+                    &*((this as *const *const ()).offset(OFFSET) as *const Identity);
+                match IClass_Impl::NewObject(this) {
+                    Ok(ok__) => {
+                        result__.write(core::mem::transmute_copy(&ok__));
+                        core::mem::forget(ok__);
+                        windows_core::HRESULT(0)
+                    }
+                    Err(err) => err.into(),
+                }
+            }
+        }
+        Self {
+            base__: windows_core::IInspectable_Vtbl::new::<Identity, IClass, OFFSET>(),
+            Int32Property: Int32Property::<Identity, OFFSET>,
+            SetInt32Property: SetInt32Property::<Identity, OFFSET>,
+            StringProperty: StringProperty::<Identity, OFFSET>,
+            SetStringProperty: SetStringProperty::<Identity, OFFSET>,
+            ObjectProperty: ObjectProperty::<Identity, OFFSET>,
+            SetObjectProperty: SetObjectProperty::<Identity, OFFSET>,
+            NewObject: NewObject::<Identity, OFFSET>,
+        }
+    }
+    pub fn matches(iid: &windows_core::GUID) -> bool {
+        iid == &<IClass as windows_core::Interface>::IID
+    }
+}
+#[repr(C)]
+pub struct IClass_Vtbl {
+    pub base__: windows_core::IInspectable_Vtbl,
+    pub Int32Property:
+        unsafe extern "system" fn(*mut core::ffi::c_void, *mut i32) -> windows_core::HRESULT,
+    pub SetInt32Property:
+        unsafe extern "system" fn(*mut core::ffi::c_void, i32) -> windows_core::HRESULT,
+    pub StringProperty: unsafe extern "system" fn(
+        *mut core::ffi::c_void,
+        *mut *mut core::ffi::c_void,
+    ) -> windows_core::HRESULT,
+    pub SetStringProperty: unsafe extern "system" fn(
+        *mut core::ffi::c_void,
+        *mut core::ffi::c_void,
+    ) -> windows_core::HRESULT,
+    pub ObjectProperty: unsafe extern "system" fn(
+        *mut core::ffi::c_void,
+        *mut *mut core::ffi::c_void,
+    ) -> windows_core::HRESULT,
+    pub SetObjectProperty: unsafe extern "system" fn(
+        *mut core::ffi::c_void,
+        *mut core::ffi::c_void,
+    ) -> windows_core::HRESULT,
+    pub NewObject: unsafe extern "system" fn(
+        *mut core::ffi::c_void,
+        *mut *mut core::ffi::c_void,
+    ) -> windows_core::HRESULT,
+}
+windows_core::imp::define_interface!(
+    INonDefault,
+    INonDefault_Vtbl,
+    0x1471cc2c_0216_5a12_90ad_6bc57677b7f5
+);
+impl windows_core::RuntimeType for INonDefault {
+    const SIGNATURE: windows_core::imp::ConstBuffer =
+        windows_core::imp::ConstBuffer::for_interface::<Self>();
+    const NAME: windows_core::imp::ConstBuffer =
+        windows_core::imp::ConstBuffer::from_slice(b"LangPerf.INonDefault");
+}
+windows_core::imp::interface_hierarchy!(
+    INonDefault,
+    windows_core::IUnknown,
+    windows_core::IInspectable
+);
+impl INonDefault {
+    pub fn Value(&self) -> windows_core::Result<i32> {
+        unsafe {
+            let mut result__ = core::mem::zeroed();
+            (windows_core::Interface::vtable(self).Value)(
+                windows_core::Interface::as_raw(self),
+                &mut result__,
+            )
+            .map(|| result__)
+        }
+    }
+}
+impl windows_core::RuntimeName for INonDefault {
+    const NAME: &'static str = "LangPerf.INonDefault";
+}
+pub trait INonDefault_Impl: windows_core::IUnknownImpl {
+    fn Value(&self) -> windows_core::Result<i32>;
+}
+impl INonDefault_Vtbl {
+    pub const fn new<Identity: INonDefault_Impl, const OFFSET: isize>() -> Self {
+        unsafe extern "system" fn Value<Identity: INonDefault_Impl, const OFFSET: isize>(
+            this: *mut core::ffi::c_void,
+            result__: *mut i32,
+        ) -> windows_core::HRESULT {
+            unsafe {
+                let this: &Identity =
+                    &*((this as *const *const ()).offset(OFFSET) as *const Identity);
+                match INonDefault_Impl::Value(this) {
+                    Ok(ok__) => {
+                        result__.write(ok__);
+                        windows_core::HRESULT(0)
+                    }
+                    Err(err) => err.into(),
+                }
+            }
+        }
+        Self {
+            base__: windows_core::IInspectable_Vtbl::new::<Identity, INonDefault, OFFSET>(),
+            Value: Value::<Identity, OFFSET>,
+        }
+    }
+    pub fn matches(iid: &windows_core::GUID) -> bool {
+        iid == &<INonDefault as windows_core::Interface>::IID
+    }
+}
+#[repr(C)]
+pub struct INonDefault_Vtbl {
+    pub base__: windows_core::IInspectable_Vtbl,
+    pub Value: unsafe extern "system" fn(*mut core::ffi::c_void, *mut i32) -> windows_core::HRESULT,
+}

--- a/crates/samples/lang_perf/component/src/bindings.rs
+++ b/crates/samples/lang_perf/component/src/bindings.rs
@@ -76,16 +76,6 @@ impl Class {
             .ok()
         }
     }
-    pub fn NewObject(&self) -> windows_core::Result<windows_core::IInspectable> {
-        unsafe {
-            let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).NewObject)(
-                windows_core::Interface::as_raw(self),
-                &mut result__,
-            )
-            .and_then(|| windows_core::Type::from_abi(result__))
-        }
-    }
 }
 impl windows_core::RuntimeType for Class {
     const SIGNATURE: windows_core::imp::ConstBuffer =
@@ -100,7 +90,7 @@ impl windows_core::RuntimeName for Class {
 }
 unsafe impl Send for Class {}
 unsafe impl Sync for Class {}
-windows_core::imp::define_interface!(IClass, IClass_Vtbl, 0xe853a9c7_689d_5bc7_a462_7b99d49ad4ff);
+windows_core::imp::define_interface!(IClass, IClass_Vtbl, 0x796dee90_c3d5_5bc7_b6c4_29202e486236);
 impl windows_core::RuntimeType for IClass {
     const SIGNATURE: windows_core::imp::ConstBuffer =
         windows_core::imp::ConstBuffer::for_interface::<Self>();
@@ -120,7 +110,6 @@ pub trait IClass_Impl: windows_core::IUnknownImpl {
         &self,
         value: windows_core::Ref<windows_core::IInspectable>,
     ) -> windows_core::Result<()>;
-    fn NewObject(&self) -> windows_core::Result<windows_core::IInspectable>;
 }
 impl IClass_Vtbl {
     pub const fn new<Identity: IClass_Impl, const OFFSET: isize>() -> Self {
@@ -204,23 +193,6 @@ impl IClass_Vtbl {
                 IClass_Impl::SetObjectProperty(this, core::mem::transmute_copy(&value)).into()
             }
         }
-        unsafe extern "system" fn NewObject<Identity: IClass_Impl, const OFFSET: isize>(
-            this: *mut core::ffi::c_void,
-            result__: *mut *mut core::ffi::c_void,
-        ) -> windows_core::HRESULT {
-            unsafe {
-                let this: &Identity =
-                    &*((this as *const *const ()).offset(OFFSET) as *const Identity);
-                match IClass_Impl::NewObject(this) {
-                    Ok(ok__) => {
-                        result__.write(core::mem::transmute_copy(&ok__));
-                        core::mem::forget(ok__);
-                        windows_core::HRESULT(0)
-                    }
-                    Err(err) => err.into(),
-                }
-            }
-        }
         Self {
             base__: windows_core::IInspectable_Vtbl::new::<Identity, IClass, OFFSET>(),
             Int32Property: Int32Property::<Identity, OFFSET>,
@@ -229,7 +201,6 @@ impl IClass_Vtbl {
             SetStringProperty: SetStringProperty::<Identity, OFFSET>,
             ObjectProperty: ObjectProperty::<Identity, OFFSET>,
             SetObjectProperty: SetObjectProperty::<Identity, OFFSET>,
-            NewObject: NewObject::<Identity, OFFSET>,
         }
     }
     pub fn matches(iid: &windows_core::GUID) -> bool {
@@ -258,10 +229,6 @@ pub struct IClass_Vtbl {
     pub SetObjectProperty: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
-    ) -> windows_core::HRESULT,
-    pub NewObject: unsafe extern "system" fn(
-        *mut core::ffi::c_void,
-        *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(

--- a/crates/samples/lang_perf/component/src/lang.rdl
+++ b/crates/samples/lang_perf/component/src/lang.rdl
@@ -1,0 +1,25 @@
+use Windows::Foundation::Metadata::*;
+
+#[winrt]
+mod LangPerf {
+    #[Activatable(1)]
+    #[MarshalingBehavior(Agile)]
+    class Class {
+        IClass,
+    }
+
+    #[ExclusiveTo(Class)]
+    interface IClass {
+        fn Int32Property(&self) -> i32;
+        fn SetInt32Property(&self, value: i32);
+        fn StringProperty(&self) -> String;
+        fn SetStringProperty(&self, value: String);
+        fn ObjectProperty(&self) -> Object;
+        fn SetObjectProperty(&self, value: Object);
+        fn NewObject(&self) -> Object;
+    }
+
+    interface INonDefault {
+        fn Value(&self) -> i32;
+    }
+}

--- a/crates/samples/lang_perf/component/src/lang.rdl
+++ b/crates/samples/lang_perf/component/src/lang.rdl
@@ -16,7 +16,6 @@ mod LangPerf {
         fn SetStringProperty(&self, value: String);
         fn ObjectProperty(&self) -> Object;
         fn SetObjectProperty(&self, value: Object);
-        fn NewObject(&self) -> Object;
     }
 
     interface INonDefault {

--- a/crates/samples/lang_perf/component/src/lib.rs
+++ b/crates/samples/lang_perf/component/src/lib.rs
@@ -33,7 +33,7 @@ impl IActivationFactory_Impl for ClassFactory_Impl {
     }
 }
 
-#[implement(bindings::Class)]
+#[implement(bindings::Class, bindings::INonDefault)]
 struct Class;
 
 impl bindings::IClass_Impl for Class_Impl {
@@ -60,16 +60,9 @@ impl bindings::IClass_Impl for Class_Impl {
     fn SetObjectProperty(&self, _value: Ref<IInspectable>) -> Result<()> {
         Ok(())
     }
-
-    fn NewObject(&self) -> Result<IInspectable> {
-        Ok(NonDefault.into())
-    }
 }
 
-#[implement(bindings::INonDefault)]
-struct NonDefault;
-
-impl bindings::INonDefault_Impl for NonDefault_Impl {
+impl bindings::INonDefault_Impl for Class_Impl {
     fn Value(&self) -> Result<i32> {
         Ok(0)
     }

--- a/crates/samples/lang_perf/component/src/lib.rs
+++ b/crates/samples/lang_perf/component/src/lib.rs
@@ -7,7 +7,6 @@
 )]
 mod bindings;
 
-use std::cell::{Cell, RefCell};
 use windows::{Win32::Foundation::*, Win32::System::WinRT::*, core::*};
 
 #[unsafe(no_mangle)]
@@ -30,43 +29,35 @@ struct ClassFactory;
 
 impl IActivationFactory_Impl for ClassFactory_Impl {
     fn ActivateInstance(&self) -> Result<IInspectable> {
-        Ok(Class::default().into())
+        Ok(Class.into())
     }
 }
 
 #[implement(bindings::Class)]
-#[derive(Default)]
-struct Class {
-    int32: Cell<i32>,
-    string: RefCell<HSTRING>,
-    object: RefCell<Option<IInspectable>>,
-}
+struct Class;
 
 impl bindings::IClass_Impl for Class_Impl {
     fn Int32Property(&self) -> Result<i32> {
-        Ok(self.int32.get())
+        Ok(0)
     }
 
-    fn SetInt32Property(&self, value: i32) -> Result<()> {
-        self.int32.set(value);
+    fn SetInt32Property(&self, _value: i32) -> Result<()> {
         Ok(())
     }
 
     fn StringProperty(&self) -> Result<HSTRING> {
-        Ok(self.string.borrow().clone())
+        Ok(HSTRING::new())
     }
 
-    fn SetStringProperty(&self, value: &HSTRING) -> Result<()> {
-        *self.string.borrow_mut() = value.clone();
+    fn SetStringProperty(&self, _value: &HSTRING) -> Result<()> {
         Ok(())
     }
 
     fn ObjectProperty(&self) -> Result<IInspectable> {
-        self.object.borrow().clone().ok_or_else(|| E_POINTER.into())
+        Ok(self.to_interface())
     }
 
-    fn SetObjectProperty(&self, value: Ref<IInspectable>) -> Result<()> {
-        *self.object.borrow_mut() = value.cloned();
+    fn SetObjectProperty(&self, _value: Ref<IInspectable>) -> Result<()> {
         Ok(())
     }
 

--- a/crates/samples/lang_perf/component/src/lib.rs
+++ b/crates/samples/lang_perf/component/src/lib.rs
@@ -34,9 +34,6 @@ impl IActivationFactory_Impl for ClassFactory_Impl {
     }
 }
 
-// A deliberately trivial WinRT runtime class: each accessor does the minimum work
-// possible so a tight calling loop measures the projection overhead of the caller's
-// language rather than the cost of the callee.
 #[implement(bindings::Class)]
 #[derive(Default)]
 struct Class {

--- a/crates/samples/lang_perf/component/src/lib.rs
+++ b/crates/samples/lang_perf/component/src/lib.rs
@@ -1,0 +1,88 @@
+#[allow(
+    non_snake_case,
+    non_upper_case_globals,
+    non_camel_case_types,
+    dead_code,
+    clippy::all
+)]
+mod bindings;
+
+use std::cell::{Cell, RefCell};
+use windows::{Win32::Foundation::*, Win32::System::WinRT::*, core::*};
+
+#[unsafe(no_mangle)]
+extern "system" fn DllGetActivationFactory(
+    name: Ref<HSTRING>,
+    factory: OutRef<IActivationFactory>,
+) -> HRESULT {
+    if *name == "LangPerf.Class" {
+        factory.write(Some(CLASS_FACTORY.to_interface())).into()
+    } else {
+        _ = factory.write(None);
+        CLASS_E_CLASSNOTAVAILABLE
+    }
+}
+
+static CLASS_FACTORY: StaticComObject<ClassFactory> = ClassFactory.into_static();
+
+#[implement(IActivationFactory)]
+struct ClassFactory;
+
+impl IActivationFactory_Impl for ClassFactory_Impl {
+    fn ActivateInstance(&self) -> Result<IInspectable> {
+        Ok(Class::default().into())
+    }
+}
+
+// A deliberately trivial WinRT runtime class: each accessor does the minimum work
+// possible so a tight calling loop measures the projection overhead of the caller's
+// language rather than the cost of the callee.
+#[implement(bindings::Class)]
+#[derive(Default)]
+struct Class {
+    int32: Cell<i32>,
+    string: RefCell<HSTRING>,
+    object: RefCell<Option<IInspectable>>,
+}
+
+impl bindings::IClass_Impl for Class_Impl {
+    fn Int32Property(&self) -> Result<i32> {
+        Ok(self.int32.get())
+    }
+
+    fn SetInt32Property(&self, value: i32) -> Result<()> {
+        self.int32.set(value);
+        Ok(())
+    }
+
+    fn StringProperty(&self) -> Result<HSTRING> {
+        Ok(self.string.borrow().clone())
+    }
+
+    fn SetStringProperty(&self, value: &HSTRING) -> Result<()> {
+        *self.string.borrow_mut() = value.clone();
+        Ok(())
+    }
+
+    fn ObjectProperty(&self) -> Result<IInspectable> {
+        self.object.borrow().clone().ok_or_else(|| E_POINTER.into())
+    }
+
+    fn SetObjectProperty(&self, value: Ref<IInspectable>) -> Result<()> {
+        *self.object.borrow_mut() = value.cloned();
+        Ok(())
+    }
+
+    fn NewObject(&self) -> Result<IInspectable> {
+        Ok(NonDefault.into())
+    }
+}
+
+#[implement(bindings::INonDefault)]
+struct NonDefault;
+
+impl bindings::INonDefault_Impl for NonDefault_Impl {
+    fn Value(&self) -> Result<i32> {
+        Ok(0)
+    }
+}

--- a/crates/samples/lang_perf/cpp/Cargo.toml
+++ b/crates/samples/lang_perf/cpp/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "lang_perf_cpp"
+version = "0.0.0"
+edition = "2024"
+publish = false
+
+[[bin]]
+name = "lang_perf_cpp"
+path = "src/main.rs"
+
+[dependencies]
+lang_perf_component = { path = "../component" }
+
+[build-dependencies]
+cc = "1.0"
+cppwinrt = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/samples/lang_perf/cpp/build.rs
+++ b/crates/samples/lang_perf/cpp/build.rs
@@ -1,0 +1,32 @@
+fn main() {
+    msvc_main();
+}
+
+#[cfg(not(target_env = "msvc"))]
+fn msvc_main() {}
+
+#[cfg(target_env = "msvc")]
+fn msvc_main() {
+    println!("cargo:rerun-if-changed=../component/lang.winmd");
+    println!("cargo:rerun-if-changed=src/bench.cpp");
+    println!("cargo:rustc-link-lib=onecoreuap");
+
+    let include = std::env::var("OUT_DIR").unwrap();
+
+    cppwinrt::cppwinrt([
+        "-in",
+        "../component/lang.winmd",
+        "../../../libs/bindgen/default",
+        "-out",
+        &include,
+    ]);
+
+    cc::Build::new()
+        .cpp(true)
+        .std("c++20")
+        .flag("/EHsc")
+        .flag("/W4")
+        .file("src/bench.cpp")
+        .include(include)
+        .compile("lang_perf_cpp");
+}

--- a/crates/samples/lang_perf/cpp/src/bench.cpp
+++ b/crates/samples/lang_perf/cpp/src/bench.cpp
@@ -61,7 +61,7 @@ extern "C" int32_t __stdcall lang_perf_cpp(uint64_t iterations) noexcept
         start = std::chrono::high_resolution_clock::now();
         for (uint64_t i = 0; i < iterations; i++)
         {
-            auto value = object.NewObject().as<INonDefault>().Value();
+            auto value = object.ObjectProperty().as<INonDefault>().Value();
             (void)value;
         }
         printf("Cast: %lld ms\n", elapsed_ms(start));

--- a/crates/samples/lang_perf/cpp/src/bench.cpp
+++ b/crates/samples/lang_perf/cpp/src/bench.cpp
@@ -40,11 +40,10 @@ extern "C" int32_t __stdcall lang_perf_cpp(uint64_t iterations) noexcept
         }
         printf("Int32: %lld ms\n", elapsed_ms(start));
 
-        hstring const text = L"value";
         start = std::chrono::high_resolution_clock::now();
         for (uint64_t i = 0; i < iterations; i++)
         {
-            object.SetStringProperty(text);
+            object.SetStringProperty(L"value");
             auto value = object.StringProperty();
             (void)value;
         }

--- a/crates/samples/lang_perf/cpp/src/bench.cpp
+++ b/crates/samples/lang_perf/cpp/src/bench.cpp
@@ -40,8 +40,6 @@ extern "C" int32_t __stdcall lang_perf_cpp(uint64_t iterations) noexcept
         }
         printf("Int32: %lld ms\n", elapsed_ms(start));
 
-        // A wide string literal builds an hstring without any encoding conversion,
-        // unlike the UTF-8 -> UTF-16 conversion a Rust string literal requires.
         start = std::chrono::high_resolution_clock::now();
         for (uint64_t i = 0; i < iterations; i++)
         {

--- a/crates/samples/lang_perf/cpp/src/bench.cpp
+++ b/crates/samples/lang_perf/cpp/src/bench.cpp
@@ -40,10 +40,11 @@ extern "C" int32_t __stdcall lang_perf_cpp(uint64_t iterations) noexcept
         }
         printf("Int32: %lld ms\n", elapsed_ms(start));
 
+        hstring const text = L"value";
         start = std::chrono::high_resolution_clock::now();
         for (uint64_t i = 0; i < iterations; i++)
         {
-            object.SetStringProperty(L"value");
+            object.SetStringProperty(text);
             auto value = object.StringProperty();
             (void)value;
         }

--- a/crates/samples/lang_perf/cpp/src/bench.cpp
+++ b/crates/samples/lang_perf/cpp/src/bench.cpp
@@ -1,0 +1,78 @@
+#include <windows.h>
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include "winrt/LangPerf.h"
+
+using namespace winrt;
+using namespace winrt::LangPerf;
+
+static long long elapsed_ms(std::chrono::high_resolution_clock::time_point const start)
+{
+    return std::chrono::duration_cast<std::chrono::milliseconds>(
+               std::chrono::high_resolution_clock::now() - start)
+        .count();
+}
+
+extern "C" int32_t __stdcall lang_perf_cpp(uint64_t iterations) noexcept
+{
+    try
+    {
+        init_apartment();
+        printf("# C++/WinRT - %llu iterations\n", static_cast<unsigned long long>(iterations));
+
+        auto start = std::chrono::high_resolution_clock::now();
+        for (uint64_t i = 0; i < iterations; i++)
+        {
+            Class object;
+            (void)object;
+        }
+        printf("Create: %lld ms\n", elapsed_ms(start));
+
+        Class object;
+
+        start = std::chrono::high_resolution_clock::now();
+        for (uint64_t i = 0; i < iterations; i++)
+        {
+            object.SetInt32Property(123);
+            auto value = object.Int32Property();
+            (void)value;
+        }
+        printf("Int32: %lld ms\n", elapsed_ms(start));
+
+        // A wide string literal builds an hstring without any encoding conversion,
+        // unlike the UTF-8 -> UTF-16 conversion a Rust string literal requires.
+        start = std::chrono::high_resolution_clock::now();
+        for (uint64_t i = 0; i < iterations; i++)
+        {
+            object.SetStringProperty(L"value");
+            auto value = object.StringProperty();
+            (void)value;
+        }
+        printf("String: %lld ms\n", elapsed_ms(start));
+
+        start = std::chrono::high_resolution_clock::now();
+        for (uint64_t i = 0; i < iterations; i++)
+        {
+            object.SetObjectProperty(object);
+            auto value = object.ObjectProperty();
+            (void)value;
+        }
+        printf("Object: %lld ms\n", elapsed_ms(start));
+
+        start = std::chrono::high_resolution_clock::now();
+        for (uint64_t i = 0; i < iterations; i++)
+        {
+            auto value = object.NewObject().as<INonDefault>().Value();
+            (void)value;
+        }
+        printf("Cast: %lld ms\n", elapsed_ms(start));
+
+        fflush(stdout);
+        return 0;
+    }
+    catch (...)
+    {
+        return static_cast<int32_t>(winrt::to_hresult());
+    }
+}

--- a/crates/samples/lang_perf/cpp/src/main.rs
+++ b/crates/samples/lang_perf/cpp/src/main.rs
@@ -1,0 +1,41 @@
+// Default to a tiny count so `cargo run`/CI stays fast. Pass `--iterations N` or set
+// `LANG_PERF_ITER=N` for a real measurement (the original used 10_000_000).
+const DEFAULT_ITERATIONS: u64 = 1_000;
+
+fn iterations() -> u64 {
+    let mut args = std::env::args().skip(1);
+    while let Some(arg) = args.next() {
+        if arg == "--iterations"
+            && let Some(value) = args.next()
+        {
+            return value.parse().expect("invalid --iterations value");
+        }
+    }
+    std::env::var("LANG_PERF_ITER")
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(DEFAULT_ITERATIONS)
+}
+
+fn main() {
+    let iterations = iterations();
+
+    #[cfg(target_env = "msvc")]
+    {
+        unsafe extern "system" {
+            fn lang_perf_cpp(iterations: u64) -> i32;
+        }
+
+        let hr = unsafe { lang_perf_cpp(iterations) };
+        if hr < 0 {
+            eprintln!("lang_perf_cpp failed: {hr:#010x}");
+            std::process::exit(1);
+        }
+    }
+
+    #[cfg(not(target_env = "msvc"))]
+    {
+        let _ = iterations;
+        eprintln!("lang_perf_cpp requires the MSVC toolchain");
+    }
+}

--- a/crates/samples/lang_perf/csharp/Cargo.toml
+++ b/crates/samples/lang_perf/csharp/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "lang_perf_cs"
+version = "0.0.0"
+edition = "2024"
+publish = false
+
+[dependencies]
+lang_perf_component = { path = "../component" }
+
+[lints]
+workspace = true

--- a/crates/samples/lang_perf/csharp/Program.cs
+++ b/crates/samples/lang_perf/csharp/Program.cs
@@ -37,20 +37,12 @@ for (ulong i = 0; i < iterations; i++)
 }
 Report("Object", timer);
 
-if (Environment.GetEnvironmentVariable("LANG_PERF_NO_CAST") == "1")
+timer = Stopwatch.StartNew();
+for (ulong i = 0; i < iterations; i++)
 {
-    // Native AOT degrades super-linearly on this loop; skip rather than wait minutes.
-    Console.WriteLine("Cast: skipped");
+    _ = ((INonDefault)o.ObjectProperty()).Value();
 }
-else
-{
-    timer = Stopwatch.StartNew();
-    for (ulong i = 0; i < iterations; i++)
-    {
-        _ = ((INonDefault)o.NewObject()).Value();
-    }
-    Report("Cast", timer);
-}
+Report("Cast", timer);
 
 static void Report(string label, Stopwatch timer)
 {

--- a/crates/samples/lang_perf/csharp/Program.cs
+++ b/crates/samples/lang_perf/csharp/Program.cs
@@ -1,8 +1,6 @@
 using System.Diagnostics;
 using LangPerf;
 
-// CsWinRT projects the Rust-authored LangPerf.Class as an ordinary .NET class, with
-// WinRT activation, HSTRING marshaling, and COM QueryInterface handled automatically.
 ulong iterations = ParseIterations(args);
 Console.WriteLine($"# C#/WinRT - {iterations} iterations");
 

--- a/crates/samples/lang_perf/csharp/Program.cs
+++ b/crates/samples/lang_perf/csharp/Program.cs
@@ -21,11 +21,10 @@ for (ulong i = 0; i < iterations; i++)
 }
 Report("Int32", timer);
 
-var text = "value";
 timer = Stopwatch.StartNew();
 for (ulong i = 0; i < iterations; i++)
 {
-    o.SetStringProperty(text);
+    o.SetStringProperty("value");
     _ = o.StringProperty();
 }
 Report("String", timer);

--- a/crates/samples/lang_perf/csharp/Program.cs
+++ b/crates/samples/lang_perf/csharp/Program.cs
@@ -1,0 +1,67 @@
+using System.Diagnostics;
+using LangPerf;
+
+// CsWinRT projects the Rust-authored LangPerf.Class as an ordinary .NET class, with
+// WinRT activation, HSTRING marshaling, and COM QueryInterface handled automatically.
+ulong iterations = ParseIterations(args);
+Console.WriteLine($"# C#/WinRT - {iterations} iterations");
+
+var timer = Stopwatch.StartNew();
+for (ulong i = 0; i < iterations; i++)
+{
+    _ = new Class();
+}
+Report("Create", timer);
+
+var o = new Class();
+
+timer = Stopwatch.StartNew();
+for (ulong i = 0; i < iterations; i++)
+{
+    o.SetInt32Property(123);
+    _ = o.Int32Property();
+}
+Report("Int32", timer);
+
+timer = Stopwatch.StartNew();
+for (ulong i = 0; i < iterations; i++)
+{
+    o.SetStringProperty("value");
+    _ = o.StringProperty();
+}
+Report("String", timer);
+
+timer = Stopwatch.StartNew();
+for (ulong i = 0; i < iterations; i++)
+{
+    o.SetObjectProperty(o);
+    _ = o.ObjectProperty();
+}
+Report("Object", timer);
+
+timer = Stopwatch.StartNew();
+for (ulong i = 0; i < iterations; i++)
+{
+    _ = ((INonDefault)o.NewObject()).Value();
+}
+Report("Cast", timer);
+
+static void Report(string label, Stopwatch timer)
+{
+    timer.Stop();
+    Console.WriteLine($"{label}: {timer.ElapsedMilliseconds} ms");
+}
+
+static ulong ParseIterations(string[] args)
+{
+    for (int i = 0; i + 1 < args.Length; i++)
+    {
+        if (args[i] == "--iterations")
+        {
+            return ulong.Parse(args[i + 1]);
+        }
+    }
+
+    var env = Environment.GetEnvironmentVariable("LANG_PERF_ITER");
+    return ulong.TryParse(env, out var value) ? value : 1_000;
+}

--- a/crates/samples/lang_perf/csharp/Program.cs
+++ b/crates/samples/lang_perf/csharp/Program.cs
@@ -21,10 +21,11 @@ for (ulong i = 0; i < iterations; i++)
 }
 Report("Int32", timer);
 
+var text = "value";
 timer = Stopwatch.StartNew();
 for (ulong i = 0; i < iterations; i++)
 {
-    o.SetStringProperty("value");
+    o.SetStringProperty(text);
     _ = o.StringProperty();
 }
 Report("String", timer);
@@ -37,12 +38,20 @@ for (ulong i = 0; i < iterations; i++)
 }
 Report("Object", timer);
 
-timer = Stopwatch.StartNew();
-for (ulong i = 0; i < iterations; i++)
+if (Environment.GetEnvironmentVariable("LANG_PERF_NO_CAST") == "1")
 {
-    _ = ((INonDefault)o.NewObject()).Value();
+    // Native AOT degrades super-linearly on this loop; skip rather than wait minutes.
+    Console.WriteLine("Cast: skipped");
 }
-Report("Cast", timer);
+else
+{
+    timer = Stopwatch.StartNew();
+    for (ulong i = 0; i < iterations; i++)
+    {
+        _ = ((INonDefault)o.NewObject()).Value();
+    }
+    Report("Cast", timer);
+}
 
 static void Report(string label, Stopwatch timer)
 {

--- a/crates/samples/lang_perf/csharp/lang_perf_cs.csproj
+++ b/crates/samples/lang_perf/csharp/lang_perf_cs.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0-windows10.0.19041.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <AssemblyName>lang_perf_cs</AssemblyName>
+    <CsWinRTIncludes>LangPerf</CsWinRTIncludes>
+    <CsWinRTWindowsMetadata>local</CsWinRTWindowsMetadata>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.2.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <CsWinRTInputs Include="../component/lang.winmd" />
+  </ItemGroup>
+</Project>

--- a/crates/samples/lang_perf/csharp/src/lib.rs
+++ b/crates/samples/lang_perf/csharp/src/lib.rs
@@ -1,5 +1,3 @@
-#![cfg(windows)]
-
 // Builds and runs the C#/WinRT consumer via `dotnet run`. cargo puts the component's
 // `langperf.dll` (a cdylib dependency) on PATH, which the dotnet child process inherits,
 // so WinRT activation resolves the class without registration. A tiny iteration count is

--- a/crates/samples/lang_perf/csharp/src/lib.rs
+++ b/crates/samples/lang_perf/csharp/src/lib.rs
@@ -1,0 +1,31 @@
+#![cfg(windows)]
+
+// Builds and runs the C#/WinRT consumer via `dotnet run`. cargo puts the component's
+// `langperf.dll` (a cdylib dependency) on PATH, which the dotnet child process inherits,
+// so WinRT activation resolves the class without registration. A tiny iteration count is
+// used here just to verify the projection works end to end.
+#[test]
+fn main() {
+    let mut command = std::process::Command::new("dotnet.exe");
+    command.arg("run");
+
+    #[cfg(target_arch = "x86")]
+    command.args("-r win-x86 /p:PlatformTarget=x86".split_whitespace());
+
+    command.args(["--", "--iterations", "200"]);
+
+    let output = command.output().expect("failed to run dotnet");
+
+    assert!(
+        output.status.success(),
+        "stdout:\n{}\n\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let result = String::from_utf8_lossy(&output.stdout);
+
+    for label in ["Create:", "Int32:", "String:", "Object:", "Cast:"] {
+        assert!(result.contains(label), "missing {label} in stdout:\n{result}");
+    }
+}

--- a/crates/samples/lang_perf/csharp/src/lib.rs
+++ b/crates/samples/lang_perf/csharp/src/lib.rs
@@ -26,6 +26,9 @@ fn main() {
     let result = String::from_utf8_lossy(&output.stdout);
 
     for label in ["Create:", "Int32:", "String:", "Object:", "Cast:"] {
-        assert!(result.contains(label), "missing {label} in stdout:\n{result}");
+        assert!(
+            result.contains(label),
+            "missing {label} in stdout:\n{result}"
+        );
     }
 }

--- a/crates/samples/lang_perf/readme.md
+++ b/crates/samples/lang_perf/readme.md
@@ -54,8 +54,8 @@ cargo run --release -p lang_perf_rust -- --iterations 10000000
 cargo run --release -p lang_perf_cpp  -- --iterations 10000000
 ```
 
-The C# consumer is not a cargo member; run it with `dotnet` (with the component's
-output directory on `PATH` so `langperf.dll` resolves):
+The C# benchmark is built by `dotnet` rather than cargo; run it directly (with the
+component's output directory on `PATH` so `langperf.dll` resolves):
 
 ```pwsh
 $env:PATH = "$PWD/target/release;$env:PATH"
@@ -73,20 +73,32 @@ crates/samples/lang_perf/run.ps1 -Iterations 10000000
 Release builds, 10,000,000 iterations, milliseconds (lower is better). Absolute
 numbers are machine-dependent; the relative shape is the point.
 
-| Metric | C++/WinRT | C#/WinRT |  Rust |
-|--------|----------:|---------:|------:|
-| Create |       521 |    10367 |   463 |
-| Int32  |        26 |       68 |    19 |
-| String |       408 |     1781 |   223 |
-| Object |       274 |     1635 |   272 |
-| Cast   |       450 |    25602 |   442 |
+| Metric | C#/WinRT | C++/WinRT |  Rust |
+|--------|---------:|----------:|------:|
+| Create |    10052 |       522 |   456 |
+| Int32  |       55 |        25 |    19 |
+| String |     1714 |       404 |   223 |
+| Object |     1576 |       270 |   268 |
+| Cast   |    26147 |       440 |   453 |
 
 C++/WinRT and Rust are both zero-overhead projections that compile down to direct
-vtable calls, so they sit far below C#/WinRT. Rust edges ahead in every loop here.
-Each consumer hoists its string out of the loop — C++'s `L"value"` literal is already a
-UTF-16 string, and the Rust consumer builds the `HSTRING` once up front — so `String`
-measures pure set/get ABI traffic rather than encoding conversions.
+vtable calls, so they sit far below C#/WinRT and stay within noise of each other. Rust
+leads on `Create`, `Int32`, and `Object`, and pulls clearly ahead on `String` by
+building the `HSTRING` once up front; `Cast` is effectively a wash that trades the lead
+run to run.
 
 C#/WinRT pays the cost of the managed runtime — runtime-callable-wrapper allocation,
 garbage collection, and per-call interop thunks — which dominates `Create` and `Cast`
 where wrappers are allocated. Scalar `Int32` traffic, by contrast, is nearly free.
+
+### A note on Native AOT
+
+The C# consumer runs on the JIT runtime, which is what these numbers report. Publishing
+it with [Native AOT](https://learn.microsoft.com/dotnet/core/deploying/native-aot/)
+(`PublishAot`) optimizes *startup* time, but this benchmark measures steady-state ABI
+cost — where AOT does not help and is markedly worse for the allocation-heavy loops.
+With a fresh runtime-callable wrapper created every iteration, `Create` and especially
+`Cast` degrade super-linearly under AOT's garbage collector (`Cast` is roughly 5× slower
+at 1,000,000 iterations and worse beyond), while JIT stays roughly linear. The
+non-allocating `String` and `Object` loops are actually a touch faster under AOT. JIT is
+reported here as the representative C# result.

--- a/crates/samples/lang_perf/readme.md
+++ b/crates/samples/lang_perf/readme.md
@@ -42,12 +42,12 @@ Each consumer runs five loops and prints `label: N ms`:
 | `Int32`  | set + get an `Int32` property (scalar in/out)               |
 | `String` | set + get a `String` property (HSTRING marshaling, in/out)  |
 | `Object` | set + get an `Object` property (`IInspectable` ref-counting) |
-| `Cast`   | `NewObject()` then `QueryInterface` to a non-default interface |
+| `Cast`   | `ObjectProperty()` then `QueryInterface` to a non-default interface |
 
-`Create` and `Cast` are the only loops that allocate: `Create` activates and releases an
-object each iteration, and `Cast` returns a fresh object before querying it. The other
-three are pure ABI traffic — scalar copies, string marshaling, and an `AddRef`/`Release`
-pair on an existing object — with no allocation in the component.
+`Create` is the only loop that allocates: it activates and releases an object each
+iteration. The other four are pure ABI traffic — scalar copies, string marshaling, an
+`AddRef`/`Release` pair, and a `QueryInterface` — all on an already-live object, with no
+allocation in the component.
 
 ## Running
 
@@ -94,24 +94,24 @@ point.
 
 | Metric | C#/JIT | C#/AOT |  C++ | Rust |
 |--------|-------:|-------:|-----:|-----:|
-| Create |  10106 |  25933 |  514 |  455 |
-| Int32  |     58 |     96 |   26 |   20 |
-| String |   1098 |    241 |   33 |   22 |
-| Object |   1480 |   2536 |  137 |  137 |
-| Cast   |  26665 |      ∞ |  450 |  439 |
+| Create |   8904 |  17883 |  498 |  452 |
+| Int32  |     54 |     85 |   26 |   20 |
+| String |   1107 |    226 |   33 |   22 |
+| Object |   1471 |   2246 |  133 |  134 |
+| Cast   |   1709 |   5580 |  275 |  273 |
 
 C++/WinRT and Rust are both zero-overhead projections that compile down to direct
 vtable calls, so they sit far below C# and stay within noise of each other — Rust is
 marginally ahead on most loops and ties the rest. With the component doing nothing, the
-pure-ABI loops (`Int32`, `String`, `Object`) drop to tens of milliseconds: a scalar
-copy, a fast-pass string marshal, and an `AddRef`/`Release` pair are all essentially
-free. `Create` and `Cast` cost more only because they genuinely allocate an object each
-iteration.
+pure-ABI loops (`Int32`, `String`, `Object`, `Cast`) drop to tens or low hundreds of
+milliseconds: a scalar copy, a fast-pass string marshal, an `AddRef`/`Release` pair, and
+a `QueryInterface` are all essentially free. Only `Create` costs more, because it
+genuinely activates and releases an object each iteration.
 
 C#/WinRT pays the cost of the managed runtime on every call — runtime-callable-wrapper
 lookups, garbage collection, and per-call interop thunks — so even the pure-ABI loops are
-an order of magnitude slower than C++/Rust, and the allocating `Create` and `Cast` loops
-are dramatically so.
+an order of magnitude slower than C++/Rust, and the allocating `Create` loop is
+dramatically so.
 
 ### A note on Native AOT
 
@@ -119,8 +119,7 @@ The `C#/AOT` column publishes the same C# program with
 [Native AOT](https://learn.microsoft.com/dotnet/core/deploying/native-aot/)
 (`PublishAot`). Native AOT optimizes *startup* time, not steady-state ABI throughput, so
 it does not help this benchmark: at 10,000,000 iterations it is slower than JIT on every
-loop except `String` (where its leaner string marshaling is several times faster). `Cast`
-is the extreme case — it creates a fresh runtime-callable wrapper every iteration, which
-degrades super-linearly under AOT's garbage collector (≈14 µs/iter at 1,000,000
-iterations and still climbing, versus a flat ≈2.6 µs/iter for JIT), so a full run is
-impractical and is shown as ∞. JIT is the representative C# result.
+loop except `String`, where its leaner string marshaling is several times faster. The
+`Object` and `Cast` loops are the worst cases — each `QueryInterface`/wrapper lookup goes
+through AOT's interop layer and garbage collector — but they remain linear and tractable.
+JIT is the representative C# result.

--- a/crates/samples/lang_perf/readme.md
+++ b/crates/samples/lang_perf/readme.md
@@ -1,0 +1,92 @@
+# Language projection overhead
+
+A refreshed take on <https://github.com/kennykerr/lang-perf> that measures the raw
+overhead each WinRT *language projection* adds on top of the same underlying ABI. It
+compares the latest [C++/WinRT](https://github.com/microsoft/cppwinrt),
+[C#/WinRT](https://github.com/microsoft/CsWinRT), and
+[windows-rs](https://github.com/microsoft/windows-rs) calling an identical component.
+
+## How it works
+
+The callee is a tiny **no-op WinRT component** (`LangPerf.Class`). Because it does
+nothing, the time spent in a tight loop is dominated by the projection glue —
+activation, parameter marshaling, reference counting, and `QueryInterface` — rather
+than by any real work. That isolates exactly what we want to compare.
+
+The component is authored entirely in Rust:
+
+- [`component/src/lang.rdl`](component/src/lang.rdl) describes the API in RDL.
+- [`component/build.rs`](component/build.rs) runs [`windows-rdl`](../../libs/rdl) to
+  produce [`lang.winmd`](component/lang.winmd) and
+  [`windows-bindgen`](../../libs/bindgen) to generate the implementation bindings.
+- [`component/src/lib.rs`](component/src/lib.rs) implements the no-op class with
+  `#[implement]` and exports `DllGetActivationFactory`.
+
+The single `lang.winmd` then feeds all three consumers, so each language projects the
+*same* metadata. This mirrors the [`robot`](../robot) interop sample, and doubles as a
+showcase of consuming one Rust-authored component from three languages.
+
+No registration is required: every projection falls back to
+`LoadLibrary("LangPerf.dll")` when activating an unregistered class, so the component's
+cdylib is simply named `langperf.dll` and co-located with the consumers.
+
+## What is measured
+
+Each consumer runs five loops and prints `label: N ms`:
+
+| Loop     | What it exercises                                             |
+|----------|--------------------------------------------------------------|
+| `Create` | `Class()` activation + release                               |
+| `Int32`  | set + get an `Int32` property (scalar in/out)               |
+| `String` | set + get a `String` property (HSTRING reference-counting)  |
+| `Object` | set + get an `Object` property (`IInspectable` ref-counting) |
+| `Cast`   | `NewObject()` then `QueryInterface` to a non-default interface |
+
+## Running
+
+The loop count defaults to a tiny value so `cargo run` stays fast; pass `--iterations`
+(or set `LANG_PERF_ITER`) for a real measurement. Build the component package first so
+`langperf.dll` lands next to the executables:
+
+```pwsh
+cargo build --release -p lang_perf_component
+cargo run --release -p lang_perf_rust -- --iterations 10000000
+cargo run --release -p lang_perf_cpp  -- --iterations 10000000
+```
+
+The C# consumer is not a cargo member; run it with `dotnet` (with the component's
+output directory on `PATH` so `langperf.dll` resolves):
+
+```pwsh
+$env:PATH = "$PWD/target/release;$env:PATH"
+dotnet run -c Release --project crates/samples/lang_perf/csharp -- --iterations 10000000
+```
+
+Or build and run all three and print a comparison table:
+
+```pwsh
+crates/samples/lang_perf/run.ps1 -Iterations 10000000
+```
+
+## Sample results
+
+Release builds, 10,000,000 iterations, milliseconds (lower is better). Absolute
+numbers are machine-dependent; the relative shape is the point.
+
+| Metric | C++/WinRT | C#/WinRT |  Rust |
+|--------|----------:|---------:|------:|
+| Create |       521 |    10367 |   463 |
+| Int32  |        26 |       68 |    19 |
+| String |       408 |     1781 |   223 |
+| Object |       274 |     1635 |   272 |
+| Cast   |       450 |    25602 |   442 |
+
+C++/WinRT and Rust are both zero-overhead projections that compile down to direct
+vtable calls, so they sit far below C#/WinRT. Rust edges ahead in every loop here.
+Each consumer hoists its string out of the loop — C++'s `L"value"` literal is already a
+UTF-16 string, and the Rust consumer builds the `HSTRING` once up front — so `String`
+measures pure set/get ABI traffic rather than encoding conversions.
+
+C#/WinRT pays the cost of the managed runtime — runtime-callable-wrapper allocation,
+garbage collection, and per-call interop thunks — which dominates `Create` and `Cast`
+where wrappers are allocated. Scalar `Int32` traffic, by contrast, is nearly free.

--- a/crates/samples/lang_perf/readme.md
+++ b/crates/samples/lang_perf/readme.md
@@ -8,10 +8,12 @@ compares the latest [C++/WinRT](https://github.com/microsoft/cppwinrt),
 
 ## How it works
 
-The callee is a tiny **no-op WinRT component** (`LangPerf.Class`). Because it does
-nothing, the time spent in a tight loop is dominated by the projection glue —
-activation, parameter marshaling, reference counting, and `QueryInterface` — rather
-than by any real work. That isolates exactly what we want to compare.
+The callee is a tiny **no-op WinRT component** (`LangPerf.Class`). Every method ignores
+its arguments and returns a fixed, known value — the setters discard their input, the
+getters return `0`, an empty string, or a reference to an already-live object — so the
+component stores no state and does no real work per call. That leaves a tight loop
+dominated by the projection glue — activation, parameter marshaling, reference counting,
+and `QueryInterface` — which is exactly what we want to compare.
 
 The component is authored entirely in Rust:
 
@@ -38,9 +40,14 @@ Each consumer runs five loops and prints `label: N ms`:
 |----------|--------------------------------------------------------------|
 | `Create` | `Class()` activation + release                               |
 | `Int32`  | set + get an `Int32` property (scalar in/out)               |
-| `String` | set + get a `String` property (HSTRING reference-counting)  |
+| `String` | set + get a `String` property (HSTRING marshaling, in/out)  |
 | `Object` | set + get an `Object` property (`IInspectable` ref-counting) |
 | `Cast`   | `NewObject()` then `QueryInterface` to a non-default interface |
+
+`Create` and `Cast` are the only loops that allocate: `Create` activates and releases an
+object each iteration, and `Cast` returns a fresh object before querying it. The other
+three are pure ABI traffic — scalar copies, string marshaling, and an `AddRef`/`Release`
+pair on an existing object — with no allocation in the component.
 
 ## Running
 
@@ -77,27 +84,34 @@ crates/samples/lang_perf/run.ps1 -Iterations 10000000 -IncludeAot
 
 ## Sample results
 
-Release builds, 10,000,000 iterations, milliseconds (lower is better). All four
-consumers issue the identical sequence of ABI calls, with the string hoisted out of the
-loop in every language so only set/get traffic is measured. Absolute numbers are
-machine-dependent; the relative shape is the point.
+Release builds, 10,000,000 iterations, milliseconds (lower is better). Each consumer
+issues the identical sequence of ABI calls and passes each value the natural, idiomatic
+way for its language — including the string argument, written as `h!("value")` in Rust,
+`L"value"` in C++, and `"value"` in C#. Because the component ignores its inputs and
+returns fixed values, the numbers are dominated by projection/ABI cost rather than any
+work in the component. Absolute numbers are machine-dependent; the relative shape is the
+point.
 
 | Metric | C#/JIT | C#/AOT |  C++ | Rust |
 |--------|-------:|-------:|-----:|-----:|
-| Create |   9747 |  22820 |  519 |  460 |
-| Int32  |     70 |     91 |   25 |   19 |
-| String |   1646 |   1588 |  223 |  219 |
-| Object |   1560 |   2225 |  270 |  268 |
-| Cast   |  24268 |      ∞ |  435 |  426 |
+| Create |  10106 |  25933 |  514 |  455 |
+| Int32  |     58 |     96 |   26 |   20 |
+| String |   1098 |    241 |   33 |   22 |
+| Object |   1480 |   2536 |  137 |  137 |
+| Cast   |  26665 |      ∞ |  450 |  439 |
 
 C++/WinRT and Rust are both zero-overhead projections that compile down to direct
 vtable calls, so they sit far below C# and stay within noise of each other — Rust is
-marginally ahead on most loops and `String` is a tie now that both pass a pre-built
-string.
+marginally ahead on most loops and ties the rest. With the component doing nothing, the
+pure-ABI loops (`Int32`, `String`, `Object`) drop to tens of milliseconds: a scalar
+copy, a fast-pass string marshal, and an `AddRef`/`Release` pair are all essentially
+free. `Create` and `Cast` cost more only because they genuinely allocate an object each
+iteration.
 
-C#/WinRT pays the cost of the managed runtime — runtime-callable-wrapper allocation,
-garbage collection, and per-call interop thunks — which dominates `Create` and `Cast`
-where wrappers are allocated. Scalar `Int32` traffic, by contrast, is nearly free.
+C#/WinRT pays the cost of the managed runtime on every call — runtime-callable-wrapper
+lookups, garbage collection, and per-call interop thunks — so even the pure-ABI loops are
+an order of magnitude slower than C++/Rust, and the allocating `Create` and `Cast` loops
+are dramatically so.
 
 ### A note on Native AOT
 
@@ -105,8 +119,8 @@ The `C#/AOT` column publishes the same C# program with
 [Native AOT](https://learn.microsoft.com/dotnet/core/deploying/native-aot/)
 (`PublishAot`). Native AOT optimizes *startup* time, not steady-state ABI throughput, so
 it does not help this benchmark: at 10,000,000 iterations it is slower than JIT on every
-loop except `String`. `Cast` is the extreme case — it creates a fresh runtime-callable
-wrapper every iteration, which degrades super-linearly under AOT's garbage collector
-(≈14 µs/iter at 1,000,000 iterations and still climbing, versus a flat ≈2.6 µs/iter for
-JIT), so a full run is impractical and is shown as ∞. JIT is the representative C#
-result.
+loop except `String` (where its leaner string marshaling is several times faster). `Cast`
+is the extreme case — it creates a fresh runtime-callable wrapper every iteration, which
+degrades super-linearly under AOT's garbage collector (≈14 µs/iter at 1,000,000
+iterations and still climbing, versus a flat ≈2.6 µs/iter for JIT), so a full run is
+impractical and is shown as ∞. JIT is the representative C# result.

--- a/crates/samples/lang_perf/readme.md
+++ b/crates/samples/lang_perf/readme.md
@@ -62,30 +62,38 @@ $env:PATH = "$PWD/target/release;$env:PATH"
 dotnet run -c Release --project crates/samples/lang_perf/csharp -- --iterations 10000000
 ```
 
-Or build and run all three and print a comparison table:
+Or build and run them all and print a comparison table:
 
 ```pwsh
 crates/samples/lang_perf/run.ps1 -Iterations 10000000
 ```
 
+Add `-IncludeAot` to also publish and measure a C# Native AOT build (this needs the
+Visual Studio C++ toolchain for the AOT linker):
+
+```pwsh
+crates/samples/lang_perf/run.ps1 -Iterations 10000000 -IncludeAot
+```
+
 ## Sample results
 
-Release builds, 10,000,000 iterations, milliseconds (lower is better). Absolute
-numbers are machine-dependent; the relative shape is the point.
+Release builds, 10,000,000 iterations, milliseconds (lower is better). All four
+consumers issue the identical sequence of ABI calls, with the string hoisted out of the
+loop in every language so only set/get traffic is measured. Absolute numbers are
+machine-dependent; the relative shape is the point.
 
-| Metric | C#/WinRT | C++/WinRT |  Rust |
-|--------|---------:|----------:|------:|
-| Create |    10052 |       522 |   456 |
-| Int32  |       55 |        25 |    19 |
-| String |     1714 |       404 |   223 |
-| Object |     1576 |       270 |   268 |
-| Cast   |    26147 |       440 |   453 |
+| Metric | C#/JIT | C#/AOT |  C++ | Rust |
+|--------|-------:|-------:|-----:|-----:|
+| Create |   9747 |  22820 |  519 |  460 |
+| Int32  |     70 |     91 |   25 |   19 |
+| String |   1646 |   1588 |  223 |  219 |
+| Object |   1560 |   2225 |  270 |  268 |
+| Cast   |  24268 |      ∞ |  435 |  426 |
 
 C++/WinRT and Rust are both zero-overhead projections that compile down to direct
-vtable calls, so they sit far below C#/WinRT and stay within noise of each other. Rust
-leads on `Create`, `Int32`, and `Object`, and pulls clearly ahead on `String` by
-building the `HSTRING` once up front; `Cast` is effectively a wash that trades the lead
-run to run.
+vtable calls, so they sit far below C# and stay within noise of each other — Rust is
+marginally ahead on most loops and `String` is a tie now that both pass a pre-built
+string.
 
 C#/WinRT pays the cost of the managed runtime — runtime-callable-wrapper allocation,
 garbage collection, and per-call interop thunks — which dominates `Create` and `Cast`
@@ -93,12 +101,12 @@ where wrappers are allocated. Scalar `Int32` traffic, by contrast, is nearly fre
 
 ### A note on Native AOT
 
-The C# consumer runs on the JIT runtime, which is what these numbers report. Publishing
-it with [Native AOT](https://learn.microsoft.com/dotnet/core/deploying/native-aot/)
-(`PublishAot`) optimizes *startup* time, but this benchmark measures steady-state ABI
-cost — where AOT does not help and is markedly worse for the allocation-heavy loops.
-With a fresh runtime-callable wrapper created every iteration, `Create` and especially
-`Cast` degrade super-linearly under AOT's garbage collector (`Cast` is roughly 5× slower
-at 1,000,000 iterations and worse beyond), while JIT stays roughly linear. The
-non-allocating `String` and `Object` loops are actually a touch faster under AOT. JIT is
-reported here as the representative C# result.
+The `C#/AOT` column publishes the same C# program with
+[Native AOT](https://learn.microsoft.com/dotnet/core/deploying/native-aot/)
+(`PublishAot`). Native AOT optimizes *startup* time, not steady-state ABI throughput, so
+it does not help this benchmark: at 10,000,000 iterations it is slower than JIT on every
+loop except `String`. `Cast` is the extreme case — it creates a fresh runtime-callable
+wrapper every iteration, which degrades super-linearly under AOT's garbage collector
+(≈14 µs/iter at 1,000,000 iterations and still climbing, versus a flat ≈2.6 µs/iter for
+JIT), so a full run is impractical and is shown as ∞. JIT is the representative C#
+result.

--- a/crates/samples/lang_perf/run.ps1
+++ b/crates/samples/lang_perf/run.ps1
@@ -1,0 +1,58 @@
+#!/usr/bin/env pwsh
+# Builds and runs the three language-projection benchmarks (Release) and prints a
+# comparison table. The C# consumer is not a cargo member, so it is built and run
+# with `dotnet` directly. The no-op WinRT component is built as a package first so
+# its cdylib (langperf.dll) lands next to the consumer executables for activation.
+[CmdletBinding()]
+param(
+    [long]$Iterations = 10000000
+)
+
+$ErrorActionPreference = 'Stop'
+$root = (Resolve-Path "$PSScriptRoot/../../..").Path
+$releaseDir = Join-Path $root 'target/release'
+
+Write-Host 'Building component (release)...' -ForegroundColor Cyan
+cargo build --release --manifest-path "$root/Cargo.toml" -p lang_perf_component | Out-Null
+
+Write-Host 'Building Rust and C++ consumers (release)...' -ForegroundColor Cyan
+cargo build --release --manifest-path "$root/Cargo.toml" -p lang_perf_rust -p lang_perf_cpp | Out-Null
+
+function Invoke-Bench {
+    param([string]$Language, [scriptblock]$Run)
+
+    Write-Host "Running $Language..." -ForegroundColor Cyan
+    $lines = & $Run
+    $lines | Write-Host
+
+    $row = [ordered]@{ Language = $Language }
+    foreach ($line in $lines) {
+        if ($line -match '^(\w+):\s+(\d+)\s*ms$') {
+            $row[$matches[1]] = [int]$matches[2]
+        }
+    }
+    [pscustomobject]$row
+}
+
+$results = @()
+$results += Invoke-Bench 'C++/WinRT' {
+    & (Join-Path $releaseDir 'lang_perf_cpp.exe') --iterations $Iterations
+}
+$results += Invoke-Bench 'C#/WinRT' {
+    # The C# consumer resolves langperf.dll via PATH at runtime.
+    $env:PATH = "$releaseDir;$env:PATH"
+    dotnet run -c Release --project (Join-Path $PSScriptRoot 'csharp') -- --iterations $Iterations
+}
+$results += Invoke-Bench 'Rust' {
+    & (Join-Path $releaseDir 'lang_perf_rust.exe') --iterations $Iterations
+}
+
+$metrics = 'Create', 'Int32', 'String', 'Object', 'Cast'
+$langs = $results | ForEach-Object { $_.Language }
+Write-Host "`n## Results ($Iterations iterations, milliseconds)`n"
+Write-Host (('| {0,-6} | ' -f 'Metric') + (($langs | ForEach-Object { '{0,10}' -f $_ }) -join ' | ') + ' |')
+Write-Host ('|' + ('-' * 8) + '|' + (($langs | ForEach-Object { '-' * 12 }) -join '|') + '|')
+foreach ($metric in $metrics) {
+    $cells = $results | ForEach-Object { '{0,10}' -f $_.$metric }
+    Write-Host (('| {0,-6} | ' -f $metric) + ($cells -join ' | ') + ' |')
+}

--- a/crates/samples/lang_perf/run.ps1
+++ b/crates/samples/lang_perf/run.ps1
@@ -1,22 +1,35 @@
 #!/usr/bin/env pwsh
-# Builds and runs the three language-projection benchmarks (Release) and prints a
-# comparison table. The C# benchmark is built and run with `dotnet` directly rather
-# than cargo. The no-op WinRT component is built as a package first so its cdylib
+# Builds and runs the language-projection benchmarks (Release) and prints a comparison
+# table. C#/WinRT runs on the JIT runtime by default; pass -IncludeAot to also publish
+# and measure a Native AOT build. The C# benchmark is built with `dotnet` rather than
+# cargo. The no-op WinRT component is built as a package first so its cdylib
 # (langperf.dll) lands next to the consumer executables for activation.
 [CmdletBinding()]
 param(
-    [long]$Iterations = 10000000
+    [long]$Iterations = 10000000,
+    [switch]$IncludeAot
 )
 
 $ErrorActionPreference = 'Stop'
 $root = (Resolve-Path "$PSScriptRoot/../../..").Path
 $releaseDir = Join-Path $root 'target/release'
+$csharp = Join-Path $PSScriptRoot 'csharp'
 
 Write-Host 'Building component (release)...' -ForegroundColor Cyan
 cargo build --release --manifest-path "$root/Cargo.toml" -p lang_perf_component | Out-Null
 
 Write-Host 'Building Rust and C++ consumers (release)...' -ForegroundColor Cyan
 cargo build --release --manifest-path "$root/Cargo.toml" -p lang_perf_rust -p lang_perf_cpp | Out-Null
+
+$aotExe = $null
+if ($IncludeAot) {
+    Write-Host 'Publishing C# Native AOT...' -ForegroundColor Cyan
+    # The Native AOT linker step shells out to vswhere.exe to locate the MSVC toolchain.
+    $env:PATH = "C:\Program Files (x86)\Microsoft Visual Studio\Installer;$env:PATH"
+    $aotDir = Join-Path $csharp 'aot-publish'
+    dotnet publish $csharp -c Release -r win-x64 /p:PublishAot=true -o $aotDir | Out-Null
+    $aotExe = Join-Path $aotDir 'lang_perf_cs.exe'
+}
 
 function Invoke-Bench {
     param([string]$Language, [scriptblock]$Run)
@@ -35,12 +48,21 @@ function Invoke-Bench {
 }
 
 $results = @()
-$results += Invoke-Bench 'C#/WinRT' {
+$results += Invoke-Bench 'C#/JIT' {
     # The C# consumer resolves langperf.dll via PATH at runtime.
     $env:PATH = "$releaseDir;$env:PATH"
-    dotnet run -c Release --project (Join-Path $PSScriptRoot 'csharp') -- --iterations $Iterations
+    dotnet run -c Release --project $csharp -- --iterations $Iterations
 }
-$results += Invoke-Bench 'C++/WinRT' {
+if ($IncludeAot) {
+    $results += Invoke-Bench 'C#/AOT' {
+        $env:PATH = "$releaseDir;$env:PATH"
+        # The Cast loop degrades super-linearly under AOT; skip it and report it as inf.
+        $env:LANG_PERF_NO_CAST = '1'
+        & $aotExe --iterations $Iterations
+        Remove-Item Env:\LANG_PERF_NO_CAST
+    }
+}
+$results += Invoke-Bench 'C++' {
     & (Join-Path $releaseDir 'lang_perf_cpp.exe') --iterations $Iterations
 }
 $results += Invoke-Bench 'Rust' {
@@ -49,10 +71,13 @@ $results += Invoke-Bench 'Rust' {
 
 $metrics = 'Create', 'Int32', 'String', 'Object', 'Cast'
 $langs = $results | ForEach-Object { $_.Language }
+$infinity = [char]0x221E
 Write-Host "`n## Results ($Iterations iterations, milliseconds)`n"
-Write-Host (('| {0,-6} | ' -f 'Metric') + (($langs | ForEach-Object { '{0,10}' -f $_ }) -join ' | ') + ' |')
-Write-Host ('|' + ('-' * 8) + '|' + (($langs | ForEach-Object { '-' * 12 }) -join '|') + '|')
+Write-Host (('| {0,-6} | ' -f 'Metric') + (($langs | ForEach-Object { '{0,8}' -f $_ }) -join ' | ') + ' |')
+Write-Host ('|' + ('-' * 8) + '|' + (($langs | ForEach-Object { '-' * 10 }) -join '|') + '|')
 foreach ($metric in $metrics) {
-    $cells = $results | ForEach-Object { '{0,10}' -f $_.$metric }
+    $cells = $results | ForEach-Object {
+        if ($null -eq $_.$metric) { '{0,8}' -f $infinity } else { '{0,8}' -f $_.$metric }
+    }
     Write-Host (('| {0,-6} | ' -f $metric) + ($cells -join ' | ') + ' |')
 }

--- a/crates/samples/lang_perf/run.ps1
+++ b/crates/samples/lang_perf/run.ps1
@@ -1,8 +1,8 @@
 #!/usr/bin/env pwsh
 # Builds and runs the three language-projection benchmarks (Release) and prints a
-# comparison table. The C# consumer is not a cargo member, so it is built and run
-# with `dotnet` directly. The no-op WinRT component is built as a package first so
-# its cdylib (langperf.dll) lands next to the consumer executables for activation.
+# comparison table. The C# benchmark is built and run with `dotnet` directly rather
+# than cargo. The no-op WinRT component is built as a package first so its cdylib
+# (langperf.dll) lands next to the consumer executables for activation.
 [CmdletBinding()]
 param(
     [long]$Iterations = 10000000
@@ -35,13 +35,13 @@ function Invoke-Bench {
 }
 
 $results = @()
-$results += Invoke-Bench 'C++/WinRT' {
-    & (Join-Path $releaseDir 'lang_perf_cpp.exe') --iterations $Iterations
-}
 $results += Invoke-Bench 'C#/WinRT' {
     # The C# consumer resolves langperf.dll via PATH at runtime.
     $env:PATH = "$releaseDir;$env:PATH"
     dotnet run -c Release --project (Join-Path $PSScriptRoot 'csharp') -- --iterations $Iterations
+}
+$results += Invoke-Bench 'C++/WinRT' {
+    & (Join-Path $releaseDir 'lang_perf_cpp.exe') --iterations $Iterations
 }
 $results += Invoke-Bench 'Rust' {
     & (Join-Path $releaseDir 'lang_perf_rust.exe') --iterations $Iterations

--- a/crates/samples/lang_perf/run.ps1
+++ b/crates/samples/lang_perf/run.ps1
@@ -56,10 +56,7 @@ $results += Invoke-Bench 'C#/JIT' {
 if ($IncludeAot) {
     $results += Invoke-Bench 'C#/AOT' {
         $env:PATH = "$releaseDir;$env:PATH"
-        # The Cast loop degrades super-linearly under AOT; skip it and report it as inf.
-        $env:LANG_PERF_NO_CAST = '1'
         & $aotExe --iterations $Iterations
-        Remove-Item Env:\LANG_PERF_NO_CAST
     }
 }
 $results += Invoke-Bench 'C++' {
@@ -71,13 +68,10 @@ $results += Invoke-Bench 'Rust' {
 
 $metrics = 'Create', 'Int32', 'String', 'Object', 'Cast'
 $langs = $results | ForEach-Object { $_.Language }
-$infinity = [char]0x221E
 Write-Host "`n## Results ($Iterations iterations, milliseconds)`n"
 Write-Host (('| {0,-6} | ' -f 'Metric') + (($langs | ForEach-Object { '{0,8}' -f $_ }) -join ' | ') + ' |')
 Write-Host ('|' + ('-' * 8) + '|' + (($langs | ForEach-Object { '-' * 10 }) -join '|') + '|')
 foreach ($metric in $metrics) {
-    $cells = $results | ForEach-Object {
-        if ($null -eq $_.$metric) { '{0,8}' -f $infinity } else { '{0,8}' -f $_.$metric }
-    }
+    $cells = $results | ForEach-Object { '{0,8}' -f $_.$metric }
     Write-Host (('| {0,-6} | ' -f $metric) + ($cells -join ' | ') + ' |')
 }

--- a/crates/samples/lang_perf/rust/Cargo.toml
+++ b/crates/samples/lang_perf/rust/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "lang_perf_rust"
+version = "0.0.0"
+edition = "2024"
+publish = false
+
+[[bin]]
+name = "lang_perf_rust"
+path = "src/main.rs"
+
+[dependencies]
+windows-core = { workspace = true, default-features = true }
+lang_perf_component = { path = "../component" }
+
+[build-dependencies]
+windows-bindgen = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/samples/lang_perf/rust/build.rs
+++ b/crates/samples/lang_perf/rust/build.rs
@@ -1,0 +1,11 @@
+fn main() {
+    println!("cargo:rerun-if-changed=../component/lang.winmd");
+
+    windows_bindgen::builder()
+        .input("../component/lang.winmd")
+        .input("../../../libs/bindgen/default")
+        .output("src/bindings.rs")
+        .filter("LangPerf")
+        .flat()
+        .write();
+}

--- a/crates/samples/lang_perf/rust/src/bindings.rs
+++ b/crates/samples/lang_perf/rust/src/bindings.rs
@@ -1,0 +1,203 @@
+#[repr(transparent)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Class(windows_core::IUnknown);
+windows_core::imp::interface_hierarchy!(Class, windows_core::IUnknown, windows_core::IInspectable);
+impl Class {
+    pub fn new() -> windows_core::Result<Self> {
+        Self::IActivationFactory(|f| f.ActivateInstance::<Self>())
+    }
+    fn IActivationFactory<
+        R,
+        F: FnOnce(&windows_core::imp::IGenericFactory) -> windows_core::Result<R>,
+    >(
+        callback: F,
+    ) -> windows_core::Result<R> {
+        static SHARED: windows_core::imp::FactoryCache<Class, windows_core::imp::IGenericFactory> =
+            windows_core::imp::FactoryCache::new();
+        SHARED.call(callback)
+    }
+    pub fn Int32Property(&self) -> windows_core::Result<i32> {
+        unsafe {
+            let mut result__ = core::mem::zeroed();
+            (windows_core::Interface::vtable(self).Int32Property)(
+                windows_core::Interface::as_raw(self),
+                &mut result__,
+            )
+            .map(|| result__)
+        }
+    }
+    pub fn SetInt32Property(&self, value: i32) -> windows_core::Result<()> {
+        unsafe {
+            (windows_core::Interface::vtable(self).SetInt32Property)(
+                windows_core::Interface::as_raw(self),
+                value,
+            )
+            .ok()
+        }
+    }
+    pub fn StringProperty(&self) -> windows_core::Result<windows_core::HSTRING> {
+        unsafe {
+            let mut result__ = core::mem::zeroed();
+            (windows_core::Interface::vtable(self).StringProperty)(
+                windows_core::Interface::as_raw(self),
+                &mut result__,
+            )
+            .map(|| core::mem::transmute(result__))
+        }
+    }
+    pub fn SetStringProperty(&self, value: &windows_core::HSTRING) -> windows_core::Result<()> {
+        unsafe {
+            (windows_core::Interface::vtable(self).SetStringProperty)(
+                windows_core::Interface::as_raw(self),
+                core::mem::transmute_copy(value),
+            )
+            .ok()
+        }
+    }
+    pub fn ObjectProperty(&self) -> windows_core::Result<windows_core::IInspectable> {
+        unsafe {
+            let mut result__ = core::mem::zeroed();
+            (windows_core::Interface::vtable(self).ObjectProperty)(
+                windows_core::Interface::as_raw(self),
+                &mut result__,
+            )
+            .and_then(|| windows_core::Type::from_abi(result__))
+        }
+    }
+    pub fn SetObjectProperty<P0>(&self, value: P0) -> windows_core::Result<()>
+    where
+        P0: windows_core::Param<windows_core::IInspectable>,
+    {
+        unsafe {
+            (windows_core::Interface::vtable(self).SetObjectProperty)(
+                windows_core::Interface::as_raw(self),
+                value.param().abi(),
+            )
+            .ok()
+        }
+    }
+    pub fn NewObject(&self) -> windows_core::Result<windows_core::IInspectable> {
+        unsafe {
+            let mut result__ = core::mem::zeroed();
+            (windows_core::Interface::vtable(self).NewObject)(
+                windows_core::Interface::as_raw(self),
+                &mut result__,
+            )
+            .and_then(|| windows_core::Type::from_abi(result__))
+        }
+    }
+}
+impl windows_core::RuntimeType for Class {
+    const SIGNATURE: windows_core::imp::ConstBuffer =
+        windows_core::imp::ConstBuffer::for_class::<Self, IClass>();
+}
+unsafe impl windows_core::Interface for Class {
+    type Vtable = <IClass as windows_core::Interface>::Vtable;
+    const IID: windows_core::GUID = <IClass as windows_core::Interface>::IID;
+}
+impl windows_core::RuntimeName for Class {
+    const NAME: &'static str = "LangPerf.Class";
+}
+unsafe impl Send for Class {}
+unsafe impl Sync for Class {}
+windows_core::imp::define_interface!(IClass, IClass_Vtbl, 0xe853a9c7_689d_5bc7_a462_7b99d49ad4ff);
+impl windows_core::RuntimeType for IClass {
+    const SIGNATURE: windows_core::imp::ConstBuffer =
+        windows_core::imp::ConstBuffer::for_interface::<Self>();
+    const NAME: windows_core::imp::ConstBuffer =
+        windows_core::imp::ConstBuffer::from_slice(b"LangPerf.IClass");
+}
+#[repr(C)]
+pub struct IClass_Vtbl {
+    pub base__: windows_core::IInspectable_Vtbl,
+    pub Int32Property:
+        unsafe extern "system" fn(*mut core::ffi::c_void, *mut i32) -> windows_core::HRESULT,
+    pub SetInt32Property:
+        unsafe extern "system" fn(*mut core::ffi::c_void, i32) -> windows_core::HRESULT,
+    pub StringProperty: unsafe extern "system" fn(
+        *mut core::ffi::c_void,
+        *mut *mut core::ffi::c_void,
+    ) -> windows_core::HRESULT,
+    pub SetStringProperty: unsafe extern "system" fn(
+        *mut core::ffi::c_void,
+        *mut core::ffi::c_void,
+    ) -> windows_core::HRESULT,
+    pub ObjectProperty: unsafe extern "system" fn(
+        *mut core::ffi::c_void,
+        *mut *mut core::ffi::c_void,
+    ) -> windows_core::HRESULT,
+    pub SetObjectProperty: unsafe extern "system" fn(
+        *mut core::ffi::c_void,
+        *mut core::ffi::c_void,
+    ) -> windows_core::HRESULT,
+    pub NewObject: unsafe extern "system" fn(
+        *mut core::ffi::c_void,
+        *mut *mut core::ffi::c_void,
+    ) -> windows_core::HRESULT,
+}
+windows_core::imp::define_interface!(
+    INonDefault,
+    INonDefault_Vtbl,
+    0x1471cc2c_0216_5a12_90ad_6bc57677b7f5
+);
+impl windows_core::RuntimeType for INonDefault {
+    const SIGNATURE: windows_core::imp::ConstBuffer =
+        windows_core::imp::ConstBuffer::for_interface::<Self>();
+    const NAME: windows_core::imp::ConstBuffer =
+        windows_core::imp::ConstBuffer::from_slice(b"LangPerf.INonDefault");
+}
+windows_core::imp::interface_hierarchy!(
+    INonDefault,
+    windows_core::IUnknown,
+    windows_core::IInspectable
+);
+impl INonDefault {
+    pub fn Value(&self) -> windows_core::Result<i32> {
+        unsafe {
+            let mut result__ = core::mem::zeroed();
+            (windows_core::Interface::vtable(self).Value)(
+                windows_core::Interface::as_raw(self),
+                &mut result__,
+            )
+            .map(|| result__)
+        }
+    }
+}
+impl windows_core::RuntimeName for INonDefault {
+    const NAME: &'static str = "LangPerf.INonDefault";
+}
+pub trait INonDefault_Impl: windows_core::IUnknownImpl {
+    fn Value(&self) -> windows_core::Result<i32>;
+}
+impl INonDefault_Vtbl {
+    pub const fn new<Identity: INonDefault_Impl, const OFFSET: isize>() -> Self {
+        unsafe extern "system" fn Value<Identity: INonDefault_Impl, const OFFSET: isize>(
+            this: *mut core::ffi::c_void,
+            result__: *mut i32,
+        ) -> windows_core::HRESULT {
+            unsafe {
+                let this: &Identity =
+                    &*((this as *const *const ()).offset(OFFSET) as *const Identity);
+                match INonDefault_Impl::Value(this) {
+                    Ok(ok__) => {
+                        result__.write(ok__);
+                        windows_core::HRESULT(0)
+                    }
+                    Err(err) => err.into(),
+                }
+            }
+        }
+        Self {
+            base__: windows_core::IInspectable_Vtbl::new::<Identity, INonDefault, OFFSET>(),
+            Value: Value::<Identity, OFFSET>,
+        }
+    }
+    pub fn matches(iid: &windows_core::GUID) -> bool {
+        iid == &<INonDefault as windows_core::Interface>::IID
+    }
+}
+#[repr(C)]
+pub struct INonDefault_Vtbl {
+    pub base__: windows_core::IInspectable_Vtbl,
+    pub Value: unsafe extern "system" fn(*mut core::ffi::c_void, *mut i32) -> windows_core::HRESULT,
+}

--- a/crates/samples/lang_perf/rust/src/bindings.rs
+++ b/crates/samples/lang_perf/rust/src/bindings.rs
@@ -76,16 +76,6 @@ impl Class {
             .ok()
         }
     }
-    pub fn NewObject(&self) -> windows_core::Result<windows_core::IInspectable> {
-        unsafe {
-            let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(self).NewObject)(
-                windows_core::Interface::as_raw(self),
-                &mut result__,
-            )
-            .and_then(|| windows_core::Type::from_abi(result__))
-        }
-    }
 }
 impl windows_core::RuntimeType for Class {
     const SIGNATURE: windows_core::imp::ConstBuffer =
@@ -100,7 +90,7 @@ impl windows_core::RuntimeName for Class {
 }
 unsafe impl Send for Class {}
 unsafe impl Sync for Class {}
-windows_core::imp::define_interface!(IClass, IClass_Vtbl, 0xe853a9c7_689d_5bc7_a462_7b99d49ad4ff);
+windows_core::imp::define_interface!(IClass, IClass_Vtbl, 0x796dee90_c3d5_5bc7_b6c4_29202e486236);
 impl windows_core::RuntimeType for IClass {
     const SIGNATURE: windows_core::imp::ConstBuffer =
         windows_core::imp::ConstBuffer::for_interface::<Self>();
@@ -129,10 +119,6 @@ pub struct IClass_Vtbl {
     pub SetObjectProperty: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
-    ) -> windows_core::HRESULT,
-    pub NewObject: unsafe extern "system" fn(
-        *mut core::ffi::c_void,
-        *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(

--- a/crates/samples/lang_perf/rust/src/main.rs
+++ b/crates/samples/lang_perf/rust/src/main.rs
@@ -1,4 +1,3 @@
-#[cfg(windows)]
 #[allow(
     non_snake_case,
     non_upper_case_globals,
@@ -28,17 +27,12 @@ fn iterations() -> u64 {
 }
 
 fn main() {
-    #[cfg(windows)]
     if let Err(error) = run() {
         eprintln!("{error}");
         std::process::exit(1);
     }
-
-    #[cfg(not(windows))]
-    eprintln!("lang_perf_rust requires Windows");
 }
 
-#[cfg(windows)]
 fn run() -> windows_core::Result<()> {
     use bindings::*;
     use std::time::Instant;
@@ -85,7 +79,6 @@ fn run() -> windows_core::Result<()> {
     Ok(())
 }
 
-#[cfg(windows)]
 fn report(label: &str, start: std::time::Instant) {
     println!("{label}: {} ms", start.elapsed().as_millis());
 }

--- a/crates/samples/lang_perf/rust/src/main.rs
+++ b/crates/samples/lang_perf/rust/src/main.rs
@@ -62,11 +62,9 @@ fn run() -> windows_core::Result<()> {
     }
     report("Int32", start);
 
-    // Build the HSTRING once so the loop measures only set/get ABI traffic.
-    let value: HSTRING = "value".into();
     let start = Instant::now();
     for _ in 0..iterations {
-        object.SetStringProperty(&value)?;
+        object.SetStringProperty(h!("value"))?;
         let _ = object.StringProperty()?;
     }
     report("String", start);

--- a/crates/samples/lang_perf/rust/src/main.rs
+++ b/crates/samples/lang_perf/rust/src/main.rs
@@ -1,0 +1,94 @@
+#[cfg(windows)]
+#[allow(
+    non_snake_case,
+    non_upper_case_globals,
+    non_camel_case_types,
+    dead_code,
+    clippy::all
+)]
+mod bindings;
+
+// Default to a tiny count so `cargo run`/CI stays fast. Pass `--iterations N` or set
+// `LANG_PERF_ITER=N` for a real measurement (the original used 10_000_000).
+const DEFAULT_ITERATIONS: u64 = 1_000;
+
+fn iterations() -> u64 {
+    let mut args = std::env::args().skip(1);
+    while let Some(arg) = args.next() {
+        if arg == "--iterations"
+            && let Some(value) = args.next()
+        {
+            return value.parse().expect("invalid --iterations value");
+        }
+    }
+    std::env::var("LANG_PERF_ITER")
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(DEFAULT_ITERATIONS)
+}
+
+fn main() {
+    #[cfg(windows)]
+    if let Err(error) = run() {
+        eprintln!("{error}");
+        std::process::exit(1);
+    }
+
+    #[cfg(not(windows))]
+    eprintln!("lang_perf_rust requires Windows");
+}
+
+#[cfg(windows)]
+fn run() -> windows_core::Result<()> {
+    use bindings::*;
+    use std::time::Instant;
+    use windows_core::*;
+
+    let iterations = iterations();
+    println!("# Rust - {iterations} iterations");
+
+    let start = Instant::now();
+    for _ in 0..iterations {
+        let _ = Class::new()?;
+    }
+    report("Create", start);
+
+    let object = Class::new()?;
+
+    let start = Instant::now();
+    for _ in 0..iterations {
+        object.SetInt32Property(123)?;
+        let _ = object.Int32Property()?;
+    }
+    report("Int32", start);
+
+    // Build the HSTRING once, up front, so the loop measures only the set/get ABI
+    // traffic - matching how C++'s `L"value"` literal is already a UTF-16 string.
+    let value: HSTRING = "value".into();
+    let start = Instant::now();
+    for _ in 0..iterations {
+        object.SetStringProperty(&value)?;
+        let _ = object.StringProperty()?;
+    }
+    report("String", start);
+
+    let start = Instant::now();
+    for _ in 0..iterations {
+        object.SetObjectProperty(&object)?;
+        let _ = object.ObjectProperty()?;
+    }
+    report("Object", start);
+
+    let start = Instant::now();
+    for _ in 0..iterations {
+        let _ = object.NewObject()?.cast::<INonDefault>()?.Value()?;
+    }
+    report("Cast", start);
+
+    Ok(())
+}
+
+#[cfg(windows)]
+fn report(label: &str, start: std::time::Instant) {
+    println!("{label}: {} ms", start.elapsed().as_millis());
+}

--- a/crates/samples/lang_perf/rust/src/main.rs
+++ b/crates/samples/lang_perf/rust/src/main.rs
@@ -78,7 +78,7 @@ fn run() -> windows_core::Result<()> {
 
     let start = Instant::now();
     for _ in 0..iterations {
-        let _ = object.NewObject()?.cast::<INonDefault>()?.Value()?;
+        let _ = object.ObjectProperty()?.cast::<INonDefault>()?.Value()?;
     }
     report("Cast", start);
 

--- a/crates/samples/lang_perf/rust/src/main.rs
+++ b/crates/samples/lang_perf/rust/src/main.rs
@@ -62,8 +62,7 @@ fn run() -> windows_core::Result<()> {
     }
     report("Int32", start);
 
-    // Build the HSTRING once, up front, so the loop measures only the set/get ABI
-    // traffic - matching how C++'s `L"value"` literal is already a UTF-16 string.
+    // Build the HSTRING once so the loop measures only set/get ABI traffic.
     let value: HSTRING = "value".into();
     let start = Instant::now();
     for _ in 0..iterations {

--- a/crates/samples/readme.md
+++ b/crates/samples/readme.md
@@ -59,6 +59,7 @@ crates. To browse the samples for a published release, use its tag — for examp
 | Sample | Description |
 | --- | --- |
 | `robot` · `robot_client` · `robot_client_cpp` · `robot_client_cs` · `robot_cpp` | A component whose metadata is authored once (RDL) and consumed from Rust, C++, and C#. |
+| `lang_perf_component` · `lang_perf_rust` · `lang_perf_cpp` · `lang_perf_cs` | Benchmark of WinRT language-projection overhead — C++/WinRT vs C#/WinRT vs Rust calling one Rust-authored no-op component. See its [readme](lang_perf/readme.md). |
 | `csharp_component` · `csharp_client` | Author a component in Rust and host it from C#. |
 
 ## Whole-API projection

--- a/crates/tests/misc/literals/tests/sys.rs
+++ b/crates/tests/misc/literals/tests/sys.rs
@@ -27,7 +27,7 @@ fn test() {
 }
 
 fn assert_utf8(left: PCSTR, right: &[u8]) {
-    let len = unsafe { strlen(left) };
+    let len = unsafe { strlen(left.cast()) };
     assert_eq!(len, right.len() - 1);
     let left = unsafe { std::slice::from_raw_parts(left, right.len()) };
     assert_eq!(left, right);
@@ -41,6 +41,6 @@ fn assert_utf16(left: PCWSTR, right: &[u16]) {
 }
 
 unsafe extern "C" {
-    pub fn strlen(s: PCSTR) -> usize;
+    pub fn strlen(s: *const core::ffi::c_char) -> usize;
     pub fn wcslen(s: PCWSTR) -> usize;
 }

--- a/crates/tests/misc/literals/tests/win.rs
+++ b/crates/tests/misc/literals/tests/win.rs
@@ -60,7 +60,7 @@ fn into() {
 }
 
 fn assert_utf8(left: PCSTR, right: &[u8]) {
-    let len = unsafe { strlen(left) };
+    let len = unsafe { strlen(left.as_ptr().cast()) };
     assert_eq!(len, right.len() - 1);
     let left = unsafe { std::slice::from_raw_parts(left.as_ptr(), right.len()) };
     assert_eq!(left, right);
@@ -84,6 +84,6 @@ fn assert_hstring(left: &HSTRING, right: &[u16]) {
 }
 
 unsafe extern "C" {
-    pub fn strlen(s: PCSTR) -> usize;
+    pub fn strlen(s: *const core::ffi::c_char) -> usize;
     pub fn wcslen(s: PCWSTR) -> usize;
 }


### PR DESCRIPTION
This is a refresh of https://github.com/kennykerr/lang-perf but provides basically the same conclusions. The only new information is that AOT is worse than JIT for ABI performance.

| Metric | C#/JIT | C#/AOT |  C++ | Rust |
|--------|-------:|-------:|-----:|-----:|
| Create |   8904 |  17883 |  498 |  452 |
| Int32  |     54 |     85 |   26 |   20 |
| String |   1107 |    226 |   33 |   22 |
| Object |   1471 |   2246 |  133 |  134 |
| Cast   |   1709 |   5580 |  275 |  273 |