### PR TITLE
Fix OCR sample image path resolution

### DIFF
--- a/crates/samples/windows/ocr/src/main.rs
+++ b/crates/samples/windows/ocr/src/main.rs
@@ -6,7 +6,7 @@ fn main() -> windows::core::Result<()> {
         core::*,
     };
 
-    let mut message = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("message.png");
+    let message = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("message.png");
 
     let file =
         StorageFile::GetFileFromPathAsync(&HSTRING::from(message.to_str().unwrap()))?.join()?;

--- a/crates/samples/windows/ocr/src/main.rs
+++ b/crates/samples/windows/ocr/src/main.rs
@@ -6,8 +6,7 @@ fn main() -> windows::core::Result<()> {
         core::*,
     };
 
-    let mut message = std::env::current_dir().unwrap();
-    message.push("message.png");
+    let mut message = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("message.png");
 
     let file =
         StorageFile::GetFileFromPathAsync(&HSTRING::from(message.to_str().unwrap()))?.join()?;


### PR DESCRIPTION
Fixes: #4796

This is a sample intended to demonstrate the OCR API clearly, so error handling is kept minimal to avoid obscuring the core logic.