### PR TITLE
`windows-reactor` add properties for pane length/footer and text box appearance

### DIFF
--- a/crates/libs/reactor/src/backend/winui/generated_set_prop.rs
+++ b/crates/libs/reactor/src/backend/winui/generated_set_prop.rs
@@ -379,6 +379,9 @@ pub fn dispatch(handle: &Handle, prop: Prop, value: &PropValue) -> Result<bool> 
         (Prop::OnContent, PropValue::Unset, Handle::ToggleSwitch(h)) => {
             h.SetOnContent(None)?;
         }
+        (Prop::OpenPaneLength, PropValue::F64(v), Handle::NavigationView(h)) => {
+            h.SetOpenPaneLength(*v)?;
+        }
         (Prop::OpenPaneLength, PropValue::F64(v), Handle::SplitView(h)) => {
             h.SetOpenPaneLength(*v)?;
         }

--- a/crates/libs/reactor/src/backend/winui/mod.rs
+++ b/crates/libs/reactor/src/backend/winui/mod.rs
@@ -1010,6 +1010,37 @@ fn set_foreground(
     Ok(true)
 }
 
+fn set_border_brush(
+    handle: &Handle,
+    brush: impl windows_core::Param<bindings::Brush>,
+) -> Result<()> {
+    match handle {
+        Handle::Border(b) => b.SetBorderBrush(brush)?,
+        _ => {
+            if let Ok(ctl) = handle.cast_inner::<bindings::IControl>() {
+                ctl.SetBorderBrush(brush)?;
+            } else {
+                diag::unhandled_modifier("set_prop", Prop::BorderBrush, handle);
+            }
+        }
+    }
+    Ok(())
+}
+
+fn set_border_thickness(handle: &Handle, thickness: Thickness) -> Result<()> {
+    match handle {
+        Handle::Border(b) => b.SetBorderThickness(thickness)?,
+        _ => {
+            if let Ok(ctl) = handle.cast_inner::<bindings::IControl>() {
+                ctl.SetBorderThickness(thickness)?;
+            } else {
+                diag::unhandled_modifier("set_prop", Prop::BorderThickness, handle);
+            }
+        }
+    }
+    Ok(())
+}
+
 fn set_font_f64(handle: &Handle, v: f64) -> Result<bool> {
     match handle {
         Handle::TextBlock(h) => h.SetFontSize(v)?,
@@ -1314,23 +1345,15 @@ impl Backend for WinUIBackend {
                 (Prop::CornerRadius, PropValue::Unset, Handle::Border(b)) => {
                     b.SetCornerRadius(bindings::CornerRadius::default())
                 }
-                (Prop::BorderBrush, PropValue::Color(br), Handle::Border(b)) => {
-                    b.SetBorderBrush(&solid_brush(*br)?)
+                (Prop::BorderBrush, PropValue::Color(br), h) => {
+                    set_border_brush(h, &solid_brush(*br)?)
                 }
-                (Prop::BorderBrush, PropValue::Unset, Handle::Border(b)) => b.SetBorderBrush(None),
-                (Prop::BorderBrush, _, h) => {
-                    diag::unhandled_modifier("set_prop", Prop::BorderBrush, h);
-                    Ok(())
+                (Prop::BorderBrush, PropValue::Unset, h) => {
+                    set_border_brush(h, None::<&bindings::Brush>)
                 }
-                (Prop::BorderThickness, PropValue::Thickness(t), Handle::Border(b)) => {
-                    b.SetBorderThickness(*t)
-                }
-                (Prop::BorderThickness, PropValue::Unset, Handle::Border(b)) => {
-                    b.SetBorderThickness(Thickness::default())
-                }
-                (Prop::BorderThickness, _, h) => {
-                    diag::unhandled_modifier("set_prop", Prop::BorderThickness, h);
-                    Ok(())
+                (Prop::BorderThickness, PropValue::Thickness(t), h) => set_border_thickness(h, *t),
+                (Prop::BorderThickness, PropValue::Unset, h) => {
+                    set_border_thickness(h, Thickness::default())
                 }
                 (Prop::LineEndpoints, PropValue::LineEndpoints(p), Handle::Line(l)) => l
                     .SetX1(p.x1)
@@ -1958,6 +1981,15 @@ impl Backend for WinUIBackend {
                 }
             } else {
                 let _ = tb.SetRightHeader(None);
+            }
+        } else if let Handle::NavigationView(nv) = handle {
+            if let Some(pid) = pane_id {
+                if let Some(pane_handle) = map.get(&pid) {
+                    let ui_elem = pane_handle.as_ui_element();
+                    let _ = nv.SetPaneFooter(&ui_elem);
+                }
+            } else {
+                let _ = nv.SetPaneFooter(None);
             }
         }
     }

--- a/crates/libs/reactor/src/backend/winui/mod.rs
+++ b/crates/libs/reactor/src/backend/winui/mod.rs
@@ -550,6 +550,7 @@ fn style_target_for_handle(handle: &Handle) -> Option<(&'static str, bindings::I
         Handle::StackPanel(s) => s.cast().ok().map(|fe| ("StackPanel", fe)),
         Handle::Grid(g) => g.cast().ok().map(|fe| ("Grid", fe)),
         Handle::Button(b) => b.cast().ok().map(|fe| ("Button", fe)),
+        Handle::TextBox(t) => t.cast().ok().map(|fe| ("TextBox", fe)),
         Handle::TextBlock(t) => t.cast().ok().map(|fe| ("TextBlock", fe)),
         Handle::Canvas(c) => c.cast().ok().map(|fe| ("Canvas", fe)),
         _ => None,

--- a/crates/libs/reactor/src/bindings.rs
+++ b/crates/libs/reactor/src/bindings.rs
@@ -6775,6 +6775,27 @@ impl IControl {
             .ok()
         }
     }
+    pub(crate) fn SetBorderThickness(&self, value: Thickness) -> windows_core::Result<()> {
+        unsafe {
+            (windows_core::Interface::vtable(self).SetBorderThickness)(
+                windows_core::Interface::as_raw(self),
+                value,
+            )
+            .ok()
+        }
+    }
+    pub(crate) fn SetBorderBrush<P0>(&self, value: P0) -> windows_core::Result<()>
+    where
+        P0: windows_core::Param<Brush>,
+    {
+        unsafe {
+            (windows_core::Interface::vtable(self).SetBorderBrush)(
+                windows_core::Interface::as_raw(self),
+                value.param().abi(),
+            )
+            .ok()
+        }
+    }
 }
 #[repr(C)]
 pub struct IControl_Vtbl {
@@ -6825,6 +6846,16 @@ pub struct IControl_Vtbl {
     SetVerticalContentAlignment: usize,
     Background: usize,
     pub SetBackground: unsafe extern "system" fn(
+        *mut core::ffi::c_void,
+        *mut core::ffi::c_void,
+    ) -> windows_core::HRESULT,
+    BackgroundSizing: usize,
+    SetBackgroundSizing: usize,
+    BorderThickness: usize,
+    pub SetBorderThickness:
+        unsafe extern "system" fn(*mut core::ffi::c_void, Thickness) -> windows_core::HRESULT,
+    BorderBrush: usize,
+    pub SetBorderBrush: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
@@ -9681,6 +9712,18 @@ impl INavigationView {
             .ok()
         }
     }
+    pub(crate) fn SetPaneFooter<P0>(&self, value: P0) -> windows_core::Result<()>
+    where
+        P0: windows_core::Param<UIElement>,
+    {
+        unsafe {
+            (windows_core::Interface::vtable(self).SetPaneFooter)(
+                windows_core::Interface::as_raw(self),
+                value.param().abi(),
+            )
+            .ok()
+        }
+    }
     pub(crate) fn SetHeader<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<windows_core::IInspectable>,
@@ -9705,6 +9748,15 @@ impl INavigationView {
     pub(crate) fn SetIsPaneToggleButtonVisible(&self, value: bool) -> windows_core::Result<()> {
         unsafe {
             (windows_core::Interface::vtable(self).SetIsPaneToggleButtonVisible)(
+                windows_core::Interface::as_raw(self),
+                value,
+            )
+            .ok()
+        }
+    }
+    pub(crate) fn SetOpenPaneLength(&self, value: f64) -> windows_core::Result<()> {
+        unsafe {
+            (windows_core::Interface::vtable(self).SetOpenPaneLength)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
@@ -9812,7 +9864,10 @@ pub struct INavigationView_Vtbl {
     FooterMenuItemsSource: usize,
     SetFooterMenuItemsSource: usize,
     PaneFooter: usize,
-    SetPaneFooter: usize,
+    pub SetPaneFooter: unsafe extern "system" fn(
+        *mut core::ffi::c_void,
+        *mut core::ffi::c_void,
+    ) -> windows_core::HRESULT,
     Header: usize,
     pub SetHeader: unsafe extern "system" fn(
         *mut core::ffi::c_void,
@@ -9832,7 +9887,8 @@ pub struct INavigationView_Vtbl {
     CompactPaneLength: usize,
     SetCompactPaneLength: usize,
     OpenPaneLength: usize,
-    SetOpenPaneLength: usize,
+    pub SetOpenPaneLength:
+        unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
     PaneToggleButtonStyle: usize,
     SetPaneToggleButtonStyle: usize,
     SelectedItem: usize,

--- a/crates/libs/reactor/src/element.rs
+++ b/crates/libs/reactor/src/element.rs
@@ -1123,6 +1123,35 @@ fn apply_brush_binding(m: &mut Modifiers, prop: Prop, binding: BrushBinding, is_
     }
 }
 
+/// Applies a [`BrushBinding`] to a widget-owned brush slot (e.g. a border
+/// brush stored on the widget struct rather than in [`Modifiers`]). A direct
+/// color is stored in `slot` and any prior theme binding for `prop` is cleared;
+/// a theme reference clears `slot` and records the binding. This keeps
+/// "last call wins" holding regardless of the direct/theme call order.
+pub(crate) fn apply_widget_brush_binding(
+    slot: &mut Option<BrushBinding>,
+    m: &mut Modifiers,
+    prop: Prop,
+    binding: BrushBinding,
+) {
+    if let Some(map) = m.theme_bindings.as_deref_mut() {
+        map.remove(&prop);
+    }
+    match binding {
+        BrushBinding::Direct(b) => *slot = Some(BrushBinding::Direct(b)),
+        BrushBinding::Theme(t) => {
+            *slot = None;
+            m.theme_bindings
+                .get_or_insert_with(|| Box::new(rustc_hash::FxHashMap::default()))
+                .insert(prop, t);
+        }
+    }
+
+    if m.theme_bindings.as_deref().is_some_and(|m| m.is_empty()) {
+        m.theme_bindings = None;
+    }
+}
+
 fn ensure_animations(m: &mut Modifiers) -> &mut AnimationModifiers {
     m.animations
         .get_or_insert_with(|| Box::new(AnimationModifiers::default()))

--- a/crates/libs/reactor/src/generated.rs
+++ b/crates/libs/reactor/src/generated.rs
@@ -356,7 +356,7 @@ pub fn menu_bar_bindings(w: &MenuBar) -> PropBindings {
     )]
 }
 pub fn navigation_view_bindings(w: &NavigationView) -> PropBindings {
-    let mut out = Vec::with_capacity(12usize);
+    let mut out = Vec::with_capacity(13usize);
     out.push(Binding::Event(
         Event::BackRequested,
         w.on_back_requested
@@ -405,6 +405,10 @@ pub fn navigation_view_bindings(w: &NavigationView) -> PropBindings {
     out.push(Binding::Prop(
         Prop::IsSettingsVisible,
         PropValue::Bool(w.is_settings_visible),
+    ));
+    out.push(Binding::Prop(
+        Prop::OpenPaneLength,
+        PropValue::F64(w.open_pane_length),
     ));
     out.push(Binding::Prop(
         Prop::PaneDisplayMode,

--- a/crates/libs/reactor/src/style.rs
+++ b/crates/libs/reactor/src/style.rs
@@ -39,6 +39,17 @@ impl Color {
     pub const fn rgb(r: u8, g: u8, b: u8) -> Self {
         Self { a: 255, r, g, b }
     }
+    pub const fn argb(a: u8, r: u8, g: u8, b: u8) -> Self {
+        Self { a, r, g, b }
+    }
+    pub const fn transparent() -> Self {
+        Self {
+            a: 0,
+            r: 0,
+            g: 0,
+            b: 0,
+        }
+    }
 }
 
 #[derive(Copy, Clone, Debug, PartialEq)]

--- a/crates/libs/reactor/src/style.rs
+++ b/crates/libs/reactor/src/style.rs
@@ -39,9 +39,6 @@ impl Color {
     pub const fn rgb(r: u8, g: u8, b: u8) -> Self {
         Self { a: 255, r, g, b }
     }
-    pub const fn argb(a: u8, r: u8, g: u8, b: u8) -> Self {
-        Self { a, r, g, b }
-    }
     pub const fn transparent() -> Self {
         Self {
             a: 0,

--- a/crates/libs/reactor/src/widgets/border.rs
+++ b/crates/libs/reactor/src/widgets/border.rs
@@ -33,20 +33,12 @@ impl Border {
     /// the stroke to actually render. Accepts a direct [`Color`] or a
     /// [`ThemeRef`] for theme-aware strokes.
     pub fn border_brush(mut self, v: impl Into<BrushBinding>) -> Self {
-        match v.into() {
-            BrushBinding::Direct(b) => {
-                self.border_brush = Some(BrushBinding::Direct(b));
-            }
-            BrushBinding::Theme(t) => {
-                self.border_brush = None;
-                self.modifiers
-                    .theme_bindings
-                    .get_or_insert_with(|| {
-                        Box::new(rustc_hash::FxHashMap::default())
-                    })
-                    .insert(Prop::BorderBrush, t);
-            }
-        }
+        apply_widget_brush_binding(
+            &mut self.border_brush,
+            &mut self.modifiers,
+            Prop::BorderBrush,
+            v.into(),
+        );
         self
     }
 

--- a/crates/libs/reactor/src/widgets/navigation_view.rs
+++ b/crates/libs/reactor/src/widgets/navigation_view.rs
@@ -57,6 +57,8 @@ pub struct NavigationView {
     pub on_suggestion_chosen: Option<Callback<String>>,
     pub is_pane_toggle_button_visible: bool,
     pub is_back_button_visible: bool,
+    pub open_pane_length: f64,
+    pub pane_footer: Option<Box<Element>>,
 }
 impl Default for NavigationView {
     fn default() -> Self {
@@ -81,6 +83,8 @@ impl Default for NavigationView {
             on_suggestion_chosen: None,
             is_pane_toggle_button_visible: true,
             is_back_button_visible: true,
+            open_pane_length: 320.0,
+            pane_footer: None,
         }
     }
 }
@@ -163,6 +167,14 @@ impl NavigationView {
         self.is_back_button_visible = v;
         self
     }
+    pub fn open_pane_length(mut self, len: f64) -> Self {
+        self.open_pane_length = len;
+        self
+    }
+    pub fn pane_footer(mut self, el: impl Into<Element>) -> Self {
+        self.pane_footer = Some(Box::new(el.into()));
+        self
+    }
 }
 
 impl Widget for NavigationView {
@@ -196,5 +208,8 @@ impl Widget for NavigationView {
     }
     fn children(&self) -> Children<'_> {
         Children::PositionalSingle(&self.content)
+    }
+    fn pane_element(&self) -> Option<&Element> {
+        self.pane_footer.as_deref()
     }
 }

--- a/crates/libs/reactor/src/widgets/text_box.rs
+++ b/crates/libs/reactor/src/widgets/text_box.rs
@@ -85,18 +85,12 @@ impl TextBox {
     /// Brush used to paint the border stroke. Maps to WinUI
     /// `Control.BorderBrush`. Accepts a direct [`Color`] or a [`ThemeRef`].
     pub fn border_brush(mut self, v: impl Into<BrushBinding>) -> Self {
-        match v.into() {
-            BrushBinding::Direct(b) => {
-                self.border_brush = Some(BrushBinding::Direct(b));
-            }
-            BrushBinding::Theme(t) => {
-                self.border_brush = None;
-                self.modifiers
-                    .theme_bindings
-                    .get_or_insert_with(|| Box::new(rustc_hash::FxHashMap::default()))
-                    .insert(Prop::BorderBrush, t);
-            }
-        }
+        apply_widget_brush_binding(
+            &mut self.border_brush,
+            &mut self.modifiers,
+            Prop::BorderBrush,
+            v.into(),
+        );
         self
     }
 

--- a/crates/libs/reactor/src/widgets/text_box.rs
+++ b/crates/libs/reactor/src/widgets/text_box.rs
@@ -11,6 +11,8 @@ pub struct TextBox {
     pub is_enabled: bool,
     pub accepts_return: bool,
     pub text_wrapping: TextWrapping,
+    pub border_brush: Option<BrushBinding>,
+    pub border_thickness: Option<Thickness>,
 }
 impl TextBox {
     pub fn new(value: impl Into<String>) -> Self {
@@ -30,6 +32,15 @@ impl Widget for TextBox {
             Prop::Value,
             PropValue::Str(self.value.clone()),
         ));
+        if let Some(BrushBinding::Direct(br)) = &self.border_brush {
+            out.push(Binding::Prop(Prop::BorderBrush, PropValue::Color(*br)));
+        }
+        if let Some(v) = self.border_thickness {
+            out.push(Binding::Prop(
+                Prop::BorderThickness,
+                PropValue::Thickness(v),
+            ));
+        }
         out
     }
 }
@@ -68,6 +79,31 @@ impl TextBox {
     pub fn multiline(mut self) -> Self {
         self.accepts_return = true;
         self.text_wrapping = TextWrapping::Wrap;
+        self
+    }
+
+    /// Brush used to paint the border stroke. Maps to WinUI
+    /// `Control.BorderBrush`. Accepts a direct [`Color`] or a [`ThemeRef`].
+    pub fn border_brush(mut self, v: impl Into<BrushBinding>) -> Self {
+        match v.into() {
+            BrushBinding::Direct(b) => {
+                self.border_brush = Some(BrushBinding::Direct(b));
+            }
+            BrushBinding::Theme(t) => {
+                self.border_brush = None;
+                self.modifiers
+                    .theme_bindings
+                    .get_or_insert_with(|| Box::new(rustc_hash::FxHashMap::default()))
+                    .insert(Prop::BorderBrush, t);
+            }
+        }
+        self
+    }
+
+    /// Border stroke thickness, in DIPs, on each side. Maps to WinUI
+    /// `Control.BorderThickness`.
+    pub fn border_thickness(mut self, v: Thickness) -> Self {
+        self.border_thickness = Some(v);
         self
     }
 }

--- a/crates/samples/reactor/samples/examples/navigation_view_pane.rs
+++ b/crates/samples/reactor/samples/examples/navigation_view_pane.rs
@@ -1,0 +1,45 @@
+//! Sample for `NavigationView::open_pane_length` and `pane_footer` (issue 4669).
+//!
+//! What to look for:
+//!   * `open_pane_length(400.0)` — the open navigation pane (left column with
+//!     "Account", "Home", "Documents") is noticeably WIDE (400 DIPs) instead of
+//!     the default 320. Try changing it to 200.0 and re-running to see the pane
+//!     shrink.
+//!   * `pane_footer(...)` — the "Sign out" button is pinned to the BOTTOM of the
+//!     pane, separated from the menu items at the top. Toggle the pane with the
+//!     hamburger button (top-left) and the footer stays anchored at the bottom.
+
+use windows_reactor::*;
+
+fn app(cx: &mut RenderCx) -> Element {
+    let (page, set_page) = cx.use_state("home".to_string());
+
+    let menu_items = [
+        NavViewItem::new("Home").tag("home").icon(Symbol::Home),
+        NavViewItem::new("Documents")
+            .tag("docs")
+            .icon(Symbol::Document),
+    ];
+
+    let body: Element = match page.as_str() {
+        "docs" => text_block("Documents page").into(),
+        _ => text_block("Home page").into(),
+    };
+
+    // Footer element rendered at the bottom of the pane.
+    let footer = button("Sign out").on_click(|| println!("signed out"));
+
+    NavigationView::new(menu_items, body)
+        .selected_tag(page)
+        .on_selection_changed(set_page)
+        .pane_display_mode(NavigationViewPaneDisplayMode::Left)
+        .pane_title("Account")
+        .open_pane_length(400.0) // default is 320; 400 makes the change obvious
+        .pane_footer(footer)
+        .settings_visible(false)
+        .into()
+}
+
+fn main() -> Result<()> {
+    reactor_samples::run("NavigationView pane", app)
+}

--- a/crates/samples/reactor/samples/examples/text_box_border.rs
+++ b/crates/samples/reactor/samples/examples/text_box_border.rs
@@ -1,0 +1,38 @@
+//! Sample for `TextBox` background / border customization (issue 4671).
+//!
+//! Shows three variants:
+//!   1. A default TextBox (for comparison).
+//!   2. A thick colored border via `border_brush` + `border_thickness`.
+//!   3. A borderless, transparent input (e.g. a chat/search bar) using
+//!      `background(Color::transparent())` + `border_thickness(uniform(0.0))`.
+
+use windows_reactor::*;
+
+fn app(cx: &mut RenderCx) -> Element {
+    let (text, set_text) = cx.use_state(String::new());
+
+    vstack((
+        text_block("1. Default TextBox"),
+        text_box(text.clone())
+            .placeholder_text("Default style")
+            .on_text_changed(set_text.clone()),
+        text_block("2. Custom border (brush + thickness)"),
+        text_box(text.clone())
+            .placeholder_text("Thick blue border")
+            .border_brush(Color::rgb(60, 120, 220))
+            .border_thickness(Thickness::uniform(2.0))
+            .on_text_changed(set_text.clone()),
+        text_block("3. Borderless + transparent (chat/search bar)"),
+        text_box(text)
+            .placeholder_text("Type a message…")
+            .background(Color::transparent())
+            .border_thickness(Thickness::uniform(0.0))
+            .on_text_changed(set_text),
+    ))
+    .spacing(8.0)
+    .into()
+}
+
+fn main() -> Result<()> {
+    reactor_samples::run("TextBox border", app)
+}

--- a/crates/tests/libs/reactor/tests/controls_input.rs
+++ b/crates/tests/libs/reactor/tests/controls_input.rs
@@ -7,6 +7,7 @@ use windows_reactor::{
     CheckBox, NumberBox, RadioButton, RatingControl, RepeatButton, RichEditBox, Slider, TextBox,
     ToggleButton, ToggleSwitch,
 };
+use windows_reactor::{Color, Thickness};
 use windows_reactor::{ControlKind, Event, Prop, PropValue};
 
 fn mount(el: &Element) -> Reconciler<RecordingBackend> {
@@ -250,6 +251,37 @@ fn text_box_mounts_with_value_placeholder_header_and_accepts_return() {
         }
     }
     assert!(saw_value && saw_placeholder && saw_header && saw_accepts_return);
+}
+
+#[test]
+fn text_box_border_brush_and_thickness_set_props() {
+    let el: Element = TextBox::new("x")
+        .border_brush(Color::rgb(60, 120, 220))
+        .border_thickness(Thickness::uniform(2.0))
+        .into();
+    let r = mount(&el);
+    let (kind, _) = first_create(&r);
+    assert_eq!(kind, ControlKind::TextBox);
+
+    let mut saw_brush = false;
+    let mut saw_thickness = false;
+    for op in &r.backend.ops {
+        if let Op::SetProp { prop, value, .. } = op {
+            match (prop, value) {
+                (Prop::BorderBrush, PropValue::Color(c)) if *c == Color::rgb(60, 120, 220) => {
+                    saw_brush = true;
+                }
+                (Prop::BorderThickness, PropValue::Thickness(t))
+                    if *t == Thickness::uniform(2.0) =>
+                {
+                    saw_thickness = true;
+                }
+                _ => {}
+            }
+        }
+    }
+    assert!(saw_brush, "border brush prop not set on TextBox");
+    assert!(saw_thickness, "border thickness prop not set on TextBox");
 }
 
 #[test]

--- a/crates/tests/libs/reactor/tests/controls_shell.rs
+++ b/crates/tests/libs/reactor/tests/controls_shell.rs
@@ -298,6 +298,37 @@ fn navigation_view_mounts_with_menu_items_and_content() {
 }
 
 #[test]
+fn navigation_view_open_pane_length_and_pane_footer() {
+    let nv: Element = NavigationView::new(
+        [NavViewItem::new("Home").tag("home")],
+        text_block("home-page"),
+    )
+    .open_pane_length(260.0)
+    .pane_footer(text_block("footer"))
+    .into();
+    let r = mount(&nv);
+
+    // The footer element is mounted as its own control (here a TextBlock),
+    // in addition to the content TextBlock.
+    assert_eq!(
+        count_create_ops(&r.backend.ops, ControlKind::TextBlock),
+        2,
+        "pane footer element should be mounted alongside the content"
+    );
+
+    let mut saw_open_pane_length = false;
+    for op in &r.backend.ops {
+        if let Op::SetProp { prop, value, .. } = op
+            && let (Prop::OpenPaneLength, PropValue::F64(v)) = (prop, value)
+            && *v == 260.0
+        {
+            saw_open_pane_length = true;
+        }
+    }
+    assert!(saw_open_pane_length, "open pane length prop not set");
+}
+
+#[test]
 fn navigation_view_selection_changed_callback_fires() {
     let observed: Rc<std::cell::RefCell<Option<String>>> = Rc::new(std::cell::RefCell::new(None));
     let observed_c = Rc::clone(&observed);

--- a/crates/tests/libs/reactor/tests/theme_bindings.rs
+++ b/crates/tests/libs/reactor/tests/theme_bindings.rs
@@ -46,6 +46,33 @@ fn button_with_theme_background_emits_apply_theme_bindings_op() {
 }
 
 #[test]
+fn text_box_theme_border_brush_emits_apply_theme_bindings_op() {
+    let mut r = fresh();
+    let el: Element = text_box("x").border_brush(ThemeRef::Accent).into();
+
+    let id = r.reconcile(None, &el, None, no_rerender()).unwrap();
+
+    let theme_ops: Vec<_> = r
+        .backend
+        .ops
+        .iter()
+        .filter_map(|op| match op {
+            Op::ApplyThemeBindings {
+                id: oid,
+                kind,
+                bindings,
+                ..
+            } if *oid == id => Some((kind, bindings.clone())),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(theme_ops.len(), 1, "expected exactly one theme-binding op");
+    let (kind, bindings) = &theme_ops[0];
+    assert_eq!(**kind, ControlKind::TextBox);
+    assert_eq!(bindings, &vec![(Prop::BorderBrush, ThemeRef::Accent)]);
+}
+
+#[test]
 fn no_theme_bindings_means_no_apply_theme_bindings_op() {
     let mut r = fresh();
     let el: Element = button("Go").background(Color::rgb(255, 0, 0)).into();

--- a/crates/tests/libs/reactor/tests/theme_bindings.rs
+++ b/crates/tests/libs/reactor/tests/theme_bindings.rs
@@ -6,7 +6,7 @@ use windows_reactor::Reconciler;
 use windows_reactor::{BrushBinding, ThemeRef, tokens};
 use windows_reactor::{Color, Element};
 use windows_reactor::{ControlKind, Prop};
-use windows_reactor::{button, text_block};
+use windows_reactor::{button, text_block, text_box};
 
 use windows_reactor::vstack;
 fn fresh() -> Reconciler<RecordingBackend> {
@@ -113,6 +113,34 @@ fn direct_brush_overrides_theme_binding_when_set_last() {
         })
         .count();
     assert_eq!(direct_brush_ops, 1);
+    let bindings = r.backend.theme_bindings_of(id);
+    assert!(bindings.is_empty());
+}
+
+#[test]
+fn text_box_direct_border_brush_overrides_theme_binding_when_set_last() {
+    let mut r = fresh();
+    let el: Element = text_box("x")
+        .border_brush(ThemeRef::Accent)
+        .border_brush(Color::rgb(0, 255, 0))
+        .into();
+    let id = r.reconcile(None, &el, None, no_rerender()).unwrap();
+
+    let border_brush_ops = r
+        .backend
+        .ops
+        .iter()
+        .filter(|op| {
+            matches!(
+                op,
+                Op::SetProp {
+                    prop: Prop::BorderBrush,
+                    ..
+                }
+            )
+        })
+        .count();
+    assert_eq!(border_brush_ops, 1);
     let bindings = r.backend.theme_bindings_of(id);
     assert!(bindings.is_empty());
 }

--- a/crates/tests/libs/reactor_selftest/src/bindings.rs
+++ b/crates/tests/libs/reactor_selftest/src/bindings.rs
@@ -9105,6 +9105,27 @@ impl IControl {
             .ok()
         }
     }
+    pub(crate) fn SetBorderThickness(&self, value: Thickness) -> windows_core::Result<()> {
+        unsafe {
+            (windows_core::Interface::vtable(self).SetBorderThickness)(
+                windows_core::Interface::as_raw(self),
+                value,
+            )
+            .ok()
+        }
+    }
+    pub(crate) fn SetBorderBrush<P0>(&self, value: P0) -> windows_core::Result<()>
+    where
+        P0: windows_core::Param<Brush>,
+    {
+        unsafe {
+            (windows_core::Interface::vtable(self).SetBorderBrush)(
+                windows_core::Interface::as_raw(self),
+                value.param().abi(),
+            )
+            .ok()
+        }
+    }
 }
 #[repr(C)]
 pub struct IControl_Vtbl {
@@ -9156,6 +9177,16 @@ pub struct IControl_Vtbl {
     SetVerticalContentAlignment: usize,
     Background: usize,
     pub SetBackground: unsafe extern "system" fn(
+        *mut core::ffi::c_void,
+        *mut core::ffi::c_void,
+    ) -> windows_core::HRESULT,
+    BackgroundSizing: usize,
+    SetBackgroundSizing: usize,
+    BorderThickness: usize,
+    pub SetBorderThickness:
+        unsafe extern "system" fn(*mut core::ffi::c_void, Thickness) -> windows_core::HRESULT,
+    BorderBrush: usize,
+    pub SetBorderBrush: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
@@ -12815,6 +12846,18 @@ impl INavigationView {
             .ok()
         }
     }
+    pub(crate) fn SetPaneFooter<P0>(&self, value: P0) -> windows_core::Result<()>
+    where
+        P0: windows_core::Param<UIElement>,
+    {
+        unsafe {
+            (windows_core::Interface::vtable(self).SetPaneFooter)(
+                windows_core::Interface::as_raw(self),
+                value.param().abi(),
+            )
+            .ok()
+        }
+    }
     pub(crate) fn SetHeader<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<windows_core::IInspectable>,
@@ -12839,6 +12882,15 @@ impl INavigationView {
     pub(crate) fn SetIsPaneToggleButtonVisible(&self, value: bool) -> windows_core::Result<()> {
         unsafe {
             (windows_core::Interface::vtable(self).SetIsPaneToggleButtonVisible)(
+                windows_core::Interface::as_raw(self),
+                value,
+            )
+            .ok()
+        }
+    }
+    pub(crate) fn SetOpenPaneLength(&self, value: f64) -> windows_core::Result<()> {
+        unsafe {
+            (windows_core::Interface::vtable(self).SetOpenPaneLength)(
                 windows_core::Interface::as_raw(self),
                 value,
             )
@@ -12946,7 +12998,10 @@ pub struct INavigationView_Vtbl {
     FooterMenuItemsSource: usize,
     SetFooterMenuItemsSource: usize,
     PaneFooter: usize,
-    SetPaneFooter: usize,
+    pub SetPaneFooter: unsafe extern "system" fn(
+        *mut core::ffi::c_void,
+        *mut core::ffi::c_void,
+    ) -> windows_core::HRESULT,
     Header: usize,
     pub SetHeader: unsafe extern "system" fn(
         *mut core::ffi::c_void,
@@ -12966,7 +13021,8 @@ pub struct INavigationView_Vtbl {
     CompactPaneLength: usize,
     SetCompactPaneLength: usize,
     OpenPaneLength: usize,
-    SetOpenPaneLength: usize,
+    pub SetOpenPaneLength:
+        unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
     PaneToggleButtonStyle: usize,
     SetPaneToggleButtonStyle: usize,
     SelectedItem: usize,

--- a/crates/tools/reactor/src/base.txt
+++ b/crates/tools/reactor/src/base.txt
@@ -100,7 +100,7 @@ Microsoft::UI::Xaml::Controls::ICommandBarFlyoutFactory
 Microsoft::UI::Xaml::Controls::IContentControl::get_Content
 Microsoft::UI::Xaml::Controls::IContentDialog::{ShowAsync, Hide, Closed}
 Microsoft::UI::Xaml::Controls::IContentDialogClosedEventArgs::get_Result
-Microsoft::UI::Xaml::Controls::IControl::{put_Padding, put_Background, put_Foreground, put_FontSize, put_FontWeight, put_FontFamily}
+Microsoft::UI::Xaml::Controls::IControl::{put_Padding, put_Background, put_Foreground, put_FontSize, put_FontWeight, put_FontFamily, put_BorderBrush, put_BorderThickness}
 Microsoft::UI::Xaml::Controls::IDatePicker::SelectedDateChanged
 Microsoft::UI::Xaml::Controls::IDatePickerSelectedValueChangedEventArgs::get_NewDate
 Microsoft::UI::Xaml::Controls::IExpander::{put_Header, Expanding, Collapsed}
@@ -118,7 +118,7 @@ Microsoft::UI::Xaml::Controls::IMenuFlyout::get_Items
 Microsoft::UI::Xaml::Controls::IMenuFlyoutItem::{put_Text, get_Text, Click}
 Microsoft::UI::Xaml::Controls::IMenuFlyoutSubItem::{get_Items, put_Text}
 Microsoft::UI::Xaml::Controls::INavigationView2::{put_IsBackButtonVisible, BackRequested}
-Microsoft::UI::Xaml::Controls::INavigationView::{get_MenuItems, put_SelectedItem, put_AutoSuggestBox, get_AutoSuggestBox, SelectionChanged}
+Microsoft::UI::Xaml::Controls::INavigationView::{get_MenuItems, put_SelectedItem, put_AutoSuggestBox, get_AutoSuggestBox, put_PaneFooter, SelectionChanged}
 Microsoft::UI::Xaml::Controls::INavigationViewItem2::get_MenuItems
 Microsoft::UI::Xaml::Controls::INavigationViewItem::put_Icon
 Microsoft::UI::Xaml::Controls::INavigationViewSelectionChangedEventArgs::get_SelectedItem

--- a/crates/tools/reactor/src/generated.txt
+++ b/crates/tools/reactor/src/generated.txt
@@ -29,7 +29,7 @@ Microsoft::UI::Xaml::Controls::IExpander::put_IsExpanded
 Microsoft::UI::Xaml::Controls::IGrid::{put_ColumnSpacing, put_RowSpacing}
 Microsoft::UI::Xaml::Controls::IImage::put_Stretch
 Microsoft::UI::Xaml::Controls::IInfoBar::{put_IsClosable, put_IsOpen, put_Message, put_Severity, put_Title}
-Microsoft::UI::Xaml::Controls::INavigationView::{put_Header, put_IsPaneOpen, put_IsPaneToggleButtonVisible, put_IsSettingsVisible}
+Microsoft::UI::Xaml::Controls::INavigationView::{put_Header, put_IsPaneOpen, put_IsPaneToggleButtonVisible, put_IsSettingsVisible, put_OpenPaneLength}
 Microsoft::UI::Xaml::Controls::INavigationView2::{put_IsBackEnabled, put_PaneDisplayMode, put_PaneTitle}
 Microsoft::UI::Xaml::Controls::INumberBox::{put_Header, put_Maximum, put_Minimum, put_Value}
 Microsoft::UI::Xaml::Controls::IPasswordBox::{put_Header, put_IsPasswordRevealButtonEnabled, put_PasswordRevealMode, put_PlaceholderText}

--- a/crates/tools/reactor/src/winui.toml
+++ b/crates/tools/reactor/src/winui.toml
@@ -140,6 +140,7 @@ ItemClicked = { manual = true, type = "Str" }
 
 ["Microsoft.UI.Xaml.Controls.NavigationView"]
 IsPaneOpen = {}
+OpenPaneLength = {}
 PaneDisplayMode = {}
 IsBackEnabled = {}
 IsSettingsVisible = {}

--- a/docs/crates/windows-reactor.md
+++ b/docs/crates/windows-reactor.md
@@ -294,13 +294,17 @@ and text blocks. Containers that genuinely lack a `Padding` property (e.g. bare
 `Panel`/`Grid`) still fall through to `diag::unhandled_modifier`, which warns
 under debug builds; use `.margin(...)` there instead.
 
-`Background`, `Foreground`, `BorderBrush`, and `BorderThickness` follow the same
-pattern: `Border` handles them through its default interface, while every other
-handle falls back to a single `IControl` cast (`set_background` / `set_border_brush`
-/ `set_border_thickness` in `backend/winui/mod.rs`). This is why `TextBox` — and
-any other `Control` — can set a background fill (`.background(...)` on `ElementExt`)
-and a custom border (`.border_brush(...)` / `.border_thickness(...)` builders) even
-though only `Border` declares those setters on a dedicated interface.
+`Background` and `Foreground` follow the same pattern and are exposed as the
+universal `ElementExt` modifiers `.background(...)` / `.foreground(...)`: `Border`
+handles them through its default interface while every other handle falls back to
+a single `IControl` cast (`set_background` / `set_foreground` in
+`backend/winui/mod.rs`), so they work on any `Control`. `BorderBrush` /
+`BorderThickness` use the same `IControl` fallback in the backend
+(`set_border_brush` / `set_border_thickness`), but are *not* `ElementExt`
+modifiers — they are opt-in per-widget builders. Only `Border` and `TextBox`
+currently expose `.border_brush(...)` / `.border_thickness(...)`; the shared
+backend dispatch means any other widget could expose them without new backend
+work.
 
 ### Threading
 

--- a/docs/crates/windows-reactor.md
+++ b/docs/crates/windows-reactor.md
@@ -294,6 +294,14 @@ and text blocks. Containers that genuinely lack a `Padding` property (e.g. bare
 `Panel`/`Grid`) still fall through to `diag::unhandled_modifier`, which warns
 under debug builds; use `.margin(...)` there instead.
 
+`Background`, `Foreground`, `BorderBrush`, and `BorderThickness` follow the same
+pattern: `Border` handles them through its default interface, while every other
+handle falls back to a single `IControl` cast (`set_background` / `set_border_brush`
+/ `set_border_thickness` in `backend/winui/mod.rs`). This is why `TextBox` — and
+any other `Control` — can set a background fill (`.background(...)` on `ElementExt`)
+and a custom border (`.border_brush(...)` / `.border_thickness(...)` builders) even
+though only `Border` declares those setters on a dedicated interface.
+
 ### Threading
 
 Reactor runs on a WinUI STA thread and keeps per-thread state in `thread_local!`


### PR DESCRIPTION
Adds the missing WinUI properties requested in #4669 and #4671. 

`NavigationView` gains `open_pane_length(f64)` (declarative, via `winui.toml`) and `pane_footer(impl Into<Element>)`, which mounts arbitrary content in the pane's footer slot (reusing the existing `pane_element` reconciler path — distinct from the built-in `settings_visible` gear). 

`TextBox` gains `border_brush`/`border_thickness` builders, mirroring `Border` (direct `Color` or theme-ref). 

To support this, the backend's `BorderBrush`/`BorderThickness` dispatch is generalized from `Border`-only to any `Control` via a single `IControl` cast — matching the existing `set_background`/`set_foreground` pattern — plus a `Color::transparent()` helper for borderless inputs. Covered by two new automated tests and two runnable samples (`navigation_view_pane`, `text_box_border`); `fmt`/`clippy`/`test_reactor` clean and `tool_reactor` regen is idempotent.

Two new samples to validate:

```
cargo run -p reactor_samples --example navigation_view_pane   # open_pane_length + pane_footer
cargo run -p reactor_samples --example text_box_border        # border brush/thickness + transparent input
```

