### PR TITLE
`windows-bindgen` lang test

### DIFF
--- a/crates/samples/lang_perf/cpp/src/main.rs
+++ b/crates/samples/lang_perf/cpp/src/main.rs
@@ -17,16 +17,17 @@ fn iterations() -> u64 {
         .unwrap_or(DEFAULT_ITERATIONS)
 }
 
+#[cfg(target_env = "msvc")]
+unsafe extern "system" {
+    fn lang_perf_cpp(iterations: u64) -> i32;
+}
+
 fn main() {
     let iterations = iterations();
 
     #[cfg(target_env = "msvc")]
     {
         stage_component(component_file());
-
-        unsafe extern "system" {
-            fn lang_perf_cpp(iterations: u64) -> i32;
-        }
 
         let hr = unsafe { lang_perf_cpp(iterations) };
         if hr < 0 {
@@ -71,4 +72,18 @@ fn component_file() -> &'static str {
         }
     }
     "langperf_cpp.dll"
+}
+
+// Runs the C++/WinRT consumer against its own component with a tiny iteration count so
+// `cargo test` exercises the projection end to end - activation, marshaling, events,
+// collections, async, and error propagation - not just that the generated glue compiles.
+// The component cdylib is a build dependency, so cargo stages it beside this test binary.
+#[cfg(all(test, target_env = "msvc"))]
+mod tests {
+    #[test]
+    fn interop() {
+        super::stage_component("langperf_cpp.dll");
+        let hr = unsafe { super::lang_perf_cpp(200) };
+        assert!(hr >= 0, "lang_perf_cpp failed: {hr:#010x}");
+    }
 }

--- a/crates/samples/lang_perf/cpp/src/main.rs
+++ b/crates/samples/lang_perf/cpp/src/main.rs
@@ -82,7 +82,7 @@ fn component_file() -> &'static str {
 mod tests {
     #[test]
     fn interop() {
-        super::stage_component("langperf_cpp.dll");
+        super::stage_component(super::component_file());
         let hr = unsafe { super::lang_perf_cpp(200) };
         assert!(hr >= 0, "lang_perf_cpp failed: {hr:#010x}");
     }

--- a/crates/samples/lang_perf/csharp/lang_perf_cs.csproj
+++ b/crates/samples/lang_perf/csharp/lang_perf_cs.csproj
@@ -9,7 +9,7 @@
     <CsWinRTWindowsMetadata>local</CsWinRTWindowsMetadata>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.3.1" />
   </ItemGroup>
   <ItemGroup>
     <CsWinRTInputs Include="../component/lang.winmd" />

--- a/crates/samples/lang_perf/readme.md
+++ b/crates/samples/lang_perf/readme.md
@@ -108,7 +108,7 @@ cargo run --release -p lang_perf_rust -- --component cpp --iterations 10000000
 ```
 
 The C# benchmark uses `dotnet`. It calls the Rust component. Build that component, stage it as
-`LangPerf.dll`, add it to `PATH`, and run. It targets .NET 10 and C#/WinRT 2.2.0. The .NET 10 SDK is
+`LangPerf.dll`, add it to `PATH`, and run. It targets .NET 10 and C#/WinRT 2.3.1. The .NET 10 SDK is
 required.
 
 ```pwsh
@@ -295,3 +295,12 @@ different default-interface metadata.
 
 This does not change the comparison. The benchmark measures caller projection cost, and the
 component performs no per-call work.
+
+## Testing
+
+Each consumer runs a small iteration count under `cargo test`, so `cargo test --all` validates all
+three projections end to end on every CI target:
+
+- `lang_perf_rust` and `lang_perf_cpp` each have an in-crate `interop` test that stages their own
+  component and runs the full loop set.
+- `lang_perf_cs` spawns the C# consumer with `dotnet run` and checks its output.

--- a/crates/samples/lang_perf/rust/src/main.rs
+++ b/crates/samples/lang_perf/rust/src/main.rs
@@ -27,20 +27,18 @@ fn iterations() -> u64 {
 }
 
 fn main() {
-    if let Err(error) = run() {
+    if let Err(error) = run(iterations(), component_file()) {
         eprintln!("{error}");
         std::process::exit(1);
     }
 }
 
-fn run() -> windows_core::Result<()> {
+fn run(iterations: u64, component: &str) -> windows_core::Result<()> {
     use bindings::*;
     use std::time::Instant;
     use windows_core::*;
 
-    stage_component(component_file());
-
-    let iterations = iterations();
+    stage_component(component);
 
     let object = Class::new()?;
     println!(
@@ -177,4 +175,16 @@ fn component_file() -> &'static str {
         }
     }
     "langperf_rust.dll"
+}
+
+// Runs the Rust consumer against the Rust component with a tiny iteration count so `cargo
+// test` exercises the projection end to end - activation, events, collections, async, and
+// error propagation - not just that the bindings compile. The component cdylib is a build
+// dependency, so cargo stages it beside this test binary.
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn interop() {
+        super::run(200, "langperf_rust.dll").unwrap();
+    }
 }

--- a/crates/samples/lang_perf/rust/src/main.rs
+++ b/crates/samples/lang_perf/rust/src/main.rs
@@ -185,6 +185,6 @@ fn component_file() -> &'static str {
 mod tests {
     #[test]
     fn interop() {
-        super::run(200, "langperf_rust.dll").unwrap();
+        super::run(200, super::component_file()).unwrap();
     }
 }


### PR DESCRIPTION
Just ensures that the existing lang perf benchmark is validated as part of the build.