### PR TITLE
`windows-reactor` composition-visual interop

### DIFF
--- a/crates/libs/reactor/src/backend/mod.rs
+++ b/crates/libs/reactor/src/backend/mod.rs
@@ -11,6 +11,12 @@ mod winui;
 
 pub use winui::WinUIBackend;
 
+/// `E_INVALIDARG` — composition-interop calls return this for an unknown control id.
+const E_INVALIDARG: windows_core::HRESULT = windows_core::HRESULT(0x8007_0057u32 as _);
+
+/// `E_NOTIMPL` — the composition-interop seam's default for backends without it.
+const E_NOTIMPL: windows_core::HRESULT = windows_core::HRESULT(0x8000_4001u32 as _);
+
 /// Opaque, non-zero handle the backend assigns to every live control.
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
 pub struct ControlId(pub NonZeroU32);
@@ -534,6 +540,32 @@ pub trait Backend {
     /// Returns `None` on non-WinUI backends or if `id` is invalid.
     fn get_native_element(&self, _id: ControlId) -> Option<windows_core::IInspectable> {
         None
+    }
+
+    /// Composition-interop seam: return the `Compositor` that owns `host`'s
+    /// element visual, wrapped as an `IInspectable` so the caller can cast it and
+    /// build *same-compositor* child visuals. Returns `E_INVALIDARG` for an
+    /// unknown control id (or `E_NOTIMPL` on a backend without composition).
+    fn element_compositor(&self, _host: ControlId) -> Result<windows_core::IInspectable> {
+        Err(Error::from_hresult(E_NOTIMPL))
+    }
+
+    /// Composition-interop seam: the element's rasterization (DPI) scale, so a
+    /// hosted composition surface can be sized crisply. `1.0` when unknown.
+    fn element_rasterization_scale(&self, _host: ControlId) -> f32 {
+        1.0
+    }
+
+    /// Composition-interop seam: attach `visual` as `host`'s child visual
+    /// (hosting a custom composition island under a plain element). Returns
+    /// `E_INVALIDARG` for an unknown control id (or `E_NOTIMPL` on a backend
+    /// without composition).
+    fn set_element_child_visual(
+        &mut self,
+        _host: ControlId,
+        _visual: &windows_core::IInspectable,
+    ) -> Result<()> {
+        Err(Error::from_hresult(E_NOTIMPL))
     }
 }
 

--- a/crates/libs/reactor/src/backend/winui/mod.rs
+++ b/crates/libs/reactor/src/backend/winui/mod.rs
@@ -3257,6 +3257,44 @@ impl Backend for WinUIBackend {
     fn get_native_element(&self, id: ControlId) -> Option<windows_core::IInspectable> {
         self.get_ui_element(id)
     }
+
+    fn element_compositor(&self, host: ControlId) -> Result<windows_core::IInspectable> {
+        let map = self.controls.borrow();
+        let handle = map
+            .get(&host)
+            .ok_or_else(|| Error::from_hresult(E_INVALIDARG))?;
+        let ui = handle.as_ui_element();
+        let visual = bindings::ElementCompositionPreview::GetElementVisual(&ui)?;
+        let compositor = visual
+            .cast::<bindings::ICompositionObject>()?
+            .Compositor()?;
+        compositor.cast()
+    }
+
+    fn element_rasterization_scale(&self, host: ControlId) -> f32 {
+        let map = self.controls.borrow();
+        let Some(handle) = map.get(&host) else {
+            return 1.0;
+        };
+        handle
+            .as_ui_element()
+            .RasterizationScale()
+            .map_or(1.0, |s| s as f32)
+    }
+
+    fn set_element_child_visual(
+        &mut self,
+        host: ControlId,
+        visual: &windows_core::IInspectable,
+    ) -> Result<()> {
+        let map = self.controls.borrow();
+        let handle = map
+            .get(&host)
+            .ok_or_else(|| Error::from_hresult(E_INVALIDARG))?;
+        let ui = handle.as_ui_element();
+        let visual = visual.cast::<bindings::Visual>()?;
+        bindings::ElementCompositionPreview::SetElementChildVisual(&ui, &visual)
+    }
 }
 
 const FORMAT_TEXT: &str = "Text";

--- a/crates/libs/reactor/src/bindings.rs
+++ b/crates/libs/reactor/src/bindings.rs
@@ -7,6 +7,21 @@ windows_core::link!("user32.dll" "system" fn PostMessageW(hwnd : HWND, msg : u32
 windows_core::link!("user32.dll" "system" fn SetProcessDpiAwarenessContext(value : DPI_AWARENESS_CONTEXT) -> windows_core::BOOL);
 windows_core::link!("user32.dll" "system" fn SetWindowPos(hwnd : HWND, hwndinsertafter : HWND, x : i32, y : i32, cx : i32, cy : i32, uflags : u32) -> windows_core::BOOL);
 #[repr(transparent)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct AnimationIterationBehavior(pub i32);
+impl AnimationIterationBehavior {
+    pub const Count: Self = Self(0);
+    pub const Forever: Self = Self(1);
+}
+impl windows_core::TypeKind for AnimationIterationBehavior {
+    type TypeKind = windows_core::CopyType;
+}
+impl windows_core::RuntimeType for AnimationIterationBehavior {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::from_slice(
+        b"enum(Microsoft.UI.Composition.AnimationIterationBehavior;i4)",
+    );
+}
+#[repr(transparent)]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct AppBar(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppBar, windows_core::IUnknown, windows_core::IInspectable);
@@ -1882,6 +1897,62 @@ unsafe impl Send for CompositionAnimation {}
 unsafe impl Sync for CompositionAnimation {}
 #[repr(transparent)]
 #[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CompositionBrush(windows_core::IUnknown);
+windows_core::imp::interface_hierarchy!(
+    CompositionBrush,
+    windows_core::IUnknown,
+    windows_core::IInspectable
+);
+windows_core::imp::required_hierarchy!(CompositionBrush, CompositionObject);
+impl windows_core::RuntimeType for CompositionBrush {
+    const SIGNATURE: windows_core::imp::ConstBuffer =
+        windows_core::imp::ConstBuffer::for_class::<Self, ICompositionBrush>();
+}
+unsafe impl windows_core::Interface for CompositionBrush {
+    type Vtable = <ICompositionBrush as windows_core::Interface>::Vtable;
+    const IID: windows_core::GUID = <ICompositionBrush as windows_core::Interface>::IID;
+}
+impl core::ops::Deref for CompositionBrush {
+    type Target = ICompositionBrush;
+    fn deref(&self) -> &Self::Target {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl windows_core::RuntimeName for CompositionBrush {
+    const NAME: &'static str = "Microsoft.UI.Composition.CompositionBrush";
+}
+unsafe impl Send for CompositionBrush {}
+unsafe impl Sync for CompositionBrush {}
+#[repr(transparent)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CompositionColorBrush(windows_core::IUnknown);
+windows_core::imp::interface_hierarchy!(
+    CompositionColorBrush,
+    windows_core::IUnknown,
+    windows_core::IInspectable
+);
+windows_core::imp::required_hierarchy!(CompositionColorBrush, CompositionBrush, CompositionObject);
+impl windows_core::RuntimeType for CompositionColorBrush {
+    const SIGNATURE: windows_core::imp::ConstBuffer =
+        windows_core::imp::ConstBuffer::for_class::<Self, ICompositionColorBrush>();
+}
+unsafe impl windows_core::Interface for CompositionColorBrush {
+    type Vtable = <ICompositionColorBrush as windows_core::Interface>::Vtable;
+    const IID: windows_core::GUID = <ICompositionColorBrush as windows_core::Interface>::IID;
+}
+impl core::ops::Deref for CompositionColorBrush {
+    type Target = ICompositionColorBrush;
+    fn deref(&self) -> &Self::Target {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl windows_core::RuntimeName for CompositionColorBrush {
+    const NAME: &'static str = "Microsoft.UI.Composition.CompositionColorBrush";
+}
+unsafe impl Send for CompositionColorBrush {}
+unsafe impl Sync for CompositionColorBrush {}
+#[repr(transparent)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct CompositionEasingFunction(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(
     CompositionEasingFunction,
@@ -2061,6 +2132,34 @@ impl windows_core::RuntimeName for ContainerContentChangingEventArgs {
 }
 unsafe impl Send for ContainerContentChangingEventArgs {}
 unsafe impl Sync for ContainerContentChangingEventArgs {}
+#[repr(transparent)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ContainerVisual(windows_core::IUnknown);
+windows_core::imp::interface_hierarchy!(
+    ContainerVisual,
+    windows_core::IUnknown,
+    windows_core::IInspectable
+);
+windows_core::imp::required_hierarchy!(ContainerVisual, Visual, CompositionObject);
+impl windows_core::RuntimeType for ContainerVisual {
+    const SIGNATURE: windows_core::imp::ConstBuffer =
+        windows_core::imp::ConstBuffer::for_class::<Self, IContainerVisual>();
+}
+unsafe impl windows_core::Interface for ContainerVisual {
+    type Vtable = <IContainerVisual as windows_core::Interface>::Vtable;
+    const IID: windows_core::GUID = <IContainerVisual as windows_core::Interface>::IID;
+}
+impl core::ops::Deref for ContainerVisual {
+    type Target = IContainerVisual;
+    fn deref(&self) -> &Self::Target {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl windows_core::RuntimeName for ContainerVisual {
+    const NAME: &'static str = "Microsoft.UI.Composition.ContainerVisual";
+}
+unsafe impl Send for ContainerVisual {}
+unsafe impl Sync for ContainerVisual {}
 #[repr(transparent)]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ContentControl(windows_core::IUnknown);
@@ -2918,6 +3017,20 @@ impl ElementCompositionPreview {
                 &mut result__,
             )
             .and_then(|| windows_core::Type::from_abi(result__))
+        })
+    }
+    pub(crate) fn SetElementChildVisual<P0, P1>(element: P0, visual: P1) -> windows_core::Result<()>
+    where
+        P0: windows_core::Param<UIElement>,
+        P1: windows_core::Param<Visual>,
+    {
+        Self::IElementCompositionPreviewStatics(|this| unsafe {
+            (windows_core::Interface::vtable(this).SetElementChildVisual)(
+                windows_core::Interface::as_raw(this),
+                element.param().abi(),
+                visual.param().abi(),
+            )
+            .ok()
         })
     }
     fn IElementCompositionPreviewStatics<
@@ -6267,6 +6380,32 @@ pub struct ICompositionAnimationBase_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(
+    ICompositionBrush,
+    ICompositionBrush_Vtbl,
+    0x483924e7_99a5_5377_968b_dec6d40bbccd
+);
+impl windows_core::RuntimeType for ICompositionBrush {
+    const SIGNATURE: windows_core::imp::ConstBuffer =
+        windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
+#[repr(C)]
+pub struct ICompositionBrush_Vtbl {
+    pub base__: windows_core::IInspectable_Vtbl,
+}
+windows_core::imp::define_interface!(
+    ICompositionColorBrush,
+    ICompositionColorBrush_Vtbl,
+    0x3f8ffb69_3e71_55a7_8e79_f27a214c56ae
+);
+impl windows_core::RuntimeType for ICompositionColorBrush {
+    const SIGNATURE: windows_core::imp::ConstBuffer =
+        windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
+#[repr(C)]
+pub struct ICompositionColorBrush_Vtbl {
+    pub base__: windows_core::IInspectable_Vtbl,
+}
+windows_core::imp::define_interface!(
     ICompositionEasingFunction,
     ICompositionEasingFunction_Vtbl,
     0x8e1ecd0d_57d8_5bc9_9bcd_e43d0dd733c4
@@ -6408,6 +6547,20 @@ impl windows_core::RuntimeType for ICompositor {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl ICompositor {
+    pub(crate) fn CreateColorBrushWithColor(
+        &self,
+        color: Color,
+    ) -> windows_core::Result<CompositionColorBrush> {
+        unsafe {
+            let mut result__ = core::mem::zeroed();
+            (windows_core::Interface::vtable(self).CreateColorBrushWithColor)(
+                windows_core::Interface::as_raw(self),
+                color,
+                &mut result__,
+            )
+            .and_then(|| windows_core::Type::from_abi(result__))
+        }
+    }
     pub(crate) fn CreateCubicBezierEasingFunction(
         &self,
         controlpoint1: windows_numerics::Vector2,
@@ -6446,6 +6599,16 @@ impl ICompositor {
             .and_then(|| windows_core::Type::from_abi(result__))
         }
     }
+    pub(crate) fn CreateSpriteVisual(&self) -> windows_core::Result<SpriteVisual> {
+        unsafe {
+            let mut result__ = core::mem::zeroed();
+            (windows_core::Interface::vtable(self).CreateSpriteVisual)(
+                windows_core::Interface::as_raw(self),
+                &mut result__,
+            )
+            .and_then(|| windows_core::Type::from_abi(result__))
+        }
+    }
     pub(crate) fn CreateVector3KeyFrameAnimation(
         &self,
     ) -> windows_core::Result<Vector3KeyFrameAnimation> {
@@ -6464,7 +6627,11 @@ pub struct ICompositor_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     CreateColorKeyFrameAnimation: usize,
     CreateColorBrush: usize,
-    CreateColorBrushWithColor: usize,
+    pub CreateColorBrushWithColor: unsafe extern "system" fn(
+        *mut core::ffi::c_void,
+        Color,
+        *mut *mut core::ffi::c_void,
+    ) -> windows_core::HRESULT,
     CreateContainerVisual: usize,
     pub CreateCubicBezierEasingFunction: unsafe extern "system" fn(
         *mut core::ffi::c_void,
@@ -6489,7 +6656,10 @@ pub struct ICompositor_Vtbl {
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
     CreateScopedBatch: usize,
-    CreateSpriteVisual: usize,
+    pub CreateSpriteVisual: unsafe extern "system" fn(
+        *mut core::ffi::c_void,
+        *mut *mut core::ffi::c_void,
+    ) -> windows_core::HRESULT,
     CreateSurfaceBrush: usize,
     CreateSurfaceBrushWithSurface: usize,
     CreateVector2KeyFrameAnimation: usize,
@@ -6600,6 +6770,19 @@ pub struct IContainerContentChangingEventArgs_Vtbl {
     Handled: usize,
     pub SetHandled:
         unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
+}
+windows_core::imp::define_interface!(
+    IContainerVisual,
+    IContainerVisual_Vtbl,
+    0xc70dbce1_2c2f_5d8e_91a4_aae1121e6186
+);
+impl windows_core::RuntimeType for IContainerVisual {
+    const SIGNATURE: windows_core::imp::ConstBuffer =
+        windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
+#[repr(C)]
+pub struct IContainerVisual_Vtbl {
+    pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(
     IContentControl,
@@ -7787,6 +7970,12 @@ pub struct IElementCompositionPreviewStatics_Vtbl {
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
+    ) -> windows_core::HRESULT,
+    GetElementChildVisual: usize,
+    pub SetElementChildVisual: unsafe extern "system" fn(
+        *mut core::ffi::c_void,
+        *mut core::ffi::c_void,
+        *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
@@ -9113,6 +9302,18 @@ impl IKeyFrameAnimation {
             .ok()
         }
     }
+    pub(crate) fn SetIterationBehavior(
+        &self,
+        value: AnimationIterationBehavior,
+    ) -> windows_core::Result<()> {
+        unsafe {
+            (windows_core::Interface::vtable(self).SetIterationBehavior)(
+                windows_core::Interface::as_raw(self),
+                value,
+            )
+            .ok()
+        }
+    }
     pub(crate) fn InsertExpressionKeyFrameWithEasingFunction<P2>(
         &self,
         normalizedprogresskey: f32,
@@ -9144,7 +9345,10 @@ pub struct IKeyFrameAnimation_Vtbl {
         windows_time::TimeSpan,
     ) -> windows_core::HRESULT,
     IterationBehavior: usize,
-    SetIterationBehavior: usize,
+    pub SetIterationBehavior: unsafe extern "system" fn(
+        *mut core::ffi::c_void,
+        AnimationIterationBehavior,
+    ) -> windows_core::HRESULT,
     IterationCount: usize,
     SetIterationCount: usize,
     KeyFrameCount: usize,
@@ -13643,6 +13847,38 @@ pub struct ISplitViewFactory_Vtbl {
     ) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
+    ISpriteVisual,
+    ISpriteVisual_Vtbl,
+    0x7e964632_45e4_5761_806d_5b4022c14f26
+);
+impl windows_core::RuntimeType for ISpriteVisual {
+    const SIGNATURE: windows_core::imp::ConstBuffer =
+        windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
+impl ISpriteVisual {
+    pub(crate) fn SetBrush<P0>(&self, value: P0) -> windows_core::Result<()>
+    where
+        P0: windows_core::Param<CompositionBrush>,
+    {
+        unsafe {
+            (windows_core::Interface::vtable(self).SetBrush)(
+                windows_core::Interface::as_raw(self),
+                value.param().abi(),
+            )
+            .ok()
+        }
+    }
+}
+#[repr(C)]
+pub struct ISpriteVisual_Vtbl {
+    pub base__: windows_core::IInspectable_Vtbl,
+    Brush: usize,
+    pub SetBrush: unsafe extern "system" fn(
+        *mut core::ffi::c_void,
+        *mut core::ffi::c_void,
+    ) -> windows_core::HRESULT,
+}
+windows_core::imp::define_interface!(
     IStackPanel,
     IStackPanel_Vtbl,
     0x493ab00b_3a6a_5e4a_9452_407cd5197406
@@ -16182,6 +16418,16 @@ impl IUIElement {
             .ok()
         }
     }
+    pub(crate) fn RasterizationScale(&self) -> windows_core::Result<f64> {
+        unsafe {
+            let mut result__ = core::mem::zeroed();
+            (windows_core::Interface::vtable(self).RasterizationScale)(
+                windows_core::Interface::as_raw(self),
+                &mut result__,
+            )
+            .map(|| result__)
+        }
+    }
     pub(crate) fn DragEnter<F>(
         &self,
         handler: F,
@@ -16642,7 +16888,8 @@ pub struct IUIElement_Vtbl {
     ) -> windows_core::HRESULT,
     Shadow: usize,
     SetShadow: usize,
-    RasterizationScale: usize,
+    pub RasterizationScale:
+        unsafe extern "system" fn(*mut core::ffi::c_void, *mut f64) -> windows_core::HRESULT,
     SetRasterizationScale: usize,
     FocusState: usize,
     UseSystemFocusVisuals: usize,
@@ -16902,6 +17149,24 @@ impl IVisual {
             .ok()
         }
     }
+    pub(crate) fn SetOffset(&self, value: windows_numerics::Vector3) -> windows_core::Result<()> {
+        unsafe {
+            (windows_core::Interface::vtable(self).SetOffset)(
+                windows_core::Interface::as_raw(self),
+                value,
+            )
+            .ok()
+        }
+    }
+    pub(crate) fn SetRotationAngleInDegrees(&self, value: f32) -> windows_core::Result<()> {
+        unsafe {
+            (windows_core::Interface::vtable(self).SetRotationAngleInDegrees)(
+                windows_core::Interface::as_raw(self),
+                value,
+            )
+            .ok()
+        }
+    }
     pub(crate) fn Scale(&self) -> windows_core::Result<windows_numerics::Vector3> {
         unsafe {
             let mut result__ = core::mem::zeroed();
@@ -16910,6 +17175,15 @@ impl IVisual {
                 &mut result__,
             )
             .map(|| result__)
+        }
+    }
+    pub(crate) fn SetSize(&self, value: windows_numerics::Vector2) -> windows_core::Result<()> {
+        unsafe {
+            (windows_core::Interface::vtable(self).SetSize)(
+                windows_core::Interface::as_raw(self),
+                value,
+            )
+            .ok()
         }
     }
 }
@@ -16934,7 +17208,10 @@ pub struct IVisual_Vtbl {
     IsVisible: usize,
     SetIsVisible: usize,
     Offset: usize,
-    SetOffset: usize,
+    pub SetOffset: unsafe extern "system" fn(
+        *mut core::ffi::c_void,
+        windows_numerics::Vector3,
+    ) -> windows_core::HRESULT,
     Opacity: usize,
     SetOpacity: usize,
     Orientation: usize,
@@ -16943,12 +17220,19 @@ pub struct IVisual_Vtbl {
     RotationAngle: usize,
     SetRotationAngle: usize,
     RotationAngleInDegrees: usize,
-    SetRotationAngleInDegrees: usize,
+    pub SetRotationAngleInDegrees:
+        unsafe extern "system" fn(*mut core::ffi::c_void, f32) -> windows_core::HRESULT,
     RotationAxis: usize,
     SetRotationAxis: usize,
     pub Scale: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut windows_numerics::Vector3,
+    ) -> windows_core::HRESULT,
+    SetScale: usize,
+    Size: usize,
+    pub SetSize: unsafe extern "system" fn(
+        *mut core::ffi::c_void,
+        windows_numerics::Vector2,
     ) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
@@ -21657,6 +21941,34 @@ impl windows_core::RuntimeType for SplitViewDisplayMode {
         b"enum(Microsoft.UI.Xaml.Controls.SplitViewDisplayMode;i4)",
     );
 }
+#[repr(transparent)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SpriteVisual(windows_core::IUnknown);
+windows_core::imp::interface_hierarchy!(
+    SpriteVisual,
+    windows_core::IUnknown,
+    windows_core::IInspectable
+);
+windows_core::imp::required_hierarchy!(SpriteVisual, ContainerVisual, Visual, CompositionObject);
+impl windows_core::RuntimeType for SpriteVisual {
+    const SIGNATURE: windows_core::imp::ConstBuffer =
+        windows_core::imp::ConstBuffer::for_class::<Self, ISpriteVisual>();
+}
+unsafe impl windows_core::Interface for SpriteVisual {
+    type Vtable = <ISpriteVisual as windows_core::Interface>::Vtable;
+    const IID: windows_core::GUID = <ISpriteVisual as windows_core::Interface>::IID;
+}
+impl core::ops::Deref for SpriteVisual {
+    type Target = ISpriteVisual;
+    fn deref(&self) -> &Self::Target {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl windows_core::RuntimeName for SpriteVisual {
+    const NAME: &'static str = "Microsoft.UI.Composition.SpriteVisual";
+}
+unsafe impl Send for SpriteVisual {}
+unsafe impl Sync for SpriteVisual {}
 #[repr(transparent)]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct StackPanel(windows_core::IUnknown);

--- a/crates/libs/reactor/src/element.rs
+++ b/crates/libs/reactor/src/element.rs
@@ -349,6 +349,7 @@ define_element! {
     RelativePanel,
     ToggleButton,
     SwapChainPanel,
+    CompositionHost,
     WebView2,
 }
 
@@ -1222,6 +1223,7 @@ impl_element_ext!(
     RelativePanel,
     ToggleButton,
     SwapChainPanel,
+    CompositionHost,
     WebView2,
 );
 

--- a/crates/libs/reactor/src/widgets/composition_host.rs
+++ b/crates/libs/reactor/src/widgets/composition_host.rs
@@ -1,0 +1,176 @@
+use super::*;
+
+/// A solid-color composition island to host under a [`CompositionHost`] via
+/// [`CompositionHostHandle::set_color_island`].
+///
+/// It is a self-contained demonstration of the composition-visual interop seam:
+/// a *same-compositor* `SpriteVisual` filled with a `CompositionColorBrush`,
+/// centered in the host element and optionally spinning forever — all without an
+/// app-level dependency on the `windows` crate.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct ColorIsland {
+    /// Fill color of the hosted sprite visual.
+    pub color: Color,
+    /// Size of the sprite visual in DIPs; it is centered within the host element.
+    pub width: f32,
+    pub height: f32,
+    /// When set, the visual spins around its center forever, completing one full
+    /// revolution over this period.
+    pub spin: Option<std::time::Duration>,
+}
+
+impl ColorIsland {
+    /// A static (non-spinning) island of `color`, `width` × `height` DIPs.
+    pub fn new(color: Color, width: f32, height: f32) -> Self {
+        Self {
+            color,
+            width,
+            height,
+            spin: None,
+        }
+    }
+
+    /// Spin the island forever, one revolution per `period`.
+    pub fn spin(mut self, period: std::time::Duration) -> Self {
+        self.spin = Some(period);
+        self
+    }
+}
+
+/// Opaque handle to the native element backing a [`CompositionHost`], passed to
+/// the [`on_mounted`](CompositionHost::on_mounted) callback.
+///
+/// It exposes the composition-visual interop seam directly against the mounted
+/// element so an app can host a custom composition island (custom-drawn or
+/// off-thread animated content) under a plain reactor element.
+#[derive(Clone)]
+pub struct CompositionHostHandle(windows_core::IInspectable);
+
+impl CompositionHostHandle {
+    fn ui(&self) -> Result<bindings::UIElement> {
+        self.0.cast()
+    }
+
+    /// The host element's rasterization (DPI) scale. Multiply DIP sizes by this
+    /// to size composition surfaces crisply.
+    pub fn rasterization_scale(&self) -> Result<f32> {
+        Ok(self.ui()?.RasterizationScale()? as f32)
+    }
+
+    /// Host `island` under the element as a same-compositor `SpriteVisual`,
+    /// replacing any previously hosted child visual. The visual is sized in DIPs
+    /// with its rotation pivot at its own center and, when [`ColorIsland::spin`]
+    /// is set, animates its rotation forever.
+    pub fn set_color_island(&self, island: &ColorIsland) -> Result<()> {
+        let ui = self.ui()?;
+        let compositor = bindings::ElementCompositionPreview::GetElementVisual(&ui)?
+            .cast::<bindings::ICompositionObject>()?
+            .Compositor()?;
+        let icomp = compositor.cast::<bindings::ICompositor>()?;
+
+        let brush = icomp.CreateColorBrushWithColor(island.color)?;
+        let sprite = icomp.CreateSpriteVisual()?;
+        sprite.SetBrush(&brush.cast::<bindings::CompositionBrush>()?)?;
+
+        let visual = sprite.cast::<bindings::IVisual>()?;
+        visual.SetSize(windows_numerics::Vector2 {
+            x: island.width,
+            y: island.height,
+        })?;
+        visual.SetCenterPoint(windows_numerics::Vector3 {
+            x: island.width / 2.0,
+            y: island.height / 2.0,
+            z: 0.0,
+        })?;
+
+        if let Some(period) = island.spin {
+            let anim = icomp.CreateScalarKeyFrameAnimation()?;
+            let kfa = anim.cast::<bindings::IKeyFrameAnimation>()?;
+            kfa.SetDuration(TimeSpan::try_from(period).unwrap_or(TimeSpan::MAX))?;
+            kfa.SetIterationBehavior(bindings::AnimationIterationBehavior::Forever)?;
+            let easing = icomp
+                .CreateLinearEasingFunction()?
+                .cast::<bindings::CompositionEasingFunction>()?;
+            anim.cast::<bindings::IScalarKeyFrameAnimation>()?
+                .InsertKeyFrameWithEasingFunction(1.0, 360.0, &easing)?;
+            sprite
+                .cast::<bindings::ICompositionObject>()?
+                .StartAnimation("RotationAngleInDegrees", &anim.cast::<bindings::CompositionAnimation>()?)?;
+        }
+
+        bindings::ElementCompositionPreview::SetElementChildVisual(
+            &ui,
+            &sprite.cast::<bindings::Visual>()?,
+        )
+    }
+}
+
+/// Built-in widget that hosts a custom composition island under a plain element.
+///
+/// Backed by the same native control as [`Canvas`], it forwards the mounted
+/// element as a [`CompositionHostHandle`] (via [`on_mounted`](Self::on_mounted))
+/// so an app can attach a composition `Visual` through the interop seam.
+#[derive(Clone, Debug, PartialEq)]
+pub struct CompositionHost {
+    pub key: Option<String>,
+    pub modifiers: Modifiers,
+    pub mounted: Option<Callback<Option<windows_core::IInspectable>>>,
+    pub unmounted: Option<Callback<Option<windows_core::IInspectable>>>,
+}
+
+impl Default for CompositionHost {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl CompositionHost {
+    pub fn new() -> Self {
+        Self {
+            key: None,
+            modifiers: Modifiers::default(),
+            mounted: None,
+            unmounted: None,
+        }
+    }
+
+    /// Callback invoked once after the native host element is created, receiving a
+    /// [`CompositionHostHandle`] for attaching a composition island.
+    pub fn on_mounted(mut self, f: impl Fn(CompositionHostHandle) + 'static) -> Self {
+        self.mounted = Some(Callback::new(move |native: Option<_>| {
+            if let Some(native) = native {
+                f(CompositionHostHandle(native));
+            }
+        }));
+        self
+    }
+
+    /// Callback invoked just before the native host element is destroyed, while it
+    /// still exists. Use this to tear down resources bound to the hosted visual.
+    pub fn on_unmounted(mut self, f: impl Fn(CompositionHostHandle) + 'static) -> Self {
+        self.unmounted = Some(Callback::new(move |native: Option<_>| {
+            if let Some(native) = native {
+                f(CompositionHostHandle(native));
+            }
+        }));
+        self
+    }
+}
+
+impl Widget for CompositionHost {
+    widget_header!(ControlKind::Canvas);
+    fn bindings(&self) -> PropBindings {
+        Vec::new()
+    }
+    fn on_mounted_callback(&self) -> Option<&Callback<Option<windows_core::IInspectable>>> {
+        self.mounted.as_ref()
+    }
+    fn on_unmounted_callback(&self) -> Option<&Callback<Option<windows_core::IInspectable>>> {
+        self.unmounted.as_ref()
+    }
+}
+
+/// Factory function for a [`CompositionHost`].
+pub fn composition_host() -> CompositionHost {
+    CompositionHost::new()
+}

--- a/crates/libs/reactor/src/widgets/mod.rs
+++ b/crates/libs/reactor/src/widgets/mod.rs
@@ -44,6 +44,7 @@ widget_modules! {
     color_picker,
     combo_box,
     command_bar,
+    composition_host,
     content_dialog,
     date_picker,
     drop_down_button,

--- a/crates/samples/reactor/samples/examples/composition_island.rs
+++ b/crates/samples/reactor/samples/examples/composition_island.rs
@@ -1,0 +1,43 @@
+//! Hosts a spinning composition `SpriteVisual` under a plain reactor element via
+//! the composition-visual interop seam — with no dependency on the `windows`
+//! crate. See [`CompositionHost`] / [`CompositionHostHandle`].
+
+#![windows_subsystem = "windows"]
+
+use std::time::Duration;
+
+use windows_reactor::*;
+
+fn app(_cx: &mut RenderCx) -> Element {
+    let host = composition_host()
+        .width(220.0)
+        .height(220.0)
+        .on_mounted(|host| {
+            // The element's DPI scale is available through the seam; a solid-color
+            // island lives in the element's coordinate space (DIPs), so it is only
+            // logged here to show the accessor.
+            let scale = host.rasterization_scale().unwrap_or(1.0);
+            eprintln!("composition host rasterization scale: {scale}");
+
+            let island = ColorIsland::new(Color::rgb(80, 150, 240), 160.0, 160.0)
+                .spin(Duration::from_secs(4));
+            if let Err(e) = host.set_color_island(&island) {
+                eprintln!("failed to host composition island: {e}");
+            }
+        });
+
+    vstack((
+        text_block("A composition SpriteVisual hosted under a reactor element,"),
+        text_block("spinning forever on the composition thread."),
+        border(host)
+            .background(Color::rgb(24, 24, 24))
+            .padding(Thickness::uniform(8.0)),
+    ))
+    .spacing(12.0)
+    .padding(Thickness::uniform(16.0))
+    .into()
+}
+
+fn main() -> Result<()> {
+    reactor_samples::run("CompositionIsland", app)
+}

--- a/crates/tests/libs/reactor/src/lib.rs
+++ b/crates/tests/libs/reactor/src/lib.rs
@@ -173,7 +173,7 @@ pub struct RecordingBackend {
 /// concrete `IInspectable` works — the reconciler only forwards it opaquely to
 /// mount / unmount callbacks — so a boxed `IReference<i32>` is the cheapest
 /// dependency-free choice (the real WinUI backend returns the XAML element).
-fn stub_native_element() -> windows_core::IInspectable {
+pub fn stub_native_element() -> windows_core::IInspectable {
     windows_reference::IReference::<i32>::from(0).into()
 }
 

--- a/crates/tests/libs/reactor/tests/recording_backend.rs
+++ b/crates/tests/libs/reactor/tests/recording_backend.rs
@@ -100,3 +100,28 @@ fn control_id_display_includes_hash_prefix() {
 fn control_id_zero_panics() {
     let _ = ControlId::new(0);
 }
+
+// Composition-interop seam (`element_compositor` / `element_rasterization_scale`
+// / `set_element_child_visual`): the live WinUI behavior needs a real element, so
+// this only locks the backend-agnostic *default* contract — an unsupported backend
+// reports a typed error / neutral scale rather than panicking.
+#[test]
+fn composition_interop_seam_default_contract() {
+    let mut b = RecordingBackend::new();
+    let id = b.create(ControlKind::Border);
+
+    assert!(
+        b.element_compositor(id).is_err(),
+        "default element_compositor must be a typed error, not a panic"
+    );
+    assert_eq!(
+        b.element_rasterization_scale(id),
+        1.0,
+        "default rasterization scale must be neutral 1.0"
+    );
+    let visual = test_reactor::stub_native_element();
+    assert!(
+        b.set_element_child_visual(id, &visual).is_err(),
+        "default set_element_child_visual must be a typed error, not a panic"
+    );
+}

--- a/crates/tests/libs/reactor_selftest/src/bindings.rs
+++ b/crates/tests/libs/reactor_selftest/src/bindings.rs
@@ -13,6 +13,21 @@ windows_core::link!("user32.dll" "system" fn SetForegroundWindow(hwnd : HWND) ->
 windows_core::link!("user32.dll" "system" fn SetProcessDpiAwarenessContext(value : DPI_AWARENESS_CONTEXT) -> windows_core::BOOL);
 windows_core::link!("user32.dll" "system" fn SetWindowPos(hwnd : HWND, hwndinsertafter : HWND, x : i32, y : i32, cx : i32, cy : i32, uflags : u32) -> windows_core::BOOL);
 #[repr(transparent)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct AnimationIterationBehavior(pub i32);
+impl AnimationIterationBehavior {
+    pub const Count: Self = Self(0);
+    pub const Forever: Self = Self(1);
+}
+impl windows_core::TypeKind for AnimationIterationBehavior {
+    type TypeKind = windows_core::CopyType;
+}
+impl windows_core::RuntimeType for AnimationIterationBehavior {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::from_slice(
+        b"enum(Microsoft.UI.Composition.AnimationIterationBehavior;i4)",
+    );
+}
+#[repr(transparent)]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct AppBar(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppBar, windows_core::IUnknown, windows_core::IInspectable);
@@ -2038,6 +2053,62 @@ unsafe impl Send for CompositionAnimation {}
 unsafe impl Sync for CompositionAnimation {}
 #[repr(transparent)]
 #[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CompositionBrush(windows_core::IUnknown);
+windows_core::imp::interface_hierarchy!(
+    CompositionBrush,
+    windows_core::IUnknown,
+    windows_core::IInspectable
+);
+windows_core::imp::required_hierarchy!(CompositionBrush, CompositionObject);
+impl windows_core::RuntimeType for CompositionBrush {
+    const SIGNATURE: windows_core::imp::ConstBuffer =
+        windows_core::imp::ConstBuffer::for_class::<Self, ICompositionBrush>();
+}
+unsafe impl windows_core::Interface for CompositionBrush {
+    type Vtable = <ICompositionBrush as windows_core::Interface>::Vtable;
+    const IID: windows_core::GUID = <ICompositionBrush as windows_core::Interface>::IID;
+}
+impl core::ops::Deref for CompositionBrush {
+    type Target = ICompositionBrush;
+    fn deref(&self) -> &Self::Target {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl windows_core::RuntimeName for CompositionBrush {
+    const NAME: &'static str = "Microsoft.UI.Composition.CompositionBrush";
+}
+unsafe impl Send for CompositionBrush {}
+unsafe impl Sync for CompositionBrush {}
+#[repr(transparent)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CompositionColorBrush(windows_core::IUnknown);
+windows_core::imp::interface_hierarchy!(
+    CompositionColorBrush,
+    windows_core::IUnknown,
+    windows_core::IInspectable
+);
+windows_core::imp::required_hierarchy!(CompositionColorBrush, CompositionBrush, CompositionObject);
+impl windows_core::RuntimeType for CompositionColorBrush {
+    const SIGNATURE: windows_core::imp::ConstBuffer =
+        windows_core::imp::ConstBuffer::for_class::<Self, ICompositionColorBrush>();
+}
+unsafe impl windows_core::Interface for CompositionColorBrush {
+    type Vtable = <ICompositionColorBrush as windows_core::Interface>::Vtable;
+    const IID: windows_core::GUID = <ICompositionColorBrush as windows_core::Interface>::IID;
+}
+impl core::ops::Deref for CompositionColorBrush {
+    type Target = ICompositionColorBrush;
+    fn deref(&self) -> &Self::Target {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl windows_core::RuntimeName for CompositionColorBrush {
+    const NAME: &'static str = "Microsoft.UI.Composition.CompositionColorBrush";
+}
+unsafe impl Send for CompositionColorBrush {}
+unsafe impl Sync for CompositionColorBrush {}
+#[repr(transparent)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct CompositionEasingFunction(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(
     CompositionEasingFunction,
@@ -2217,6 +2288,34 @@ impl windows_core::RuntimeName for ContainerContentChangingEventArgs {
 }
 unsafe impl Send for ContainerContentChangingEventArgs {}
 unsafe impl Sync for ContainerContentChangingEventArgs {}
+#[repr(transparent)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ContainerVisual(windows_core::IUnknown);
+windows_core::imp::interface_hierarchy!(
+    ContainerVisual,
+    windows_core::IUnknown,
+    windows_core::IInspectable
+);
+windows_core::imp::required_hierarchy!(ContainerVisual, Visual, CompositionObject);
+impl windows_core::RuntimeType for ContainerVisual {
+    const SIGNATURE: windows_core::imp::ConstBuffer =
+        windows_core::imp::ConstBuffer::for_class::<Self, IContainerVisual>();
+}
+unsafe impl windows_core::Interface for ContainerVisual {
+    type Vtable = <IContainerVisual as windows_core::Interface>::Vtable;
+    const IID: windows_core::GUID = <IContainerVisual as windows_core::Interface>::IID;
+}
+impl core::ops::Deref for ContainerVisual {
+    type Target = IContainerVisual;
+    fn deref(&self) -> &Self::Target {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl windows_core::RuntimeName for ContainerVisual {
+    const NAME: &'static str = "Microsoft.UI.Composition.ContainerVisual";
+}
+unsafe impl Send for ContainerVisual {}
+unsafe impl Sync for ContainerVisual {}
 #[repr(transparent)]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ContentControl(windows_core::IUnknown);
@@ -3074,6 +3173,20 @@ impl ElementCompositionPreview {
                 &mut result__,
             )
             .and_then(|| windows_core::Type::from_abi(result__))
+        })
+    }
+    pub(crate) fn SetElementChildVisual<P0, P1>(element: P0, visual: P1) -> windows_core::Result<()>
+    where
+        P0: windows_core::Param<UIElement>,
+        P1: windows_core::Param<Visual>,
+    {
+        Self::IElementCompositionPreviewStatics(|this| unsafe {
+            (windows_core::Interface::vtable(this).SetElementChildVisual)(
+                windows_core::Interface::as_raw(this),
+                element.param().abi(),
+                visual.param().abi(),
+            )
+            .ok()
         })
     }
     fn IElementCompositionPreviewStatics<
@@ -6641,6 +6754,32 @@ pub struct ICompositionAnimationBase_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(
+    ICompositionBrush,
+    ICompositionBrush_Vtbl,
+    0x483924e7_99a5_5377_968b_dec6d40bbccd
+);
+impl windows_core::RuntimeType for ICompositionBrush {
+    const SIGNATURE: windows_core::imp::ConstBuffer =
+        windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
+#[repr(C)]
+pub struct ICompositionBrush_Vtbl {
+    pub base__: windows_core::IInspectable_Vtbl,
+}
+windows_core::imp::define_interface!(
+    ICompositionColorBrush,
+    ICompositionColorBrush_Vtbl,
+    0x3f8ffb69_3e71_55a7_8e79_f27a214c56ae
+);
+impl windows_core::RuntimeType for ICompositionColorBrush {
+    const SIGNATURE: windows_core::imp::ConstBuffer =
+        windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
+#[repr(C)]
+pub struct ICompositionColorBrush_Vtbl {
+    pub base__: windows_core::IInspectable_Vtbl,
+}
+windows_core::imp::define_interface!(
     ICompositionEasingFunction,
     ICompositionEasingFunction_Vtbl,
     0x8e1ecd0d_57d8_5bc9_9bcd_e43d0dd733c4
@@ -6782,6 +6921,20 @@ impl windows_core::RuntimeType for ICompositor {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl ICompositor {
+    pub(crate) fn CreateColorBrushWithColor(
+        &self,
+        color: Color,
+    ) -> windows_core::Result<CompositionColorBrush> {
+        unsafe {
+            let mut result__ = core::mem::zeroed();
+            (windows_core::Interface::vtable(self).CreateColorBrushWithColor)(
+                windows_core::Interface::as_raw(self),
+                color,
+                &mut result__,
+            )
+            .and_then(|| windows_core::Type::from_abi(result__))
+        }
+    }
     pub(crate) fn CreateCubicBezierEasingFunction(
         &self,
         controlpoint1: windows_numerics::Vector2,
@@ -6820,6 +6973,16 @@ impl ICompositor {
             .and_then(|| windows_core::Type::from_abi(result__))
         }
     }
+    pub(crate) fn CreateSpriteVisual(&self) -> windows_core::Result<SpriteVisual> {
+        unsafe {
+            let mut result__ = core::mem::zeroed();
+            (windows_core::Interface::vtable(self).CreateSpriteVisual)(
+                windows_core::Interface::as_raw(self),
+                &mut result__,
+            )
+            .and_then(|| windows_core::Type::from_abi(result__))
+        }
+    }
     pub(crate) fn CreateVector3KeyFrameAnimation(
         &self,
     ) -> windows_core::Result<Vector3KeyFrameAnimation> {
@@ -6838,7 +7001,11 @@ pub struct ICompositor_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     CreateColorKeyFrameAnimation: usize,
     CreateColorBrush: usize,
-    CreateColorBrushWithColor: usize,
+    pub CreateColorBrushWithColor: unsafe extern "system" fn(
+        *mut core::ffi::c_void,
+        Color,
+        *mut *mut core::ffi::c_void,
+    ) -> windows_core::HRESULT,
     CreateContainerVisual: usize,
     pub CreateCubicBezierEasingFunction: unsafe extern "system" fn(
         *mut core::ffi::c_void,
@@ -6863,7 +7030,10 @@ pub struct ICompositor_Vtbl {
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
     CreateScopedBatch: usize,
-    CreateSpriteVisual: usize,
+    pub CreateSpriteVisual: unsafe extern "system" fn(
+        *mut core::ffi::c_void,
+        *mut *mut core::ffi::c_void,
+    ) -> windows_core::HRESULT,
     CreateSurfaceBrush: usize,
     CreateSurfaceBrushWithSurface: usize,
     CreateVector2KeyFrameAnimation: usize,
@@ -6974,6 +7144,19 @@ pub struct IContainerContentChangingEventArgs_Vtbl {
     Handled: usize,
     pub SetHandled:
         unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
+}
+windows_core::imp::define_interface!(
+    IContainerVisual,
+    IContainerVisual_Vtbl,
+    0xc70dbce1_2c2f_5d8e_91a4_aae1121e6186
+);
+impl windows_core::RuntimeType for IContainerVisual {
+    const SIGNATURE: windows_core::imp::ConstBuffer =
+        windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
+#[repr(C)]
+pub struct IContainerVisual_Vtbl {
+    pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(
     IContentControl,
@@ -8190,6 +8373,12 @@ pub struct IElementCompositionPreviewStatics_Vtbl {
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
+    ) -> windows_core::HRESULT,
+    GetElementChildVisual: usize,
+    pub SetElementChildVisual: unsafe extern "system" fn(
+        *mut core::ffi::c_void,
+        *mut core::ffi::c_void,
+        *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
@@ -9734,6 +9923,18 @@ impl IKeyFrameAnimation {
             .ok()
         }
     }
+    pub(crate) fn SetIterationBehavior(
+        &self,
+        value: AnimationIterationBehavior,
+    ) -> windows_core::Result<()> {
+        unsafe {
+            (windows_core::Interface::vtable(self).SetIterationBehavior)(
+                windows_core::Interface::as_raw(self),
+                value,
+            )
+            .ok()
+        }
+    }
     pub(crate) fn InsertExpressionKeyFrameWithEasingFunction<P2>(
         &self,
         normalizedprogresskey: f32,
@@ -9765,7 +9966,10 @@ pub struct IKeyFrameAnimation_Vtbl {
         windows_time::TimeSpan,
     ) -> windows_core::HRESULT,
     IterationBehavior: usize,
-    SetIterationBehavior: usize,
+    pub SetIterationBehavior: unsafe extern "system" fn(
+        *mut core::ffi::c_void,
+        AnimationIterationBehavior,
+    ) -> windows_core::HRESULT,
     IterationCount: usize,
     SetIterationCount: usize,
     KeyFrameCount: usize,
@@ -14296,6 +14500,38 @@ pub struct ISplitViewFactory_Vtbl {
     ) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
+    ISpriteVisual,
+    ISpriteVisual_Vtbl,
+    0x7e964632_45e4_5761_806d_5b4022c14f26
+);
+impl windows_core::RuntimeType for ISpriteVisual {
+    const SIGNATURE: windows_core::imp::ConstBuffer =
+        windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
+impl ISpriteVisual {
+    pub(crate) fn SetBrush<P0>(&self, value: P0) -> windows_core::Result<()>
+    where
+        P0: windows_core::Param<CompositionBrush>,
+    {
+        unsafe {
+            (windows_core::Interface::vtable(self).SetBrush)(
+                windows_core::Interface::as_raw(self),
+                value.param().abi(),
+            )
+            .ok()
+        }
+    }
+}
+#[repr(C)]
+pub struct ISpriteVisual_Vtbl {
+    pub base__: windows_core::IInspectable_Vtbl,
+    Brush: usize,
+    pub SetBrush: unsafe extern "system" fn(
+        *mut core::ffi::c_void,
+        *mut core::ffi::c_void,
+    ) -> windows_core::HRESULT,
+}
+windows_core::imp::define_interface!(
     IStackPanel,
     IStackPanel_Vtbl,
     0x493ab00b_3a6a_5e4a_9452_407cd5197406
@@ -17138,6 +17374,16 @@ impl IUIElement {
             .ok()
         }
     }
+    pub(crate) fn RasterizationScale(&self) -> windows_core::Result<f64> {
+        unsafe {
+            let mut result__ = core::mem::zeroed();
+            (windows_core::Interface::vtable(self).RasterizationScale)(
+                windows_core::Interface::as_raw(self),
+                &mut result__,
+            )
+            .map(|| result__)
+        }
+    }
     pub(crate) fn DragEnter<F>(
         &self,
         handler: F,
@@ -17608,7 +17854,8 @@ pub struct IUIElement_Vtbl {
     ) -> windows_core::HRESULT,
     Shadow: usize,
     SetShadow: usize,
-    RasterizationScale: usize,
+    pub RasterizationScale:
+        unsafe extern "system" fn(*mut core::ffi::c_void, *mut f64) -> windows_core::HRESULT,
     SetRasterizationScale: usize,
     FocusState: usize,
     UseSystemFocusVisuals: usize,
@@ -17909,6 +18156,24 @@ impl IVisual {
             .ok()
         }
     }
+    pub(crate) fn SetOffset(&self, value: windows_numerics::Vector3) -> windows_core::Result<()> {
+        unsafe {
+            (windows_core::Interface::vtable(self).SetOffset)(
+                windows_core::Interface::as_raw(self),
+                value,
+            )
+            .ok()
+        }
+    }
+    pub(crate) fn SetRotationAngleInDegrees(&self, value: f32) -> windows_core::Result<()> {
+        unsafe {
+            (windows_core::Interface::vtable(self).SetRotationAngleInDegrees)(
+                windows_core::Interface::as_raw(self),
+                value,
+            )
+            .ok()
+        }
+    }
     pub(crate) fn Scale(&self) -> windows_core::Result<windows_numerics::Vector3> {
         unsafe {
             let mut result__ = core::mem::zeroed();
@@ -17917,6 +18182,15 @@ impl IVisual {
                 &mut result__,
             )
             .map(|| result__)
+        }
+    }
+    pub(crate) fn SetSize(&self, value: windows_numerics::Vector2) -> windows_core::Result<()> {
+        unsafe {
+            (windows_core::Interface::vtable(self).SetSize)(
+                windows_core::Interface::as_raw(self),
+                value,
+            )
+            .ok()
         }
     }
 }
@@ -17941,7 +18215,10 @@ pub struct IVisual_Vtbl {
     IsVisible: usize,
     SetIsVisible: usize,
     Offset: usize,
-    SetOffset: usize,
+    pub SetOffset: unsafe extern "system" fn(
+        *mut core::ffi::c_void,
+        windows_numerics::Vector3,
+    ) -> windows_core::HRESULT,
     Opacity: usize,
     SetOpacity: usize,
     Orientation: usize,
@@ -17950,12 +18227,19 @@ pub struct IVisual_Vtbl {
     RotationAngle: usize,
     SetRotationAngle: usize,
     RotationAngleInDegrees: usize,
-    SetRotationAngleInDegrees: usize,
+    pub SetRotationAngleInDegrees:
+        unsafe extern "system" fn(*mut core::ffi::c_void, f32) -> windows_core::HRESULT,
     RotationAxis: usize,
     SetRotationAxis: usize,
     pub Scale: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut windows_numerics::Vector3,
+    ) -> windows_core::HRESULT,
+    SetScale: usize,
+    Size: usize,
+    pub SetSize: unsafe extern "system" fn(
+        *mut core::ffi::c_void,
+        windows_numerics::Vector2,
     ) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
@@ -22944,6 +23228,34 @@ impl windows_core::RuntimeType for SplitViewDisplayMode {
         b"enum(Microsoft.UI.Xaml.Controls.SplitViewDisplayMode;i4)",
     );
 }
+#[repr(transparent)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SpriteVisual(windows_core::IUnknown);
+windows_core::imp::interface_hierarchy!(
+    SpriteVisual,
+    windows_core::IUnknown,
+    windows_core::IInspectable
+);
+windows_core::imp::required_hierarchy!(SpriteVisual, ContainerVisual, Visual, CompositionObject);
+impl windows_core::RuntimeType for SpriteVisual {
+    const SIGNATURE: windows_core::imp::ConstBuffer =
+        windows_core::imp::ConstBuffer::for_class::<Self, ISpriteVisual>();
+}
+unsafe impl windows_core::Interface for SpriteVisual {
+    type Vtable = <ISpriteVisual as windows_core::Interface>::Vtable;
+    const IID: windows_core::GUID = <ISpriteVisual as windows_core::Interface>::IID;
+}
+impl core::ops::Deref for SpriteVisual {
+    type Target = ISpriteVisual;
+    fn deref(&self) -> &Self::Target {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl windows_core::RuntimeName for SpriteVisual {
+    const NAME: &'static str = "Microsoft.UI.Composition.SpriteVisual";
+}
+unsafe impl Send for SpriteVisual {}
+unsafe impl Sync for SpriteVisual {}
 #[repr(transparent)]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct StackPanel(windows_core::IUnknown);

--- a/crates/tools/reactor/src/base.txt
+++ b/crates/tools/reactor/src/base.txt
@@ -1,4 +1,7 @@
+Microsoft::UI::Composition::AnimationIterationBehavior
 Microsoft::UI::Composition::CompositionAnimation
+Microsoft::UI::Composition::CompositionBrush
+Microsoft::UI::Composition::CompositionColorBrush
 Microsoft::UI::Composition::CompositionEasingFunction
 Microsoft::UI::Composition::CompositionObject
 Microsoft::UI::Composition::Compositor
@@ -8,15 +11,17 @@ Microsoft::UI::Composition::ICompositionAnimationBase
 Microsoft::UI::Composition::ICompositionObject2::put_ImplicitAnimations
 Microsoft::UI::Composition::ICompositionObject::{get_Compositor, StartAnimation}
 Microsoft::UI::Composition::ICompositor2::CreateImplicitAnimationCollection
-Microsoft::UI::Composition::ICompositor::{CreateScalarKeyFrameAnimation, CreateVector3KeyFrameAnimation, CreateLinearEasingFunction, CreateCubicBezierEasingFunction}
-Microsoft::UI::Composition::IKeyFrameAnimation::{put_Duration, InsertExpressionKeyFrameWithEasingFunction}
+Microsoft::UI::Composition::ICompositor::{CreateScalarKeyFrameAnimation, CreateVector3KeyFrameAnimation, CreateLinearEasingFunction, CreateCubicBezierEasingFunction, CreateSpriteVisual, CreateColorBrushWithColor}
+Microsoft::UI::Composition::IKeyFrameAnimation::{put_Duration, put_IterationBehavior, InsertExpressionKeyFrameWithEasingFunction}
 Microsoft::UI::Composition::IScalarKeyFrameAnimation::InsertKeyFrameWithEasingFunction
+Microsoft::UI::Composition::ISpriteVisual::put_Brush
 Microsoft::UI::Composition::IVector3KeyFrameAnimation::InsertKeyFrameWithEasingFunction
-Microsoft::UI::Composition::IVisual::{put_CenterPoint, get_Scale}
+Microsoft::UI::Composition::IVisual::{put_CenterPoint, get_Scale, put_Size, put_Offset, put_RotationAngleInDegrees}
 Microsoft::UI::Composition::ImplicitAnimationCollection
 Microsoft::UI::Composition::KeyFrameAnimation
 Microsoft::UI::Composition::LinearEasingFunction
 Microsoft::UI::Composition::ScalarKeyFrameAnimation
+Microsoft::UI::Composition::SpriteVisual
 Microsoft::UI::Composition::SystemBackdrops::MicaKind
 Microsoft::UI::Composition::Vector3KeyFrameAnimation
 Microsoft::UI::Composition::Visual
@@ -235,7 +240,7 @@ Microsoft::UI::Xaml::FrameworkElement
 Microsoft::UI::Xaml::GridLength
 Microsoft::UI::Xaml::GridUnitType
 Microsoft::UI::Xaml::HorizontalAlignment
-Microsoft::UI::Xaml::Hosting::ElementCompositionPreview::GetElementVisual
+Microsoft::UI::Xaml::Hosting::ElementCompositionPreview::{GetElementVisual, SetElementChildVisual}
 Microsoft::UI::Xaml::IApplication::get_Resources
 Microsoft::UI::Xaml::IApplicationOverrides
 Microsoft::UI::Xaml::IDragEventArgs::{put_AcceptedOperation, get_DataView, get_DragUIOverride, GetDeferral}
@@ -244,7 +249,7 @@ Microsoft::UI::Xaml::IDragUIOverride::{put_Caption, put_IsGlyphVisible, put_IsCo
 Microsoft::UI::Xaml::IFrameworkElement::{put_VerticalAlignment, put_HorizontalAlignment, put_Margin, put_Height, put_Width, put_MinWidth, put_MaxWidth, put_MinHeight, put_MaxHeight, put_RequestedTheme, get_ActualTheme, ActualThemeChanged, put_Tag, get_Tag, get_ActualWidth, get_ActualHeight, put_Style, SizeChanged, get_Resources}
 Microsoft::UI::Xaml::IResourceDictionary::get_MergedDictionaries
 Microsoft::UI::Xaml::ISizeChangedEventArgs::get_NewSize
-Microsoft::UI::Xaml::IUIElement::{put_AllowDrop, put_Opacity, put_XamlRoot, get_XamlRoot, get_KeyboardAccelerators, put_KeyboardAcceleratorPlacementMode, PointerPressed, PointerReleased, PointerMoved, PointerEntered, PointerExited, Tapped, RightTapped, DragEnter, DragLeave, DragOver, Drop}
+Microsoft::UI::Xaml::IUIElement::{put_AllowDrop, put_Opacity, put_XamlRoot, get_XamlRoot, get_KeyboardAccelerators, put_KeyboardAcceleratorPlacementMode, get_RasterizationScale, PointerPressed, PointerReleased, PointerMoved, PointerEntered, PointerExited, Tapped, RightTapped, DragEnter, DragLeave, DragOver, Drop}
 Microsoft::UI::Xaml::IWindow2::{get_AppWindow, put_SystemBackdrop}
 Microsoft::UI::Xaml::IWindow::{put_Title, put_Content, put_ExtendsContentIntoTitleBar, SetTitleBar, Activate, Closed}
 Microsoft::UI::Xaml::IWindowEventArgs::{}

--- a/docs/crates/windows-reactor.md
+++ b/docs/crates/windows-reactor.md
@@ -206,6 +206,8 @@ tree is the best reference:
   `tictactoe`, `dotsweeper`.
 - **`gallery`** — a WinUI-gallery-style shell with navigation across many controls.
 - **`direct2d`** / **`swap_chain_panel`** — hosting Direct2D / Direct3D content.
+- **`composition_island`** — hosting a spinning composition `SpriteVisual` under a
+  reactor element via the composition-interop seam, with no raw `windows` crate use.
 - **`webview`** — hosting a WebView2 browser via `windows-webview`'s `reactor` feature.
 - **`framework_dependent`** / **`self_contained`** — the two deployment models,
   differing only in `build.rs`.
@@ -810,27 +812,76 @@ landed; *(gap)* items are still outstanding.
    canvas-backed on-demand surface (shared device + safe drawing into a
    `SurfaceImageSource`) would let such apps avoid the `windows` crate entirely.
 
-5. **No general composition-interop seam for hosting GPU / Direct2D content
-   *(gap)*.** Hosting GPU-drawn content requires reaching the
-   Windows.UI.Composition layer *under an arbitrary reactor element*: attach a
-   custom `Visual` (`ElementCompositionPreview.SetElementChildVisual`), obtain the
-   `Compositor` that owns the element's visual so it can build *same-compositor*
-   child visuals, and read the element's rasterization (DPI) scale so the
-   composition surface is crisp. Reactor already drives this plumbing internally
-   for its opacity/scale transitions — `ElementCompositionPreview::GetElementVisual`
-   plus `Visual.Compositor()` (`backend/winui/mod.rs:603`, `:612`, `:667`) — but it
-   is `pub(crate)` and single-purpose, and the two other pieces aren't even bound:
-   `SetElementChildVisual` is absent from `bindings.rs` (only `GetElementVisual`
-   is) and `RasterizationScale` is a `usize` vtable stub (`bindings.rs:16313`). The
-   dedicated `SwapChainPanel` widget (`widgets/swap_chain_panel.rs`) already covers
-   the DXGI-swap-chain case via `ISwapChainPanelNative::SetSwapChain`, but there is
-   no seam for the *composition-visual* case — hosting a custom composition island
-   (custom-drawn / off-thread animated content) under a plain host element. Filling
-   this means exposing three `Backend` methods — `element_compositor(host)`,
-   `element_rasterization_scale(host)` (default `1.0`), and
-   `set_element_child_visual(host, visual)` — binding `SetElementChildVisual` and
-   `RasterizationScale`, and returning `E_INVALIDARG` (not `panic!`) for an unknown
-   control id.
+5. **Composition-interop seam for hosting GPU / Direct2D content *(fixed)*.**
+   Hosting GPU-drawn content requires reaching the Windows.UI.Composition layer
+   *under an arbitrary reactor element*: attach a custom `Visual`
+   (`ElementCompositionPreview.SetElementChildVisual`), obtain the `Compositor`
+   that owns the element's visual so it can build *same-compositor* child visuals,
+   and read the element's rasterization (DPI) scale so the composition surface is
+   crisp. Reactor already drove the first piece internally for its opacity/scale
+   transitions (`ElementCompositionPreview::GetElementVisual` plus
+   `Visual.Compositor()` in `backend/winui/mod.rs`), but the other two weren't
+   bound: `SetElementChildVisual` was absent from `bindings.rs` and
+   `RasterizationScale` was a `usize` vtable stub. The dedicated `SwapChainPanel`
+   widget (`widgets/swap_chain_panel.rs`) already covers the DXGI-swap-chain case
+   via `ISwapChainPanelNative::SetSwapChain`, but there was no seam for the
+   *composition-visual* case — hosting a custom composition island (custom-drawn /
+   off-thread animated content) under a plain host element.
+
+   **Engine seam.** `SetElementChildVisual` (on `ElementCompositionPreview`) and
+   `get_RasterizationScale` (on `IUIElement`) are un-stubbed in the reactor
+   bindings filter (`crates/tools/reactor/src/base.txt`), and the `Backend` trait
+   exposes three methods (`backend/mod.rs`) — `element_compositor(host)` (returns
+   the owning `Compositor` as an `IInspectable` the caller casts to build
+   same-compositor child visuals), `element_rasterization_scale(host)` (the
+   element's DPI scale, `1.0` when unknown), and
+   `set_element_child_visual(host, visual)`. The WinUI backend implements them over
+   the existing `GetElementVisual`/`Compositor` plumbing and returns `E_INVALIDARG`
+   (not `panic!`) for an unknown control id; other backends inherit defaults that
+   return `E_NOTIMPL` / `1.0`. The backend-agnostic default contract is covered by
+   `test_reactor::composition_interop_seam_default_contract`.
+
+   **App-facing surface.** The engine seam is keyed by `ControlId`, which apps
+   never hold, so a higher-level handle sits on top. The `CompositionHost` widget
+   (`widgets/composition_host.rs`, mirroring `swap_chain_panel.rs`) is backed by
+   the existing `ControlKind::Canvas` — no new backend `ControlKind`/`Handle` is
+   needed, since mount/unmount dispatch is generic over `Widget` and
+   `get_native_element` returns the native element for any control. Its
+   `on_mounted` callback hands the app a `CompositionHostHandle` wrapping the
+   mounted element, exposing safe methods: `rasterization_scale() -> Result<f32>`
+   and `set_color_island(&ColorIsland)`, which builds a same-compositor
+   `SpriteVisual` + `CompositionColorBrush`, sizes it in DIPs with its rotation
+   pivot at its center, attaches it via
+   `ElementCompositionPreview::SetElementChildVisual`, and — when
+   `ColorIsland::spin` is set — starts a forever `RotationAngleInDegrees` animation
+   (`ScalarKeyFrameAnimation`, linear easing,
+   `AnimationIterationBehavior::Forever`). The `reactor_samples`
+   `composition_island` example demonstrates the whole path with no dependency on
+   the raw `windows` crate.
+
+   **Relationship to `windows-canvas`.** This is the *composition-visual* seam,
+   distinct from the *swap-chain* one:
+   [`windows-canvas`](windows-canvas.md)'s `animated_canvas` hosts a continuously
+   rendered DXGI swap chain via `SwapChainPanel`/`SwapChainPanelHandle::set_swap_chain`
+   (and reads DPI through the panel-specific `CompositionScaleX/Y`), whereas
+   `CompositionHost` attaches a composition `Visual` under a plain element via
+   `SetElementChildVisual` (and reads DPI through `IUIElement::RasterizationScale`).
+   They don't overlap or share bindings — canvas generates its own `bindings.rs`
+   from `canvas.txt`, independent of the reactor filter. Use `animated_canvas` for
+   GPU-drawn frames; use `CompositionHost` to host a custom composition island.
+
+   The composition-visual APIs the handle needs are bound through the
+   `Microsoft::UI::Composition` section of `base.txt`
+   (`ICompositor::{CreateSpriteVisual, CreateColorBrushWithColor}`,
+   `ISpriteVisual::put_Brush`, `IVisual::{put_Size, put_Offset,
+   put_RotationAngleInDegrees}`, `IKeyFrameAnimation::put_IterationBehavior`, plus
+   the `SpriteVisual`, `CompositionColorBrush`, `CompositionBrush`, and
+   `AnimationIterationBehavior` types). Composition types live in
+   `Microsoft.UI.winmd` (already an `--in` input); the visual layer is
+   `Microsoft.UI.Composition`, not `Windows.UI.Composition`, under WinUI 3.
+   Parent-class conversions have no generated `CanInto` impls under `--minimal`, so
+   the handle uses explicit `.cast()` (e.g. `sprite.cast::<Visual>()`,
+   `brush.cast::<CompositionBrush>()`).
 
 6. **Templated list stays blank when it grows from empty *(fixed)*.** Previously,
    eager realization queued `Realize` requests for rows `0..count` only at *mount*,


### PR DESCRIPTION
Lets a `windows-reactor` app host a custom composition `Visual` under a plain element - the composition-visual counterpart to the existing swap-chain hosting (`SwapChainPanel` / `windows-canvas`'s `animated_canvas`).