### PR TITLE
`windows-clang` context alignment sample

### DIFF
--- a/crates/samples/bindgen/context_alignment/Cargo.toml
+++ b/crates/samples/bindgen/context_alignment/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sample_context_alignment"
+version = "0.0.0"
+edition = "2024"
+publish = false
+
+[build-dependencies]
+windows-bindgen = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/samples/bindgen/context_alignment/build.rs
+++ b/crates/samples/bindgen/context_alignment/build.rs
@@ -1,0 +1,12 @@
+fn main() {
+    let out_dir = std::env::var("OUT_DIR").unwrap();
+    let bindings = format!("{out_dir}/bindings.rs");
+
+    windows_bindgen::builder()
+        .input("default")
+        .output(&bindings)
+        .filter("CONTEXT")
+        .sys()
+        .flat()
+        .write();
+}

--- a/crates/samples/bindgen/context_alignment/src/main.rs
+++ b/crates/samples/bindgen/context_alignment/src/main.rs
@@ -1,0 +1,23 @@
+// Generates `CONTEXT` from the in-house Win32 metadata with `windows-bindgen`
+// and prints its size and alignment. This confirms the metadata scrapes the
+// architecture-specific `CONTEXT` (and its `__declspec(align(16))` `M128A`
+// members) with correct layout — including the 16-byte alignment on x64/arm64.
+
+#![expect(nonstandard_style)]
+
+include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
+
+fn main() {
+    println!("target arch: {}\n", std::env::consts::ARCH);
+    println!("        size   align");
+    println!(
+        "M128A   {:>4}      {:>2}",
+        size_of::<M128A>(),
+        align_of::<M128A>()
+    );
+    println!(
+        "CONTEXT {:>4}      {:>2}",
+        size_of::<CONTEXT>(),
+        align_of::<CONTEXT>()
+    );
+}


### PR DESCRIPTION
This sample illustrates that the long-standing `CONTEXT` parsing bug in Win32metadata is fixed with the in-house metadata generation (#4649).

```
> cargo run -p sample_context_alignment
target arch: x86_64

        size   align
M128A     16      16
CONTEXT 1232      16


> cargo run -p sample_context_alignment --target i686-pc-windows-msvc
target arch: x86

        size   align
M128A     16      16
CONTEXT  716       4
```