### PR TITLE
`windows-implement` dedup and test coverage

### DIFF
--- a/crates/libs/core/src/implement_macro.rs
+++ b/crates/libs/core/src/implement_macro.rs
@@ -326,118 +326,8 @@ macro_rules! __implement_decl_struct {
         impl $crate::IUnknownImpl for $impl_name {
             type Impl = $name;
 
-            #[inline(always)]
-            fn get_impl(&self) -> &Self::Impl {
-                &self.this
-            }
-
-            #[inline(always)]
-            fn get_impl_mut(&mut self) -> &mut Self::Impl {
-                &mut self.this
-            }
-
-            #[inline(always)]
-            fn into_inner(self) -> Self::Impl {
-                self.this
-            }
-
-            #[inline(always)]
-            fn AddRef(&self) -> u32 {
-                self.count.add_ref()
-            }
-
-            #[inline(always)]
-            unsafe fn Release(self_: *mut Self) -> u32 {
-                unsafe {
-                    let remaining = (*self_).count.release();
-                    if remaining == 0 {
-                        _ = $crate::imp::box_from_raw(self_);
-                    }
-                    remaining
-                }
-            }
-
-            #[inline(always)]
-            fn is_reference_count_one(&self) -> bool {
-                self.count.is_one()
-            }
-
-            unsafe fn GetTrustLevel(&self, value: *mut i32) -> $crate::HRESULT {
-                if value.is_null() {
-                    return $crate::imp::E_POINTER;
-                }
-                unsafe { *value = 0; }
-                $crate::HRESULT(0)
-            }
-
-            fn to_object(&self) -> $crate::ComObject<Self::Impl> {
-                self.count.add_ref();
-                unsafe {
-                    $crate::ComObject::from_raw(
-                        ::core::ptr::NonNull::new_unchecked(self as *const Self as *mut Self),
-                    )
-                }
-            }
-
-            unsafe fn QueryInterface(
-                &self,
-                iid: *const $crate::GUID,
-                interface: *mut *mut ::core::ffi::c_void,
-            ) -> $crate::HRESULT {
-                unsafe {
-                    if iid.is_null() || interface.is_null() {
-                        return $crate::imp::E_POINTER;
-                    }
-                    let iid = *iid;
-                    let interface_ptr: *const ::core::ffi::c_void = 'found: {
-                        if iid == <$crate::IUnknown as $crate::Interface>::IID
-                            || iid == <$crate::IInspectable as $crate::Interface>::IID
-                            || iid == <$crate::imp::IAgileObject as $crate::Interface>::IID
-                        {
-                            break 'found &self.identity as *const _ as *const ::core::ffi::c_void;
-                        }
-                        $(
-                            if <<$qi_iface as $crate::Interface>::Vtable>::matches(&iid) {
-                                break 'found &self.$qi_iface as *const _ as *const ::core::ffi::c_void;
-                            }
-                        )*
-                        #[cfg(windows)]
-                        if iid == <$crate::imp::IMarshal as $crate::Interface>::IID {
-                            return $crate::imp::marshaler(
-                                <Self as $crate::IUnknownImpl>::to_interface::<$crate::IUnknown>(self),
-                                interface,
-                            );
-                        }
-                        if iid == $crate::DYNAMIC_CAST_IID {
-                            // Special protocol: write the `&dyn Any` directly to the
-                            // out-parameter without reference-counting.
-                            (interface as *mut *const dyn ::core::any::Any)
-                                .write(self as &dyn ::core::any::Any as *const dyn ::core::any::Any);
-                            return $crate::HRESULT(0);
-                        }
-                        let tear_off_ptr = self.count.query(
-                            &iid,
-                            &self.identity as *const _ as *mut _,
-                        );
-                        if !tear_off_ptr.is_null() {
-                            *interface = tear_off_ptr;
-                            return $crate::HRESULT(0);
-                        }
-                        if let ::core::option::Option::Some(base) = self.base.as_option() {
-                            return $crate::Interface::query(
-                                base,
-                                &iid as *const $crate::GUID,
-                                interface,
-                            );
-                        }
-                        *interface = ::core::ptr::null_mut();
-                        return $crate::imp::E_NOINTERFACE;
-                    };
-                    debug_assert!(!interface_ptr.is_null());
-                    *interface = interface_ptr as *mut ::core::ffi::c_void;
-                    self.count.add_ref();
-                    $crate::HRESULT(0)
-                }
+            $crate::__implement_decl_iunknown_methods! {
+                qi: [ $( ($qi_iface : $qi_iface) )* ]
             }
         }
 
@@ -453,7 +343,168 @@ macro_rules! __implement_decl_struct {
             }
         }
 
-        impl $crate::Compose for $name {
+        $crate::__implement_decl_shared_tail! {
+            gen:       [ ],
+            wc:        { },
+            name:      $name,
+            impl_name: $impl_name,
+        }
+    };
+}
+
+// --- Shared IUnknownImpl method body ----------------------------------------------------
+//
+// Emits every `IUnknownImpl` method except the `type Impl` associated type (which differs
+// per arm). Both the generic and non-generic base arms invoke this so the reference-count
+// methods and — more importantly — the `QueryInterface`/identity routing exist in exactly
+// one place. That routing is security-sensitive (it decides which vtable a given IID maps
+// to) and must never drift between the two arms.
+//
+// `qi` is the list of `(field_ident : vtable_owning_type)` pairs. For the non-generic arm
+// the interface ident doubles as its own type, so each entry is passed as `(IFoo : IFoo)`.
+//
+// Hygiene: all references to `self`, `iid`, and the `'found` label are produced by this
+// single invocation, so they share one expansion context (see the note on
+// `__implement_decl_struct`). The accumulator still carries only data tokens.
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __implement_decl_iunknown_methods {
+    ( qi: [ $( ($qi_iface:ident : $qi_ty:ty) )* ] ) => {
+        #[inline(always)]
+        fn get_impl(&self) -> &Self::Impl {
+            &self.this
+        }
+
+        #[inline(always)]
+        fn get_impl_mut(&mut self) -> &mut Self::Impl {
+            &mut self.this
+        }
+
+        #[inline(always)]
+        fn into_inner(self) -> Self::Impl {
+            self.this
+        }
+
+        #[inline(always)]
+        fn AddRef(&self) -> u32 {
+            self.count.add_ref()
+        }
+
+        #[inline(always)]
+        unsafe fn Release(self_: *mut Self) -> u32 {
+            unsafe {
+                let remaining = (*self_).count.release();
+                if remaining == 0 {
+                    _ = $crate::imp::box_from_raw(self_);
+                }
+                remaining
+            }
+        }
+
+        #[inline(always)]
+        fn is_reference_count_one(&self) -> bool {
+            self.count.is_one()
+        }
+
+        unsafe fn GetTrustLevel(&self, value: *mut i32) -> $crate::HRESULT {
+            if value.is_null() {
+                return $crate::imp::E_POINTER;
+            }
+            unsafe { *value = 0; }
+            $crate::HRESULT(0)
+        }
+
+        fn to_object(&self) -> $crate::ComObject<Self::Impl> {
+            self.count.add_ref();
+            unsafe {
+                $crate::ComObject::from_raw(
+                    ::core::ptr::NonNull::new_unchecked(self as *const Self as *mut Self),
+                )
+            }
+        }
+
+        unsafe fn QueryInterface(
+            &self,
+            iid: *const $crate::GUID,
+            interface: *mut *mut ::core::ffi::c_void,
+        ) -> $crate::HRESULT {
+            unsafe {
+                if iid.is_null() || interface.is_null() {
+                    return $crate::imp::E_POINTER;
+                }
+                let iid = *iid;
+                let interface_ptr: *const ::core::ffi::c_void = 'found: {
+                    if iid == <$crate::IUnknown as $crate::Interface>::IID
+                        || iid == <$crate::IInspectable as $crate::Interface>::IID
+                        || iid == <$crate::imp::IAgileObject as $crate::Interface>::IID
+                    {
+                        break 'found &self.identity as *const _ as *const ::core::ffi::c_void;
+                    }
+                    $(
+                        if <<$qi_ty as $crate::Interface>::Vtable>::matches(&iid) {
+                            break 'found &self.$qi_iface as *const _ as *const ::core::ffi::c_void;
+                        }
+                    )*
+                    #[cfg(windows)]
+                    if iid == <$crate::imp::IMarshal as $crate::Interface>::IID {
+                        return $crate::imp::marshaler(
+                            <Self as $crate::IUnknownImpl>::to_interface::<$crate::IUnknown>(self),
+                            interface,
+                        );
+                    }
+                    if iid == $crate::DYNAMIC_CAST_IID {
+                        // Special protocol: write the `&dyn Any` directly to the
+                        // out-parameter without reference-counting.
+                        (interface as *mut *const dyn ::core::any::Any)
+                            .write(self as &dyn ::core::any::Any as *const dyn ::core::any::Any);
+                        return $crate::HRESULT(0);
+                    }
+                    let tear_off_ptr = self.count.query(
+                        &iid,
+                        &self.identity as *const _ as *mut _,
+                    );
+                    if !tear_off_ptr.is_null() {
+                        *interface = tear_off_ptr;
+                        return $crate::HRESULT(0);
+                    }
+                    if let ::core::option::Option::Some(base) = self.base.as_option() {
+                        return $crate::Interface::query(
+                            base,
+                            &iid as *const $crate::GUID,
+                            interface,
+                        );
+                    }
+                    *interface = ::core::ptr::null_mut();
+                    return $crate::imp::E_NOINTERFACE;
+                };
+                debug_assert!(!interface_ptr.is_null());
+                *interface = interface_ptr as *mut ::core::ffi::c_void;
+                self.count.add_ref();
+                $crate::HRESULT(0)
+            }
+        }
+    };
+}
+
+// --- Shared tail impls ------------------------------------------------------------------
+//
+// Emits the per-object impls that are identical across both base arms apart from the
+// generic-parameter / `where`-clause plumbing: `Compose`, `From<Foo>` for `IUnknown` and
+// `IInspectable`, and `ComObjectInterface` for `IUnknown` and `IInspectable`. The
+// non-generic arm invokes this with an empty `gen`/`wc`, which expands to `impl<>`,
+// `Foo<>`, and an empty `where` — all accepted by the compiler.
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __implement_decl_shared_tail {
+    (
+        gen:       [ $($gp:ident),* ],
+        wc:        { $($wc:tt)* },
+        name:      $name:ident,
+        impl_name: $impl_name:ident,
+    ) => {
+        impl< $($gp),* > $crate::Compose for $name < $($gp),* >
+        where $($wc)*
+        {
             unsafe fn compose<'a>(
                 implementation: Self,
             ) -> ($crate::IInspectable, &'a mut ::core::option::Option<$crate::IInspectable>) {
@@ -469,30 +520,38 @@ macro_rules! __implement_decl_struct {
             }
         }
 
-        impl ::core::convert::From<$name> for $crate::IUnknown {
+        impl< $($gp),* > ::core::convert::From<$name < $($gp),* >> for $crate::IUnknown
+        where $($wc)*
+        {
             #[inline(always)]
-            fn from(this: $name) -> Self {
+            fn from(this: $name < $($gp),* >) -> Self {
                 let com_object = $crate::ComObject::new(this);
                 com_object.into_interface()
             }
         }
 
-        impl ::core::convert::From<$name> for $crate::IInspectable {
+        impl< $($gp),* > ::core::convert::From<$name < $($gp),* >> for $crate::IInspectable
+        where $($wc)*
+        {
             #[inline(always)]
-            fn from(this: $name) -> Self {
+            fn from(this: $name < $($gp),* >) -> Self {
                 let com_object = $crate::ComObject::new(this);
                 com_object.into_interface()
             }
         }
 
-        impl $crate::ComObjectInterface<$crate::IUnknown> for $impl_name {
+        impl< $($gp),* > $crate::ComObjectInterface<$crate::IUnknown> for $impl_name < $($gp),* >
+        where $($wc)*
+        {
             #[inline(always)]
             fn as_interface_ref(&self) -> $crate::InterfaceRef<'_, $crate::IUnknown> {
                 unsafe { ::core::mem::transmute(&self.identity) }
             }
         }
 
-        impl $crate::ComObjectInterface<$crate::IInspectable> for $impl_name {
+        impl< $($gp),* > $crate::ComObjectInterface<$crate::IInspectable> for $impl_name < $($gp),* >
+        where $($wc)*
+        {
             #[inline(always)]
             fn as_interface_ref(&self) -> $crate::InterfaceRef<'_, $crate::IInspectable> {
                 unsafe { ::core::mem::transmute(&self.identity) }
@@ -508,63 +567,37 @@ macro_rules! __implement_decl_struct {
 // identity is at -1, the first interface chain at -2, the second at -3, and so on.
 //
 // `__implement_decl_offset_negate!()` takes a unary-counted token list and emits the
-// corresponding negative `isize` literal.  Each `()` in the input represents one
+// corresponding negative `isize` value.  Each `()` in the input represents one
 // pointer-sized slot of offset.  The accumulator starts with `[() ()]` (= -2) before any
 // interface is consumed; each interface push adds one more `()`.
 
 #[doc(hidden)]
 #[macro_export]
 macro_rules! __implement_decl_offset_negate {
-    (()) => {
-        -1isize
+    ( $($unit:tt)* ) => {
+        -( $crate::__implement_decl_count_units!($($unit)*) as isize )
     };
-    (() ()) => {
-        -2isize
+}
+
+// Counts a unary `()`-per-slot token list into a parenthesized `usize` sum. Shared by
+// `__implement_decl_offset_negate!` (the vtable `OFFSET` const generic) and
+// `__implement_decl_index_plus_two!` (the `AsImpl` pointer adjustment), replacing two
+// hand-written 16-arm lookup tables with one recursive count. There is no fixed interface
+// cap anymore — the sum grows with the input.
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __implement_decl_count_units {
+    ( $($unit:tt)* ) => {
+        ( 0usize $( + $crate::__implement_decl_unit_to_one!($unit) )* )
     };
-    (() () ()) => {
-        -3isize
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __implement_decl_unit_to_one {
+    ( $unit:tt ) => {
+        1usize
     };
-    (() () () ()) => {
-        -4isize
-    };
-    (() () () () ()) => {
-        -5isize
-    };
-    (() () () () () ()) => {
-        -6isize
-    };
-    (() () () () () () ()) => {
-        -7isize
-    };
-    (() () () () () () () ()) => {
-        -8isize
-    };
-    (() () () () () () () () ()) => {
-        -9isize
-    };
-    (() () () () () () () () () ()) => {
-        -10isize
-    };
-    (() () () () () () () () () () ()) => {
-        -11isize
-    };
-    (() () () () () () () () () () () ()) => {
-        -12isize
-    };
-    (() () () () () () () () () () () () ()) => {
-        -13isize
-    };
-    (() () () () () () () () () () () () () ()) => {
-        -14isize
-    };
-    (() () () () () () () () () () () () () () ()) => {
-        -15isize
-    };
-    (() () () () () () () () () () () () () () () ()) => {
-        -16isize
-    }; // Hand-written implementers rarely declare more than a handful of interfaces; the
-       // hard cap is more than the practical maximum.  If you hit this, split your
-       // implementation across multiple objects or use the proc-macro.
 }
 
 // --- Per-interface impls ----------------------------------------------------------------
@@ -644,57 +677,12 @@ macro_rules! __implement_decl_per_iface_impls {
     ) => {};
 }
 
-// `index` is a unary count starting at 0 (empty); emit `2 + index` as a usize literal.
+// `index` is a unary count starting at 0 (empty); emit `2 + index` as a `usize`.
 #[doc(hidden)]
 #[macro_export]
 macro_rules! __implement_decl_index_plus_two {
-    () => {
-        2usize
-    };
-    (()) => {
-        3usize
-    };
-    (() ()) => {
-        4usize
-    };
-    (() () ()) => {
-        5usize
-    };
-    (() () () ()) => {
-        6usize
-    };
-    (() () () () ()) => {
-        7usize
-    };
-    (() () () () () ()) => {
-        8usize
-    };
-    (() () () () () () ()) => {
-        9usize
-    };
-    (() () () () () () () ()) => {
-        10usize
-    };
-    (() () () () () () () () ()) => {
-        11usize
-    };
-    (() () () () () () () () () ()) => {
-        12usize
-    };
-    (() () () () () () () () () () ()) => {
-        13usize
-    };
-    (() () () () () () () () () () () ()) => {
-        14usize
-    };
-    (() () () () () () () () () () () () ()) => {
-        15usize
-    };
-    (() () () () () () () () () () () () () ()) => {
-        16usize
-    };
-    (() () () () () () () () () () () () () () ()) => {
-        17usize
+    ( $($unit:tt)* ) => {
+        ( $crate::__implement_decl_count_units!($($unit)*) + 2usize )
     };
 }
 
@@ -931,116 +919,8 @@ macro_rules! __implement_decl_g_struct {
         {
             type Impl = $name < $($gp),+ >;
 
-            #[inline(always)]
-            fn get_impl(&self) -> &Self::Impl {
-                &self.this
-            }
-
-            #[inline(always)]
-            fn get_impl_mut(&mut self) -> &mut Self::Impl {
-                &mut self.this
-            }
-
-            #[inline(always)]
-            fn into_inner(self) -> Self::Impl {
-                self.this
-            }
-
-            #[inline(always)]
-            fn AddRef(&self) -> u32 {
-                self.count.add_ref()
-            }
-
-            #[inline(always)]
-            unsafe fn Release(self_: *mut Self) -> u32 {
-                unsafe {
-                    let remaining = (*self_).count.release();
-                    if remaining == 0 {
-                        _ = $crate::imp::box_from_raw(self_);
-                    }
-                    remaining
-                }
-            }
-
-            #[inline(always)]
-            fn is_reference_count_one(&self) -> bool {
-                self.count.is_one()
-            }
-
-            unsafe fn GetTrustLevel(&self, value: *mut i32) -> $crate::HRESULT {
-                if value.is_null() {
-                    return $crate::imp::E_POINTER;
-                }
-                unsafe { *value = 0; }
-                $crate::HRESULT(0)
-            }
-
-            fn to_object(&self) -> $crate::ComObject<Self::Impl> {
-                self.count.add_ref();
-                unsafe {
-                    $crate::ComObject::from_raw(
-                        ::core::ptr::NonNull::new_unchecked(self as *const Self as *mut Self),
-                    )
-                }
-            }
-
-            unsafe fn QueryInterface(
-                &self,
-                iid: *const $crate::GUID,
-                interface: *mut *mut ::core::ffi::c_void,
-            ) -> $crate::HRESULT {
-                unsafe {
-                    if iid.is_null() || interface.is_null() {
-                        return $crate::imp::E_POINTER;
-                    }
-                    let iid = *iid;
-                    let interface_ptr: *const ::core::ffi::c_void = 'found: {
-                        if iid == <$crate::IUnknown as $crate::Interface>::IID
-                            || iid == <$crate::IInspectable as $crate::Interface>::IID
-                            || iid == <$crate::imp::IAgileObject as $crate::Interface>::IID
-                        {
-                            break 'found &self.identity as *const _ as *const ::core::ffi::c_void;
-                        }
-                        $(
-                            if <<$qi_ifty as $crate::Interface>::Vtable>::matches(&iid) {
-                                break 'found &self.$qi_iface as *const _ as *const ::core::ffi::c_void;
-                            }
-                        )*
-                        #[cfg(windows)]
-                        if iid == <$crate::imp::IMarshal as $crate::Interface>::IID {
-                            return $crate::imp::marshaler(
-                                <Self as $crate::IUnknownImpl>::to_interface::<$crate::IUnknown>(self),
-                                interface,
-                            );
-                        }
-                        if iid == $crate::DYNAMIC_CAST_IID {
-                            (interface as *mut *const dyn ::core::any::Any)
-                                .write(self as &dyn ::core::any::Any as *const dyn ::core::any::Any);
-                            return $crate::HRESULT(0);
-                        }
-                        let tear_off_ptr = self.count.query(
-                            &iid,
-                            &self.identity as *const _ as *mut _,
-                        );
-                        if !tear_off_ptr.is_null() {
-                            *interface = tear_off_ptr;
-                            return $crate::HRESULT(0);
-                        }
-                        if let ::core::option::Option::Some(base) = self.base.as_option() {
-                            return $crate::Interface::query(
-                                base,
-                                &iid as *const $crate::GUID,
-                                interface,
-                            );
-                        }
-                        *interface = ::core::ptr::null_mut();
-                        return $crate::imp::E_NOINTERFACE;
-                    };
-                    debug_assert!(!interface_ptr.is_null());
-                    *interface = interface_ptr as *mut ::core::ffi::c_void;
-                    self.count.add_ref();
-                    $crate::HRESULT(0)
-                }
+            $crate::__implement_decl_iunknown_methods! {
+                qi: [ $( ($qi_iface : $qi_ifty) )* ]
             }
         }
 
@@ -1058,58 +938,11 @@ macro_rules! __implement_decl_g_struct {
             }
         }
 
-        impl< $($gp),+ > $crate::Compose for $name < $($gp),+ >
-        where $($wc)*
-        {
-            unsafe fn compose<'a>(
-                implementation: Self,
-            ) -> ($crate::IInspectable, &'a mut ::core::option::Option<$crate::IInspectable>) {
-                unsafe {
-                    let inspectable: $crate::IInspectable = implementation.into();
-                    let identity_ptr: *mut ::core::ffi::c_void = $crate::Interface::as_raw(&inspectable);
-                    let base_ptr = (identity_ptr as *mut *mut ::core::ffi::c_void).sub(1)
-                        as *mut ::core::option::Option<$crate::IInspectable>;
-                    (inspectable, &mut *base_ptr)
-                }
-            }
-        }
-
-        impl< $($gp),+ > ::core::convert::From<$name < $($gp),+ >> for $crate::IUnknown
-        where $($wc)*
-        {
-            #[inline(always)]
-            fn from(this: $name < $($gp),+ >) -> Self {
-                let com_object = $crate::ComObject::new(this);
-                com_object.into_interface()
-            }
-        }
-
-        impl< $($gp),+ > ::core::convert::From<$name < $($gp),+ >> for $crate::IInspectable
-        where $($wc)*
-        {
-            #[inline(always)]
-            fn from(this: $name < $($gp),+ >) -> Self {
-                let com_object = $crate::ComObject::new(this);
-                com_object.into_interface()
-            }
-        }
-
-        impl< $($gp),+ > $crate::ComObjectInterface<$crate::IUnknown> for $impl_name < $($gp),+ >
-        where $($wc)*
-        {
-            #[inline(always)]
-            fn as_interface_ref(&self) -> $crate::InterfaceRef<'_, $crate::IUnknown> {
-                unsafe { ::core::mem::transmute(&self.identity) }
-            }
-        }
-
-        impl< $($gp),+ > $crate::ComObjectInterface<$crate::IInspectable> for $impl_name < $($gp),+ >
-        where $($wc)*
-        {
-            #[inline(always)]
-            fn as_interface_ref(&self) -> $crate::InterfaceRef<'_, $crate::IInspectable> {
-                unsafe { ::core::mem::transmute(&self.identity) }
-            }
+        $crate::__implement_decl_shared_tail! {
+            gen:       [ $($gp),+ ],
+            wc:        { $($wc)* },
+            name:      $name,
+            impl_name: $impl_name,
         }
     };
 }

--- a/crates/libs/implement/src/gen.rs
+++ b/crates/libs/implement/src/gen.rs
@@ -66,10 +66,10 @@ fn gen_impl_struct(inputs: &ImplementInputs) -> syn::Item {
     let vis = &inputs.original_type.vis;
 
     let mut impl_fields = quote! {
-        // Holds the inner non-delegating `IInspectable` when this type aggregates a composable
-        // WinRT class; otherwise stays `None`. `QueryInterface` falls through here when the
-        // requested IID is not handled locally. Wrapped in `ComposeBase` (`repr(transparent)`
-        // over `Option<IInspectable>`) for `Sync`.
+        // Aggregation slot: holds the inner non-delegating `IInspectable` when this type
+        // composes a WinRT class, else `None`; `QueryInterface` falls through to it for
+        // unhandled IIDs. `ComposeBase` is `repr(transparent)` over `Option<IInspectable>`
+        // for `Sync`.
         base: ::windows_core::ComposeBase,
         identity: &'static ::windows_core::IInspectable_Vtbl,
     };
@@ -275,13 +275,11 @@ fn gen_impl_com_object_inner(inputs: &ImplementInputs) -> syn::Item {
     }
 }
 
-/// Generates the `Compose` implementation that lets `Foo` be used as the Rust derived
-/// implementation in a composable WinRT runtime class.
+/// Generates `Compose`, letting `Foo` back a composable WinRT runtime class.
 ///
-/// Assembles an `IInspectable` for the freshly constructed implementation and then computes
-/// a mutable reference into the `base` field of its `Foo_Impl` (offset 0, immediately
-/// before `identity`). The composable factory writes the inner non-delegating
-/// `IInspectable` back through that reference.
+/// Returns an `IInspectable` for the new implementation plus a mutable reference to its
+/// `base` field (offset 0, just before `identity`); the composable factory writes the
+/// inner non-delegating `IInspectable` back through that reference.
 fn gen_impl_compose(inputs: &ImplementInputs) -> syn::Item {
     let original_ident = &inputs.original_type.ident;
     let generics = &inputs.generics;
@@ -326,12 +324,9 @@ fn gen_query_interface(inputs: &ImplementInputs) -> syn::ImplItemFn {
     let dynamic_cast_query = if enable_dyn_casting {
         quote! {
             if iid == ::windows_core::DYNAMIC_CAST_IID {
-                // DYNAMIC_CAST_IID is special. We _do not_ increase the reference count for this pseudo-interface.
-                // Also, instead of returning an interface pointer, we simply write the `&dyn Any` directly to the
-                // 'interface' pointer. Since the size of `&dyn Any` is 2 pointers, not one, the caller must be
-                // prepared for this. This is not a normal QueryInterface call.
-                //
-                // See the `Interface::cast_to_any` method, which is the only caller that should use DYNAMIC_CAST_ID.
+                // Pseudo-interface: no AddRef. Writes the `&dyn Any` (two pointers wide)
+                // directly to `interface`, so the caller must expect a fat pointer. Only
+                // `Interface::cast_to_any` uses this.
                 (interface as *mut *const dyn core::any::Any).write(self as &dyn ::core::any::Any as *const dyn ::core::any::Any);
                 return ::windows_core::HRESULT(0);
             }
@@ -448,18 +443,11 @@ fn gen_into_outer(inputs: &ImplementInputs) -> syn::ImplItem {
     };
 
     parse_quote! {
-        // Constructs the "outer" object. Used only by the implementation of the outer object,
-        // never by application code.
+        // Builds the outer object. Internal only: app code must never own a `Foo_Impl`,
+        // since mutable access to it would shear the refcount. Callers `into_static` and
+        // `into_object` uphold this by only handing out `StaticComObject` / `ComObject`.
         //
-        // The callers of this function (`into_static` and `into_object`) are both responsible
-        // for maintaining one of our invariants: application code never has an owned instance
-        // of the outer (implementation) type. `into_static` maintains this invariant by
-        // returning a wrapped `StaticComObject` value, which owns its contents but never gives
-        // application code a way to mutably access them. This prevents the refcount-shearing
-        // problem.
-        //
-        // TODO: Make it impossible for app code to call this function, by placing it in a
-        // module and marking this as private to the module.
+        // TODO: hide this in a private module so app code can't call it.
         #[inline(always)]
         #maybe_const fn into_outer(self) -> #impl_ident::#generics_idents {
             #impl_ident::#generics_idents {
@@ -485,31 +473,12 @@ fn gen_into_static(inputs: &ImplementInputs) -> syn::ImplItem {
     }
 }
 
-/// Generates `From`-based conversions.
+/// Generates `From<Foo>` conversions to `IUnknown`, `IInspectable`, and each declared
+/// interface (shorthand for `ComObject::new(value).into_interface()`).
 ///
-/// These conversions convert from the user's type `T` to `ComObject<T>` or to an interface
-/// implemented by `T`. These conversions are shorthand for calling `ComObject::new(value)`.
-///
-/// We can only generate conversions from `T` to the roots of each interface chain. We can't
-/// generate `From` conversions from `T` to an interface that is inherited by an interface chain,
-/// because this proc macro does not have access to any information about the inheritance chain
-/// of interfaces that are referenced.
-///
-/// For example:
-///
-/// ```rust,ignore
-/// #[implement(IFoo3)]
-/// struct MyType;
-/// ```
-///
-/// If `IFoo3` inherits from `IFoo2`, then this code will _not_ generate a conversion for `IFoo2`.
-/// However, user code can still do this:
-///
-/// ```rust,ignore
-/// let ifoo2 = IFoo3::from(MyType).into();
-/// ```
-///
-/// This works because the `IFoo3` type has an `Into` impl for `IFoo2`.
+/// Only the declared interface chain roots get a conversion — the macro can't see an
+/// interface's parents. For a base interface, go through the child:
+/// `IFoo3::from(value).into()`.
 fn gen_impl_from(inputs: &ImplementInputs) -> Vec<syn::Item> {
     let mut items = Vec::new();
 

--- a/crates/libs/implement/src/lib.rs
+++ b/crates/libs/implement/src/lib.rs
@@ -17,10 +17,9 @@
 //!
 //! `Foo_Impl` is a `#[repr(C)]` struct with these fields, in order:
 //!
-//! 1. `base` — `Option<IInspectable>` slot for COM aggregation (composition). Holds the
-//!    inner non-delegating `IInspectable` written back by a composable factory; otherwise
-//!    `None`. At offset 0 so that the vtable pointers below it occupy negative offsets
-//!    relative to the COM pointer.
+//! 1. `base` — aggregation slot (`Option<IInspectable>`), at offset 0 so the vtable
+//!    pointers below it sit at negative offsets from the COM pointer. Holds a composable
+//!    class's inner non-delegating `IInspectable`, else `None`.
 //! 2. `identity` — a `&'static IInspectable_Vtbl` (offset -1) acting as the IUnknown /
 //!    IInspectable identity pointer.
 //! 3. One `&'static <IFoo as Interface>::Vtable` per interface chain in declaration order

--- a/crates/tests/libs/interface_core/tests/macro_rules_decl.rs
+++ b/crates/tests/libs/interface_core/tests/macro_rules_decl.rs
@@ -4,6 +4,8 @@
 //! Both sides — interface declaration and implementer wiring — are done with declarative
 //! macros, so this test doubles as proof that the fully proc-macro-free path produces an
 //! object that is layout- and ABI-compatible with what the proc-macros would have emitted.
+//! Coverage spans the non-generic and `impl<T>` arms, the IInspectable identity, and
+//! cross-interface `QueryInterface`.
 
 #![expect(non_snake_case)]
 
@@ -65,6 +67,51 @@ impl IRaw_Impl for Test_Impl {
     unsafe fn Echo(&self, code: HRESULT, out: *mut HRESULT) -> HRESULT {
         unsafe { *out = code };
         code
+    }
+}
+
+// A generic implementer, exercising the `impl<T>` arm of `implement_decl!`. Each `T`
+// contributes an offset so the wrapped value is observably used per monomorphization.
+trait Offset {
+    fn offset(&self) -> i32;
+}
+
+impl Offset for i32 {
+    fn offset(&self) -> i32 {
+        *self
+    }
+}
+
+impl Offset for &'static str {
+    fn offset(&self) -> i32 {
+        self.len() as i32
+    }
+}
+
+struct Generic<T>(T);
+
+implement_decl! {
+    impl<T> Generic as Generic_Impl: [ITest, IOther]
+    where T: Offset + 'static
+}
+
+impl<T> ITest_Impl for Generic_Impl<T>
+where
+    T: Offset + 'static,
+{
+    unsafe fn Void(&self) {}
+    unsafe fn Result(&self, code: HRESULT) -> Result<()> {
+        code.ok()
+    }
+}
+
+impl<T> IOther_Impl for Generic_Impl<T>
+where
+    T: Offset + 'static,
+{
+    unsafe fn Sum(&self, a: i32, b: i32, out: *mut i32) -> Result<()> {
+        unsafe { *out = a + b + self.0.offset() };
+        Ok(())
     }
 }
 
@@ -137,4 +184,46 @@ fn refcount_drops_to_zero() {
     let other: IOther = test.cast().unwrap();
     drop(test);
     drop(other);
+}
+
+#[test]
+fn iinspectable_identity() {
+    // `implement_decl!` always emits the IInspectable identity (`From`,
+    // `ComObjectInterface<IInspectable>`, and the QI route), even for IUnknown-only
+    // interfaces, with a fixed trust level of 0.
+    let inspectable: IInspectable = Test.into();
+    assert_eq!(inspectable.GetTrustLevel().unwrap(), 0);
+
+    // QI(IID_IInspectable) succeeds from any interface and round-trips back.
+    let test: ITest = Test.into();
+    let inspectable: IInspectable = test.cast().unwrap();
+    assert_eq!(inspectable.GetTrustLevel().unwrap(), 0);
+    let test: ITest = inspectable.cast().unwrap();
+    unsafe { test.Void() };
+
+    // IUnknown <-> IInspectable in both directions.
+    let unknown: IUnknown = inspectable.cast().unwrap();
+    let _: IInspectable = unknown.cast().unwrap();
+}
+
+#[test]
+fn generic_implementer() {
+    unsafe {
+        // T = i32: the wrapped value adds 10.
+        let other: IOther = Generic(10_i32).into();
+        let mut value = 0;
+        other.Sum(2, 3, &mut value).unwrap();
+        assert_eq!(value, 15);
+
+        // QI across to ITest and to the IInspectable identity.
+        let test: ITest = other.cast().unwrap();
+        test.Void();
+        let inspectable: IInspectable = other.cast().unwrap();
+        assert_eq!(inspectable.GetTrustLevel().unwrap(), 0);
+
+        // A second monomorphization (T = &str) wires up independently.
+        let other: IOther = Generic("abcd").into();
+        other.Sum(1, 1, &mut value).unwrap();
+        assert_eq!(value, 6);
+    }
 }


### PR DESCRIPTION
Simplify and dedup the  `implement_decl!` declarative macro, tighten `#[implement]` proc-macro comments, and add generic-arm and `IInspectable`-identity regression tests for the decl macro.