### PR TITLE
`windows-reactor` dialog state

### DIFF
--- a/crates/libs/reactor/src/app.rs
+++ b/crates/libs/reactor/src/app.rs
@@ -116,6 +116,10 @@ trait LivePump {
         Err("live event delivery is unsupported".to_string())
     }
     #[cfg(feature = "test")]
+    fn live_content_dialog_lifecycle_step(&mut self) -> Result<bool, String> {
+        Err("live ContentDialog lifecycle is unsupported".to_string())
+    }
+    #[cfg(feature = "test")]
     fn live_controlled_feedback_start(&mut self) -> bool {
         false
     }
@@ -138,6 +142,10 @@ struct ComponentLoop {
     event_delivery_observed: Option<Rc<std::cell::Cell<bool>>>,
     #[cfg(feature = "test")]
     event_delivery_waits: usize,
+    #[cfg(feature = "test")]
+    content_dialog_stage: usize,
+    #[cfg(feature = "test")]
+    content_dialog_waits: usize,
 }
 
 #[cfg(feature = "test")]
@@ -323,6 +331,105 @@ impl ComponentLoop {
         }
         Ok(false)
     }
+
+    fn live_content_dialog_lifecycle_step_impl(&mut self) -> Result<bool, String> {
+        let view = |first_open, second_open| {
+            StackPanel::new().keyed_children([
+                KeyedView::new(
+                    "first",
+                    ContentDialog::new().title("First").is_open(first_open),
+                ),
+                KeyedView::new(
+                    "second",
+                    ContentDialog::new().title("Second").is_open(second_open),
+                ),
+            ])
+        };
+        let mut wait = |states: &[LiveContentDialogState]| {
+            self.content_dialog_waits += 1;
+            if self.content_dialog_waits == 250 {
+                Err(format!(
+                    "ContentDialog probe stalled at stage {}: {states:?}",
+                    self.content_dialog_stage
+                ))
+            } else {
+                Ok(false)
+            }
+        };
+        match self.content_dialog_stage {
+            0 => {
+                self.pump
+                    .update_view(view(true, false))
+                    .map_err(|error| format!("ContentDialog mount failed: {error:?}"))?;
+                self.content_dialog_stage = 1;
+                self.content_dialog_waits = 0;
+            }
+            1 => {
+                let states = self.pump.runtime().live_content_dialog_states();
+                let [first, second] = states.as_slice() else {
+                    return Err("ContentDialog probe expected two dialogs".to_string());
+                };
+                if !first.pending || second.pending {
+                    return wait(&states);
+                }
+                self.pump
+                    .update_view(view(true, true))
+                    .and_then(|_| self.pump.update_view(view(false, true)))
+                    .and_then(|_| self.pump.update_view(view(true, true)))
+                    .map_err(|error| format!("ContentDialog queue setup failed: {error:?}"))?;
+                self.content_dialog_stage = 2;
+                self.content_dialog_waits = 0;
+            }
+            2 => {
+                let states = self.pump.runtime().live_content_dialog_states();
+                let [first, second] = states.as_slice() else {
+                    return Err("ContentDialog probe lost a dialog".to_string());
+                };
+                if first.pending || !first.queued || !second.pending {
+                    return wait(&states);
+                }
+                self.pump
+                    .runtime()
+                    .live_hide_content_dialog(second.node)
+                    .map_err(|error| format!("second ContentDialog hide failed: {error:?}"))?;
+                self.content_dialog_stage = 3;
+                self.content_dialog_waits = 0;
+            }
+            3 => {
+                let states = self.pump.runtime().live_content_dialog_states();
+                let [first, second] = states.as_slice() else {
+                    return Err("ContentDialog probe lost a dialog".to_string());
+                };
+                if first.pending && !first.queued && !second.pending {
+                    self.pump
+                        .update_view(view(false, false))
+                        .map_err(|error| format!("ContentDialog cleanup failed: {error:?}"))?;
+                    self.content_dialog_stage = 4;
+                    self.content_dialog_waits = 0;
+                    return Ok(false);
+                }
+                return wait(&states);
+            }
+            4 => {
+                let states = self.pump.runtime().live_content_dialog_states();
+                let [first, second] = states.as_slice() else {
+                    return Err("ContentDialog probe lost a dialog".to_string());
+                };
+                if !first.desired_open
+                    && !first.pending
+                    && !first.queued
+                    && !second.desired_open
+                    && !second.pending
+                    && !second.queued
+                {
+                    return Ok(true);
+                }
+                return wait(&states);
+            }
+            _ => return Err("ContentDialog probe stage is invalid".to_string()),
+        }
+        Ok(false)
+    }
 }
 
 impl LivePump for ComponentLoop {
@@ -459,6 +566,11 @@ impl LivePump for ComponentLoop {
     #[cfg(feature = "test")]
     fn live_event_delivery_step(&mut self) -> Result<bool, String> {
         self.live_event_delivery_step_impl()
+    }
+
+    #[cfg(feature = "test")]
+    fn live_content_dialog_lifecycle_step(&mut self) -> Result<bool, String> {
+        self.live_content_dialog_lifecycle_step_impl()
     }
 
     #[cfg(feature = "test")]
@@ -683,6 +795,10 @@ impl App {
                 event_delivery_observed: None,
                 #[cfg(feature = "test")]
                 event_delivery_waits: 0,
+                #[cfg(feature = "test")]
+                content_dialog_stage: 0,
+                #[cfg(feature = "test")]
+                content_dialog_waits: 0,
             })]
         })
     }
@@ -711,6 +827,10 @@ impl App {
                         event_delivery_observed: None,
                         #[cfg(feature = "test")]
                         event_delivery_waits: 0,
+                        #[cfg(feature = "test")]
+                        content_dialog_stage: 0,
+                        #[cfg(feature = "test")]
+                        content_dialog_waits: 0,
                     }) as Box<dyn LivePump>
                 })
                 .collect()
@@ -877,6 +997,10 @@ pub(crate) fn open_live_windows(roots: Vec<View>) -> Result<(), RuntimeError> {
                 event_delivery_observed: None,
                 #[cfg(feature = "test")]
                 event_delivery_waits: 0,
+                #[cfg(feature = "test")]
+                content_dialog_stage: 0,
+                #[cfg(feature = "test")]
+                content_dialog_waits: 0,
             }) as Box<dyn LivePump>
         })
         .collect::<Vec<_>>();
@@ -1003,12 +1127,12 @@ pub(crate) fn dispatch_native_events(token: WindowToken) {
         }) else {
             return;
         };
-        let mut retry = false;
+        let mut rearm = false;
         let mut fault = None;
         #[cfg(feature = "test")]
         let dispatch_started = std::time::Instant::now();
         match live.dispatch_events() {
-            Ok(()) => retry = live.native_work_pending(),
+            Ok(()) => rearm = live.native_work_pending(),
             Err(error) => {
                 let error = pump_error(error);
                 eprintln!("windows-reactor fault: {error}");
@@ -1051,7 +1175,7 @@ pub(crate) fn dispatch_native_events(token: WindowToken) {
             .as_ref()
             .is_some_and(|host| host.closed_in_flight.contains(&token));
         if !closed
-            && retry
+            && rearm
             && let Err(error) = live.schedule_dispatch()
         {
             fault = Some(runtime_error(error));

--- a/crates/libs/reactor/src/app/test_support.rs
+++ b/crates/libs/reactor/src/app/test_support.rs
@@ -73,6 +73,7 @@ pub fn schedule_live_window_handle(
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum LiveProbe {
+    ContentDialogLifecycle,
     ControlledFeedback,
     EventDelivery,
     EventRevokers,
@@ -86,17 +87,14 @@ pub fn schedule_live_probe(
     let verify_dispatcher = dispatcher.clone();
     let completion: Rc<dyn Fn(Result<(), String>)> = Rc::new(completion);
     let handler = DispatcherQueueHandler::new(move || {
-        if probe == LiveProbe::EventDelivery {
-            let result = HOST.with(|host| {
-                host.borrow_mut()
-                    .as_mut()
-                    .and_then(LiveHost::secondary_mut)
-                    .ok_or_else(|| "live probe window is unavailable".to_string())?
-                    .live_event_delivery_step()
-            });
+        if matches!(
+            probe,
+            LiveProbe::ContentDialogLifecycle | LiveProbe::EventDelivery
+        ) {
+            let result = live_staged_probe_step(probe);
             match result {
                 Ok(true) => finish_live_probe(probe, Ok(()), Rc::clone(&completion)),
-                Ok(false) => continue_live_event_delivery(
+                Ok(false) => continue_live_staged_probe(
                     verify_dispatcher.clone(),
                     probe,
                     Rc::clone(&completion),
@@ -111,6 +109,7 @@ pub fn schedule_live_probe(
                 return Err("live probe window is unavailable".to_string());
             };
             let passed = match probe {
+                LiveProbe::ContentDialogLifecycle => unreachable!(),
                 LiveProbe::ControlledFeedback => live.live_controlled_feedback_start(),
                 LiveProbe::EventDelivery => unreachable!(),
                 LiveProbe::EventRevokers => live.live_event_revokers(),
@@ -176,7 +175,22 @@ pub fn schedule_live_probe(
     }
 }
 
-fn continue_live_event_delivery(
+fn live_staged_probe_step(probe: LiveProbe) -> Result<bool, String> {
+    HOST.with(|host| {
+        let mut host = host.borrow_mut();
+        let live = host
+            .as_mut()
+            .and_then(LiveHost::secondary_mut)
+            .ok_or_else(|| "live probe window is unavailable".to_string())?;
+        match probe {
+            LiveProbe::ContentDialogLifecycle => live.live_content_dialog_lifecycle_step(),
+            LiveProbe::EventDelivery => live.live_event_delivery_step(),
+            _ => Err(format!("{probe:?} is not a staged probe")),
+        }
+    })
+}
+
+fn continue_live_staged_probe(
     dispatcher: DispatcherQueue,
     probe: LiveProbe,
     completion: Rc<dyn Fn(Result<(), String>)>,
@@ -184,16 +198,10 @@ fn continue_live_event_delivery(
     let next_dispatcher = dispatcher.clone();
     let next_completion = Rc::clone(&completion);
     let step = move || {
-        let result = HOST.with(|host| {
-            host.borrow_mut()
-                .as_mut()
-                .and_then(LiveHost::secondary_mut)
-                .ok_or_else(|| "live probe window is unavailable".to_string())?
-                .live_event_delivery_step()
-        });
+        let result = live_staged_probe_step(probe);
         match result {
             Ok(true) => finish_live_probe(probe, Ok(()), Rc::clone(&next_completion)),
-            Ok(false) => continue_live_event_delivery(
+            Ok(false) => continue_live_staged_probe(
                 next_dispatcher.clone(),
                 probe,
                 Rc::clone(&next_completion),

--- a/crates/libs/reactor/src/core/pump/mod.rs
+++ b/crates/libs/reactor/src/core/pump/mod.rs
@@ -278,7 +278,7 @@ impl<R: NativeRuntime> Pump<R> {
             ..UpdatePlan::new(self.identity)
         };
         let mut changes = ComponentChanges {
-            retry: self.planning_dirty.clone(),
+            recompose: self.planning_dirty.clone(),
             ..ComponentChanges::default()
         };
         if let Err(error) = Self::reconcile_planned_view(
@@ -289,18 +289,18 @@ impl<R: NativeRuntime> Pump<R> {
             &mut changes,
             &mut plan,
         ) {
-            self.fail_component_candidate(&changes, CandidateFailureStage::PlanningRetry);
+            self.fail_component_candidate(&changes, CandidateFailureStage::PlanningRearm);
             return Err(error);
         }
         let window = self.window.ok_or(PumpError::NotMounted)?;
         let candidate_root = match candidate.children(window) {
             Ok([candidate_root]) => *candidate_root,
             Ok(_) => {
-                self.fail_component_candidate(&changes, CandidateFailureStage::PlanningRetry);
+                self.fail_component_candidate(&changes, CandidateFailureStage::PlanningRearm);
                 return Err(PumpError::StructureUnsupported);
             }
             Err(error) => {
-                self.fail_component_candidate(&changes, CandidateFailureStage::PlanningRetry);
+                self.fail_component_candidate(&changes, CandidateFailureStage::PlanningRearm);
                 return Err(error.into());
             }
         };
@@ -660,21 +660,21 @@ impl<R: NativeRuntime> Pump<R> {
     ) -> Result<(), PumpError> {
         let window = self.window.ok_or(PumpError::NotMounted)?;
         if let Err(error) = Self::plan_window_title_bar(window, &self.tree, &candidate, &mut plan) {
-            self.fail_component_candidate(&changes, CandidateFailureStage::PlanningRetry);
+            self.fail_component_candidate(&changes, CandidateFailureStage::PlanningRearm);
             return Err(error);
         }
         if let Err(error) = Self::plan_window_title(window, &self.tree, &candidate, &mut plan) {
-            self.fail_component_candidate(&changes, CandidateFailureStage::PlanningRetry);
+            self.fail_component_candidate(&changes, CandidateFailureStage::PlanningRearm);
             return Err(error);
         }
         if let Err(error) = Self::plan_window_visuals(window, &self.tree, &candidate, &mut plan) {
-            self.fail_component_candidate(&changes, CandidateFailureStage::PlanningRetry);
+            self.fail_component_candidate(&changes, CandidateFailureStage::PlanningRearm);
             return Err(error);
         }
         if let Err(error) =
             Self::plan_window_observations(window, &self.tree, &candidate, &mut plan)
         {
-            self.fail_component_candidate(&changes, CandidateFailureStage::PlanningRetry);
+            self.fail_component_candidate(&changes, CandidateFailureStage::PlanningRearm);
             return Err(error);
         }
         Self::plan_host_requests(window, &mut changes.host_requests, &mut plan);
@@ -692,7 +692,7 @@ impl<R: NativeRuntime> Pump<R> {
             plan,
             FrontendChanges::Component(changes),
             next_version,
-            CandidateFailureStage::PlanningRetry,
+            CandidateFailureStage::PlanningRearm,
         )?;
         self.planning_dirty
             .retain(|token| !resolved.contains(token));

--- a/crates/libs/reactor/src/core/pump/plan.rs
+++ b/crates/libs/reactor/src/core/pump/plan.rs
@@ -28,7 +28,7 @@ pub(super) struct ComponentChanges {
     pub(super) composed: HashSet<ComponentToken>,
     pub(super) context_reads: HashMap<ComponentToken, HashSet<ContextDependency>>,
     pub(super) deferred: HashSet<ComponentToken>,
-    pub(super) retry: HashSet<ComponentToken>,
+    pub(super) recompose: HashSet<ComponentToken>,
     pub(super) reserved: Vec<ComponentToken>,
     pub(super) retired: Vec<ComponentToken>,
     pub(super) touched: HashSet<ComponentToken>,
@@ -38,7 +38,7 @@ pub(super) struct ComponentChanges {
 #[derive(Clone, Copy)]
 pub(super) enum CandidateFailureStage {
     PlanningDiscard,
-    PlanningRetry,
+    PlanningRearm,
     EffectPreparation,
     NativeApply,
     Publication,

--- a/crates/libs/reactor/src/core/pump/planner/view.rs
+++ b/crates/libs/reactor/src/core/pump/planner/view.rs
@@ -132,7 +132,7 @@ impl<R: NativeRuntime> Pump<R> {
                 if changed {
                     changes.touched.insert(token);
                 }
-                if changed || changes.retry.contains(&token) {
+                if changed || changes.recompose.contains(&token) {
                     if changes.deferred.contains(&token) {
                         Ok(node)
                     } else {

--- a/crates/libs/reactor/src/core/pump/publish.rs
+++ b/crates/libs/reactor/src/core/pump/publish.rs
@@ -13,7 +13,7 @@ impl<R: NativeRuntime> Pump<R> {
         changes: &ComponentChanges,
         stage: CandidateFailureStage,
     ) {
-        if matches!(stage, CandidateFailureStage::PlanningRetry) {
+        if matches!(stage, CandidateFailureStage::PlanningRearm) {
             self.planning_dirty.extend(changes.touched.iter().copied());
         }
         Self::remove_reservations(&mut self.components, &changes.reserved);

--- a/crates/libs/reactor/src/core/pump/tests/components_turn_ordering.rs
+++ b/crates/libs/reactor/src/core/pump/tests/components_turn_ordering.rs
@@ -261,7 +261,7 @@ impl Component for PlanningFailureComponent {
 }
 
 #[test]
-fn identical_input_retry_recomposes_after_planning_failure() {
+fn identical_input_recomposes_after_planning_failure() {
     for (mode, expected) in [
         (PlanningMode::InvalidArity, PumpError::StructureUnsupported),
         (
@@ -293,7 +293,7 @@ fn identical_input_retry_recomposes_after_planning_failure() {
 }
 
 #[test]
-fn component_turn_retry_recomposes_touched_child_after_planning_failure() {
+fn component_turn_recomposes_touched_child_after_planning_failure() {
     #[derive(Clone)]
     struct ParentInput(Rc<RefCell<Option<LocalSender<PlanningMode>>>>);
 

--- a/crates/libs/reactor/src/core/pump/tests/content_dialogs.rs
+++ b/crates/libs/reactor/src/core/pump/tests/content_dialogs.rs
@@ -50,6 +50,25 @@ fn host(open: bool) -> View {
     StackPanel::new().children((TextBlock::new().text("Page"), dialog(open)))
 }
 
+fn dialog_pair(first_open: bool, second_open: bool) -> View {
+    StackPanel::new().keyed_children([
+        KeyedView::new(
+            "first",
+            ContentDialog::new()
+                .title("First")
+                .is_open(first_open)
+                .on_closed(|_| {}),
+        ),
+        KeyedView::new(
+            "second",
+            ContentDialog::new()
+                .title("Second")
+                .is_open(second_open)
+                .on_closed(|_| {}),
+        ),
+    ])
+}
+
 #[test]
 fn mounts_closed_without_showing_and_owns_rich_content() {
     let mut pump = Pump::new(RecordingRuntime::default());
@@ -136,7 +155,7 @@ fn declarative_close_hides_and_pending_reopen_waits_for_completion() {
     )
     .unwrap();
     let reopening = pump.runtime().content_dialog(dialog).unwrap();
-    assert!(reopening.reopen);
+    assert!(reopening.queued);
     assert_eq!(reopening.show_count, 1);
 
     pump.runtime_mut()
@@ -144,7 +163,7 @@ fn declarative_close_hides_and_pending_reopen_waits_for_completion() {
     assert_eq!(pump.dispatch_events().unwrap(), 0);
     let reopened = pump.runtime().content_dialog(dialog).unwrap();
     assert!(reopened.pending);
-    assert!(!reopened.reopen);
+    assert!(!reopened.queued);
     assert_eq!(reopened.show_count, 2);
 }
 
@@ -373,7 +392,7 @@ fn replacing_open_native_dialog_hides_old_and_serializes_replacement_show() {
         .unwrap();
     assert!(hide < destroy);
     assert!(destroy < show);
-    assert!(pump.runtime().content_dialog(replacement).unwrap().waiting);
+    assert!(pump.runtime().content_dialog(replacement).unwrap().queued);
     assert_eq!(
         pump.runtime()
             .content_dialog(replacement)
@@ -410,7 +429,7 @@ fn serializes_two_open_dialogs_owned_by_the_same_native_root() {
         1
     );
     assert_eq!(
-        usize::from(first_state.waiting) + usize::from(second_state.waiting),
+        usize::from(first_state.queued) + usize::from(second_state.queued),
         1
     );
     let (active, waiting) = if first_state.pending {
@@ -429,6 +448,71 @@ fn serializes_two_open_dialogs_owned_by_the_same_native_root() {
         pump.runtime().content_dialog(waiting).unwrap().show_count,
         1
     );
+}
+
+#[test]
+fn preserves_a_reopen_queued_behind_an_older_dialog_request() {
+    let mut pump = Pump::new(RecordingRuntime::default());
+    pump.mount_view(dialog_pair(true, false)).unwrap();
+    let dialogs = dialog_nodes(pump.runtime());
+    let [first, second] = dialogs.as_slice() else {
+        panic!("expected two dialogs");
+    };
+
+    pump.update_view(dialog_pair(true, true)).unwrap();
+    pump.update_view(dialog_pair(false, true)).unwrap();
+    pump.update_view(dialog_pair(true, true)).unwrap();
+
+    let first_revision = pump
+        .event_revision(*first, EventId::ContentDialogClosed)
+        .unwrap();
+    pump.runtime_mut()
+        .complete_content_dialog(*first, first_revision, ContentDialogResult::None);
+    assert_eq!(pump.dispatch_events().unwrap(), 0);
+    let first_state = pump.runtime().content_dialog(*first).unwrap();
+    let second_state = pump.runtime().content_dialog(*second).unwrap();
+    assert!(first_state.desired_open);
+    assert!(first_state.queued);
+    assert!(!first_state.pending);
+    assert!(second_state.pending);
+
+    let second_revision = pump
+        .event_revision(*second, EventId::ContentDialogClosed)
+        .unwrap();
+    pump.runtime_mut()
+        .complete_content_dialog(*second, second_revision, ContentDialogResult::None);
+    assert_eq!(pump.dispatch_events().unwrap(), 1);
+    let first_state = pump.runtime().content_dialog(*first).unwrap();
+    assert!(first_state.pending);
+    assert!(!first_state.queued);
+    assert_eq!(first_state.show_count, 2);
+}
+
+#[test]
+fn cancels_a_queued_dialog_before_the_active_dialog_completes() {
+    let mut pump = Pump::new(RecordingRuntime::default());
+    pump.mount_view(dialog_pair(true, false)).unwrap();
+    let dialogs = dialog_nodes(pump.runtime());
+    let [first, second] = dialogs.as_slice() else {
+        panic!("expected two dialogs");
+    };
+
+    pump.update_view(dialog_pair(true, true)).unwrap();
+    assert!(pump.runtime().content_dialog(*second).unwrap().queued);
+    pump.update_view(dialog_pair(true, false)).unwrap();
+    let second_state = pump.runtime().content_dialog(*second).unwrap();
+    assert!(!second_state.desired_open);
+    assert!(!second_state.queued);
+
+    let first_revision = pump
+        .event_revision(*first, EventId::ContentDialogClosed)
+        .unwrap();
+    pump.runtime_mut()
+        .complete_content_dialog(*first, first_revision, ContentDialogResult::None);
+    assert_eq!(pump.dispatch_events().unwrap(), 1);
+    let second_state = pump.runtime().content_dialog(*second).unwrap();
+    assert!(!second_state.pending);
+    assert_eq!(second_state.show_count, 0);
 }
 
 #[test]

--- a/crates/libs/reactor/src/core/pump/tests/failure_policy.rs
+++ b/crates/libs/reactor/src/core/pump/tests/failure_policy.rs
@@ -16,7 +16,7 @@ fn candidate_with_reservation(
 }
 
 #[test]
-fn planning_discard_removes_reservations_without_retry_or_poison() {
+fn planning_discard_removes_reservations_without_rearming_or_poison() {
     let mut pump = Pump::new(RecordingRuntime::default());
     let (changes, token) = candidate_with_reservation(&mut pump);
 
@@ -28,11 +28,11 @@ fn planning_discard_removes_reservations_without_retry_or_poison() {
 }
 
 #[test]
-fn planning_retry_removes_reservations_and_retains_touched_scopes() {
+fn planning_rearm_removes_reservations_and_retains_touched_scopes() {
     let mut pump = Pump::new(RecordingRuntime::default());
     let (changes, token) = candidate_with_reservation(&mut pump);
 
-    pump.fail_component_candidate(&changes, CandidateFailureStage::PlanningRetry);
+    pump.fail_component_candidate(&changes, CandidateFailureStage::PlanningRearm);
 
     assert!(pump.components.publish(token).is_err());
     assert!(pump.planning_dirty.contains(&token));

--- a/crates/libs/reactor/src/core/pump/tests/imperative_references.rs
+++ b/crates/libs/reactor/src/core/pump/tests/imperative_references.rs
@@ -973,7 +973,7 @@ impl Component for PropReference {
 }
 
 #[test]
-fn duplicate_reference_retry_recomposes_staged_component_input() {
+fn duplicate_reference_recomposes_staged_component_input() {
     let shared = ElementRef::<TextBox>::new();
     let mut owner = Pump::new(RecordingRuntime::default());
     owner

--- a/crates/libs/reactor/src/core/pump/turn.rs
+++ b/crates/libs/reactor/src/core/pump/turn.rs
@@ -115,7 +115,7 @@ impl<R: NativeRuntime> Pump<R> {
                             token,
                         },
                         next_version,
-                        CandidateFailureStage::PlanningRetry,
+                        CandidateFailureStage::PlanningRearm,
                     )?;
                     self.planning_dirty.remove(&token);
                     self.dirty_components.clear();
@@ -134,7 +134,7 @@ impl<R: NativeRuntime> Pump<R> {
         let mut changes = ComponentChanges {
             deferred,
             host_requests: staged_host_requests,
-            retry: self.planning_dirty.clone(),
+            recompose: self.planning_dirty.clone(),
             ..ComponentChanges::default()
         };
         let mut dirty = self
@@ -159,7 +159,7 @@ impl<R: NativeRuntime> Pump<R> {
                 if changes.retired.contains(&token) {
                     continue;
                 }
-                self.fail_component_candidate(&changes, CandidateFailureStage::PlanningRetry);
+                self.fail_component_candidate(&changes, CandidateFailureStage::PlanningRearm);
                 return Err(PumpError::StructureUnsupported);
             };
             let result = if composed_view
@@ -204,7 +204,7 @@ impl<R: NativeRuntime> Pump<R> {
                 )
             };
             if let Err(error) = result {
-                self.fail_component_candidate(&changes, CandidateFailureStage::PlanningRetry);
+                self.fail_component_candidate(&changes, CandidateFailureStage::PlanningRearm);
                 return Err(error);
             }
         }

--- a/crates/libs/reactor/src/native/recording.rs
+++ b/crates/libs/reactor/src/native/recording.rs
@@ -276,24 +276,18 @@ impl RecordingRuntime {
         }
         let invoke_callback = !state.suppress_callback;
         let retired = state.retired;
-        let reopen = state.reopen;
         state.pending = false;
         state.suppress_callback = false;
-        state.reopen = false;
 
         let candidate = self
             .content_dialogs
             .iter()
-            .filter(|(candidate, state)| {
-                ((**candidate == node && reopen) || state.waiting)
-                    && state.desired_open
-                    && !state.retired
-            })
+            .filter(|(_, state)| state.queued && state.desired_open && !state.retired)
             .min_by_key(|(_, state)| state.request_order)
             .map(|(node, _)| *node);
         if let Some(candidate) = candidate {
             let state = self.content_dialogs.get_mut(&candidate).unwrap();
-            state.waiting = false;
+            state.queued = false;
             state.pending = true;
             state.show_count += 1;
         }
@@ -1044,12 +1038,8 @@ impl RecordingRuntime {
                 }
                 state.desired_open = *open;
                 if *open {
-                    if state.pending {
-                        state.reopen = true;
-                        self.content_dialog_request_order += 1;
-                        state.request_order = self.content_dialog_request_order;
-                    } else if occupied {
-                        state.waiting = true;
+                    if state.pending || occupied {
+                        state.queued = true;
                         self.content_dialog_request_order += 1;
                         state.request_order = self.content_dialog_request_order;
                     } else {
@@ -1057,8 +1047,7 @@ impl RecordingRuntime {
                         state.show_count += 1;
                     }
                 } else {
-                    state.reopen = false;
-                    state.waiting = false;
+                    state.queued = false;
                     if state.pending {
                         state.suppress_callback = true;
                         state.hide_count += 1;
@@ -1335,8 +1324,7 @@ impl NativeRuntime for RecordingRuntime {
 pub struct RecordedContentDialog {
     pub desired_open: bool,
     pub pending: bool,
-    pub reopen: bool,
-    pub waiting: bool,
+    pub queued: bool,
     pub show_count: usize,
     pub hide_count: usize,
     request_order: u64,

--- a/crates/libs/reactor/src/native/winui/mod.rs
+++ b/crates/libs/reactor/src/native/winui/mod.rs
@@ -2539,9 +2539,15 @@ impl WinUiRuntime {
                 } else {
                     state.queued = false;
                     state.root_loaded = None;
-                    if state.pending {
+                    let hide = if state.pending {
                         state.suppress_callback = true;
-                        state.dialog.Hide().map_err(native_error)?;
+                        Some(state.dialog.clone())
+                    } else {
+                        None
+                    };
+                    drop(dialogs);
+                    if let Some(dialog) = hide {
+                        dialog.Hide().map_err(native_error)?;
                     }
                 }
             }
@@ -4089,17 +4095,18 @@ impl NativeRuntime for WinUiRuntime {
         self.composition_host_subscriptions.clear();
         self.owned_menus.clear();
         self.command_bar_flyouts.clear();
-        for state in self
+        let dialogs = self
             .content_dialogs
             .borrow_mut()
             .drain()
             .map(|(_, state)| state)
-        {
+            .collect::<Vec<_>>();
+        self.content_dialog_subscriptions.borrow_mut().clear();
+        self.content_dialog_request_order = 0;
+        for state in dialogs {
             if state.pending {
                 _ = state.dialog.Hide();
             }
-            self.content_dialog_subscriptions.borrow_mut().clear();
-            self.content_dialog_request_order = 0;
         }
         for (target, (flyout, _)) in self.flyouts.drain() {
             _ = flyout.SetContent(None::<&UIElement>);

--- a/crates/libs/reactor/src/native/winui/mod.rs
+++ b/crates/libs/reactor/src/native/winui/mod.rs
@@ -134,14 +134,23 @@ struct ContentDialogLifecycle {
     desired_open: bool,
     generation: u64,
     pending: bool,
+    queued: bool,
     request_order: u64,
-    reopen: bool,
     retired: bool,
     revision: u32,
     root_loaded: Option<windows_core::EventRevoker>,
     suppress_callback: bool,
-    waiting: bool,
     xaml_root: Option<XamlRoot>,
+}
+
+#[cfg(feature = "test")]
+#[derive(Debug)]
+pub(crate) struct LiveContentDialogState {
+    pub(crate) desired_open: bool,
+    pub(crate) generation: u64,
+    pub(crate) node: NodeId,
+    pub(crate) pending: bool,
+    pub(crate) queued: bool,
 }
 
 struct WebViewInitialization {
@@ -688,6 +697,36 @@ impl WinUiRuntime {
     #[cfg(feature = "test")]
     pub fn live_event_subscription_count(&self) -> usize {
         self.subscriptions.len() + self.content_dialog_subscriptions.borrow().len()
+    }
+
+    #[cfg(feature = "test")]
+    pub(crate) fn live_content_dialog_states(&self) -> Vec<LiveContentDialogState> {
+        let mut states = self
+            .content_dialogs
+            .borrow()
+            .iter()
+            .map(|(node, state)| LiveContentDialogState {
+                desired_open: state.desired_open,
+                generation: state.generation,
+                node: *node,
+                pending: state.pending,
+                queued: state.queued,
+            })
+            .collect::<Vec<_>>();
+        states.sort_unstable_by_key(|state| state.generation);
+        states
+    }
+
+    #[cfg(feature = "test")]
+    pub(crate) fn live_hide_content_dialog(&self, node: NodeId) -> Result<(), RuntimeError> {
+        let dialog = self
+            .content_dialogs
+            .borrow()
+            .get(&node)
+            .ok_or(RuntimeError::MissingNode(node))?
+            .dialog
+            .clone();
+        dialog.Hide().map_err(native_error)
     }
 
     #[cfg(feature = "test")]
@@ -1367,13 +1406,12 @@ impl WinUiRuntime {
                             desired_open: false,
                             generation: self.next_content_dialog_generation,
                             pending: false,
+                            queued: false,
                             request_order: 0,
-                            reopen: false,
                             retired: false,
                             revision: 0,
                             root_loaded: None,
                             suppress_callback: false,
-                            waiting: false,
                             xaml_root: None,
                         },
                     );
@@ -2490,12 +2528,8 @@ impl WinUiRuntime {
                             .get_mut(node)
                             .ok_or(RuntimeError::MissingNode(*node))?;
                         state.root_loaded = Some(loaded);
-                    } else if state.pending {
-                        state.reopen = true;
-                        self.content_dialog_request_order += 1;
-                        state.request_order = self.content_dialog_request_order;
-                    } else if occupied {
-                        state.waiting = true;
+                    } else if state.pending || occupied {
+                        state.queued = true;
                         self.content_dialog_request_order += 1;
                         state.request_order = self.content_dialog_request_order;
                     } else {
@@ -2503,8 +2537,7 @@ impl WinUiRuntime {
                         state.pending = true;
                     }
                 } else {
-                    state.reopen = false;
-                    state.waiting = false;
+                    state.queued = false;
                     state.root_loaded = None;
                     if state.pending {
                         state.suppress_callback = true;
@@ -3324,7 +3357,7 @@ impl EventSink {
             .and_then(|dialog| dialog.SetXamlRoot(&xaml_root))
             .map_err(native_error)?;
         if occupied {
-            state.waiting = true;
+            state.queued = true;
         } else {
             show_content_dialog(&state.dialog)?;
             state.pending = true;
@@ -3356,7 +3389,7 @@ impl EventSink {
                 .borrow()
                 .iter()
                 .filter(|(_, state)| {
-                    (state.reopen || state.waiting)
+                    state.queued
                         && state.desired_open
                         && !state.retired
                         && state
@@ -3394,7 +3427,7 @@ impl EventSink {
                                 && state.desired_open
                                 && !state.retired
                                 && !state.pending
-                                && (state.reopen || state.waiting)
+                                && state.queued
                                 && state
                                     .xaml_root
                                     .as_ref()
@@ -3408,7 +3441,7 @@ impl EventSink {
                                     state.desired_open
                                         && !state.retired
                                         && !state.pending
-                                        && (state.reopen || state.waiting)
+                                        && state.queued
                                         && state
                                             .xaml_root
                                             .as_ref()
@@ -3421,8 +3454,7 @@ impl EventSink {
                         return;
                     };
                     let state = dialogs.get_mut(&candidate).unwrap();
-                    state.reopen = false;
-                    state.waiting = false;
+                    state.queued = false;
                     (
                         candidate,
                         state.dialog.ShowAsync().map(|_| {

--- a/crates/tests/libs/reactor_selftest/src/runner.rs
+++ b/crates/tests/libs/reactor_selftest/src/runner.rs
@@ -14,6 +14,7 @@ pub(crate) const SUITE_TIMEOUT: Duration =
 
 #[derive(Clone, Copy)]
 enum FixtureKind {
+    ContentDialogLifecycle,
     FocusPublication,
     EventDelivery,
     EventRevokers,
@@ -37,6 +38,10 @@ const FIXTURES: &[Fixture] = &[
     Fixture {
         name: "Focus_PublicationAndRetirement",
         kind: FixtureKind::FocusPublication,
+    },
+    Fixture {
+        name: "ContentDialog_QueuedReopenLifecycle",
+        kind: FixtureKind::ContentDialogLifecycle,
     },
     Fixture {
         name: "Events_NativePayloadDelivery",
@@ -123,6 +128,7 @@ impl FixtureRunner {
 
     fn open_probe(&self, context: &ComponentContext<Self>) {
         let probe = match FIXTURES[self.current].kind {
+            FixtureKind::ContentDialogLifecycle => LiveProbe::ContentDialogLifecycle,
             FixtureKind::EventDelivery => LiveProbe::EventDelivery,
             FixtureKind::EventRevokers => LiveProbe::EventRevokers,
             FixtureKind::ControlledFeedback => LiveProbe::ControlledFeedback,
@@ -195,6 +201,9 @@ impl Component for FixtureRunner {
             complete: context.callback(move |result| Message::Complete { generation, result }),
         };
         match FIXTURES.get(self.current).map(|fixture| fixture.kind) {
+            Some(FixtureKind::ContentDialogLifecycle) => TextBlock::new()
+                .text("ContentDialog lifecycle probe")
+                .into(),
             Some(FixtureKind::FocusPublication) => View::component::<FocusPublication>(input),
             Some(FixtureKind::EventDelivery) => {
                 TextBlock::new().text("event delivery probe").into()


### PR DESCRIPTION
This cleans up Reactor’s dialog and failure-state terminology by replacing the separate `ContentDialog` reopen and waiting flags with a single queued state and renaming planning retries to rearming/recomposition since failed native work is never replayed. It also fixes a recording-backend bug that could lose a reopen request when an older queued dialog won, adds deterministic coverage for that race and queued cancellation, and adds a headless live WinUI fixture that runs the full two-dialog close/reopen sequence against real ContentDialogs.