### PR TITLE
`windows-bindgen` vss backup sample

### DIFF
--- a/crates/samples/bindgen/vss_backup/Cargo.toml
+++ b/crates/samples/bindgen/vss_backup/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "sample_vss_backup"
+version = "0.0.0"
+edition = "2024"
+publish = false
+
+[dependencies]
+windows-core = { workspace = true }
+
+[build-dependencies]
+windows-bindgen = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/samples/bindgen/vss_backup/build.rs
+++ b/crates/samples/bindgen/vss_backup/build.rs
@@ -4,8 +4,11 @@ fn main() {
 
     windows_bindgen::builder()
         .output(&bindings)
-        .filter("CONTEXT")
-        .sys()
+        .filters([
+            "CreateVssBackupComponentsInternal",
+            "CoIncrementMTAUsage",
+            "VSS_BT_FULL",
+        ])
         .flat()
         .write();
 }

--- a/crates/samples/bindgen/vss_backup/src/main.rs
+++ b/crates/samples/bindgen/vss_backup/src/main.rs
@@ -1,0 +1,24 @@
+// Generates the Volume Shadow Copy backup API from the in-house Win32 metadata
+// with `windows-bindgen` and saves the Backup Components Document as XML.
+// `IVssBackupComponents` is defined in the C++-only `vsbackup.h` header. Run elevated.
+
+#![allow(unused_qualifications, nonstandard_style, clippy::all)]
+
+include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
+
+use windows_core::*;
+
+fn main() -> Result<()> {
+    unsafe {
+        CoIncrementMTAUsage()?;
+
+        let backup = CreateVssBackupComponentsInternal()?;
+        backup.InitializeForBackup(&BSTR::new())?;
+        backup.SetBackupState(true, true, VSS_BT_FULL, false)?;
+
+        let mut xml = BSTR::new();
+        backup.SaveAsXML(&mut xml)?;
+        println!("{}", xml.display());
+        Ok(())
+    }
+}


### PR DESCRIPTION
This sample illustrates using the VSS backup API thanks to the in-house metadata generation (https://github.com/microsoft/windows-rs/pull/4649).