### PR TITLE
`windows-bindgen` remove workarounds for the retired Win32 metadata

### DIFF
--- a/crates/libs/bindgen/src/tables/field.rs
+++ b/crates/libs/bindgen/src/tables/field.rs
@@ -6,11 +6,6 @@ pub trait FieldExt {
 
 impl FieldExt for Field {
     fn field_type(&self, enclosing: Option<&CppStruct>, reader: &Reader) -> Type {
-        let ty = Type::from_metadata_type(&self.ty(), enclosing, &[], reader);
-        if self.has_attribute("ConstAttribute") {
-            ty.to_const_type().to_const_ptr()
-        } else {
-            ty
-        }
+        Type::from_metadata_type(&self.ty(), enclosing, &[], reader)
     }
 }

--- a/crates/libs/bindgen/src/tables/method_def.rs
+++ b/crates/libs/bindgen/src/tables/method_def.rs
@@ -19,22 +19,9 @@ impl MethodDefExt for MethodDef {
     }
 
     fn module_name(&self) -> String {
-        const COMBASE_FUNCTIONS: [&str; 5] = [
-            "CoCreateFreeThreadedMarshaler",
-            "CoIncrementMTAUsage",
-            "CoTaskMemAlloc",
-            "CoTaskMemFree",
-            "RoGetAgileReference",
-        ];
-
-        // Workaround for https://github.com/microsoft/windows-rs/pull/3743
-        if COMBASE_FUNCTIONS.contains(&self.name()) {
-            "combase.dll".to_string()
-        } else {
-            self.impl_map()
-                .map_or("", |map| map.import_scope().name())
-                .to_lowercase()
-        }
+        self.impl_map()
+            .map_or("", |map| map.import_scope().name())
+            .to_lowercase()
     }
 
     #[track_caller]

--- a/crates/libs/bindgen/src/types/cpp_fn.rs
+++ b/crates/libs/bindgen/src/types/cpp_fn.rs
@@ -195,18 +195,6 @@ impl CppFn {
                     }
                 }
             }
-            ReturnHint::ResultVoid => {
-                let where_clause = method.write_where(config, false);
-
-                quote! {
-                    #cfg
-                    #[inline]
-                    pub unsafe fn #name<#generics>(#params) -> #result Result<()> #where_clause {
-                        #link
-                        unsafe { #name(#args).ok() }
-                    }
-                }
-            }
             ReturnHint::ReturnValue => {
                 let where_clause = method.write_where(config, false);
 
@@ -255,26 +243,12 @@ impl CppFn {
             ReturnHint::ReturnStruct | ReturnHint::None | ReturnHint::HResult => {
                 let where_clause = method.write_where(config, false);
 
-                if method.handle_last_error(config.reader) {
-                    let return_type = signature.return_type.write_name(config);
-
-                    quote! {
-                        #cfg
-                        #[inline]
-                        pub unsafe fn #name<#generics>(#params) -> #result Result<#return_type> #where_clause {
-                            #link
-                            let result__ = unsafe { #name(#args) };
-                            (!result__.is_invalid()).then_some(result__).ok_or_else(windows_core::Error::from_thread)
-                        }
-                    }
-                } else {
-                    quote! {
-                        #cfg
-                        #[inline]
-                        pub unsafe fn #name<#generics>(#params) #abi_return_type #where_clause {
-                            #link
-                            unsafe { #name(#args) }
-                        }
+                quote! {
+                    #cfg
+                    #[inline]
+                    pub unsafe fn #name<#generics>(#params) #abi_return_type #where_clause {
+                        #link
+                        unsafe { #name(#args) }
                     }
                 }
             }

--- a/crates/libs/bindgen/src/types/cpp_method.rs
+++ b/crates/libs/bindgen/src/types/cpp_method.rs
@@ -15,7 +15,6 @@ pub enum ReturnHint {
     Query(usize, usize),
     QueryOptional(usize, usize),
     ResultValue,
-    ResultVoid,
     HResult,
     ReturnStruct,
     ReturnValue,
@@ -159,12 +158,6 @@ impl CppMethod {
         let is_retval = signature.is_retval(reader);
         let mut return_hint = ReturnHint::None;
 
-        let last_error = if let Some(map) = def.impl_map() {
-            map.flags().contains(PInvokeAttributes::SupportsLastError)
-        } else {
-            false
-        };
-
         match &signature.return_type {
             Type::Void if is_retval => return_hint = ReturnHint::ReturnValue,
             Type::HRESULT => {
@@ -189,7 +182,6 @@ impl CppMethod {
                     }
                 }
             }
-            Type::BOOL if last_error => return_hint = ReturnHint::ResultVoid,
             Type::GUID => return_hint = ReturnHint::ReturnStruct,
             Type::CppStruct(ty) if !ty.is_handle(reader) => {
                 return_hint = ReturnHint::ReturnStruct;
@@ -296,15 +288,6 @@ impl CppMethod {
                             let mut result__ = core::mem::zeroed();
                             (windows_core::Interface::vtable(self).#vname)(windows_core::Interface::as_raw(self),#args).#map
                         }
-                    }
-                }
-            }
-            ReturnHint::ResultVoid => {
-                let where_clause = self.write_where(config, false);
-
-                quote! {
-                    #vis unsafe fn #name<#generics>(&self, #params) -> #result Result<()> #where_clause {
-                        unsafe { (windows_core::Interface::vtable(self).#vname)(windows_core::Interface::as_raw(self),#args).ok() }
                     }
                 }
             }
@@ -415,10 +398,7 @@ impl CppMethod {
                     }
                 }
             }
-            ReturnHint::Query(..)
-            | ReturnHint::QueryOptional(..)
-            | ReturnHint::ResultVoid
-            | ReturnHint::HResult => {
+            ReturnHint::Query(..) | ReturnHint::QueryOptional(..) | ReturnHint::HResult => {
                 let invoke_args = self
                     .signature
                     .params
@@ -487,10 +467,7 @@ impl CppMethod {
         let result = config.write_core();
 
         let return_type = match self.return_hint {
-            ReturnHint::Query(..)
-            | ReturnHint::QueryOptional(..)
-            | ReturnHint::ResultVoid
-            | ReturnHint::HResult => {
+            ReturnHint::Query(..) | ReturnHint::QueryOptional(..) | ReturnHint::HResult => {
                 quote! { -> #result Result<()> }
             }
             ReturnHint::ResultValue => {
@@ -767,25 +744,6 @@ impl CppMethod {
                 quote! { -> #ty }
             }
         }
-    }
-
-    pub fn handle_last_error(&self, reader: &Reader) -> bool {
-        if let Some(map) = self.def.impl_map() {
-            if map.flags().contains(PInvokeAttributes::SupportsLastError) {
-                if let Type::CppStruct(ty) = &self.signature.return_type {
-                    if ty.is_handle(reader) {
-                        // https://github.com/microsoft/windows-rs/issues/2392#issuecomment-1477765781
-                        if self.def.name() == "LocalFree" {
-                            return false;
-                        }
-                        if ty.def.underlying_type_ext(reader).is_pointer() {
-                            return true;
-                        }
-                    }
-                }
-            }
-        }
-        false
     }
 }
 

--- a/crates/libs/core/src/imp/bindings.rs
+++ b/crates/libs/core/src/imp/bindings.rs
@@ -1,12 +1,12 @@
-windows_core::link!("combase.dll" "system" fn CoIncrementMTAUsage(pcookie : *mut CO_MTA_USAGE_COOKIE) -> windows_core::HRESULT);
-windows_core::link!("combase.dll" "system" fn CoTaskMemAlloc(cb : usize) -> *mut core::ffi::c_void);
-windows_core::link!("combase.dll" "system" fn CoTaskMemFree(pv : *mut core::ffi::c_void));
+windows_core::link!("ole32.dll" "system" fn CoIncrementMTAUsage(pcookie : *mut CO_MTA_USAGE_COOKIE) -> windows_core::HRESULT);
+windows_core::link!("ole32.dll" "system" fn CoTaskMemAlloc(cb : usize) -> *mut core::ffi::c_void);
+windows_core::link!("ole32.dll" "system" fn CoTaskMemFree(pv : *mut core::ffi::c_void));
 windows_core::link!("kernel32.dll" "system" fn EncodePointer(ptr : *const core::ffi::c_void) -> *mut core::ffi::c_void);
 windows_core::link!("kernel32.dll" "system" fn FreeLibrary(hlibmodule : HMODULE) -> windows_core::BOOL);
 windows_core::link!("kernel32.dll" "system" fn GetProcAddress(hmodule : HMODULE, lpprocname : windows_core::PCSTR) -> FARPROC);
 windows_core::link!("kernel32.dll" "system" fn LoadLibraryExA(lplibfilename : windows_core::PCSTR, hfile : HANDLE, dwflags : u32) -> HMODULE);
 windows_core::link!("api-ms-win-core-winrt-l1-1-0.dll" "system" fn RoGetActivationFactory(activatableclassid : *mut core::ffi::c_void, iid : *const windows_core::GUID, factory : *mut *mut core::ffi::c_void) -> windows_core::HRESULT);
-windows_core::link!("combase.dll" "system" fn RoGetAgileReference(options : AgileReferenceOptions, riid : *const windows_core::GUID, punk : *mut core::ffi::c_void, ppagilereference : *mut *mut core::ffi::c_void) -> windows_core::HRESULT);
+windows_core::link!("ole32.dll" "system" fn RoGetAgileReference(options : AgileReferenceOptions, riid : *const windows_core::GUID, punk : *mut core::ffi::c_void, ppagilereference : *mut *mut core::ffi::c_void) -> windows_core::HRESULT);
 windows_core::link!("rpcrt4.dll" "system" fn UuidCreate(uuid : *mut windows_core::GUID) -> RPC_STATUS);
 pub const AGILEREFERENCE_DEFAULT: AgileReferenceOptions = 0;
 pub type AgileReferenceOptions = i32;

--- a/crates/libs/core/src/imp/marshaler.rs
+++ b/crates/libs/core/src/imp/marshaler.rs
@@ -4,7 +4,7 @@ use core::ffi::c_void;
 use core::mem::{transmute, transmute_copy};
 use core::ptr::null_mut;
 
-windows_link::link!("combase.dll" "system" fn CoCreateFreeThreadedMarshaler(punkouter: *mut c_void, ppunkmarshal: *mut *mut c_void) -> HRESULT);
+windows_link::link!("ole32.dll" "system" fn CoCreateFreeThreadedMarshaler(punkouter: *mut c_void, ppunkmarshal: *mut *mut c_void) -> HRESULT);
 
 pub unsafe fn marshaler(outer: IUnknown, result: *mut *mut c_void) -> HRESULT {
     unsafe {

--- a/crates/libs/rdl/src/reader/fn.rs
+++ b/crates/libs/rdl/src/reader/fn.rs
@@ -85,36 +85,28 @@ impl Encoder<'_> {
             return self.err(&item.sig, "`library` attribute not found");
         };
 
-        let (library, last_error, import) = attribute
+        let (library, import) = attribute
             .parse_args_with(
-                |input: syn::parse::ParseStream| -> syn::Result<(syn::LitStr, bool, Option<String>)> {
+                |input: syn::parse::ParseStream| -> syn::Result<(syn::LitStr, Option<String>)> {
                     let library: syn::LitStr = input.parse()?;
-                    let mut last_error = false;
                     let mut import = None;
                     while input.peek(syn::Token![,]) {
                         input.parse::<syn::Token![,]>()?;
                         let ident: syn::Ident = input.parse()?;
                         input.parse::<syn::Token![=]>()?;
-                        if ident == "last_error" {
-                            let value: syn::LitBool = input.parse()?;
-                            last_error = value.value();
-                        } else if ident == "import" {
+                        if ident == "import" {
                             let value: syn::LitStr = input.parse()?;
                             import = Some(value.value());
                         } else {
                             return Err(syn::Error::new(ident.span(), "unknown library option"));
                         }
                     }
-                    Ok((library, last_error, import))
+                    Ok((library, import))
                 },
             )
             .or_else(|_| self.err(attribute.span(), "`library` name missing"))?;
 
         let mut flags = metadata::PInvokeAttributes::NoMangle;
-
-        if last_error {
-            flags |= metadata::PInvokeAttributes::SupportsLastError;
-        }
 
         if let Some(abi) = &item.abi {
             match abi.value().as_str() {

--- a/crates/libs/rdl/src/writer/fn.rs
+++ b/crates/libs/rdl/src/writer/fn.rs
@@ -44,9 +44,6 @@ pub fn write_fn(namespace: &str, item: &metadata::reader::MethodDef) -> Result<T
     )?;
 
     let mut library_opts = TokenStream::new();
-    if flags.contains(metadata::PInvokeAttributes::SupportsLastError) {
-        library_opts.extend(quote! { , last_error = true });
-    }
     let import = impl_map.import_name();
     if import != item.name() {
         library_opts.extend(quote! { , import = #import });

--- a/crates/libs/sys/src/Windows/combaseapi/mod.rs
+++ b/crates/libs/sys/src/Windows/combaseapi/mod.rs
@@ -5,7 +5,7 @@ windows_link::link!("ole32.dll" "system" fn CoAddRefServerProcess() -> u32);
 windows_link::link!("ole32.dll" "system" fn CoAllowUnmarshalerCLSID(clsid : *const windows_sys::core::GUID) -> windows_sys::core::HRESULT);
 windows_link::link!("ole32.dll" "system" fn CoCancelCall(dwthreadid : u32, ultimeout : u32) -> windows_sys::core::HRESULT);
 windows_link::link!("ole32.dll" "system" fn CoCopyProxy(pproxy : *mut core::ffi::c_void, ppcopy : *mut *mut core::ffi::c_void) -> windows_sys::core::HRESULT);
-windows_link::link!("combase.dll" "system" fn CoCreateFreeThreadedMarshaler(punkouter : *mut core::ffi::c_void, ppunkmarshal : *mut *mut core::ffi::c_void) -> windows_sys::core::HRESULT);
+windows_link::link!("ole32.dll" "system" fn CoCreateFreeThreadedMarshaler(punkouter : *mut core::ffi::c_void, ppunkmarshal : *mut *mut core::ffi::c_void) -> windows_sys::core::HRESULT);
 windows_link::link!("ole32.dll" "system" fn CoCreateGuid(pguid : *mut windows_sys::core::GUID) -> windows_sys::core::HRESULT);
 windows_link::link!("ole32.dll" "system" fn CoCreateInstance(rclsid : *const windows_sys::core::GUID, punkouter : *mut core::ffi::c_void, dwclscontext : u32, riid : *const windows_sys::core::GUID, ppv : *mut *mut core::ffi::c_void) -> windows_sys::core::HRESULT);
 #[cfg(all(feature = "objidlbase", feature = "wtypesbase"))]
@@ -45,7 +45,7 @@ windows_link::link!("ole32.dll" "system" fn CoGetStandardMarshal(riid : *const w
 windows_link::link!("ole32.dll" "system" fn CoGetStdMarshalEx(punkouter : *mut core::ffi::c_void, smexflags : u32, ppunkinner : *mut *mut core::ffi::c_void) -> windows_sys::core::HRESULT);
 windows_link::link!("ole32.dll" "system" fn CoGetTreatAsClass(clsidold : *const windows_sys::core::GUID, pclsidnew : *mut windows_sys::core::GUID) -> windows_sys::core::HRESULT);
 windows_link::link!("ole32.dll" "system" fn CoImpersonateClient() -> windows_sys::core::HRESULT);
-windows_link::link!("combase.dll" "system" fn CoIncrementMTAUsage(pcookie : *mut CO_MTA_USAGE_COOKIE) -> windows_sys::core::HRESULT);
+windows_link::link!("ole32.dll" "system" fn CoIncrementMTAUsage(pcookie : *mut CO_MTA_USAGE_COOKIE) -> windows_sys::core::HRESULT);
 windows_link::link!("ole32.dll" "system" fn CoInitializeEx(pvreserved : *const core::ffi::c_void, dwcoinit : u32) -> windows_sys::core::HRESULT);
 #[cfg(all(feature = "objidlbase", feature = "winnt", feature = "wtypesbase"))]
 windows_link::link!("ole32.dll" "system" fn CoInitializeSecurity(psecdesc : super::winnt::PSECURITY_DESCRIPTOR, cauthsvc : i32, asauthsvc : *const super::objidlbase::SOLE_AUTHENTICATION_SERVICE, preserved1 : *const core::ffi::c_void, dwauthnlevel : u32, dwimplevel : u32, pauthlist : *const core::ffi::c_void, dwcapabilities : u32, preserved3 : *const core::ffi::c_void) -> windows_sys::core::HRESULT);
@@ -83,8 +83,8 @@ windows_link::link!("ole32.dll" "system" fn CoSetCancelObject(punk : *mut core::
 windows_link::link!("ole32.dll" "system" fn CoSetProxyBlanket(pproxy : *mut core::ffi::c_void, dwauthnsvc : u32, dwauthzsvc : u32, pserverprincname : *const super::wtypesbase::OLECHAR, dwauthnlevel : u32, dwimplevel : u32, pauthinfo : super::rpc::RPC_AUTH_IDENTITY_HANDLE, dwcapabilities : u32) -> windows_sys::core::HRESULT);
 windows_link::link!("ole32.dll" "system" fn CoSuspendClassObjects() -> windows_sys::core::HRESULT);
 windows_link::link!("ole32.dll" "system" fn CoSwitchCallContext(pnewobject : *mut core::ffi::c_void, ppoldobject : *mut *mut core::ffi::c_void) -> windows_sys::core::HRESULT);
-windows_link::link!("combase.dll" "system" fn CoTaskMemAlloc(cb : usize) -> *mut core::ffi::c_void);
-windows_link::link!("combase.dll" "system" fn CoTaskMemFree(pv : *mut core::ffi::c_void));
+windows_link::link!("ole32.dll" "system" fn CoTaskMemAlloc(cb : usize) -> *mut core::ffi::c_void);
+windows_link::link!("ole32.dll" "system" fn CoTaskMemFree(pv : *mut core::ffi::c_void));
 windows_link::link!("ole32.dll" "system" fn CoTaskMemRealloc(pv : *mut core::ffi::c_void, cb : usize) -> *mut core::ffi::c_void);
 windows_link::link!("ole32.dll" "system" fn CoTestCancel() -> windows_sys::core::HRESULT);
 windows_link::link!("ole32.dll" "system" fn CoUninitialize());
@@ -109,7 +109,7 @@ windows_link::link!("ole32.dll" "system" fn PropVariantClear(pvar : *mut super::
 #[cfg(all(feature = "minwindef", feature = "oaidl", feature = "objidl", feature = "objidlbase", feature = "propidlbase", feature = "wtypes", feature = "wtypesbase"))]
 windows_link::link!("ole32.dll" "system" fn PropVariantCopy(pvardest : *mut super::propidlbase::PROPVARIANT, pvarsrc : *const super::propidlbase::PROPVARIANT) -> windows_sys::core::HRESULT);
 #[cfg(feature = "objidlbase")]
-windows_link::link!("combase.dll" "system" fn RoGetAgileReference(options : AgileReferenceOptions, riid : *const windows_sys::core::GUID, punk : *mut core::ffi::c_void, ppagilereference : *mut *mut core::ffi::c_void) -> windows_sys::core::HRESULT);
+windows_link::link!("ole32.dll" "system" fn RoGetAgileReference(options : AgileReferenceOptions, riid : *const windows_sys::core::GUID, punk : *mut core::ffi::c_void, ppagilereference : *mut *mut core::ffi::c_void) -> windows_sys::core::HRESULT);
 windows_link::link!("ole32.dll" "system" fn StringFromCLSID(rclsid : *const windows_sys::core::GUID, lplpsz : *mut windows_sys::core::PWSTR) -> windows_sys::core::HRESULT);
 windows_link::link!("ole32.dll" "system" fn StringFromGUID2(rguid : *const windows_sys::core::GUID, lpsz : windows_sys::core::PWSTR, cchmax : i32) -> i32);
 windows_link::link!("ole32.dll" "system" fn StringFromIID(rclsid : *const windows_sys::core::GUID, lplpsz : *mut windows_sys::core::PWSTR) -> windows_sys::core::HRESULT);

--- a/crates/libs/webview/src/bindings.rs
+++ b/crates/libs/webview/src/bindings.rs
@@ -1,6 +1,6 @@
 windows_core::link!("ole32.dll" "system" fn CoInitializeEx(pvreserved : *const core::ffi::c_void, dwcoinit : u32) -> windows_core::HRESULT);
-windows_core::link!("combase.dll" "system" fn CoTaskMemAlloc(cb : usize) -> *mut core::ffi::c_void);
-windows_core::link!("combase.dll" "system" fn CoTaskMemFree(pv : *mut core::ffi::c_void));
+windows_core::link!("ole32.dll" "system" fn CoTaskMemAlloc(cb : usize) -> *mut core::ffi::c_void);
+windows_core::link!("ole32.dll" "system" fn CoTaskMemFree(pv : *mut core::ffi::c_void));
 windows_core::link!("webview2loader.dll" "system" fn CreateCoreWebView2Environment(environmentcreatedhandler : *mut core::ffi::c_void) -> windows_core::HRESULT);
 windows_core::link!("webview2loader.dll" "system" fn CreateCoreWebView2EnvironmentWithOptions(browserexecutablefolder : windows_core::PCWSTR, userdatafolder : windows_core::PCWSTR, environmentoptions : *mut core::ffi::c_void, environmentcreatedhandler : *mut core::ffi::c_void) -> windows_core::HRESULT);
 windows_core::link!("user32.dll" "system" fn DispatchMessageW(lpmsg : *const MSG) -> LRESULT);

--- a/crates/libs/windows/src/Windows/combaseapi/mod.rs
+++ b/crates/libs/windows/src/Windows/combaseapi/mod.rs
@@ -62,7 +62,7 @@ pub unsafe fn CoCreateFreeThreadedMarshaler<P0>(punkouter: P0) -> windows_core::
 where
     P0: windows_core::Param<windows_core::IUnknown>,
 {
-    windows_core::link!("combase.dll" "system" fn CoCreateFreeThreadedMarshaler(punkouter : *mut core::ffi::c_void, ppunkmarshal : *mut *mut core::ffi::c_void) -> windows_core::HRESULT);
+    windows_core::link!("ole32.dll" "system" fn CoCreateFreeThreadedMarshaler(punkouter : *mut core::ffi::c_void, ppunkmarshal : *mut *mut core::ffi::c_void) -> windows_core::HRESULT);
     unsafe {
         let mut result__ = core::mem::zeroed();
         CoCreateFreeThreadedMarshaler(punkouter.param().abi(), &mut result__).and_then(|| windows_core::Type::from_abi(result__))
@@ -314,7 +314,7 @@ pub unsafe fn CoImpersonateClient() -> windows_core::HRESULT {
 }
 #[inline]
 pub unsafe fn CoIncrementMTAUsage() -> windows_core::Result<CO_MTA_USAGE_COOKIE> {
-    windows_core::link!("combase.dll" "system" fn CoIncrementMTAUsage(pcookie : *mut CO_MTA_USAGE_COOKIE) -> windows_core::HRESULT);
+    windows_core::link!("ole32.dll" "system" fn CoIncrementMTAUsage(pcookie : *mut CO_MTA_USAGE_COOKIE) -> windows_core::HRESULT);
     unsafe {
         let mut result__ = core::mem::zeroed();
         CoIncrementMTAUsage(&mut result__).map(|| result__)
@@ -521,12 +521,12 @@ where
 }
 #[inline]
 pub unsafe fn CoTaskMemAlloc(cb: usize) -> *mut core::ffi::c_void {
-    windows_core::link!("combase.dll" "system" fn CoTaskMemAlloc(cb : usize) -> *mut core::ffi::c_void);
+    windows_core::link!("ole32.dll" "system" fn CoTaskMemAlloc(cb : usize) -> *mut core::ffi::c_void);
     unsafe { CoTaskMemAlloc(cb) }
 }
 #[inline]
 pub unsafe fn CoTaskMemFree(pv: *mut core::ffi::c_void) {
-    windows_core::link!("combase.dll" "system" fn CoTaskMemFree(pv : *mut core::ffi::c_void));
+    windows_core::link!("ole32.dll" "system" fn CoTaskMemFree(pv : *mut core::ffi::c_void));
     unsafe { CoTaskMemFree(pv as _) }
 }
 #[inline]
@@ -649,7 +649,7 @@ pub unsafe fn RoGetAgileReference<P2>(options: AgileReferenceOptions, riid: *con
 where
     P2: windows_core::Param<windows_core::IUnknown>,
 {
-    windows_core::link!("combase.dll" "system" fn RoGetAgileReference(options : AgileReferenceOptions, riid : *const windows_core::GUID, punk : *mut core::ffi::c_void, ppagilereference : *mut *mut core::ffi::c_void) -> windows_core::HRESULT);
+    windows_core::link!("ole32.dll" "system" fn RoGetAgileReference(options : AgileReferenceOptions, riid : *const windows_core::GUID, punk : *mut core::ffi::c_void, ppagilereference : *mut *mut core::ffi::c_void) -> windows_core::HRESULT);
     unsafe {
         let mut result__ = core::mem::zeroed();
         RoGetAgileReference(options, riid, punk.param().abi(), &mut result__).and_then(|| windows_core::Type::from_abi(result__))

--- a/crates/samples/animation/samples/src/lib.rs
+++ b/crates/samples/animation/samples/src/lib.rs
@@ -11,7 +11,7 @@ pub use windows_animation::*;
 /// manager's in-process COM server can be created.
 pub fn init_com() {
     unsafe {
-        windows_core::link!("combase.dll" "system" fn CoIncrementMTAUsage(cookie: *mut *mut core::ffi::c_void) -> windows_core::HRESULT);
+        windows_core::link!("ole32.dll" "system" fn CoIncrementMTAUsage(cookie: *mut *mut core::ffi::c_void) -> windows_core::HRESULT);
         let mut cookie = core::ptr::null_mut();
         let _ = CoIncrementMTAUsage(&mut cookie);
     }

--- a/crates/tests/libs/animation/src/lib.rs
+++ b/crates/tests/libs/animation/src/lib.rs
@@ -8,7 +8,7 @@ mod tests {
 
     fn ensure_com_initialized() {
         unsafe {
-            windows_core::link!("combase.dll" "system" fn CoIncrementMTAUsage(pcookie: *mut *mut core::ffi::c_void) -> windows_core::HRESULT);
+            windows_core::link!("ole32.dll" "system" fn CoIncrementMTAUsage(pcookie: *mut *mut core::ffi::c_void) -> windows_core::HRESULT);
             let mut cookie = core::ptr::null_mut();
             let _ = CoIncrementMTAUsage(&mut cookie);
         }

--- a/crates/tests/libs/bindgen/input/fn_result.rdl
+++ b/crates/tests/libs/bindgen/input/fn_result.rdl
@@ -6,6 +6,6 @@ mod Test {
     #[library("test.dll")]
     extern fn HresultFunction(value: u32) -> HRESULT;
 
-    #[library("test.dll", last_error = true)]
+    #[library("test.dll")]
     extern fn BoolFunction(value: u32) -> BOOL;
 }

--- a/crates/tests/libs/canvas/src/lib.rs
+++ b/crates/tests/libs/canvas/src/lib.rs
@@ -9,7 +9,7 @@ mod tests {
 
     fn ensure_com_initialized() {
         unsafe {
-            windows_core::link!("combase.dll" "system" fn CoIncrementMTAUsage(pcookie: *mut *mut core::ffi::c_void) -> windows_core::HRESULT);
+            windows_core::link!("ole32.dll" "system" fn CoIncrementMTAUsage(pcookie: *mut *mut core::ffi::c_void) -> windows_core::HRESULT);
             let mut cookie = core::ptr::null_mut();
             let _ = CoIncrementMTAUsage(&mut cookie);
         }

--- a/metadata/win32/readme.md
+++ b/metadata/win32/readme.md
@@ -22,8 +22,9 @@ These files are produced by `tool_win32`:
 cargo run -p tool_win32
 ```
 
-Re-run the tool after changing the manifest (`crates/tools/win32/src/win32.toml`),
-the hand-authored vocabulary seed (`metadata/win32/metadata.rdl`), or the scraper,
+Re-run the tool after changing the manifest (the `const` slices in
+`crates/tools/win32/src/main.rs`), the hand-authored vocabulary seed
+(`metadata/win32/metadata.rdl`), or the scraper,
 and commit the resulting diff. Hand edits will be overwritten on the next run — the
 tool clears the generated partitions (preserving only the seed) and re-emits the
 whole closure.


### PR DESCRIPTION
Removes the long-standing `windows-bindgen` workaround that hardcoded five COM base functions (`CoTaskMemFree`, `CoTaskMemAlloc`, `CoIncrementMTAUsage`, `CoCreateFreeThreadedMarshaler`, `RoGetAgileReference`) to link `combase.dll` instead of the `ole32.dll` recorded by the Windows SDK import libraries. Now that `windows`/`windows-sys` are generated from in-house metadata, this override (originally added in #3743 for compatibility) is no longer warranted — `module_name()` simply returns the faithful import-scope name, making `bindgen` a straight mirror of the SDK (which is the source of truth; any remapping belongs in the SDK or `tool_win32`'s `IMPORT_LIBS`). The five functions and all generated `windows`/`windows-sys`/`webview` bindings now link `ole32.dll`, and the hand-written `windows-core` marshaler plus the animation/canvas test and sample `link!` declarations were updated to match. 

Also cleaned up two dead win32metadata-era artifacts: a dead `ConstAttribute` read in `field.rs` and a stale `win32.toml` reference in `metadata/win32/readme.md`. Verified with `cargo check`/`test`/`clippy` across `windows-core`, animation, canvas, and webview — the animation tests exercise `CoIncrementMTAUsage` through `ole32.dll` at runtime and pass.
