### PR TITLE
`windows-reactor` inference

### DIFF
--- a/crates/libs/reactor/src/native/winui/bindings.rs
+++ b/crates/libs/reactor/src/native/winui/bindings.rs
@@ -19811,6 +19811,32 @@ pub struct IUIElement_Vtbl {
     ) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
+    IUIElementCollection,
+    IUIElementCollection_Vtbl,
+    0x23050cb1_db88_54ed_9083_5ecfb12512fd
+);
+impl windows_core::RuntimeType for IUIElementCollection {
+    const SIGNATURE: windows_core::imp::ConstBuffer =
+        windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
+impl IUIElementCollection {
+    pub(crate) fn Move(&self, oldindex: u32, newindex: u32) -> windows_core::Result<()> {
+        unsafe {
+            (windows_core::Interface::vtable(self).Move)(
+                windows_core::Interface::as_raw(self),
+                oldindex,
+                newindex,
+            )
+            .ok()
+        }
+    }
+}
+#[repr(C)]
+pub struct IUIElementCollection_Vtbl {
+    pub base__: windows_core::IInspectable_Vtbl,
+    pub Move: unsafe extern "system" fn(*mut core::ffi::c_void, u32, u32) -> windows_core::HRESULT,
+}
+windows_core::imp::define_interface!(
     IUIElementStatics,
     IUIElementStatics_Vtbl,
     0xd2921d87_3584_5e22_8a3a_c2c78dab4f6e

--- a/crates/libs/reactor/src/native/winui/element_factory.rs
+++ b/crates/libs/reactor/src/native/winui/element_factory.rs
@@ -67,11 +67,7 @@ impl VirtualHandle {
     pub fn reset(&self, item_count: usize, source_revision: u64) -> Result<()> {
         let values = item_values(item_count)?;
         self.source_revision.set(source_revision);
-        self.source.Clear()?;
-        for value in values {
-            self.source.Append(value.as_ref())?;
-        }
-        Ok(())
+        self.source.ReplaceAll(&values)
     }
 
     pub fn set_content(
@@ -311,6 +307,8 @@ impl IElementFactory_Impl for ReactorElementFactory_Impl {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
     #[test]
     fn every_shell_lifetime_gets_a_fresh_token() {
@@ -361,5 +359,22 @@ mod tests {
 
         let (live, _) = shells.take(|| Ok(43)).unwrap();
         assert!(shells.acknowledge_recycle(live).is_err());
+    }
+
+    #[test]
+    fn replacing_virtual_items_raises_one_source_change() {
+        let source: windows_collections::IObservableVector<IInspectable> =
+            item_values(2).unwrap().into();
+        let changes = Arc::new(AtomicUsize::new(0));
+        let observed = Arc::clone(&changes);
+        let _changed = source
+            .VectorChanged(move |_, _| {
+                observed.fetch_add(1, Ordering::Relaxed);
+            })
+            .unwrap();
+
+        source.ReplaceAll(&item_values(100).unwrap()).unwrap();
+
+        assert_eq!(changes.load(Ordering::Relaxed), 1);
     }
 }

--- a/crates/libs/reactor/src/native/winui/mod.rs
+++ b/crates/libs/reactor/src/native/winui/mod.rs
@@ -3045,9 +3045,10 @@ impl WinUiRuntime {
                         .collect::<Vec<_>>();
                     physical_retained_index(&current, &retained, index)?
                 };
-                children.RemoveAt(from).map_err(native_error)?;
+                let index = index32(index)?;
                 children
-                    .InsertAt(index32(index)?, &child)
+                    .cast::<IUIElementCollection>()
+                    .and_then(|children| children.Move(from, index))
                     .map_err(native_error)
             } else {
                 Err(RuntimeError::UnsupportedKind)

--- a/crates/tools/reactor/src/control_bindings.txt
+++ b/crates/tools/reactor/src/control_bindings.txt
@@ -316,6 +316,7 @@ Microsoft::UI::Xaml::Controls::IToggleSwitch::{add_Toggled, remove_Toggled}
 Microsoft::UI::Xaml::Controls::ITreeView::put_SelectionMode
 Microsoft::UI::Xaml::Controls::ITreeView::{add_ItemInvoked, remove_ItemInvoked}
 Microsoft::UI::Xaml::Controls::ITreeViewItemInvokedEventArgs::get_InvokedItem
+Microsoft::UI::Xaml::Controls::IUIElementCollection::Move
 Microsoft::UI::Xaml::Controls::IVariableSizedWrapGrid::put_ItemHeight
 Microsoft::UI::Xaml::Controls::IVariableSizedWrapGrid::put_ItemWidth
 Microsoft::UI::Xaml::Controls::IVariableSizedWrapGrid::put_Orientation

--- a/crates/tools/reactor/src/generate_winui.rs
+++ b/crates/tools/reactor/src/generate_winui.rs
@@ -24,6 +24,9 @@ pub(crate) fn generate_control_bindings_filter(schema: &ResolvedSchema) -> Strin
                 entries.insert("Microsoft::UI::Xaml::Controls::IPanel::Children".to_string());
                 entries
                     .insert("Microsoft::UI::Xaml::Controls::UIElementCollection::{}".to_string());
+                entries.insert(
+                    "Microsoft::UI::Xaml::Controls::IUIElementCollection::Move".to_string(),
+                );
             }
             Role::Leaf | Role::Content | Role::Slots | Role::Virtual => {}
         }

--- a/crates/tools/reactor/src/metadata.rs
+++ b/crates/tools/reactor/src/metadata.rs
@@ -5,8 +5,8 @@
 use std::collections::HashMap;
 use std::path::Path;
 
-use windows_metadata::Type;
 use windows_metadata::reader::{File, Index, TypeCategory, TypeDef, TypeDefOrRef};
+use windows_metadata::{HasAttributes, Type, Value};
 
 /// Resolved interface location: namespace + name.
 #[derive(Clone, Debug)]
@@ -72,6 +72,7 @@ pub struct MetadataResolver {
     /// Non-generic delegate → args class short name, resolved from the
     /// delegate's `Invoke` method signature.
     delegate_args: HashMap<String, String>,
+    content_properties: HashMap<(String, String), String>,
 }
 
 impl MetadataResolver {
@@ -108,6 +109,7 @@ impl MetadataResolver {
         let mut lookup = HashMap::new();
         let mut interface_owners = HashMap::new();
         let mut base_classes = HashMap::new();
+        let mut content_properties = HashMap::new();
 
         // Walk all types in the index, collecting method→interface for classes
         // in Microsoft.UI.Xaml namespaces.
@@ -128,6 +130,22 @@ impl MetadataResolver {
                     if let Some(base) = base {
                         base_classes.insert((namespace.to_string(), name.to_string()), base);
                     }
+                }
+                if let Some(content) =
+                    typedef
+                        .find_attribute("ContentPropertyAttribute")
+                        .and_then(|attribute| {
+                            attribute.value().into_iter().find_map(|(name, value)| {
+                                (name == "Name")
+                                    .then_some(value)
+                                    .and_then(|value| match value {
+                                        Value::Utf8(value) => Some(value),
+                                        _ => None,
+                                    })
+                            })
+                        })
+                {
+                    content_properties.insert((namespace.to_string(), name.to_string()), content);
                 }
                 for implementation in typedef.interface_impls() {
                     let interface = implementation.interface(&[]);
@@ -231,6 +249,7 @@ impl MetadataResolver {
             single_field_types,
             enum_variants,
             delegate_args,
+            content_properties,
         }
     }
 
@@ -249,6 +268,17 @@ impl MetadataResolver {
             current.clone_from(parent);
         }
         false
+    }
+
+    pub fn content_property(&self, class: &str) -> Option<String> {
+        let (namespace, name) = class.rsplit_once('.')?;
+        let mut current = (namespace.to_string(), name.to_string());
+        loop {
+            if let Some(content) = self.content_properties.get(&current) {
+                return Some(content.clone());
+            }
+            current = self.base_classes.get(&current)?.clone();
+        }
     }
 
     /// Walk a class's interface hierarchy and record every `put_*` / `get_*` /
@@ -845,6 +875,24 @@ mod tests {
                 .return_vector_element_class_name("SelectorBar", "get_Items")
                 .as_deref(),
             Some("Microsoft.UI.Xaml.Controls.SelectorBarItem")
+        );
+    }
+
+    #[test]
+    fn resolves_inherited_content_properties() {
+        let resolver = MetadataResolver::load(Path::new("winmd"));
+
+        assert_eq!(
+            resolver.content_property("Microsoft.UI.Xaml.Controls.Border"),
+            Some("Child".to_string())
+        );
+        assert_eq!(
+            resolver.content_property("Microsoft.UI.Xaml.Controls.Button"),
+            Some("Content".to_string())
+        );
+        assert_eq!(
+            resolver.content_property("Microsoft.UI.Xaml.Controls.TextBlock"),
+            Some("Inlines".to_string())
         );
     }
 

--- a/crates/tools/reactor/src/schema.rs
+++ b/crates/tools/reactor/src/schema.rs
@@ -402,7 +402,21 @@ impl Schema {
             };
 
             let content = if matches!(role, Role::Content) {
-                let content = control.content.as_deref().unwrap_or("Content");
+                let metadata_content =
+                    metadata
+                        .content_property(&control.type_name)
+                        .ok_or_else(|| {
+                            format!("{} has no metadata content property", control.type_name)
+                        })?;
+                if let Some(content) = control.content.as_deref()
+                    && content != metadata_content
+                {
+                    return Err(format!(
+                        "{} content property {} does not match metadata property {}",
+                        control.type_name, content, metadata_content
+                    ));
+                }
+                let content = metadata_content.as_str();
                 let method = format!("put_{content}");
                 let interface = metadata.resolve(&name, &method).ok_or_else(|| {
                     format!(
@@ -2307,7 +2321,7 @@ name = "Header"
     fn rejects_structural_role_not_supported_by_metadata() {
         let source = r#"
 [[control]]
-type = "Microsoft.UI.Xaml.Controls.Viewbox"
+type = "Microsoft.UI.Xaml.Controls.StackPanel"
 capabilities = ["layout", "content"]
 "#;
         let metadata = MetadataResolver::load(&workspace_path("crates/tools/reactor/winmd"));

--- a/crates/tools/reactor/src/winui.toml
+++ b/crates/tools/reactor/src/winui.toml
@@ -126,7 +126,6 @@ name = "Click"
 
 [[control]]
 type = "Microsoft.UI.Xaml.Controls.Border"
-content = "Child"
 capabilities = ["layout", "content"]
 
 [[control.property]]
@@ -1111,7 +1110,6 @@ adapter = "path_data"
 
 [[control]]
 type = "Microsoft.UI.Xaml.Controls.ListBoxItem"
-content = "Content"
 capabilities = ["layout", "content"]
 
 [[control.property]]
@@ -1235,7 +1233,6 @@ item_controls = ["PivotItem"]
 
 [[control]]
 type = "Microsoft.UI.Xaml.Controls.PivotItem"
-content = "Content"
 capabilities = ["layout", "content"]
 
 [[control.property]]
@@ -1341,7 +1338,6 @@ collection = true
 
 [[control]]
 type = "Microsoft.UI.Xaml.Controls.TabViewItem"
-content = "Content"
 capabilities = ["layout", "content"]
 
 [[control.property]]
@@ -1400,7 +1396,6 @@ name = "ActionButtonClick"
 
 [[control]]
 type = "Microsoft.UI.Xaml.Controls.DropDownButton"
-content = "Content"
 capabilities = ["layout", "content", "enabled"]
 
 [[control.property]]
@@ -1464,7 +1459,6 @@ clearable = true
 
 [[control]]
 type = "Microsoft.UI.Xaml.Controls.SplitButton"
-content = "Content"
 capabilities = ["layout", "content", "enabled"]
 
 [[control.property]]
@@ -1590,12 +1584,10 @@ name = "Header"
 [[control]]
 type = "Microsoft.UI.Xaml.Controls.ToolTip"
 placement = "tooltip_attachment"
-content = "Content"
 capabilities = ["content"]
 
 [[control]]
 type = "Microsoft.UI.Xaml.Controls.ContentDialog"
-content = "Content"
 capabilities = ["content"]
 lifecycle = "content_dialog"
 
@@ -1692,7 +1684,6 @@ collection = true
 
 [[control]]
 type = "Microsoft.UI.Xaml.Controls.ListViewItem"
-content = "Content"
 capabilities = ["layout", "content", "enabled"]
 
 [[control.property]]
@@ -1752,7 +1743,6 @@ collection = true
 
 [[control]]
 type = "Microsoft.UI.Xaml.Controls.GridViewItem"
-content = "Content"
 capabilities = ["layout", "content", "enabled"]
 
 [[control.property]]

--- a/docs/crates/windows-reactor.md
+++ b/docs/crates/windows-reactor.md
@@ -184,7 +184,9 @@ the `windows-reactor-setup` bootstrap DLLs from pinned NuGet packages. It then r
 `crates/tools/reactor/src/bindings.txt` contains the hand-maintained runtime binding filter.
 `control_bindings.txt` is generated from `winui.toml` and supplies control-specific entries. The
 filters name only APIs used by the runtime or live test hooks. Feedback events obtain values from
-their event payloads rather than generating property readers for the full schema.
+their event payloads rather than generating property readers for the full schema. Content controls
+take their content property name from WinUI's `ContentPropertyAttribute`, including inherited
+properties.
 
 Bindings used only by the `test` feature are dead in a normal library build. The bindings module
 allows dead code only when that feature is disabled. Building with the feature removes the


### PR DESCRIPTION
This change makes Reactor work with WinUI more directly: child reorders use WinUI’s native move operation instead of removing and reinserting controls, and virtual-list resets happen in one update instead of sending a notification for every item. It also reads content property names such as `Content`, `Child`, and `Inlines` from WinUI metadata rather than repeating them in Reactor’s configuration. The result is fewer unnecessary WinUI operations, fewer transient states, and less metadata guesswork to maintain.