### PR TITLE
`windows-collections` move rather than clone during buffering

### DIFF
--- a/crates/libs/collections/src/buffered_iterator.rs
+++ b/crates/libs/collections/src/buffered_iterator.rs
@@ -48,12 +48,6 @@ impl<T: windows_core::RuntimeType + 'static> Iterator for BufferedIterator<T> {
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.index >= self.len {
-            // Release the previous block's values before refilling. Resetting to
-            // a zeroed default drops the held references and leaves a valid
-            // buffer for `GetMany` to overwrite.
-            for slot in &mut self.buffer[..self.len] {
-                *slot = unsafe { core::mem::zeroed() };
-            }
             self.index = 0;
             self.len = self.iterator.GetMany(&mut self.buffer).unwrap_or(0) as usize;
             self.len = self.len.min(self.buffer.len());
@@ -62,8 +56,13 @@ impl<T: windows_core::RuntimeType + 'static> Iterator for BufferedIterator<T> {
             }
         }
 
-        let result = T::from_default(&self.buffer[self.index]).ok();
+        // Move the element out of the buffer rather than cloning it, leaving a zeroed slot
+        // behind. For interface elements (such as the `IKeyValuePair` yielded by map iteration)
+        // this hands the buffer's existing reference to the caller, skipping the `AddRef` a
+        // clone would take and the matching `Release` when the slot is later overwritten. Slots
+        // left unconsumed (early-drop, or beyond a short `GetMany`) are released by the `Vec`.
+        let slot = core::mem::replace(&mut self.buffer[self.index], unsafe { core::mem::zeroed() });
         self.index += 1;
-        result
+        T::from_default_owned(slot).ok()
     }
 }

--- a/crates/libs/core/src/type.rs
+++ b/crates/libs/core/src/type.rs
@@ -33,6 +33,12 @@ pub trait Type<T: TypeKind, C = <T as TypeKind>::TypeKind>: TypeKind + Sized + C
     unsafe fn assume_init_ref(abi: &Self::Abi) -> &Self;
     unsafe fn from_abi(abi: Self::Abi) -> Result<Self>;
     fn from_default(default: &Self::Default) -> Result<Self>;
+
+    /// Like [`from_default`](Self::from_default) but consumes the value, transferring ownership
+    /// instead of cloning. For interface types this moves the existing reference out rather than
+    /// taking an extra `AddRef`, which lets buffered iterators yield owned elements without a
+    /// per-element `AddRef`/`Release` round trip.
+    fn from_default_owned(default: Self::Default) -> Result<Self>;
 }
 
 impl<T> Type<T, InterfaceType> for T
@@ -67,6 +73,10 @@ where
     fn from_default(default: &Self::Default) -> Result<Self> {
         default.as_ref().cloned().ok_or(Error::empty())
     }
+
+    fn from_default_owned(default: Self::Default) -> Result<Self> {
+        default.ok_or(Error::empty())
+    }
 }
 
 impl<T> Type<T, CloneType> for T
@@ -95,6 +105,10 @@ where
     fn from_default(default: &Self::Default) -> Result<Self> {
         Ok(default.clone())
     }
+
+    fn from_default_owned(default: Self::Default) -> Result<Self> {
+        Ok(default)
+    }
 }
 
 impl<T> Type<T, CopyType> for T
@@ -122,6 +136,10 @@ where
 
     fn from_default(default: &Self) -> Result<Self> {
         Ok(default.clone())
+    }
+
+    fn from_default_owned(default: Self) -> Result<Self> {
+        Ok(default)
     }
 }
 

--- a/crates/samples/lang_perf/readme.md
+++ b/crates/samples/lang_perf/readme.md
@@ -346,11 +346,16 @@ the vector — that loop is **batched**: `IMap<K, V>` implements `IIterable<IKey
 so its iterator exposes `GetMany`, and windows-rs drives it through the same `BufferedIterator`
 (bindgen emits the `IntoIterator` for every iterable, maps included, so the speedup is general).
 The catch is *what* `GetMany` returns: for `IVector<Int32>` it bulk-copies the `Int32` values
-inline, but for a map it hands back a block of `IKeyValuePair` **COM objects** (one `AddRef`
-each), and reading every `pair.Value()` is still a per-pair vtable crossing. So batching erases
-the iterator-stepping cost but not the per-pair accessor — which is why `Map` stays an order of
-magnitude above `IterateVector` (at 10M, Rust `775` vs `4`) yet only modestly ahead of C++
-`955` and C#/JIT `1813`, since all three pay the same per-pair `Value()` crossing. It stays
+inline, but for a map it hands back a block of `IKeyValuePair` **COM objects**, and reading every
+`pair.Value()` is still a per-pair vtable crossing. windows-rs shaves what it can from the
+consumer side: the `BufferedIterator` *moves* each `IKeyValuePair` out of its buffer rather than
+cloning it, so yielding a pair no longer takes an `AddRef` and a matching `Release` — only the
+`Value()` accessor and the final `Release` remain per pair. But that residual accessor crossing,
+plus the per-pair `IKeyValuePair` allocation the component must make to satisfy the ABI, is
+irreducible: batching erases the iterator-stepping cost but not the per-pair object lifecycle —
+which is why `Map` stays an order of magnitude above `IterateVector` (at 10M, Rust `775` vs `4`)
+yet only modestly ahead of C++ `955` and C#/JIT `1813`, since all three pay the same per-pair
+`Value()` crossing. It stays
 consumer-driven (`Rust→Rust` `74` vs `Rust→C++` `84` at 1M), so Rust again leads. Getting there exposed — and
 fixed — a quadratic in windows-rs: the stock map iterator originally located each element with
 `map.iter().nth(current)`, an O(n) walk per step, turning a full traversal into O(n²) (a 1M C#


### PR DESCRIPTION
`BufferedIterator::next` now moves each element out of the buffer instead of cloning, eliminating the per-element `AddRef ` + buffer-reset `Release` for interface iteration.