### PR TITLE
`windows-reactor` image loading

### DIFF
--- a/crates/libs/reactor/public-api.txt
+++ b/crates/libs/reactor/public-api.txt
@@ -1149,6 +1149,15 @@ pub fn windows_reactor::Ellipse::min_width(self, impl core::convert::Into<core::
 pub fn windows_reactor::Ellipse::opacity(self, impl core::convert::Into<core::option::Option<f64>>) -> Self where Self: core::marker::Sized
 pub fn windows_reactor::Ellipse::vertical_alignment(self, impl core::convert::Into<core::option::Option<windows_reactor::VerticalAlignment>>) -> Self where Self: core::marker::Sized
 pub fn windows_reactor::Ellipse::width(self, impl core::convert::Into<core::option::Option<f64>>) -> Self where Self: core::marker::Sized
+pub struct windows_reactor::EncodedImage(_)
+impl windows_reactor::EncodedImage
+pub fn windows_reactor::EncodedImage::as_bytes(&self) -> &[u8]
+pub fn windows_reactor::EncodedImage::from_static(&'static [u8]) -> Self
+pub fn windows_reactor::EncodedImage::new(impl core::convert::Into<alloc::sync::Arc<[u8]>>) -> Self
+impl core::cmp::PartialEq for windows_reactor::EncodedImage
+pub fn windows_reactor::EncodedImage::eq(&self, &Self) -> bool
+impl core::fmt::Debug for windows_reactor::EncodedImage
+pub fn windows_reactor::EncodedImage::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 pub struct windows_reactor::ExitTransition
 impl windows_reactor::ExitTransition
 pub fn windows_reactor::ExitTransition::duration(self) -> core::time::Duration
@@ -1359,7 +1368,10 @@ pub struct windows_reactor::Image
 impl windows_reactor::Image
 pub fn windows_reactor::Image::element_ref(self, &windows_reactor::ElementRef<Self>) -> Self
 pub fn windows_reactor::Image::new() -> Self
+pub fn windows_reactor::Image::on_failed(self, impl windows_reactor::IntoUnitCallback) -> Self
+pub fn windows_reactor::Image::on_opened(self, impl windows_reactor::IntoUnitCallback) -> Self
 pub fn windows_reactor::Image::source(self, impl core::convert::Into<alloc::string::String>) -> windows_result::Result<Self>
+pub fn windows_reactor::Image::source_data(self, windows_reactor::EncodedImage) -> Self
 pub fn windows_reactor::Image::source_file(self, impl core::convert::AsRef<std::path::Path>) -> windows_result::Result<Self>
 pub fn windows_reactor::Image::source_optional<T>(self, core::option::Option<T>) -> windows_result::Result<Self> where T: core::convert::Into<alloc::string::String>
 pub fn windows_reactor::Image::stretch(self, impl core::convert::Into<core::option::Option<windows_reactor::Stretch>>) -> Self
@@ -1383,6 +1395,7 @@ pub struct windows_reactor::ImageIcon
 impl windows_reactor::ImageIcon
 pub fn windows_reactor::ImageIcon::new() -> Self
 pub fn windows_reactor::ImageIcon::source(self, impl core::convert::Into<alloc::string::String>) -> windows_result::Result<Self>
+pub fn windows_reactor::ImageIcon::source_data(self, windows_reactor::EncodedImage) -> Self
 pub fn windows_reactor::ImageIcon::source_file(self, impl core::convert::AsRef<std::path::Path>) -> windows_result::Result<Self>
 pub fn windows_reactor::ImageIcon::source_optional<T>(self, core::option::Option<T>) -> windows_result::Result<Self> where T: core::convert::Into<alloc::string::String>
 impl core::convert::From<windows_reactor::ImageIcon> for windows_reactor::View

--- a/crates/libs/reactor/readme.md
+++ b/crates/libs/reactor/readme.md
@@ -78,3 +78,16 @@ default; passing `None` sets an explicit empty value.
 
 Constrained values are checked by their builders. For example, text weights use constants such as
 `FontWeight::BOLD`, with custom values available through `FontWeight::new`.
+
+Images can load encoded PNG and other WinUI-supported bitmap data without a file or URI:
+
+```rust,ignore
+Image::new()
+    .source_data(EncodedImage::from_static(include_bytes!("logo.png")))
+    .on_opened(|| println!("image ready"))
+    .on_failed(|| eprintln!("image could not be decoded"))
+```
+
+`EncodedImage::from_static` borrows static data without copying it. `EncodedImage::new` owns shared
+data supplied at runtime. Decoding is asynchronous; replacing or removing the image cancels its
+pending load.

--- a/crates/libs/reactor/src/core/pump/tests/image_properties.rs
+++ b/crates/libs/reactor/src/core/pump/tests/image_properties.rs
@@ -67,6 +67,71 @@ fn image_uri_source_updates_clears_and_remains_idempotent() {
 }
 
 #[test]
+fn encoded_image_source_updates_clears_and_remains_idempotent() {
+    static FIRST: &[u8] = b"first encoded image";
+    static SECOND: &[u8] = b"second encoded image";
+    let first = EncodedImage::from_static(FIRST);
+    let second = EncodedImage::from_static(SECOND);
+    let mut pump = Pump::new(RecordingRuntime::default());
+
+    pump.mount(Image::new().source_data(first.clone()).into())
+        .unwrap();
+    let root = pump.root().unwrap();
+    assert_eq!(
+        pump.runtime()
+            .node(root)
+            .and_then(|node| node.property(PropertyId::ImageSource)),
+        Some(&PropertyValue::EncodedImage(first.clone()))
+    );
+
+    let batches = pump.runtime().batches();
+    pump.update(Image::new().source_data(first).into()).unwrap();
+    assert_eq!(pump.runtime().batches(), batches);
+
+    pump.update(Image::new().source_data(second.clone()).into())
+        .unwrap();
+    assert_eq!(
+        pump.runtime()
+            .node(root)
+            .and_then(|node| node.property(PropertyId::ImageSource)),
+        Some(&PropertyValue::EncodedImage(second))
+    );
+
+    pump.update(Image::new().source_optional(None::<String>).unwrap().into())
+        .unwrap();
+    assert!(
+        pump.runtime()
+            .commands()
+            .last()
+            .unwrap()
+            .iter()
+            .any(|command| matches!(
+                command,
+                Command::ClearProperty {
+                    property: PropertyId::ImageSource,
+                    ..
+                }
+            ))
+    );
+}
+
+#[test]
+fn image_icon_accepts_encoded_image_source() {
+    let source = EncodedImage::new(Vec::from(b"encoded icon"));
+    let mut pump = Pump::new(RecordingRuntime::default());
+    pump.mount(ImageIcon::new().source_data(source.clone()).into())
+        .unwrap();
+    let root = pump.root().unwrap();
+
+    assert_eq!(
+        pump.runtime()
+            .node(root)
+            .and_then(|node| node.property(PropertyId::ImageIconSource)),
+        Some(&PropertyValue::EncodedImage(source))
+    );
+}
+
+#[test]
 fn bitmap_dimensions_reject_invalid_values() {
     for value in [-1.0, f64::INFINITY, f64::NAN] {
         assert!(std::panic::catch_unwind(|| Image::new().width(value)).is_err());

--- a/crates/libs/reactor/src/element.rs
+++ b/crates/libs/reactor/src/element.rs
@@ -1,6 +1,7 @@
 use std::any::Any;
 use std::fmt;
 use std::rc::Rc;
+use std::sync::Arc;
 use std::time::Duration;
 
 use super::*;
@@ -12,6 +13,86 @@ pub(crate) fn validate_image_uri(value: &str) -> windows_core::Result<()> {
 
 pub(crate) fn validate_uri(value: &str) -> windows_core::Result<()> {
     native::validate_native_uri(value)
+}
+
+/// Immutable encoded bitmap data for an [`Image`] or [`ImageIcon`] source.
+#[derive(Clone)]
+pub struct EncodedImage(EncodedImageBytes);
+
+#[derive(Clone)]
+enum EncodedImageBytes {
+    Static(&'static [u8]),
+    Shared(Arc<[u8]>),
+}
+
+impl EncodedImage {
+    /// Owns encoded bitmap data that may be shared across views.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the data exceeds the WinRT buffer limit of 4 GiB.
+    pub fn new(bytes: impl Into<Arc<[u8]>>) -> Self {
+        let bytes = bytes.into();
+        assert!(
+            bytes.len() <= u32::MAX as usize,
+            "encoded image data cannot exceed 4 GiB"
+        );
+        Self(EncodedImageBytes::Shared(bytes))
+    }
+
+    /// Retains encoded bitmap data with static storage without copying it.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the data exceeds the WinRT buffer limit of 4 GiB.
+    pub fn from_static(bytes: &'static [u8]) -> Self {
+        assert!(
+            bytes.len() <= u32::MAX as usize,
+            "encoded image data cannot exceed 4 GiB"
+        );
+        Self(EncodedImageBytes::Static(bytes))
+    }
+
+    /// Returns the encoded bitmap data.
+    pub fn as_bytes(&self) -> &[u8] {
+        match &self.0 {
+            EncodedImageBytes::Static(bytes) => bytes,
+            EncodedImageBytes::Shared(bytes) => bytes,
+        }
+    }
+}
+
+impl fmt::Debug for EncodedImage {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("EncodedImage")
+            .field("len", &self.as_bytes().len())
+            .finish()
+    }
+}
+
+impl PartialEq for EncodedImage {
+    fn eq(&self, other: &Self) -> bool {
+        match (&self.0, &other.0) {
+            (EncodedImageBytes::Static(left), EncodedImageBytes::Static(right))
+                if std::ptr::eq(*left, *right) =>
+            {
+                true
+            }
+            (EncodedImageBytes::Shared(left), EncodedImageBytes::Shared(right))
+                if Arc::ptr_eq(left, right) =>
+            {
+                true
+            }
+            _ => self.as_bytes() == other.as_bytes(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) enum ImageValue {
+    Uri(String),
+    Encoded(EncodedImage),
 }
 
 pub(crate) fn file_uri(path: &std::path::Path) -> windows_core::Result<String> {

--- a/crates/libs/reactor/src/generated.rs
+++ b/crates/libs/reactor/src/generated.rs
@@ -34,6 +34,11 @@ pub(crate) struct NavigationViewEvents {
     on_selected_tag_changed: Option<Callback<Option<String>>>,
 }
 #[derive(Clone, Debug, Default, PartialEq)]
+pub(crate) struct ImageEvents {
+    on_opened: Option<Callback<()>>,
+    on_failed: Option<Callback<()>>,
+}
+#[derive(Clone, Debug, Default, PartialEq)]
 pub(crate) struct TabViewEvents {
     on_selection_changed: Option<Callback<Option<usize>>>,
     on_close_requested: Option<Callback<String>>,
@@ -2761,8 +2766,9 @@ pub mod public {
     }
     #[derive(Clone, Debug, Default, PartialEq)]
     pub struct Image {
-        source: Property<String>,
+        source: Property<ImageValue>,
         stretch: Property<Stretch>,
+        events: Option<std::rc::Rc<ImageEvents>>,
         reference: Option<NativeElementRef>,
         element_state: Option<std::rc::Rc<ElementState>>,
     }
@@ -2777,7 +2783,7 @@ pub mod public {
         pub fn source(mut self, value: impl Into<String>) -> windows_core::Result<Self> {
             let value = value.into();
             validate_image_uri(&value)?;
-            self.source = Property::Set(value);
+            self.source = Property::Set(ImageValue::Uri(value));
             Ok(self)
         }
         pub fn source_optional<T>(mut self, value: Option<T>) -> windows_core::Result<Self>
@@ -2788,7 +2794,7 @@ pub mod public {
                 Some(value) => {
                     let value = value.into();
                     validate_image_uri(&value)?;
-                    Property::Set(value)
+                    Property::Set(ImageValue::Uri(value))
                 }
                 None => Property::Inherited,
             };
@@ -2797,9 +2803,29 @@ pub mod public {
         pub fn source_file(self, value: impl AsRef<std::path::Path>) -> windows_core::Result<Self> {
             self.source(file_uri(value.as_ref())?)
         }
+        pub fn source_data(mut self, value: EncodedImage) -> Self {
+            self.source = Property::Set(ImageValue::Encoded(value));
+            self
+        }
         pub fn stretch(mut self, value: impl Into<Option<Stretch>>) -> Self {
             let value = value.into();
             self.stretch = Property::from(value);
+            self
+        }
+        pub fn on_opened(mut self, callback: impl IntoUnitCallback) -> Self {
+            std::rc::Rc::make_mut(
+                self.events
+                    .get_or_insert_with(|| std::rc::Rc::new(Default::default())),
+            )
+            .on_opened = Some(callback.into_unit_callback());
+            self
+        }
+        pub fn on_failed(mut self, callback: impl IntoUnitCallback) -> Self {
+            std::rc::Rc::make_mut(
+                self.events
+                    .get_or_insert_with(|| std::rc::Rc::new(Default::default())),
+            )
+            .on_failed = Some(callback.into_unit_callback());
             self
         }
     }
@@ -3175,7 +3201,7 @@ pub mod public {
     impl LayoutControl for SymbolIcon {}
     #[derive(Clone, Debug, Default, PartialEq)]
     pub struct ImageIcon {
-        source: Property<String>,
+        source: Property<ImageValue>,
         element_state: Option<std::rc::Rc<ElementState>>,
     }
     impl ImageIcon {
@@ -3185,7 +3211,7 @@ pub mod public {
         pub fn source(mut self, value: impl Into<String>) -> windows_core::Result<Self> {
             let value = value.into();
             validate_image_uri(&value)?;
-            self.source = Property::Set(value);
+            self.source = Property::Set(ImageValue::Uri(value));
             Ok(self)
         }
         pub fn source_optional<T>(mut self, value: Option<T>) -> windows_core::Result<Self>
@@ -3196,7 +3222,7 @@ pub mod public {
                 Some(value) => {
                     let value = value.into();
                     validate_image_uri(&value)?;
-                    Property::Set(value)
+                    Property::Set(ImageValue::Uri(value))
                 }
                 None => Property::Inherited,
             };
@@ -3204,6 +3230,10 @@ pub mod public {
         }
         pub fn source_file(self, value: impl AsRef<std::path::Path>) -> windows_core::Result<Self> {
             self.source(file_uri(value.as_ref())?)
+        }
+        pub fn source_data(mut self, value: EncodedImage) -> Self {
+            self.source = Property::Set(ImageValue::Encoded(value));
+            self
         }
     }
     impl sealed::Sealed for ImageIcon {}
@@ -7113,6 +7143,7 @@ pub mod public {
                     let Image {
                         source,
                         stretch,
+                        events,
                         reference,
                         element_state,
                     } = *value;
@@ -7121,6 +7152,7 @@ pub mod public {
                         props: MountedProps::Image(std::rc::Rc::new(ImageMountedProps {
                             source,
                             stretch,
+                            events,
                         })),
                         reference,
                         element_state,
@@ -8310,7 +8342,9 @@ pub mod public {
                             == mounted.vertical_scroll_bar_visibility
                 }
                 (Self::Image(value), MountedProps::Image(mounted)) => {
-                    true && value.source == mounted.source && value.stretch == mounted.stretch
+                    true && value.source == mounted.source
+                        && value.stretch == mounted.stretch
+                        && value.events == mounted.events
                 }
                 (Self::ProgressRing(value), MountedProps::ProgressRing(mounted)) => {
                     true && f64_property_eq(&value.minimum, &mounted.minimum)
@@ -9056,7 +9090,22 @@ pub mod public {
                 Self::PersonPicture(_) => {}
                 Self::ScrollViewer(_) => {}
                 Self::ScrollView(_) => {}
-                Self::Image(_) => {}
+                Self::Image(value) => {
+                    visit(
+                        EventId::ImageImageOpened,
+                        value
+                            .events
+                            .as_ref()
+                            .is_some_and(|events| events.on_opened.is_some()),
+                    );
+                    visit(
+                        EventId::ImageImageFailed,
+                        value
+                            .events
+                            .as_ref()
+                            .is_some_and(|events| events.on_failed.is_some()),
+                    );
+                }
                 Self::ProgressRing(_) => {}
                 Self::ListBox(_) => {
                     visit(EventId::ListBoxSelectionChanged, true);
@@ -10163,7 +10212,12 @@ impl MountedPropsExt for MountedProps {
                     PropertyId::ImageSource,
                     match &values.source {
                         Property::Inherited => None,
-                        Property::Set(value) => Some(PropertyValueRef::Str(value.as_str())),
+                        Property::Set(ImageValue::Uri(value)) => {
+                            Some(PropertyValueRef::Str(value.as_str()))
+                        }
+                        Property::Set(ImageValue::Encoded(value)) => {
+                            Some(PropertyValueRef::EncodedImage(value))
+                        }
                     },
                 );
                 visit(
@@ -10355,7 +10409,12 @@ impl MountedPropsExt for MountedProps {
                     PropertyId::ImageIconSource,
                     match &values.source {
                         Property::Inherited => None,
-                        Property::Set(value) => Some(PropertyValueRef::Str(value.as_str())),
+                        Property::Set(ImageValue::Uri(value)) => {
+                            Some(PropertyValueRef::Str(value.as_str()))
+                        }
+                        Property::Set(ImageValue::Encoded(value)) => {
+                            Some(PropertyValueRef::EncodedImage(value))
+                        }
                     },
                 );
             }
@@ -11349,7 +11408,22 @@ impl MountedEventsExt for MountedProps {
             Self::PersonPicture(_) => {}
             Self::ScrollViewer(_) => {}
             Self::ScrollView(_) => {}
-            Self::Image(_) => {}
+            Self::Image(values) => {
+                visit(
+                    EventId::ImageImageOpened,
+                    values
+                        .events
+                        .as_ref()
+                        .is_some_and(|events| events.on_opened.is_some()),
+                );
+                visit(
+                    EventId::ImageImageFailed,
+                    values
+                        .events
+                        .as_ref()
+                        .is_some_and(|events| events.on_failed.is_some()),
+                );
+            }
             Self::ProgressRing(_) => {}
             Self::ListBox(_) => {
                 visit(EventId::ListBoxSelectionChanged, true);
@@ -11735,6 +11809,16 @@ impl MountedEventsExt for MountedProps {
             (Self::InfoBar(values), EventId::InfoBarClosed, EventPayload::Unit) => {
                 values.on_closed.as_ref().map(|callback| callback.call(()))
             }
+            (Self::Image(values), EventId::ImageImageOpened, EventPayload::Unit) => values
+                .events
+                .as_ref()
+                .and_then(|events| events.on_opened.as_ref())
+                .map(|callback| callback.call(())),
+            (Self::Image(values), EventId::ImageImageFailed, EventPayload::Unit) => values
+                .events
+                .as_ref()
+                .and_then(|events| events.on_failed.as_ref())
+                .map(|callback| callback.call(())),
             (
                 Self::ListBox(values),
                 EventId::ListBoxSelectionChanged,
@@ -12918,12 +13002,15 @@ impl PartialEq for ScrollViewMountedProps {
 }
 #[derive(Clone, Debug)]
 pub(crate) struct ImageMountedProps {
-    source: Property<String>,
+    source: Property<ImageValue>,
     stretch: Property<Stretch>,
+    events: Option<std::rc::Rc<ImageEvents>>,
 }
 impl PartialEq for ImageMountedProps {
     fn eq(&self, other: &Self) -> bool {
-        true && self.source == other.source && self.stretch == other.stretch
+        true && self.source == other.source
+            && self.stretch == other.stretch
+            && self.events == other.events
     }
 }
 #[derive(Clone, Debug)]
@@ -13016,7 +13103,7 @@ impl PartialEq for SymbolIconMountedProps {
 }
 #[derive(Clone, Debug)]
 pub(crate) struct ImageIconMountedProps {
-    source: Property<String>,
+    source: Property<ImageValue>,
 }
 impl PartialEq for ImageIconMountedProps {
     fn eq(&self, other: &Self) -> bool {
@@ -13924,6 +14011,8 @@ pub enum EventId {
     RadioButtonChecked,
     RadioButtonsSelectionChanged,
     InfoBarClosed,
+    ImageImageOpened,
+    ImageImageFailed,
     ListBoxSelectionChanged,
     RatingControlValueChanged,
     ExpanderIsExpandedChanged,
@@ -13962,6 +14051,7 @@ pub enum PropertyValue {
     CornerRadius(CornerRadius),
     DragDropPolicy(DragDropPolicy),
     Duration(std::time::Duration),
+    EncodedImage(EncodedImage),
     F64(f64),
     FontWeight(FontWeight),
     GridLengths(std::rc::Rc<Vec<GridLength>>),
@@ -14002,6 +14092,7 @@ impl PartialEq for PropertyValue {
             (Self::CornerRadius(left), Self::CornerRadius(right)) => left == right,
             (Self::DragDropPolicy(left), Self::DragDropPolicy(right)) => left == right,
             (Self::Duration(left), Self::Duration(right)) => left == right,
+            (Self::EncodedImage(left), Self::EncodedImage(right)) => left == right,
             (Self::F64(left), Self::F64(right)) => f64_eq(*left, *right),
             (Self::FontWeight(left), Self::FontWeight(right)) => left == right,
             (Self::GridLengths(left), Self::GridLengths(right)) => left == right,
@@ -14063,6 +14154,7 @@ pub enum PropertyValueRef<'a> {
     CornerRadius(&'a CornerRadius),
     DragDropPolicy(&'a DragDropPolicy),
     Duration(std::time::Duration),
+    EncodedImage(&'a EncodedImage),
     F64(f64),
     FontWeight(FontWeight),
     GridLengths(&'a std::rc::Rc<Vec<GridLength>>),
@@ -14103,6 +14195,7 @@ impl PropertyValueRef<'_> {
             (Self::CornerRadius(left), PropertyValue::CornerRadius(right)) => left == right,
             (Self::DragDropPolicy(left), PropertyValue::DragDropPolicy(right)) => left == right,
             (Self::Duration(left), PropertyValue::Duration(right)) => left == *right,
+            (Self::EncodedImage(left), PropertyValue::EncodedImage(right)) => left == right,
             (Self::F64(left), PropertyValue::F64(right)) => f64_eq(left, *right),
             (Self::FontWeight(left), PropertyValue::FontWeight(right)) => left == *right,
             (Self::GridLengths(left), PropertyValue::GridLengths(right)) => left == right,
@@ -14176,6 +14269,7 @@ impl PropertyValueRef<'_> {
             Self::CornerRadius(value) => PropertyValue::CornerRadius(value.clone()),
             Self::DragDropPolicy(value) => PropertyValue::DragDropPolicy(value.clone()),
             Self::Duration(value) => PropertyValue::Duration(value),
+            Self::EncodedImage(value) => PropertyValue::EncodedImage(value.clone()),
             Self::F64(value) => PropertyValue::F64(value),
             Self::FontWeight(value) => PropertyValue::FontWeight(value),
             Self::GridLengths(value) => PropertyValue::GridLengths(value.clone()),
@@ -14247,6 +14341,11 @@ impl From<DragDropPolicy> for PropertyValue {
 impl From<std::time::Duration> for PropertyValue {
     fn from(value: std::time::Duration) -> Self {
         Self::Duration(value)
+    }
+}
+impl From<EncodedImage> for PropertyValue {
+    fn from(value: EncodedImage) -> Self {
+        Self::EncodedImage(value)
     }
 }
 impl From<f64> for PropertyValue {
@@ -16310,7 +16409,7 @@ const IMAGE_PROPERTIES: &[PropertyDescriptor] = &[
         id: PropertyId::ImageSource,
         name: "Source",
         field: "source",
-        value: "Str",
+        value: "ImageValue",
         interface: "Microsoft.UI.Xaml.Controls.IImage",
         clearable: true,
         feedback: None,
@@ -16329,7 +16428,22 @@ const IMAGE_PROPERTIES: &[PropertyDescriptor] = &[
         observes_feedback: false,
     },
 ];
-const IMAGE_EVENTS: &[EventDescriptor] = &[];
+const IMAGE_EVENTS: &[EventDescriptor] = &[
+    EventDescriptor {
+        id: EventId::ImageImageOpened,
+        name: "ImageOpened",
+        field: "on_opened",
+        payload: "Unit",
+        interface: "Microsoft.UI.Xaml.Controls.IImage",
+    },
+    EventDescriptor {
+        id: EventId::ImageImageFailed,
+        name: "ImageFailed",
+        field: "on_failed",
+        payload: "Unit",
+        interface: "Microsoft.UI.Xaml.Controls.IImage",
+    },
+];
 const IMAGE_SLOTS: &[SlotDescriptor] = &[];
 const PROGRESS_RING_PROPERTIES: &[PropertyDescriptor] = &[
     PropertyDescriptor {
@@ -16609,7 +16723,7 @@ const IMAGE_ICON_PROPERTIES: &[PropertyDescriptor] = &[PropertyDescriptor {
     id: PropertyId::ImageIconSource,
     name: "Source",
     field: "source",
-    value: "Str",
+    value: "ImageValue",
     interface: "Microsoft.UI.Xaml.Controls.IImageIcon",
     clearable: true,
     feedback: None,

--- a/crates/libs/reactor/src/native/winui/bindings.rs
+++ b/crates/libs/reactor/src/native/winui/bindings.rs
@@ -2026,6 +2026,7 @@ windows_core::imp::interface_hierarchy!(
     windows_core::IUnknown,
     windows_core::IInspectable
 );
+windows_core::imp::required_hierarchy!(CompositionObject, IClosable);
 impl windows_core::RuntimeType for CompositionObject {
     const SIGNATURE: windows_core::imp::ConstBuffer =
         windows_core::imp::ConstBuffer::for_class::<Self, ICompositionObject>();
@@ -2124,6 +2125,7 @@ windows_core::imp::interface_hierarchy!(
     windows_core::IUnknown,
     windows_core::IInspectable
 );
+windows_core::imp::required_hierarchy!(Compositor, IClosable);
 impl windows_core::RuntimeType for Compositor {
     const SIGNATURE: windows_core::imp::ConstBuffer =
         windows_core::imp::ConstBuffer::for_class::<Self, ICompositor>();
@@ -2632,6 +2634,59 @@ impl windows_core::RuntimeName for DataPackageView {
 }
 unsafe impl Send for DataPackageView {}
 unsafe impl Sync for DataPackageView {}
+#[repr(transparent)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DataWriter(windows_core::IUnknown);
+windows_core::imp::interface_hierarchy!(
+    DataWriter,
+    windows_core::IUnknown,
+    windows_core::IInspectable,
+    IDataWriter
+);
+windows_core::imp::required_hierarchy!(DataWriter, IClosable);
+impl DataWriter {
+    pub(crate) fn CreateDataWriter<P0>(outputstream: P0) -> windows_core::Result<Self>
+    where
+        P0: windows_core::Param<IOutputStream>,
+    {
+        Self::IDataWriterFactory(|this| unsafe {
+            let mut result__ = core::mem::zeroed();
+            (windows_core::Interface::vtable(this).CreateDataWriter)(
+                windows_core::Interface::as_raw(this),
+                outputstream.param().abi(),
+                &mut result__,
+            )
+            .and_then(|| windows_core::Type::from_abi(result__))
+        })
+    }
+    fn IDataWriterFactory<R, F: FnOnce(&IDataWriterFactory) -> windows_core::Result<R>>(
+        callback: F,
+    ) -> windows_core::Result<R> {
+        static SHARED: windows_core::imp::FactoryCache<DataWriter, IDataWriterFactory> =
+            windows_core::imp::FactoryCache::new();
+        SHARED.call(callback)
+    }
+}
+impl windows_core::RuntimeType for DataWriter {
+    const SIGNATURE: windows_core::imp::ConstBuffer =
+        windows_core::imp::ConstBuffer::for_class::<Self, IDataWriter>();
+}
+unsafe impl windows_core::Interface for DataWriter {
+    type Vtable = <IDataWriter as windows_core::Interface>::Vtable;
+    const IID: windows_core::GUID = <IDataWriter as windows_core::Interface>::IID;
+}
+impl core::ops::Deref for DataWriter {
+    type Target = IDataWriter;
+    fn deref(&self) -> &Self::Target {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl windows_core::RuntimeName for DataWriter {
+    const NAME: &'static str = "Windows.Storage.Streams.DataWriter";
+}
+unsafe impl Send for DataWriter {}
+unsafe impl Sync for DataWriter {}
+pub type DataWriterStoreOperation = windows_future::IAsyncOperation<u32>;
 #[repr(transparent)]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct DatePicker(windows_core::IUnknown);
@@ -3531,6 +3586,90 @@ impl<
             (this.invoke)(
                 core::mem::transmute_copy(&sender),
                 core::mem::transmute_copy(&args),
+            );
+            windows_core::HRESULT(0)
+        }
+    }
+}
+#[repr(transparent)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ExceptionRoutedEventArgs(windows_core::IUnknown);
+windows_core::imp::interface_hierarchy!(
+    ExceptionRoutedEventArgs,
+    windows_core::IUnknown,
+    windows_core::IInspectable
+);
+windows_core::imp::required_hierarchy!(ExceptionRoutedEventArgs, RoutedEventArgs);
+impl windows_core::RuntimeType for ExceptionRoutedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer =
+        windows_core::imp::ConstBuffer::for_class::<Self, IExceptionRoutedEventArgs>();
+}
+unsafe impl windows_core::Interface for ExceptionRoutedEventArgs {
+    type Vtable = <IExceptionRoutedEventArgs as windows_core::Interface>::Vtable;
+    const IID: windows_core::GUID = <IExceptionRoutedEventArgs as windows_core::Interface>::IID;
+}
+impl core::ops::Deref for ExceptionRoutedEventArgs {
+    type Target = IExceptionRoutedEventArgs;
+    fn deref(&self) -> &Self::Target {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl windows_core::RuntimeName for ExceptionRoutedEventArgs {
+    const NAME: &'static str = "Microsoft.UI.Xaml.ExceptionRoutedEventArgs";
+}
+unsafe impl Send for ExceptionRoutedEventArgs {}
+unsafe impl Sync for ExceptionRoutedEventArgs {}
+windows_core::imp::define_interface!(
+    ExceptionRoutedEventHandler,
+    ExceptionRoutedEventHandler_Vtbl,
+    0x45fbb85d_54f9_5a2a_8a38_00a3b7761f96
+);
+impl windows_core::RuntimeType for ExceptionRoutedEventHandler {
+    const SIGNATURE: windows_core::imp::ConstBuffer =
+        windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
+#[repr(C)]
+pub struct ExceptionRoutedEventHandler_Vtbl {
+    base__: windows_core::IUnknown_Vtbl,
+    Invoke: unsafe extern "system" fn(
+        this: *mut core::ffi::c_void,
+        sender: *mut core::ffi::c_void,
+        e: *mut core::ffi::c_void,
+    ) -> windows_core::HRESULT,
+}
+struct ExceptionRoutedEventHandlerBox<
+    F: Fn(
+            windows_core::Ref<windows_core::IInspectable>,
+            windows_core::Ref<ExceptionRoutedEventArgs>,
+        ) + 'static,
+>(core::marker::PhantomData<(fn() -> F,)>);
+impl<
+    F: Fn(
+            windows_core::Ref<windows_core::IInspectable>,
+            windows_core::Ref<ExceptionRoutedEventArgs>,
+        ) + 'static,
+> ExceptionRoutedEventHandlerBox<F>
+{
+    const VTABLE: ExceptionRoutedEventHandler_Vtbl = ExceptionRoutedEventHandler_Vtbl {
+        base__: windows_core::IUnknown_Vtbl {
+            QueryInterface:
+                windows_core::imp::DelegateBox::<ExceptionRoutedEventHandler, F>::QueryInterface,
+            AddRef: windows_core::imp::DelegateBox::<ExceptionRoutedEventHandler, F>::AddRef,
+            Release: windows_core::imp::DelegateBox::<ExceptionRoutedEventHandler, F>::Release,
+        },
+        Invoke: Self::Invoke,
+    };
+    unsafe extern "system" fn Invoke(
+        this: *mut core::ffi::c_void,
+        sender: *mut core::ffi::c_void,
+        e: *mut core::ffi::c_void,
+    ) -> windows_core::HRESULT {
+        unsafe {
+            let this = &mut *(this as *mut *mut core::ffi::c_void
+                as *mut windows_core::imp::DelegateBox<ExceptionRoutedEventHandler, F>);
+            (this.invoke)(
+                core::mem::transmute_copy(&sender),
+                core::mem::transmute_copy(&e),
             );
             windows_core::HRESULT(0)
         }
@@ -5557,9 +5696,36 @@ impl windows_core::RuntimeType for IBitmapSource {
     const SIGNATURE: windows_core::imp::ConstBuffer =
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
+impl IBitmapSource {
+    pub(crate) fn SetSourceAsync<P0>(
+        &self,
+        streamsource: P0,
+    ) -> windows_core::Result<windows_future::IAsyncAction>
+    where
+        P0: windows_core::Param<IRandomAccessStream>,
+    {
+        unsafe {
+            let mut result__ = core::mem::zeroed();
+            (windows_core::Interface::vtable(self).SetSourceAsync)(
+                windows_core::Interface::as_raw(self),
+                streamsource.param().abi(),
+                &mut result__,
+            )
+            .and_then(|| windows_core::Type::from_abi(result__))
+        }
+    }
+}
 #[repr(C)]
 pub struct IBitmapSource_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
+    PixelWidth: usize,
+    PixelHeight: usize,
+    SetSource: usize,
+    pub SetSourceAsync: unsafe extern "system" fn(
+        *mut core::ffi::c_void,
+        *mut core::ffi::c_void,
+        *mut *mut core::ffi::c_void,
+    ) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBlock, IBlock_Vtbl, 0x8149d507_672f_5fd5_a10a_351389ba9659);
 impl windows_core::RuntimeType for IBlock {
@@ -6646,6 +6812,24 @@ pub struct ICheckBoxFactory_Vtbl {
         *mut *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
+}
+windows_core::imp::define_interface!(
+    IClosable,
+    IClosable_Vtbl,
+    0x30d5a829_7fa4_4026_83bb_d75bae4ea99e
+);
+impl windows_core::RuntimeType for IClosable {
+    const SIGNATURE: windows_core::imp::ConstBuffer =
+        windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
+windows_core::imp::interface_hierarchy!(
+    IClosable,
+    windows_core::IUnknown,
+    windows_core::IInspectable
+);
+#[repr(C)]
+pub struct IClosable_Vtbl {
+    pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(
     IColorChangedEventArgs,
@@ -7910,6 +8094,108 @@ pub struct IDataPackageView_Vtbl {
     ) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
+    IDataWriter,
+    IDataWriter_Vtbl,
+    0x64b89265_d341_4922_b38a_dd4af8808c4e
+);
+impl windows_core::RuntimeType for IDataWriter {
+    const SIGNATURE: windows_core::imp::ConstBuffer =
+        windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
+windows_core::imp::interface_hierarchy!(
+    IDataWriter,
+    windows_core::IUnknown,
+    windows_core::IInspectable
+);
+impl IDataWriter {
+    pub(crate) fn WriteBytes(&self, value: &[u8]) -> windows_core::Result<()> {
+        unsafe {
+            (windows_core::Interface::vtable(self).WriteBytes)(
+                windows_core::Interface::as_raw(self),
+                value.len().try_into().unwrap(),
+                value.as_ptr(),
+            )
+            .ok()
+        }
+    }
+    pub(crate) fn StoreAsync(&self) -> windows_core::Result<DataWriterStoreOperation> {
+        unsafe {
+            let mut result__ = core::mem::zeroed();
+            (windows_core::Interface::vtable(self).StoreAsync)(
+                windows_core::Interface::as_raw(self),
+                &mut result__,
+            )
+            .and_then(|| windows_core::Type::from_abi(result__))
+        }
+    }
+    pub(crate) fn DetachStream(&self) -> windows_core::Result<IOutputStream> {
+        unsafe {
+            let mut result__ = core::mem::zeroed();
+            (windows_core::Interface::vtable(self).DetachStream)(
+                windows_core::Interface::as_raw(self),
+                &mut result__,
+            )
+            .and_then(|| windows_core::Type::from_abi(result__))
+        }
+    }
+}
+#[repr(C)]
+pub struct IDataWriter_Vtbl {
+    pub base__: windows_core::IInspectable_Vtbl,
+    UnstoredBufferLength: usize,
+    UnicodeEncoding: usize,
+    SetUnicodeEncoding: usize,
+    ByteOrder: usize,
+    SetByteOrder: usize,
+    WriteByte: usize,
+    pub WriteBytes:
+        unsafe extern "system" fn(*mut core::ffi::c_void, u32, *const u8) -> windows_core::HRESULT,
+    WriteBuffer: usize,
+    WriteBufferRange: usize,
+    WriteBoolean: usize,
+    WriteGuid: usize,
+    WriteInt16: usize,
+    WriteInt32: usize,
+    WriteInt64: usize,
+    WriteUInt16: usize,
+    WriteUInt32: usize,
+    WriteUInt64: usize,
+    WriteSingle: usize,
+    WriteDouble: usize,
+    WriteDateTime: usize,
+    WriteTimeSpan: usize,
+    WriteString: usize,
+    MeasureString: usize,
+    pub StoreAsync: unsafe extern "system" fn(
+        *mut core::ffi::c_void,
+        *mut *mut core::ffi::c_void,
+    ) -> windows_core::HRESULT,
+    FlushAsync: usize,
+    DetachBuffer: usize,
+    pub DetachStream: unsafe extern "system" fn(
+        *mut core::ffi::c_void,
+        *mut *mut core::ffi::c_void,
+    ) -> windows_core::HRESULT,
+}
+windows_core::imp::define_interface!(
+    IDataWriterFactory,
+    IDataWriterFactory_Vtbl,
+    0x338c67c2_8b84_4c2b_9c50_7b8767847a1f
+);
+impl windows_core::RuntimeType for IDataWriterFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer =
+        windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
+#[repr(C)]
+pub struct IDataWriterFactory_Vtbl {
+    pub base__: windows_core::IInspectable_Vtbl,
+    pub CreateDataWriter: unsafe extern "system" fn(
+        *mut core::ffi::c_void,
+        *mut core::ffi::c_void,
+        *mut *mut core::ffi::c_void,
+    ) -> windows_core::HRESULT,
+}
+windows_core::imp::define_interface!(
     IDatePicker,
     IDatePicker_Vtbl,
     0xca1dc351_3ae3_5247_8263_16bd516c6e72
@@ -8876,6 +9162,19 @@ impl windows_core::RuntimeType for IEllipse {
 }
 #[repr(C)]
 pub struct IEllipse_Vtbl {
+    pub base__: windows_core::IInspectable_Vtbl,
+}
+windows_core::imp::define_interface!(
+    IExceptionRoutedEventArgs,
+    IExceptionRoutedEventArgs_Vtbl,
+    0xe8bcb6d2_d3f5_5393_a84f_dfcd44a2df34
+);
+impl windows_core::RuntimeType for IExceptionRoutedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer =
+        windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
+#[repr(C)]
+pub struct IExceptionRoutedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(
@@ -10069,6 +10368,68 @@ impl IImage {
             .ok()
         }
     }
+    pub(crate) fn ImageFailed<F>(
+        &self,
+        handler: F,
+    ) -> windows_core::Result<windows_core::EventRevoker>
+    where
+        F: Fn(
+                windows_core::Ref<windows_core::IInspectable>,
+                windows_core::Ref<ExceptionRoutedEventArgs>,
+            ) + 'static,
+    {
+        let handler: ExceptionRoutedEventHandler = {
+            let com = windows_core::imp::DelegateBox::<ExceptionRoutedEventHandler, F>::new(
+                &ExceptionRoutedEventHandlerBox::<F>::VTABLE,
+                handler,
+            );
+            unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
+        };
+        unsafe {
+            let mut result__ = core::mem::zeroed();
+            let token__ = (windows_core::Interface::vtable(self).ImageFailed)(
+                windows_core::Interface::as_raw(self),
+                windows_core::Interface::as_raw(&handler),
+                &mut result__,
+            )
+            .map(|| result__)?;
+            Ok(windows_core::EventRevoker::new(
+                self.clone(),
+                token__,
+                windows_core::Interface::vtable(self).RemoveImageFailed,
+            ))
+        }
+    }
+    pub(crate) fn ImageOpened<F>(
+        &self,
+        handler: F,
+    ) -> windows_core::Result<windows_core::EventRevoker>
+    where
+        F: Fn(windows_core::Ref<windows_core::IInspectable>, windows_core::Ref<RoutedEventArgs>)
+            + 'static,
+    {
+        let handler: RoutedEventHandler = {
+            let com = windows_core::imp::DelegateBox::<RoutedEventHandler, F>::new(
+                &RoutedEventHandlerBox::<F>::VTABLE,
+                handler,
+            );
+            unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
+        };
+        unsafe {
+            let mut result__ = core::mem::zeroed();
+            let token__ = (windows_core::Interface::vtable(self).ImageOpened)(
+                windows_core::Interface::as_raw(self),
+                windows_core::Interface::as_raw(&handler),
+                &mut result__,
+            )
+            .map(|| result__)?;
+            Ok(windows_core::EventRevoker::new(
+                self.clone(),
+                token__,
+                windows_core::Interface::vtable(self).RemoveImageOpened,
+            ))
+        }
+    }
 }
 #[repr(C)]
 pub struct IImage_Vtbl {
@@ -10084,6 +10445,22 @@ pub struct IImage_Vtbl {
     Stretch: usize,
     pub SetStretch:
         unsafe extern "system" fn(*mut core::ffi::c_void, Stretch) -> windows_core::HRESULT,
+    NineGrid: usize,
+    SetNineGrid: usize,
+    pub ImageFailed: unsafe extern "system" fn(
+        *mut core::ffi::c_void,
+        *mut core::ffi::c_void,
+        *mut i64,
+    ) -> windows_core::HRESULT,
+    pub RemoveImageFailed:
+        unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
+    pub ImageOpened: unsafe extern "system" fn(
+        *mut core::ffi::c_void,
+        *mut core::ffi::c_void,
+        *mut i64,
+    ) -> windows_core::HRESULT,
+    pub RemoveImageOpened:
+        unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
     IImageIcon,
@@ -10462,6 +10839,25 @@ impl windows_core::RuntimeType for IInline {
 }
 #[repr(C)]
 pub struct IInline_Vtbl {
+    pub base__: windows_core::IInspectable_Vtbl,
+}
+windows_core::imp::define_interface!(
+    IInputStream,
+    IInputStream_Vtbl,
+    0x905a0fe2_bc53_11df_8c49_001e4fc686da
+);
+impl windows_core::RuntimeType for IInputStream {
+    const SIGNATURE: windows_core::imp::ConstBuffer =
+        windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
+windows_core::imp::interface_hierarchy!(
+    IInputStream,
+    windows_core::IUnknown,
+    windows_core::IInspectable
+);
+windows_core::imp::required_hierarchy!(IInputStream, IClosable);
+#[repr(C)]
+pub struct IInputStream_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(
@@ -12622,6 +13018,25 @@ pub struct INumberBoxValueChangedEventArgs_Vtbl {
         unsafe extern "system" fn(*mut core::ffi::c_void, *mut f64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
+    IOutputStream,
+    IOutputStream_Vtbl,
+    0x905a0fe6_bc53_11df_8c49_001e4fc686da
+);
+impl windows_core::RuntimeType for IOutputStream {
+    const SIGNATURE: windows_core::imp::ConstBuffer =
+        windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
+windows_core::imp::interface_hierarchy!(
+    IOutputStream,
+    windows_core::IUnknown,
+    windows_core::IInspectable
+);
+windows_core::imp::required_hierarchy!(IOutputStream, IClosable);
+#[repr(C)]
+pub struct IOutputStream_Vtbl {
+    pub base__: windows_core::IInspectable_Vtbl,
+}
+windows_core::imp::define_interface!(
     IOverlappedPresenter3,
     IOverlappedPresenter3_Vtbl,
     0x55d26138_4c38_57e7_a0c1_d467b774db8c
@@ -14008,6 +14423,57 @@ pub struct IRadioButtonsStatics_Vtbl {
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
+}
+windows_core::imp::define_interface!(
+    IRandomAccessStream,
+    IRandomAccessStream_Vtbl,
+    0x905a0fe1_bc53_11df_8c49_001e4fc686da
+);
+impl windows_core::RuntimeType for IRandomAccessStream {
+    const SIGNATURE: windows_core::imp::ConstBuffer =
+        windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
+windows_core::imp::interface_hierarchy!(
+    IRandomAccessStream,
+    windows_core::IUnknown,
+    windows_core::IInspectable
+);
+windows_core::imp::required_hierarchy!(IRandomAccessStream, IClosable, IInputStream, IOutputStream);
+impl IRandomAccessStream {
+    pub(crate) fn GetOutputStreamAt(&self, position: u64) -> windows_core::Result<IOutputStream> {
+        unsafe {
+            let mut result__ = core::mem::zeroed();
+            (windows_core::Interface::vtable(self).GetOutputStreamAt)(
+                windows_core::Interface::as_raw(self),
+                position,
+                &mut result__,
+            )
+            .and_then(|| windows_core::Type::from_abi(result__))
+        }
+    }
+    pub(crate) fn Seek(&self, position: u64) -> windows_core::Result<()> {
+        unsafe {
+            (windows_core::Interface::vtable(self).Seek)(
+                windows_core::Interface::as_raw(self),
+                position,
+            )
+            .ok()
+        }
+    }
+}
+#[repr(C)]
+pub struct IRandomAccessStream_Vtbl {
+    pub base__: windows_core::IInspectable_Vtbl,
+    Size: usize,
+    SetSize: usize,
+    GetInputStreamAt: usize,
+    pub GetOutputStreamAt: unsafe extern "system" fn(
+        *mut core::ffi::c_void,
+        u64,
+        *mut *mut core::ffi::c_void,
+    ) -> windows_core::HRESULT,
+    Position: usize,
+    pub Seek: unsafe extern "system" fn(*mut core::ffi::c_void, u64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
     IRangeBase,
@@ -21231,6 +21697,57 @@ impl windows_core::RuntimeName for ImageSource {
 }
 unsafe impl Send for ImageSource {}
 unsafe impl Sync for ImageSource {}
+#[repr(transparent)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct InMemoryRandomAccessStream(windows_core::IUnknown);
+windows_core::imp::interface_hierarchy!(
+    InMemoryRandomAccessStream,
+    windows_core::IUnknown,
+    windows_core::IInspectable,
+    IRandomAccessStream
+);
+windows_core::imp::required_hierarchy!(
+    InMemoryRandomAccessStream,
+    IClosable,
+    IInputStream,
+    IOutputStream
+);
+impl InMemoryRandomAccessStream {
+    pub(crate) fn new() -> windows_core::Result<Self> {
+        Self::IActivationFactory(|f| f.ActivateInstance::<Self>())
+    }
+    fn IActivationFactory<
+        R,
+        F: FnOnce(&windows_core::imp::IGenericFactory) -> windows_core::Result<R>,
+    >(
+        callback: F,
+    ) -> windows_core::Result<R> {
+        static SHARED: windows_core::imp::FactoryCache<
+            InMemoryRandomAccessStream,
+            windows_core::imp::IGenericFactory,
+        > = windows_core::imp::FactoryCache::new();
+        SHARED.call(callback)
+    }
+}
+impl windows_core::RuntimeType for InMemoryRandomAccessStream {
+    const SIGNATURE: windows_core::imp::ConstBuffer =
+        windows_core::imp::ConstBuffer::for_class::<Self, IRandomAccessStream>();
+}
+unsafe impl windows_core::Interface for InMemoryRandomAccessStream {
+    type Vtable = <IRandomAccessStream as windows_core::Interface>::Vtable;
+    const IID: windows_core::GUID = <IRandomAccessStream as windows_core::Interface>::IID;
+}
+impl core::ops::Deref for InMemoryRandomAccessStream {
+    type Target = IRandomAccessStream;
+    fn deref(&self) -> &Self::Target {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl windows_core::RuntimeName for InMemoryRandomAccessStream {
+    const NAME: &'static str = "Windows.Storage.Streams.InMemoryRandomAccessStream";
+}
+unsafe impl Send for InMemoryRandomAccessStream {}
+unsafe impl Sync for InMemoryRandomAccessStream {}
 #[repr(transparent)]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct InfoBadge(windows_core::IUnknown);
@@ -29472,7 +29989,7 @@ impl core::ops::Not for VirtualKeyModifiers {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Visual(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(Visual, windows_core::IUnknown, windows_core::IInspectable);
-windows_core::imp::required_hierarchy!(Visual, CompositionObject);
+windows_core::imp::required_hierarchy!(Visual, IClosable, CompositionObject);
 impl windows_core::RuntimeType for Visual {
     const SIGNATURE: windows_core::imp::ConstBuffer =
         windows_core::imp::ConstBuffer::for_class::<Self, IVisual>();

--- a/crates/libs/reactor/src/native/winui/generated.rs
+++ b/crates/libs/reactor/src/native/winui/generated.rs
@@ -4652,7 +4652,10 @@ pub fn subscribe_event(
                 .Click(move |_, _| {
                     sink.enqueue(node, EventId::ButtonClick, revision, EventPayload::Unit);
                 })
-                .map(|revoker| NativeSubscription::Event { _revoker: revoker })
+                .map(|revoker| NativeSubscription::Event {
+                    _revoker: revoker,
+                    revision,
+                })
                 .map_err(native_error)
         }
         (Handle::HyperlinkButton(value), EventId::HyperlinkButtonClick) => {
@@ -4666,7 +4669,10 @@ pub fn subscribe_event(
                         EventPayload::Unit,
                     );
                 })
-                .map(|revoker| NativeSubscription::Event { _revoker: revoker })
+                .map(|revoker| NativeSubscription::Event {
+                    _revoker: revoker,
+                    revision,
+                })
                 .map_err(native_error)
         }
         (Handle::RepeatButton(value), EventId::RepeatButtonClick) => {
@@ -4680,7 +4686,10 @@ pub fn subscribe_event(
                         EventPayload::Unit,
                     );
                 })
-                .map(|revoker| NativeSubscription::Event { _revoker: revoker })
+                .map(|revoker| NativeSubscription::Event {
+                    _revoker: revoker,
+                    revision,
+                })
                 .map_err(native_error)
         }
         (Handle::Border(value), EventId::BorderDragEnter) => {
@@ -4736,7 +4745,10 @@ pub fn subscribe_event(
                         }
                     };
                 })
-                .map(|revoker| NativeSubscription::Event { _revoker: revoker })
+                .map(|revoker| NativeSubscription::Event {
+                    _revoker: revoker,
+                    revision,
+                })
                 .map_err(native_error)
         }
         (Handle::Border(value), EventId::BorderDragOver) => {
@@ -4792,7 +4804,10 @@ pub fn subscribe_event(
                         }
                     };
                 })
-                .map(|revoker| NativeSubscription::Event { _revoker: revoker })
+                .map(|revoker| NativeSubscription::Event {
+                    _revoker: revoker,
+                    revision,
+                })
                 .map_err(native_error)
         }
         (Handle::Border(value), EventId::BorderDragLeave) => {
@@ -4801,7 +4816,10 @@ pub fn subscribe_event(
                 .DragLeave(move |_, _| {
                     sink.enqueue(node, EventId::BorderDragLeave, revision, EventPayload::Unit);
                 })
-                .map(|revoker| NativeSubscription::Event { _revoker: revoker })
+                .map(|revoker| NativeSubscription::Event {
+                    _revoker: revoker,
+                    revision,
+                })
                 .map_err(native_error)
         }
         (Handle::Border(value), EventId::BorderDrop) => {
@@ -4919,7 +4937,10 @@ pub fn subscribe_event(
                         }
                     };
                 })
-                .map(|revoker| NativeSubscription::Event { _revoker: revoker })
+                .map(|revoker| NativeSubscription::Event {
+                    _revoker: revoker,
+                    revision,
+                })
                 .map_err(native_error)
         }
         (Handle::Border(value), EventId::BorderPointerPressed) => {
@@ -4968,7 +4989,10 @@ pub fn subscribe_event(
                         );
                     }
                 })
-                .map(|revoker| NativeSubscription::Event { _revoker: revoker })
+                .map(|revoker| NativeSubscription::Event {
+                    _revoker: revoker,
+                    revision,
+                })
                 .map_err(native_error)
         }
         (Handle::Border(value), EventId::BorderPointerMoved) => {
@@ -5008,7 +5032,10 @@ pub fn subscribe_event(
                         );
                     }
                 })
-                .map(|revoker| NativeSubscription::Event { _revoker: revoker })
+                .map(|revoker| NativeSubscription::Event {
+                    _revoker: revoker,
+                    revision,
+                })
                 .map_err(native_error)
         }
         (Handle::Border(value), EventId::BorderPointerEntered) => {
@@ -5048,7 +5075,10 @@ pub fn subscribe_event(
                         );
                     }
                 })
-                .map(|revoker| NativeSubscription::Event { _revoker: revoker })
+                .map(|revoker| NativeSubscription::Event {
+                    _revoker: revoker,
+                    revision,
+                })
                 .map_err(native_error)
         }
         (Handle::Border(value), EventId::BorderPointerExited) => {
@@ -5088,7 +5118,10 @@ pub fn subscribe_event(
                         );
                     }
                 })
-                .map(|revoker| NativeSubscription::Event { _revoker: revoker })
+                .map(|revoker| NativeSubscription::Event {
+                    _revoker: revoker,
+                    revision,
+                })
                 .map_err(native_error)
         }
         (Handle::Border(value), EventId::BorderPointerReleased) => {
@@ -5132,7 +5165,10 @@ pub fn subscribe_event(
                         );
                     }
                 })
-                .map(|revoker| NativeSubscription::Event { _revoker: revoker })
+                .map(|revoker| NativeSubscription::Event {
+                    _revoker: revoker,
+                    revision,
+                })
                 .map_err(native_error)
         }
         (Handle::Border(value), EventId::BorderPointerCaptureLost) => {
@@ -5146,7 +5182,10 @@ pub fn subscribe_event(
                         EventPayload::Unit,
                     );
                 })
-                .map(|revoker| NativeSubscription::Event { _revoker: revoker })
+                .map(|revoker| NativeSubscription::Event {
+                    _revoker: revoker,
+                    revision,
+                })
                 .map_err(native_error)
         }
         (Handle::Border(value), EventId::BorderPointerCanceled) => {
@@ -5160,7 +5199,10 @@ pub fn subscribe_event(
                         EventPayload::Unit,
                     );
                 })
-                .map(|revoker| NativeSubscription::Event { _revoker: revoker })
+                .map(|revoker| NativeSubscription::Event {
+                    _revoker: revoker,
+                    revision,
+                })
                 .map_err(native_error)
         }
         (Handle::BreadcrumbBar(value), EventId::BreadcrumbBarItemClicked) => {
@@ -5191,7 +5233,10 @@ pub fn subscribe_event(
                         }
                     }
                 })
-                .map(|revoker| NativeSubscription::Event { _revoker: revoker })
+                .map(|revoker| NativeSubscription::Event {
+                    _revoker: revoker,
+                    revision,
+                })
                 .map_err(native_error)
         }
         (Handle::TextBox(value), EventId::TextBoxTextChanged) => {
@@ -5214,7 +5259,10 @@ pub fn subscribe_event(
                         ),
                     }
                 })
-                .map(|revoker| NativeSubscription::Event { _revoker: revoker })
+                .map(|revoker| NativeSubscription::Event {
+                    _revoker: revoker,
+                    revision,
+                })
                 .map_err(native_error)
         }
         (Handle::AutoSuggestBox(value), EventId::AutoSuggestBoxTextChanged) => {
@@ -5237,7 +5285,10 @@ pub fn subscribe_event(
                         ),
                     }
                 })
-                .map(|revoker| NativeSubscription::Event { _revoker: revoker })
+                .map(|revoker| NativeSubscription::Event {
+                    _revoker: revoker,
+                    revision,
+                })
                 .map_err(native_error)
         }
         (Handle::AutoSuggestBox(value), EventId::AutoSuggestBoxSuggestionChosen) => {
@@ -5268,7 +5319,10 @@ pub fn subscribe_event(
                         }
                     }
                 })
-                .map(|revoker| NativeSubscription::Event { _revoker: revoker })
+                .map(|revoker| NativeSubscription::Event {
+                    _revoker: revoker,
+                    revision,
+                })
                 .map_err(native_error)
         }
         (Handle::PasswordBox(value), EventId::PasswordBoxPasswordChanged) => {
@@ -5291,7 +5345,10 @@ pub fn subscribe_event(
                         ),
                     }
                 })
-                .map(|revoker| NativeSubscription::Event { _revoker: revoker })
+                .map(|revoker| NativeSubscription::Event {
+                    _revoker: revoker,
+                    revision,
+                })
                 .map_err(native_error)
         }
         (Handle::NumberBox(value), EventId::NumberBoxValueChanged) => {
@@ -5318,7 +5375,10 @@ pub fn subscribe_event(
                         }
                     }
                 })
-                .map(|revoker| NativeSubscription::Event { _revoker: revoker })
+                .map(|revoker| NativeSubscription::Event {
+                    _revoker: revoker,
+                    revision,
+                })
                 .map_err(native_error)
         }
         (Handle::Slider(value), EventId::SliderValueChanged) => {
@@ -5345,7 +5405,10 @@ pub fn subscribe_event(
                         }
                     }
                 })
-                .map(|revoker| NativeSubscription::Event { _revoker: revoker })
+                .map(|revoker| NativeSubscription::Event {
+                    _revoker: revoker,
+                    revision,
+                })
                 .map_err(native_error)
         }
         (Handle::TitleBar(value), EventId::TitleBarBackRequested) => {
@@ -5359,7 +5422,10 @@ pub fn subscribe_event(
                         EventPayload::Unit,
                     );
                 })
-                .map(|revoker| NativeSubscription::Event { _revoker: revoker })
+                .map(|revoker| NativeSubscription::Event {
+                    _revoker: revoker,
+                    revision,
+                })
                 .map_err(native_error)
         }
         (Handle::TitleBar(value), EventId::TitleBarPaneToggleRequested) => {
@@ -5373,7 +5439,10 @@ pub fn subscribe_event(
                         EventPayload::Unit,
                     );
                 })
-                .map(|revoker| NativeSubscription::Event { _revoker: revoker })
+                .map(|revoker| NativeSubscription::Event {
+                    _revoker: revoker,
+                    revision,
+                })
                 .map_err(native_error)
         }
         (Handle::NavigationView(value), EventId::NavigationViewIsPaneOpenChanged) => {
@@ -5440,7 +5509,10 @@ pub fn subscribe_event(
                         }
                     }
                 })
-                .map(|revoker| NativeSubscription::Event { _revoker: revoker })
+                .map(|revoker| NativeSubscription::Event {
+                    _revoker: revoker,
+                    revision,
+                })
                 .map_err(native_error)
         }
         (Handle::NavigationView(value), EventId::NavigationViewSelectionChanged) => {
@@ -5494,7 +5566,10 @@ pub fn subscribe_event(
                         }
                     }
                 })
-                .map(|revoker| NativeSubscription::Event { _revoker: revoker })
+                .map(|revoker| NativeSubscription::Event {
+                    _revoker: revoker,
+                    revision,
+                })
                 .map_err(native_error)
         }
         (Handle::SplitView(value), EventId::SplitViewPaneClosed) => {
@@ -5546,7 +5621,10 @@ pub fn subscribe_event(
                         ),
                     }
                 })
-                .map(|revoker| NativeSubscription::Event { _revoker: revoker })
+                .map(|revoker| NativeSubscription::Event {
+                    _revoker: revoker,
+                    revision,
+                })
                 .map_err(native_error)
         }
         (Handle::CheckBox(value), EventId::CheckBoxIsCheckedChanged) => {
@@ -5667,7 +5745,10 @@ pub fn subscribe_event(
                         ),
                     }
                 })
-                .map(|revoker| NativeSubscription::Event { _revoker: revoker })
+                .map(|revoker| NativeSubscription::Event {
+                    _revoker: revoker,
+                    revision,
+                })
                 .map_err(native_error)
         }
         (Handle::InfoBar(value), EventId::InfoBarClosed) => {
@@ -5676,7 +5757,44 @@ pub fn subscribe_event(
                 .Closed(move |_, _| {
                     sink.enqueue(node, EventId::InfoBarClosed, revision, EventPayload::Unit);
                 })
-                .map(|revoker| NativeSubscription::Event { _revoker: revoker })
+                .map(|revoker| NativeSubscription::Event {
+                    _revoker: revoker,
+                    revision,
+                })
+                .map_err(native_error)
+        }
+        (Handle::Image(value), EventId::ImageImageOpened) => {
+            let source = value.cast::<IImage>().map_err(native_error)?;
+            source
+                .ImageOpened(move |_, _| {
+                    sink.enqueue(
+                        node,
+                        EventId::ImageImageOpened,
+                        revision,
+                        EventPayload::Unit,
+                    );
+                })
+                .map(|revoker| NativeSubscription::Event {
+                    _revoker: revoker,
+                    revision,
+                })
+                .map_err(native_error)
+        }
+        (Handle::Image(value), EventId::ImageImageFailed) => {
+            let source = value.cast::<IImage>().map_err(native_error)?;
+            source
+                .ImageFailed(move |_, _| {
+                    sink.enqueue(
+                        node,
+                        EventId::ImageImageFailed,
+                        revision,
+                        EventPayload::Unit,
+                    );
+                })
+                .map(|revoker| NativeSubscription::Event {
+                    _revoker: revoker,
+                    revision,
+                })
                 .map_err(native_error)
         }
         (Handle::ListBox(value), EventId::ListBoxSelectionChanged) => {
@@ -5728,7 +5846,10 @@ pub fn subscribe_event(
                         }
                     }
                 })
-                .map(|revoker| NativeSubscription::Event { _revoker: revoker })
+                .map(|revoker| NativeSubscription::Event {
+                    _revoker: revoker,
+                    revision,
+                })
                 .map_err(native_error)
         }
         (Handle::RatingControl(value), EventId::RatingControlValueChanged) => {
@@ -5751,7 +5872,10 @@ pub fn subscribe_event(
                         ),
                     }
                 })
-                .map(|revoker| NativeSubscription::Event { _revoker: revoker })
+                .map(|revoker| NativeSubscription::Event {
+                    _revoker: revoker,
+                    revision,
+                })
                 .map_err(native_error)
         }
         (Handle::Expander(value), EventId::ExpanderIsExpandedChanged) => {
@@ -5814,7 +5938,10 @@ pub fn subscribe_event(
                         ),
                     }
                 })
-                .map(|revoker| NativeSubscription::Event { _revoker: revoker })
+                .map(|revoker| NativeSubscription::Event {
+                    _revoker: revoker,
+                    revision,
+                })
                 .map_err(native_error)
         }
         (Handle::Pivot(value), EventId::PivotSelectionChanged) => {
@@ -5848,7 +5975,10 @@ pub fn subscribe_event(
                         ),
                     }
                 })
-                .map(|revoker| NativeSubscription::Event { _revoker: revoker })
+                .map(|revoker| NativeSubscription::Event {
+                    _revoker: revoker,
+                    revision,
+                })
                 .map_err(native_error)
         }
         (Handle::FlipView(value), EventId::FlipViewSelectionChanged) => {
@@ -5882,7 +6012,10 @@ pub fn subscribe_event(
                         ),
                     }
                 })
-                .map(|revoker| NativeSubscription::Event { _revoker: revoker })
+                .map(|revoker| NativeSubscription::Event {
+                    _revoker: revoker,
+                    revision,
+                })
                 .map_err(native_error)
         }
         (Handle::SelectorBar(value), EventId::SelectorBarSelectionChanged) => {
@@ -5947,7 +6080,10 @@ pub fn subscribe_event(
                         }
                     }
                 })
-                .map(|revoker| NativeSubscription::Event { _revoker: revoker })
+                .map(|revoker| NativeSubscription::Event {
+                    _revoker: revoker,
+                    revision,
+                })
                 .map_err(native_error)
         }
         (Handle::TabView(value), EventId::TabViewSelectionChanged) => {
@@ -5981,7 +6117,10 @@ pub fn subscribe_event(
                         ),
                     }
                 })
-                .map(|revoker| NativeSubscription::Event { _revoker: revoker })
+                .map(|revoker| NativeSubscription::Event {
+                    _revoker: revoker,
+                    revision,
+                })
                 .map_err(native_error)
         }
         (Handle::TabView(value), EventId::TabViewTabCloseRequested) => {
@@ -6020,7 +6159,10 @@ pub fn subscribe_event(
                         }
                     }
                 })
-                .map(|revoker| NativeSubscription::Event { _revoker: revoker })
+                .map(|revoker| NativeSubscription::Event {
+                    _revoker: revoker,
+                    revision,
+                })
                 .map_err(native_error)
         }
         (Handle::TabView(value), EventId::TabViewAddTabButtonClick) => {
@@ -6034,7 +6176,10 @@ pub fn subscribe_event(
                         EventPayload::Unit,
                     );
                 })
-                .map(|revoker| NativeSubscription::Event { _revoker: revoker })
+                .map(|revoker| NativeSubscription::Event {
+                    _revoker: revoker,
+                    revision,
+                })
                 .map_err(native_error)
         }
         (Handle::TabView(value), EventId::TabViewTabItemsChanged) => {
@@ -6078,7 +6223,10 @@ pub fn subscribe_event(
                         }
                     }
                 })
-                .map(|revoker| NativeSubscription::Event { _revoker: revoker })
+                .map(|revoker| NativeSubscription::Event {
+                    _revoker: revoker,
+                    revision,
+                })
                 .map_err(native_error)
         }
         (Handle::TeachingTip(value), EventId::TeachingTipClosed) => {
@@ -6092,7 +6240,10 @@ pub fn subscribe_event(
                         EventPayload::Unit,
                     );
                 })
-                .map(|revoker| NativeSubscription::Event { _revoker: revoker })
+                .map(|revoker| NativeSubscription::Event {
+                    _revoker: revoker,
+                    revision,
+                })
                 .map_err(native_error)
         }
         (Handle::TeachingTip(value), EventId::TeachingTipActionButtonClick) => {
@@ -6106,7 +6257,10 @@ pub fn subscribe_event(
                         EventPayload::Unit,
                     );
                 })
-                .map(|revoker| NativeSubscription::Event { _revoker: revoker })
+                .map(|revoker| NativeSubscription::Event {
+                    _revoker: revoker,
+                    revision,
+                })
                 .map_err(native_error)
         }
         (Handle::DropDownButton(value), EventId::DropDownButtonClick) => {
@@ -6120,7 +6274,10 @@ pub fn subscribe_event(
                         EventPayload::Unit,
                     );
                 })
-                .map(|revoker| NativeSubscription::Event { _revoker: revoker })
+                .map(|revoker| NativeSubscription::Event {
+                    _revoker: revoker,
+                    revision,
+                })
                 .map_err(native_error)
         }
         (Handle::AppBarButton(value), EventId::AppBarButtonClick) => {
@@ -6134,7 +6291,10 @@ pub fn subscribe_event(
                         EventPayload::Unit,
                     );
                 })
-                .map(|revoker| NativeSubscription::Event { _revoker: revoker })
+                .map(|revoker| NativeSubscription::Event {
+                    _revoker: revoker,
+                    revision,
+                })
                 .map_err(native_error)
         }
         (Handle::SplitButton(value), EventId::SplitButtonClick) => {
@@ -6148,7 +6308,10 @@ pub fn subscribe_event(
                         EventPayload::Unit,
                     );
                 })
-                .map(|revoker| NativeSubscription::Event { _revoker: revoker })
+                .map(|revoker| NativeSubscription::Event {
+                    _revoker: revoker,
+                    revision,
+                })
                 .map_err(native_error)
         }
         (Handle::ColorPicker(value), EventId::ColorPickerColorChanged) => {
@@ -6180,7 +6343,10 @@ pub fn subscribe_event(
                         }
                     }
                 })
-                .map(|revoker| NativeSubscription::Event { _revoker: revoker })
+                .map(|revoker| NativeSubscription::Event {
+                    _revoker: revoker,
+                    revision,
+                })
                 .map_err(native_error)
         }
         (Handle::DatePicker(value), EventId::DatePickerSelectedDateChanged) => {
@@ -6213,7 +6379,10 @@ pub fn subscribe_event(
                         }
                     }
                 })
-                .map(|revoker| NativeSubscription::Event { _revoker: revoker })
+                .map(|revoker| NativeSubscription::Event {
+                    _revoker: revoker,
+                    revision,
+                })
                 .map_err(native_error)
         }
         (Handle::TimePicker(value), EventId::TimePickerSelectedTimeChanged) => {
@@ -6246,7 +6415,10 @@ pub fn subscribe_event(
                         }
                     }
                 })
-                .map(|revoker| NativeSubscription::Event { _revoker: revoker })
+                .map(|revoker| NativeSubscription::Event {
+                    _revoker: revoker,
+                    revision,
+                })
                 .map_err(native_error)
         }
         (Handle::CalendarDatePicker(value), EventId::CalendarDatePickerDateChanged) => {
@@ -6279,7 +6451,10 @@ pub fn subscribe_event(
                         }
                     }
                 })
-                .map(|revoker| NativeSubscription::Event { _revoker: revoker })
+                .map(|revoker| NativeSubscription::Event {
+                    _revoker: revoker,
+                    revision,
+                })
                 .map_err(native_error)
         }
         (Handle::ContentDialog(value), EventId::ContentDialogClosed) => {
@@ -6318,7 +6493,10 @@ pub fn subscribe_event(
                         }
                     }
                 })
-                .map(|revoker| NativeSubscription::Event { _revoker: revoker })
+                .map(|revoker| NativeSubscription::Event {
+                    _revoker: revoker,
+                    revision,
+                })
                 .map_err(native_error)
         }
         (Handle::CalendarView(value), EventId::CalendarViewSelectedDatesChanged) => {
@@ -6332,7 +6510,10 @@ pub fn subscribe_event(
                         EventPayload::Unit,
                     );
                 })
-                .map(|revoker| NativeSubscription::Event { _revoker: revoker })
+                .map(|revoker| NativeSubscription::Event {
+                    _revoker: revoker,
+                    revision,
+                })
                 .map_err(native_error)
         }
         (Handle::ListView(value), EventId::ListViewSelectionChanged) => {
@@ -6366,7 +6547,10 @@ pub fn subscribe_event(
                         ),
                     }
                 })
-                .map(|revoker| NativeSubscription::Event { _revoker: revoker })
+                .map(|revoker| NativeSubscription::Event {
+                    _revoker: revoker,
+                    revision,
+                })
                 .map_err(native_error)
         }
         (Handle::ListView(value), EventId::ListViewDragItemsCompleted) => {
@@ -6410,7 +6594,10 @@ pub fn subscribe_event(
                         }
                     }
                 })
-                .map(|revoker| NativeSubscription::Event { _revoker: revoker })
+                .map(|revoker| NativeSubscription::Event {
+                    _revoker: revoker,
+                    revision,
+                })
                 .map_err(native_error)
         }
         (Handle::TreeView(value), EventId::TreeViewItemInvoked) => {
@@ -6443,7 +6630,10 @@ pub fn subscribe_event(
                         }
                     }
                 })
-                .map(|revoker| NativeSubscription::Event { _revoker: revoker })
+                .map(|revoker| NativeSubscription::Event {
+                    _revoker: revoker,
+                    revision,
+                })
                 .map_err(native_error)
         }
         (Handle::GridView(value), EventId::GridViewDragItemsCompleted) => {
@@ -6487,7 +6677,10 @@ pub fn subscribe_event(
                         }
                     }
                 })
-                .map(|revoker| NativeSubscription::Event { _revoker: revoker })
+                .map(|revoker| NativeSubscription::Event {
+                    _revoker: revoker,
+                    revision,
+                })
                 .map_err(native_error)
         }
         (Handle::GridView(value), EventId::GridViewSelectionChanged) => {
@@ -6521,7 +6714,10 @@ pub fn subscribe_event(
                         ),
                     }
                 })
-                .map(|revoker| NativeSubscription::Event { _revoker: revoker })
+                .map(|revoker| NativeSubscription::Event {
+                    _revoker: revoker,
+                    revision,
+                })
                 .map_err(native_error)
         }
         (Handle::RichEditBox(value), EventId::RichEditBoxTextChanged) => {
@@ -6552,7 +6748,10 @@ pub fn subscribe_event(
                         }
                     }
                 })
-                .map(|revoker| NativeSubscription::Event { _revoker: revoker })
+                .map(|revoker| NativeSubscription::Event {
+                    _revoker: revoker,
+                    revision,
+                })
                 .map_err(native_error)
         }
         _ => Err(RuntimeError::UnsupportedKind),

--- a/crates/libs/reactor/src/native/winui/mod.rs
+++ b/crates/libs/reactor/src/native/winui/mod.rs
@@ -57,6 +57,7 @@ mod grid;
 pub enum NativeSubscription {
     Event {
         _revoker: windows_core::EventRevoker,
+        revision: u32,
     },
     Property {
         object: DependencyObject,
@@ -87,6 +88,7 @@ pub struct WinUiRuntime {
     host_events: Rc<RefCell<Vec<NativeWork<HostEvent>>>>,
     async_ingress: Arc<Mutex<AsyncIngressQueue>>,
     async_state: Rc<RefCell<AsyncIngressState>>,
+    encoded_image_nodes: Rc<RefCell<HashSet<NodeId>>>,
     feedback: Rc<RefCell<HashMap<(NodeId, EventId), FeedbackExpectation>>>,
     controlled_collection_indices: HashMap<NodeId, i32>,
     content_dialogs: Rc<RefCell<HashMap<NodeId, ContentDialogLifecycle>>>,
@@ -106,6 +108,7 @@ pub struct WinUiRuntime {
     realizations: Rc<RefCell<Vec<NativeWork<RealizationRequest>>>>,
     retained_subtrees: HashMap<NodeId, NativeRetainedSubtree>,
     scheduler: Rc<RefCell<SchedulerState>>,
+    image_decode_tickets: HashMap<NodeId, u64>,
     image_scale_subscriptions: HashMap<(NodeId, u64), ImageScaleSubscriptions>,
     swap_chain_panel_subscriptions: HashMap<(NodeId, u64), SwapChainPanelSubscriptions>,
     subscriptions: HashMap<(NodeId, EventId), NativeSubscription>,
@@ -1877,6 +1880,26 @@ impl WinUiRuntime {
             } => {
                 if matches!(
                     property,
+                    PropertyId::ImageSource | PropertyId::ImageIconSource
+                ) {
+                    self.cancel_image_decode(*node);
+                    self.purge_image_events(*node);
+                    if let PropertyValue::EncodedImage(value) = value {
+                        self.encoded_image_nodes.borrow_mut().insert(*node);
+                        let handle = self
+                            .handles
+                            .get(node)
+                            .ok_or(RuntimeError::MissingNode(*node))?;
+                        clear_property(handle, *property)?;
+                        if let Err(error) = self.start_encoded_image(*node, value) {
+                            self.report_image_decode_error(error);
+                        }
+                        return Ok(());
+                    }
+                    self.encoded_image_nodes.borrow_mut().remove(node);
+                }
+                if matches!(
+                    property,
                     PropertyId::ButtonKeyboardAccelerators | PropertyId::GridKeyboardAccelerators
                 ) {
                     return match value {
@@ -1994,6 +2017,14 @@ impl WinUiRuntime {
                 }
             }
             Command::ClearProperty { node, property } => {
+                if matches!(
+                    property,
+                    PropertyId::ImageSource | PropertyId::ImageIconSource
+                ) {
+                    self.cancel_image_decode(*node);
+                    self.purge_image_events(*node);
+                    self.encoded_image_nodes.borrow_mut().remove(node);
+                }
                 if matches!(
                     property,
                     PropertyId::ButtonKeyboardAccelerators | PropertyId::GridKeyboardAccelerators
@@ -3068,6 +3099,7 @@ impl WinUiRuntime {
             async_ingress: Arc::clone(&self.async_ingress),
             async_state: Rc::clone(&self.async_state),
             drop_policies: Rc::clone(&self.drop_policies),
+            encoded_image_nodes: Rc::clone(&self.encoded_image_nodes),
             feedback: Rc::clone(&self.feedback),
             content_dialogs: Rc::clone(&self.content_dialogs),
             content_dialog_subscriptions: Rc::clone(&self.content_dialog_subscriptions),
@@ -3150,6 +3182,7 @@ pub struct EventSink {
     async_ingress: Arc<Mutex<AsyncIngressQueue>>,
     async_state: Rc<RefCell<AsyncIngressState>>,
     drop_policies: Rc<RefCell<HashMap<NodeId, DragDropPolicy>>>,
+    encoded_image_nodes: Rc<RefCell<HashSet<NodeId>>>,
     feedback: Rc<RefCell<HashMap<(NodeId, EventId), FeedbackExpectation>>>,
     content_dialogs: Rc<RefCell<HashMap<NodeId, ContentDialogLifecycle>>>,
     content_dialog_subscriptions: Rc<RefCell<HashMap<NodeId, NativeSubscription>>>,
@@ -3447,6 +3480,11 @@ impl EventSink {
     }
 
     pub fn enqueue(&self, node: NodeId, event: EventId, revision: u32, payload: EventPayload) {
+        if self.encoded_image_nodes.borrow().contains(&node)
+            && matches!(event, EventId::ImageImageOpened | EventId::ImageImageFailed)
+        {
+            return;
+        }
         {
             let mut feedback = self.feedback.borrow_mut();
             if let Some(expected) = feedback.get_mut(&(node, event)) {
@@ -3995,6 +4033,8 @@ impl NativeRuntime for WinUiRuntime {
             );
         }
         self.subscriptions.clear();
+        self.encoded_image_nodes.borrow_mut().clear();
+        self.image_decode_tickets.clear();
         self.swap_chain_panel_subscriptions.clear();
         self.image_scale_subscriptions.clear();
         self.composition_host_subscriptions.clear();
@@ -4163,6 +4203,149 @@ impl WinUiRuntime {
         ))
     }
 
+    fn start_encoded_image(
+        &mut self,
+        node: NodeId,
+        image: &EncodedImage,
+    ) -> Result<(), RuntimeError> {
+        match self.handles.get(&node) {
+            Some(Handle::Image(_) | Handle::ImageIcon(_)) => {}
+            Some(_) => return Err(RuntimeError::UnsupportedKind),
+            None => return Err(RuntimeError::MissingNode(node)),
+        }
+
+        let stream = InMemoryRandomAccessStream::new().map_err(native_error)?;
+        let output = stream.GetOutputStreamAt(0).map_err(native_error)?;
+        let writer = DataWriter::CreateDataWriter(&output).map_err(native_error)?;
+        writer.WriteBytes(image.as_bytes()).map_err(native_error)?;
+        let operation = writer.StoreAsync().map_err(native_error)?;
+        let cancel_operation = operation.clone();
+        let (ticket, sender) = self.register_async_completion(
+            node,
+            move || {
+                _ = cancel_operation.Cancel();
+            },
+            move |runtime, result: Result<u32, RuntimeError>| {
+                runtime.image_decode_tickets.remove(&node);
+                if let Err(error) = result {
+                    runtime.report_image_decode_error(error);
+                    return;
+                }
+                if let Err(error) = runtime.start_bitmap_decode(node, stream, writer) {
+                    runtime.report_image_decode_error(error);
+                }
+            },
+        )?;
+        self.image_decode_tickets.insert(node, ticket);
+        if let Err(error) = operation.when(move |result| {
+            _ = sender.complete(result.map_err(native_error));
+        }) {
+            self.cancel_image_decode(node);
+            return Err(native_error(error));
+        }
+        Ok(())
+    }
+
+    fn start_bitmap_decode(
+        &mut self,
+        node: NodeId,
+        stream: InMemoryRandomAccessStream,
+        writer: DataWriter,
+    ) -> Result<(), RuntimeError> {
+        _ = writer.DetachStream().map_err(native_error)?;
+        stream.Seek(0).map_err(native_error)?;
+        let bitmap = BitmapImage::new().map_err(native_error)?;
+        let operation = bitmap
+            .cast::<IBitmapSource>()
+            .map_err(native_error)?
+            .SetSourceAsync(&stream)
+            .map_err(native_error)?;
+        let cancel_operation = operation.clone();
+        let (ticket, sender) = self.register_async_completion(
+            node,
+            move || {
+                _ = cancel_operation.Cancel();
+            },
+            move |runtime, result: Result<(), RuntimeError>| {
+                runtime.image_decode_tickets.remove(&node);
+                match result {
+                    Ok(()) => {
+                        if let Err(error) = runtime.set_decoded_image(node, &bitmap) {
+                            runtime.report_image_decode_error(error);
+                        } else {
+                            runtime.enqueue_image_decode_event(node, EventId::ImageImageOpened);
+                        }
+                    }
+                    Err(_) => {
+                        runtime.enqueue_image_decode_event(node, EventId::ImageImageFailed);
+                    }
+                }
+                drop(stream);
+            },
+        )?;
+        self.image_decode_tickets.insert(node, ticket);
+        if let Err(error) = operation.when(move |result| {
+            _ = sender.complete(result.map_err(native_error));
+        }) {
+            self.cancel_image_decode(node);
+            return Err(native_error(error));
+        }
+        Ok(())
+    }
+
+    fn set_decoded_image(&self, node: NodeId, bitmap: &BitmapImage) -> Result<(), RuntimeError> {
+        let source = bitmap.cast::<ImageSource>().map_err(native_error)?;
+        match self.handles.get(&node) {
+            Some(Handle::Image(control)) => control.SetSource(&source).map_err(native_error),
+            Some(Handle::ImageIcon(control)) => control.SetSource(&source).map_err(native_error),
+            Some(_) => Err(RuntimeError::UnsupportedKind),
+            None => Err(RuntimeError::MissingNode(node)),
+        }
+    }
+
+    fn cancel_image_decode(&mut self, node: NodeId) {
+        let Some(ticket) = self.image_decode_tickets.remove(&node) else {
+            return;
+        };
+        let pending = self.async_state.borrow_mut().pending.remove(&ticket);
+        if let Some(pending) = pending {
+            (pending.cancel)();
+        }
+    }
+
+    fn report_image_decode_error(&mut self, error: RuntimeError) {
+        let Some(identity) = self.identity.get() else {
+            return;
+        };
+        self.host_events.borrow_mut().push(NativeWork {
+            identity,
+            work: HostEvent::Error(error),
+        });
+    }
+
+    fn enqueue_image_decode_event(&mut self, node: NodeId, event: EventId) -> bool {
+        let Some(NativeSubscription::Event { revision, .. }) =
+            self.subscriptions.get(&(node, event))
+        else {
+            return false;
+        };
+        self.events.borrow_mut().push(NativeWork {
+            identity: self.identity.get().unwrap(),
+            work: QueuedEvent::new(node, event, *revision, EventPayload::Unit),
+        });
+        true
+    }
+
+    fn purge_image_events(&mut self, node: NodeId) {
+        self.events.borrow_mut().retain(|event| {
+            event.work.node != node
+                || !matches!(
+                    event.work.event,
+                    EventId::ImageImageOpened | EventId::ImageImageFailed
+                )
+        });
+    }
+
     fn start_retirement(
         &mut self,
         root: NodeId,
@@ -4175,6 +4358,10 @@ impl WinUiRuntime {
             || nodes.iter().any(|node| !self.contains(*node))
         {
             return Err(RuntimeError::MissingNode(root));
+        }
+        for node in &nodes {
+            self.cancel_image_decode(*node);
+            self.purge_image_events(*node);
         }
         let duration =
             TimeSpan::try_from(transition.duration()).map_err(|_| RuntimeError::UnsupportedKind)?;
@@ -4282,6 +4469,9 @@ impl WinUiRuntime {
     }
 
     fn remove_node_state(&mut self, node: NodeId) -> Result<(), RuntimeError> {
+        self.cancel_image_decode(node);
+        self.encoded_image_nodes.borrow_mut().remove(&node);
+        self.purge_image_events(node);
         self.subscriptions
             .retain(|(subscription_node, _), _| *subscription_node != node);
         self.cancel_async_for_node(node);
@@ -4382,6 +4572,8 @@ impl WinUiRuntime {
         for pending in pending {
             (pending.cancel)();
         }
+        self.image_decode_tickets.clear();
+        self.encoded_image_nodes.borrow_mut().clear();
     }
 
     fn flush_async_ingress(&mut self) {

--- a/crates/libs/reactor/src/native/winui/mod.rs
+++ b/crates/libs/reactor/src/native/winui/mod.rs
@@ -1703,19 +1703,21 @@ impl WinUiRuntime {
                 source,
                 completion,
             } => {
-                let result = match self.handles.get(node) {
-                    Some(Handle::Image(control)) => {
-                        let source = source
-                            .as_ref()
-                            .map(|source| source.cast::<ImageSource>().map_err(native_error))
-                            .transpose();
-                        source.and_then(|source| {
-                            control.SetSource(source.as_ref()).map_err(native_error)
-                        })
-                    }
+                let control = match self.handles.get(node) {
+                    Some(Handle::Image(control)) => Ok(control.clone()),
                     Some(_) => Err(RuntimeError::UnsupportedKind),
                     None => Err(RuntimeError::MissingNode(*node)),
                 };
+                let source = source
+                    .as_ref()
+                    .map(|source| source.cast::<ImageSource>().map_err(native_error))
+                    .transpose();
+                let result = control.and_then(|control| {
+                    source.and_then(|source| {
+                        self.release_encoded_image_source(*node);
+                        control.SetSource(source.as_ref()).map_err(native_error)
+                    })
+                });
                 _ = completion.call(result);
             }
             Command::ObserveImageScale {
@@ -1882,8 +1884,7 @@ impl WinUiRuntime {
                     property,
                     PropertyId::ImageSource | PropertyId::ImageIconSource
                 ) {
-                    self.cancel_image_decode(*node);
-                    self.purge_image_events(*node);
+                    self.release_encoded_image_source(*node);
                     if let PropertyValue::EncodedImage(value) = value {
                         self.encoded_image_nodes.borrow_mut().insert(*node);
                         let handle = self
@@ -1896,7 +1897,6 @@ impl WinUiRuntime {
                         }
                         return Ok(());
                     }
-                    self.encoded_image_nodes.borrow_mut().remove(node);
                 }
                 if matches!(
                     property,
@@ -2021,9 +2021,7 @@ impl WinUiRuntime {
                     property,
                     PropertyId::ImageSource | PropertyId::ImageIconSource
                 ) {
-                    self.cancel_image_decode(*node);
-                    self.purge_image_events(*node);
-                    self.encoded_image_nodes.borrow_mut().remove(node);
+                    self.release_encoded_image_source(*node);
                 }
                 if matches!(
                     property,
@@ -3763,15 +3761,44 @@ fn child_index(
 #[cfg(test)]
 mod tests {
     use super::{
-        AsyncIngressQueue, AsyncIngressSender, Command, DroppedData, NodeId, RuntimeError, SlotId,
-        WindowId, WindowToken, is_internal_detach, merge_retained_identities,
-        native_number_box_value, native_rating_value, native_selection_index, number_box_value,
-        physical_retained_index, rating_value, retained_subsequence, selection_index,
+        AsyncIngressQueue, AsyncIngressSender, Command, DroppedData, NodeId, PendingAsync,
+        RuntimeError, SlotId, WinUiRuntime, WindowId, WindowToken, is_internal_detach,
+        merge_retained_identities, native_number_box_value, native_rating_value,
+        native_selection_index, number_box_value, physical_retained_index, rating_value,
+        retained_subsequence, selection_index,
     };
+    use std::cell::Cell;
     use std::collections::HashSet;
     use std::marker::PhantomData;
+    use std::rc::Rc;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::{Arc, Mutex};
+
+    #[test]
+    fn releasing_encoded_image_source_cancels_pending_decode_and_ownership() {
+        let node = NodeId::from_parts(1, 0);
+        let ticket = 7;
+        let canceled = Rc::new(Cell::new(false));
+        let canceled_capture = Rc::clone(&canceled);
+        let mut runtime = WinUiRuntime::default();
+        runtime.encoded_image_nodes.borrow_mut().insert(node);
+        runtime.image_decode_tickets.insert(node, ticket);
+        runtime.async_state.borrow_mut().pending.insert(
+            ticket,
+            PendingAsync {
+                node,
+                cancel: Box::new(move || canceled_capture.set(true)),
+                finalize: Box::new(|_, _| {}),
+            },
+        );
+
+        runtime.release_encoded_image_source(node);
+
+        assert!(canceled.get());
+        assert!(!runtime.encoded_image_nodes.borrow().contains(&node));
+        assert!(!runtime.image_decode_tickets.contains_key(&node));
+        assert!(!runtime.async_state.borrow().pending.contains_key(&ticket));
+    }
 
     #[test]
     fn skips_only_internal_detaches_for_destroyed_subtrees() {
@@ -4313,6 +4340,12 @@ impl WinUiRuntime {
         }
     }
 
+    fn release_encoded_image_source(&mut self, node: NodeId) {
+        self.cancel_image_decode(node);
+        self.purge_image_events(node);
+        self.encoded_image_nodes.borrow_mut().remove(&node);
+    }
+
     fn report_image_decode_error(&mut self, error: RuntimeError) {
         let Some(identity) = self.identity.get() else {
             return;
@@ -4469,9 +4502,7 @@ impl WinUiRuntime {
     }
 
     fn remove_node_state(&mut self, node: NodeId) -> Result<(), RuntimeError> {
-        self.cancel_image_decode(node);
-        self.encoded_image_nodes.borrow_mut().remove(&node);
-        self.purge_image_events(node);
+        self.release_encoded_image_source(node);
         self.subscriptions
             .retain(|(subscription_node, _), _| *subscription_node != node);
         self.cancel_async_for_node(node);

--- a/crates/samples/reactor/samples/examples/image.rs
+++ b/crates/samples/reactor/samples/examples/image.rs
@@ -14,6 +14,11 @@ fn main() {
                 .height(60.0)
                 .source_file(&bitmap)
                 .unwrap(),
+            "PNG from encoded bytes",
+            Image::new()
+                .width(120.0)
+                .height(60.0)
+                .source_data(EncodedImage::from_static(include_bytes!("image.png"))),
             "SVG",
             Image::new()
                 .width(120.0)

--- a/crates/tests/libs/reactor_selftest/src/fixtures.rs
+++ b/crates/tests/libs/reactor_selftest/src/fixtures.rs
@@ -681,12 +681,15 @@ pub(crate) enum ImageMessage {
 
 pub(crate) enum EncodedImageMessage {
     Advance(u8),
+    AwaitOverride,
+    NativeCleared(Result<(), ImageSourceError>),
     Opened(u8),
     Failed(u8),
 }
 
 pub(crate) struct EncodedImageLifecycle {
     error: Option<&'static str>,
+    image: ElementRef<Image>,
     stage: u8,
 }
 
@@ -697,12 +700,31 @@ impl Component for EncodedImageLifecycle {
     fn create(_input: &Self::Input, _context: &ComponentContext<Self>) -> Self {
         Self {
             error: None,
+            image: ElementRef::new(),
             stage: 0,
         }
     }
 
-    fn update(&mut self, message: Self::Message, _context: &ComponentContext<Self>) {
+    fn update(&mut self, message: Self::Message, context: &ComponentContext<Self>) {
         match message {
+            EncodedImageMessage::NativeCleared(Ok(())) if self.stage == 0 => {
+                context.spawn_background(|_| {
+                    std::thread::sleep(Duration::from_millis(250));
+                    EncodedImageMessage::AwaitOverride
+                });
+            }
+            EncodedImageMessage::AwaitOverride if self.stage == 0 => {
+                self.stage = 1;
+            }
+            EncodedImageMessage::NativeCleared(Err(_)) => {
+                self.error = Some("native image source clear failed");
+            }
+            EncodedImageMessage::NativeCleared(Ok(())) => {
+                self.error = Some("received an unexpected native image source completion");
+            }
+            EncodedImageMessage::AwaitOverride => {
+                self.error = Some("received an unexpected native image source wait");
+            }
             EncodedImageMessage::Advance(stage) if stage == self.stage => {
                 self.stage += 1;
             }
@@ -746,7 +768,19 @@ impl Component for EncodedImageLifecycle {
             return TextBlock::new().text("encoded image complete").into();
         }
 
-        if matches!(self.stage, 0 | 3) {
+        if self.stage == 0 {
+            let image = self.image.clone();
+            let sender = context.sender();
+            context.use_effect("override-encoded-image", (), move || {
+                if !image.request_set_native_source(None, move |result| {
+                    sender.send(EncodedImageMessage::NativeCleared(result));
+                }) {
+                    eprintln!("native image source clear was rejected");
+                    std::process::exit(1);
+                }
+                None
+            });
+        } else if self.stage == 3 {
             let stage = self.stage;
             let sender = context.sender();
             context.use_effect("advance-encoded-image", stage, move || {
@@ -770,6 +804,7 @@ impl Component for EncodedImageLifecycle {
         let stage = self.stage;
         Image::new()
             .source_data(source)
+            .element_ref(&self.image)
             .on_opened(context.callback(move |()| EncodedImageMessage::Opened(stage)))
             .on_failed(context.callback(move |()| EncodedImageMessage::Failed(stage)))
             .width(64.0)

--- a/crates/tests/libs/reactor_selftest/src/fixtures.rs
+++ b/crates/tests/libs/reactor_selftest/src/fixtures.rs
@@ -679,6 +679,105 @@ pub(crate) enum ImageMessage {
     Cleared(Result<(), ImageSourceError>),
 }
 
+pub(crate) enum EncodedImageMessage {
+    Advance(u8),
+    Opened(u8),
+    Failed(u8),
+}
+
+pub(crate) struct EncodedImageLifecycle {
+    error: Option<&'static str>,
+    stage: u8,
+}
+
+impl Component for EncodedImageLifecycle {
+    type Input = FixtureInput;
+    type Message = EncodedImageMessage;
+
+    fn create(_input: &Self::Input, _context: &ComponentContext<Self>) -> Self {
+        Self {
+            error: None,
+            stage: 0,
+        }
+    }
+
+    fn update(&mut self, message: Self::Message, _context: &ComponentContext<Self>) {
+        match message {
+            EncodedImageMessage::Advance(stage) if stage == self.stage => {
+                self.stage += 1;
+            }
+            EncodedImageMessage::Opened(stage) if stage == self.stage && stage == 1 => {
+                self.stage += 1;
+            }
+            EncodedImageMessage::Failed(2) if self.stage == 2 => {
+                self.stage = 3;
+            }
+            EncodedImageMessage::Opened(_) => {
+                self.error = Some("received an unexpected or duplicate ImageOpened event");
+            }
+            EncodedImageMessage::Failed(_) => {
+                self.error = Some("received an unexpected or duplicate ImageFailed event");
+            }
+            EncodedImageMessage::Advance(_) => {}
+        }
+    }
+
+    fn view(&self, input: &Self::Input, context: &mut ViewContext<Self>) -> View {
+        if let Some(error) = self.error {
+            let complete = input.complete.clone();
+            context.use_effect("fail-encoded-image", (), move || {
+                if !complete.call(Err(error.to_string())) {
+                    eprintln!("encoded image fixture completion was rejected");
+                    std::process::exit(1);
+                }
+                None
+            });
+            return TextBlock::new().text(error).into();
+        }
+        if self.stage == 4 {
+            let complete = input.complete.clone();
+            context.use_effect("complete-encoded-image", (), move || {
+                if !complete.call(Ok(())) {
+                    eprintln!("encoded image fixture completion was rejected");
+                    std::process::exit(1);
+                }
+                None
+            });
+            return TextBlock::new().text("encoded image complete").into();
+        }
+
+        if matches!(self.stage, 0 | 3) {
+            let stage = self.stage;
+            let sender = context.sender();
+            context.use_effect("advance-encoded-image", stage, move || {
+                sender.send(EncodedImageMessage::Advance(stage));
+                None
+            });
+        }
+        let source = match self.stage {
+            0 => EncodedImage::from_static(include_bytes!(
+                "../../../../samples/reactor/samples/examples/image.png"
+            )),
+            1 => EncodedImage::from_static(include_bytes!(
+                "../../../../samples/reactor/gallery/assets/Image.png"
+            )),
+            2 => EncodedImage::from_static(b"not an encoded image"),
+            3 => EncodedImage::from_static(include_bytes!(
+                "../../../../samples/reactor/gallery/assets/Image.png"
+            )),
+            _ => unreachable!(),
+        };
+        let stage = self.stage;
+        Image::new()
+            .source_data(source)
+            .on_opened(context.callback(move |()| EncodedImageMessage::Opened(stage)))
+            .on_failed(context.callback(move |()| EncodedImageMessage::Failed(stage)))
+            .width(64.0)
+            .height(64.0)
+            .into()
+    }
+}
+
 pub(crate) struct ImageSourceLifecycle {
     device: Option<GpuDevice>,
     image: ElementRef<Image>,

--- a/crates/tests/libs/reactor_selftest/src/runner.rs
+++ b/crates/tests/libs/reactor_selftest/src/runner.rs
@@ -3,9 +3,9 @@ use std::time::Duration;
 use windows_reactor::*;
 
 use crate::fixtures::{
-    CompositionLifecycle, FixtureInput, FixtureResult, FocusPublication, ImageSourceLifecycle,
-    KeyedNativeMutations, PointerInjection, ProbeFixture, ProbeInput, SwapChainLifecycle,
-    ThemeResources, WindowLifecycle,
+    CompositionLifecycle, EncodedImageLifecycle, FixtureInput, FixtureResult, FocusPublication,
+    ImageSourceLifecycle, KeyedNativeMutations, PointerInjection, ProbeFixture, ProbeInput,
+    SwapChainLifecycle, ThemeResources, WindowLifecycle,
 };
 
 const FIXTURE_TIMEOUT: Duration = Duration::from_secs(15);
@@ -19,6 +19,7 @@ enum FixtureKind {
     EventRevokers,
     ControlledFeedback,
     WindowLifecycle,
+    EncodedImageLifecycle,
     ImageSourceLifecycle,
     CompositionLifecycle,
     SwapChainLifecycle,
@@ -56,6 +57,10 @@ const FIXTURES: &[Fixture] = &[
     Fixture {
         name: "ImageSource_DpiAttachClearRetire",
         kind: FixtureKind::ImageSourceLifecycle,
+    },
+    Fixture {
+        name: "Image_EncodedLoadReplaceAndFailure",
+        kind: FixtureKind::EncodedImageLifecycle,
     },
     Fixture {
         name: "Composition_AttachReplaceClearRetire",
@@ -201,6 +206,9 @@ impl Component for FixtureRunner {
             Some(FixtureKind::WindowLifecycle) => View::component::<WindowLifecycle>(input),
             Some(FixtureKind::ImageSourceLifecycle) => {
                 View::component::<ImageSourceLifecycle>(input)
+            }
+            Some(FixtureKind::EncodedImageLifecycle) => {
+                View::component::<EncodedImageLifecycle>(input)
             }
             Some(FixtureKind::CompositionLifecycle) => {
                 View::component::<CompositionLifecycle>(input)

--- a/crates/tests/libs/reactor_surface/src/generated_surface.rs
+++ b/crates/tests/libs/reactor_surface/src/generated_surface.rs
@@ -47,7 +47,7 @@ pub struct ExtensionSurface {
 }
 pub(crate) const PROJECTED_CONTROL_COUNT: usize = 79usize;
 pub(crate) const PROJECTED_PROPERTY_COUNT: usize = 230usize;
-pub(crate) const PROJECTED_EVENT_COUNT: usize = 61usize;
+pub(crate) const PROJECTED_EVENT_COUNT: usize = 63usize;
 pub(crate) const CAPABILITY_PROPERTY_COUNT: usize = 27usize;
 pub(crate) const STRUCTURAL_COUNT: usize = 64usize;
 pub(crate) const EXTENSION_COUNT: usize = 5;
@@ -2603,6 +2603,30 @@ fn event_info_bar_on_closed(stage: usize) -> View {
             let _ = 0u8;
         }),)),
         2 => Grid::new().children((InfoBar::new().on_closed(move || {
+            let _ = 1u8;
+        }),)),
+        _ => unreachable!(),
+    }
+}
+fn event_image_on_opened(stage: usize) -> View {
+    match stage {
+        0 | 3 => Grid::new().children((Image::new(),)),
+        1 => Grid::new().children((Image::new().on_opened(move || {
+            let _ = 0u8;
+        }),)),
+        2 => Grid::new().children((Image::new().on_opened(move || {
+            let _ = 1u8;
+        }),)),
+        _ => unreachable!(),
+    }
+}
+fn event_image_on_failed(stage: usize) -> View {
+    match stage {
+        0 | 3 => Grid::new().children((Image::new(),)),
+        1 => Grid::new().children((Image::new().on_failed(move || {
+            let _ = 0u8;
+        }),)),
+        2 => Grid::new().children((Image::new().on_failed(move || {
             let _ = 1u8;
         }),)),
         _ => unreachable!(),
@@ -5826,6 +5850,20 @@ pub(crate) static SURFACE_CASES: &[SurfaceCase] = &[
         build: property_image_stretch,
     },
     SurfaceCase {
+        name: "event.Image.ImageOpened",
+        kind: SurfaceKind::Event,
+        stages: 4,
+        subscription_delta: Some(1usize),
+        build: event_image_on_opened,
+    },
+    SurfaceCase {
+        name: "event.Image.ImageFailed",
+        kind: SurfaceKind::Event,
+        stages: 4,
+        subscription_delta: Some(1usize),
+        build: event_image_on_failed,
+    },
+    SurfaceCase {
         name: "control.ProgressRing.construct",
         kind: SurfaceKind::Control,
         stages: 1,
@@ -8474,7 +8512,7 @@ pub static PROJECTED_PROPERTIES: &[PropertySurface] = &[
     PropertySurface {
         control: "Image",
         property: "Source",
-        value: "Str",
+        value: "ImageValue",
         adapter: "ImageUri",
         validation: None,
         clearable: true,
@@ -8690,7 +8728,7 @@ pub static PROJECTED_PROPERTIES: &[PropertySurface] = &[
     PropertySurface {
         control: "ImageIcon",
         property: "Source",
-        value: "Str",
+        value: "ImageValue",
         adapter: "ImageUri",
         validation: None,
         clearable: true,
@@ -9772,6 +9810,24 @@ pub static PROJECTED_EVENTS: &[EventSurface] = &[
     EventSurface {
         control: "InfoBar",
         event: "Closed",
+        payload: "Unit",
+        conversion: "Identity",
+        subscription: "callback",
+        delivery: "registration+deterministic",
+        active_property: None,
+    },
+    EventSurface {
+        control: "Image",
+        event: "ImageOpened",
+        payload: "Unit",
+        conversion: "Identity",
+        subscription: "callback",
+        delivery: "registration+deterministic",
+        active_property: None,
+    },
+    EventSurface {
+        control: "Image",
+        event: "ImageFailed",
         payload: "Unit",
         conversion: "Identity",
         subscription: "callback",

--- a/crates/tools/reactor/src/control_bindings.txt
+++ b/crates/tools/reactor/src/control_bindings.txt
@@ -138,6 +138,8 @@ Microsoft::UI::Xaml::Controls::IHyperlinkButton::put_NavigateUri
 Microsoft::UI::Xaml::Controls::IImage::get_Source
 Microsoft::UI::Xaml::Controls::IImage::put_Source
 Microsoft::UI::Xaml::Controls::IImage::put_Stretch
+Microsoft::UI::Xaml::Controls::IImage::{add_ImageFailed, remove_ImageFailed}
+Microsoft::UI::Xaml::Controls::IImage::{add_ImageOpened, remove_ImageOpened}
 Microsoft::UI::Xaml::Controls::IImageIcon::put_Source
 Microsoft::UI::Xaml::Controls::IInfoBadge::put_Value
 Microsoft::UI::Xaml::Controls::IInfoBar::put_IsClosable
@@ -560,6 +562,7 @@ Microsoft::UI::Xaml::Media::ISolidColorBrush::put_Color
 Microsoft::UI::Xaml::Media::ImageSource
 Microsoft::UI::Xaml::Media::Imaging::BitmapImage::CreateInstance
 Microsoft::UI::Xaml::Media::Imaging::IBitmapImage::{get_UriSource, put_UriSource}
+Microsoft::UI::Xaml::Media::Imaging::IBitmapSource::SetSourceAsync
 Microsoft::UI::Xaml::Media::Imaging::ISvgImageSource::put_UriSource
 Microsoft::UI::Xaml::Media::Imaging::SvgImageSource::CreateInstance
 Microsoft::UI::Xaml::Media::SolidColorBrush::CreateInstance
@@ -594,4 +597,8 @@ Windows::ApplicationModel::DataTransfer::IDataPackageView::{Contains, GetTextAsy
 Windows::Foundation::IUriRuntimeClass::get_AbsoluteUri
 Windows::Foundation::Uri::CreateUri
 Windows::Storage::IStorageItem::{get_Name, get_Path}
+Windows::Storage::Streams::DataWriter::CreateDataWriter
+Windows::Storage::Streams::IDataWriter::{WriteBytes, StoreAsync, DetachStream}
+Windows::Storage::Streams::IRandomAccessStream::{GetOutputStreamAt, Seek}
+Windows::Storage::Streams::InMemoryRandomAccessStream::CreateInstance
 Windows::UI::Color

--- a/crates/tools/reactor/src/generate.rs
+++ b/crates/tools/reactor/src/generate.rs
@@ -929,6 +929,22 @@ fn generate_mounted_props_visitor(control: &ResolvedControl) -> TokenStream {
     let properties = control.properties.iter().map(|property| {
         let field = ident(&property.field);
         let id = ident(&format!("{}{}", control.name, property.name));
+        if property.adapter == Some(PropertyAdapter::ImageUri) {
+            return quote! {
+                visit(
+                    PropertyId::#id,
+                    match &values.#field {
+                        Property::Inherited => None,
+                        Property::Set(ImageValue::Uri(value)) => {
+                            Some(PropertyValueRef::Str(value.as_str()))
+                        }
+                        Property::Set(ImageValue::Encoded(value)) => {
+                            Some(PropertyValueRef::EncodedImage(value))
+                        }
+                    },
+                );
+            };
+        }
         let variant = ident(&property.value);
         if property.theme_style {
             return quote! {
@@ -1169,6 +1185,7 @@ fn generate_event_observers(control: &ResolvedControl) -> Vec<TokenStream> {
 
 fn generate_property_values(schema: &ResolvedSchema) -> TokenStream {
     let mut values = BTreeMap::from([
+        ("EncodedImage".to_string(), quote! { EncodedImage }),
         ("F64".to_string(), quote! { f64 }),
         (
             "GridLengths".to_string(),
@@ -1190,6 +1207,7 @@ fn generate_property_values(schema: &ResolvedSchema) -> TokenStream {
         .controls
         .iter()
         .flat_map(|control| &control.properties)
+        .filter(|property| property.adapter != Some(PropertyAdapter::ImageUri))
         .filter(|property| !property.theme_style || property.value == "Brush")
     {
         values
@@ -1210,6 +1228,7 @@ fn generate_property_values(schema: &ResolvedSchema) -> TokenStream {
             "ResourceOverrides" => quote! { &'a ResourceOverrides },
             "KeyAccelerators" => quote! { &'a KeyAccelerators },
             "DragDropPolicy" => quote! { &'a DragDropPolicy },
+            "EncodedImage" => quote! { &'a EncodedImage },
             "Str" => quote! { &'a str },
             "Thickness" => quote! { &'a Thickness },
             "CornerRadius" => quote! { &'a CornerRadius },
@@ -1272,6 +1291,7 @@ fn generate_property_values(schema: &ResolvedSchema) -> TokenStream {
                 | "Thickness"
                 | "CornerRadius"
                 | "DragDropPolicy"
+                | "EncodedImage"
         ) {
             quote! {
                 (Self::#variant(left), PropertyValue::#variant(right)) => left == right
@@ -1292,7 +1312,7 @@ fn generate_property_values(schema: &ResolvedSchema) -> TokenStream {
                 Self::#variant(value) => PropertyValue::#variant(value.to_string())
             },
             "KeyAccelerators" | "ResourceOverrides" | "RichText" | "Thickness" | "CornerRadius"
-            | "DragDropPolicy" => {
+            | "DragDropPolicy" | "EncodedImage" => {
                 quote! {
                     Self::#variant(value) => PropertyValue::#variant(value.clone())
                 }
@@ -1547,6 +1567,7 @@ fn generate_element(control: &ResolvedControl) -> TokenStream {
         } else if property.adapter == Some(PropertyAdapter::ImageUri) {
             let optional = ident(&format!("{}_optional", property.field));
             let file = ident(&format!("{}_file", property.field));
+            let data = ident(&format!("{}_data", property.field));
             quote! {
                 pub fn #field(
                     mut self,
@@ -1554,7 +1575,7 @@ fn generate_element(control: &ResolvedControl) -> TokenStream {
                 ) -> windows_core::Result<Self> {
                     let value = value.into();
                     validate_image_uri(&value)?;
-                    self.#field = Property::Set(value);
+                    self.#field = Property::Set(ImageValue::Uri(value));
                     Ok(self)
                 }
 
@@ -1569,7 +1590,7 @@ fn generate_element(control: &ResolvedControl) -> TokenStream {
                         Some(value) => {
                             let value = value.into();
                             validate_image_uri(&value)?;
-                            Property::Set(value)
+                            Property::Set(ImageValue::Uri(value))
                         }
                         None => Property::Inherited,
                     };
@@ -1581,6 +1602,11 @@ fn generate_element(control: &ResolvedControl) -> TokenStream {
                     value: impl AsRef<std::path::Path>,
                 ) -> windows_core::Result<Self> {
                     self.#field(file_uri(value.as_ref())?)
+                }
+
+                pub fn #data(mut self, value: EncodedImage) -> Self {
+                    self.#field = Property::Set(ImageValue::Encoded(value));
+                    self
                 }
             }
         } else if property.adapter == Some(PropertyAdapter::Uri) {

--- a/crates/tools/reactor/src/generate_winui.rs
+++ b/crates/tools/reactor/src/generate_winui.rs
@@ -178,6 +178,10 @@ pub(crate) fn generate_control_bindings_filter(schema: &ResolvedSchema) -> Strin
                         .to_string(),
                 );
                 entries.insert(
+                    "Microsoft::UI::Xaml::Media::Imaging::IBitmapSource::SetSourceAsync"
+                        .to_string(),
+                );
+                entries.insert(
                     "Microsoft::UI::Xaml::Media::Imaging::SvgImageSource::CreateInstance"
                         .to_string(),
                 );
@@ -186,6 +190,22 @@ pub(crate) fn generate_control_bindings_filter(schema: &ResolvedSchema) -> Strin
                         .to_string(),
                 );
                 entries.insert("Microsoft::UI::Xaml::Controls::IImage::get_Source".to_string());
+                entries.insert(
+                    "Windows::Storage::Streams::InMemoryRandomAccessStream::CreateInstance"
+                        .to_string(),
+                );
+                entries.insert(
+                    "Windows::Storage::Streams::IRandomAccessStream::{\
+                     GetOutputStreamAt, Seek}"
+                        .to_string(),
+                );
+                entries
+                    .insert("Windows::Storage::Streams::DataWriter::CreateDataWriter".to_string());
+                entries.insert(
+                    "Windows::Storage::Streams::IDataWriter::{\
+                     WriteBytes, StoreAsync, DetachStream}"
+                        .to_string(),
+                );
             }
         }
         for event in &control.events {
@@ -1699,7 +1719,10 @@ fn generate_event_arm(control: &ResolvedControl, event: &ResolvedEvent) -> Token
                 let source = value.cast::<#interface>().map_err(native_error)?;
                 source
                     .#method(#callback)
-                    .map(|revoker| NativeSubscription::Event { _revoker: revoker })
+                    .map(|revoker| NativeSubscription::Event {
+                        _revoker: revoker,
+                        revision,
+                    })
                     .map_err(native_error)
             }
         },
@@ -2661,7 +2684,10 @@ property = "FontWeight"
             struct EventRevoker;
 
             enum NativeSubscription {
-                Event { _revoker: EventRevoker },
+                Event {
+                    _revoker: EventRevoker,
+                    revision: u32,
+                },
             }
 
             #[derive(Clone, Copy)]

--- a/crates/tools/reactor/src/schema.rs
+++ b/crates/tools/reactor/src/schema.rs
@@ -578,7 +578,7 @@ impl Schema {
                                 control.type_name, property.name
                             ));
                         }
-                        ("Str".to_string(), false)
+                        ("ImageValue".to_string(), false)
                     }
                     Some(PropertyAdapter::ContentDialogResult) => {
                         return Err(format!(

--- a/crates/tools/reactor/src/winui.toml
+++ b/crates/tools/reactor/src/winui.toml
@@ -917,6 +917,14 @@ adapter = "image_uri"
 name = "Stretch"
 clearable = true
 
+[[control.event]]
+name = "ImageOpened"
+field = "on_opened"
+
+[[control.event]]
+name = "ImageFailed"
+field = "on_failed"
+
 [[control]]
 type = "Microsoft.UI.Xaml.Controls.ProgressRing"
 capabilities = ["layout", "enabled"]

--- a/docs/crates/windows-reactor.md
+++ b/docs/crates/windows-reactor.md
@@ -90,6 +90,19 @@ range 1 through 999. `TextBlock::max_lines` accepts non-negative values, and
 `TimePicker::minute_increment` accepts values from 0 through 59. Passing `None` still inherits the
 native default.
 
+`Image::source_data` and `ImageIcon::source_data` accept an `EncodedImage` containing PNG or other
+bitmap data supported by WinUI. SVG remains available through the URI-based `source` and
+`source_file` methods. `EncodedImage::from_static` retains a static slice without copying;
+`EncodedImage::new` owns shared runtime data. The encoded data is compared declaratively, while
+decoding runs asynchronously on the native runtime. Replacing or clearing the source, retiring the
+node, and resetting the runtime cancel pending work. Late completions are rejected by the window
+identity and native async ticket.
+
+`Image::on_opened` and `Image::on_failed` report URI load events and completion of encoded loads.
+Malformed encoded data produces `on_failed` when a failure callback is registered. `ImageIcon`
+does not expose image-load events, matching the underlying WinUI control. Failures while
+constructing or writing the stream or scheduling native work are reported as host errors.
+
 ### Migration from the render-and-hook API
 
 The Component/View API replaces the earlier render-function and hook frontend:

--- a/docs/crates/windows-reactor.md
+++ b/docs/crates/windows-reactor.md
@@ -98,6 +98,10 @@ decoding runs asynchronously on the native runtime. Replacing or clearing the so
 node, and resetting the runtime cancel pending work. Late completions are rejected by the window
 identity and native async ticket.
 
+A native source accepted by `ElementRef<Image>::request_set_native_source` ends encoded-source
+ownership and cancels any pending encoded load. A successfully assigned native source remains
+authoritative until the declarative source changes.
+
 `Image::on_opened` and `Image::on_failed` report URI load events and completion of encoded loads.
 Malformed encoded data produces `on_failed` when a failure callback is registered. `ImageIcon`
 does not expose image-load events, matching the underlying WinUI control. Failures while


### PR DESCRIPTION
Adds in-memory image loading to `windows-reactor` through `EncodedImage` and the new `Image::source_data` and `ImageIcon::source_data` builders. Encoded bitmap data is decoded asynchronously with cancellation and stale-completion protection when sources are replaced, cleared, retired, reset, or overridden by an application-owned native source. 

Fixes #4790