### PR TITLE
`windows-reactor` cleanup

### DIFF
--- a/crates/libs/reactor/src/core/component.rs
+++ b/crates/libs/reactor/src/core/component.rs
@@ -961,10 +961,6 @@ trait ErasedScope {
 pub(crate) struct ComponentRender {
     pub(crate) color_scheme_observation: Option<Callback<ColorScheme>>,
     pub(crate) dependencies: HashSet<ContextDependency>,
-    pub(crate) duplicate_color_scheme_observation: bool,
-    pub(crate) duplicate_window_size_observation: bool,
-    pub(crate) duplicate_window_title: bool,
-    pub(crate) duplicate_window_visuals: bool,
     pub(crate) view: View,
     pub(crate) window_size_observation: Option<Callback<WindowSize>>,
     pub(crate) window_title: Option<String>,
@@ -1105,7 +1101,7 @@ struct TypedScope<C, I, M> {
         LocalSender<M>,
         Rc<RefCell<ComponentEffects>>,
         ContextSnapshot,
-    ) -> ComponentRender,
+    ) -> Result<ComponentRender, ComponentStoreError>,
     window: WindowEndpoint,
 }
 
@@ -1208,19 +1204,7 @@ where
             self.sender.clone(),
             Rc::clone(&self.effects),
             contexts,
-        );
-        if render.duplicate_color_scheme_observation {
-            return Err(ComponentStoreError::DuplicateColorSchemeObservation);
-        }
-        if render.duplicate_window_size_observation {
-            return Err(ComponentStoreError::DuplicateWindowSizeObservation);
-        }
-        if render.duplicate_window_title {
-            return Err(ComponentStoreError::DuplicateWindowTitle);
-        }
-        if render.duplicate_window_visuals {
-            return Err(ComponentStoreError::DuplicateWindowVisuals);
-        }
+        )?;
         self.effects.borrow().finish_view()?;
         Ok(render)
     }
@@ -1332,7 +1316,7 @@ impl ComponentStore {
             sender: LocalSender<C::Message>,
             effects: Rc<RefCell<ComponentEffects>>,
             contexts: ContextSnapshot,
-        ) -> ComponentRender {
+        ) -> Result<ComponentRender, ComponentStoreError> {
             let mut context = ViewContext {
                 contexts,
                 duplicate_color_scheme_observation: false,
@@ -1348,18 +1332,26 @@ impl ComponentStore {
                 window_visuals: None,
             };
             let view = component.view(input, &mut context);
-            ComponentRender {
+            if context.duplicate_color_scheme_observation {
+                return Err(ComponentStoreError::DuplicateColorSchemeObservation);
+            }
+            if context.duplicate_window_size_observation {
+                return Err(ComponentStoreError::DuplicateWindowSizeObservation);
+            }
+            if context.duplicate_window_title {
+                return Err(ComponentStoreError::DuplicateWindowTitle);
+            }
+            if context.duplicate_window_visuals {
+                return Err(ComponentStoreError::DuplicateWindowVisuals);
+            }
+            Ok(ComponentRender {
                 color_scheme_observation: context.color_scheme_observation,
                 dependencies: context.reads,
-                duplicate_color_scheme_observation: context.duplicate_color_scheme_observation,
-                duplicate_window_size_observation: context.duplicate_window_size_observation,
-                duplicate_window_title: context.duplicate_window_title,
-                duplicate_window_visuals: context.duplicate_window_visuals,
                 view,
                 window_size_observation: context.window_size_observation,
                 window_title: context.window_title,
                 window_visuals: context.window_visuals,
-            }
+            })
         }
 
         let background = Arc::clone(&self.background);

--- a/crates/libs/reactor/src/core/pump/planner/view.rs
+++ b/crates/libs/reactor/src/core/pump/planner/view.rs
@@ -54,12 +54,12 @@ impl<R: NativeRuntime> Pump<R> {
         changes: &mut ComponentChanges,
         plan: &mut UpdatePlan,
     ) -> Result<NodeId, PumpError> {
-        if Self::view_uses_native_tooltip(view.as_kind())
+        if Self::view_uses_native_control(view.as_kind(), MountedKind::ToolTip)
             && !Self::is_tooltip_implementation(tree, node)?
         {
             return Err(PumpError::StructureUnsupported);
         }
-        if Self::view_uses_native_content_dialog(view.as_kind())
+        if Self::view_uses_native_control(view.as_kind(), MountedKind::ContentDialog)
             && !Self::is_content_dialog_implementation(tree, node)?
         {
             return Err(PumpError::StructureUnsupported);
@@ -1270,30 +1270,12 @@ impl<R: NativeRuntime> Pump<R> {
         Ok(())
     }
 
-    fn view_uses_native_tooltip(view: &ViewKind) -> bool {
+    fn view_uses_native_control(view: &ViewKind, expected: MountedKind) -> bool {
         match view {
             ViewKind::Native(control)
             | ViewKind::Content { control, .. }
             | ViewKind::Children { control, .. }
-            | ViewKind::Slots { control, .. } => control.kind() == MountedKind::ToolTip,
-            ViewKind::Component(_)
-            | ViewKind::Fragment(_)
-            | ViewKind::Provider { .. }
-            | ViewKind::Tooltip { .. }
-            | ViewKind::Flyout { .. }
-            | ViewKind::Menu { .. }
-            | ViewKind::CommandBarFlyout { .. }
-            | ViewKind::TreeNodes { .. }
-            | ViewKind::ContentDialog { .. } => false,
-        }
-    }
-
-    fn view_uses_native_content_dialog(view: &ViewKind) -> bool {
-        match view {
-            ViewKind::Native(control)
-            | ViewKind::Content { control, .. }
-            | ViewKind::Children { control, .. }
-            | ViewKind::Slots { control, .. } => control.kind() == MountedKind::ContentDialog,
+            | ViewKind::Slots { control, .. } => control.kind() == expected,
             ViewKind::Component(_)
             | ViewKind::Fragment(_)
             | ViewKind::Provider { .. }
@@ -1806,22 +1788,13 @@ impl<R: NativeRuntime> Pump<R> {
         let ComponentRender {
             color_scheme_observation,
             dependencies,
-            duplicate_color_scheme_observation: _,
-            duplicate_window_size_observation: _,
-            duplicate_window_title,
-            duplicate_window_visuals,
             view,
             window_size_observation,
             window_title,
             window_visuals,
         } = components.view(token, tree.context_snapshot(node)?)?;
-        Self::reconcile_component_window_title(tree, token, duplicate_window_title, window_title)?;
-        Self::reconcile_component_window_visuals(
-            tree,
-            token,
-            duplicate_window_visuals,
-            window_visuals,
-        )?;
+        Self::reconcile_component_window_title(tree, token, window_title);
+        Self::reconcile_component_window_visuals(tree, token, window_visuals);
         tree.set_window_size_observation(token.scope(), window_size_observation);
         tree.set_color_scheme_observation(token.scope(), color_scheme_observation);
         changes.context_reads.insert(token, dependencies);
@@ -1831,28 +1804,18 @@ impl<R: NativeRuntime> Pump<R> {
     pub(in super::super) fn reconcile_component_window_title(
         tree: &mut Tree,
         token: ComponentToken,
-        duplicate: bool,
         title: Option<String>,
-    ) -> Result<(), PumpError> {
-        if duplicate {
-            return Err(PumpError::DuplicateWindowTitle);
-        }
+    ) {
         let scope = token.scope();
         tree.set_window_title(scope, title.map(Into::into));
-        Ok(())
     }
 
     pub(in super::super) fn reconcile_component_window_visuals(
         tree: &mut Tree,
         token: ComponentToken,
-        duplicate: bool,
         visuals: Option<WindowVisuals>,
-    ) -> Result<(), PumpError> {
-        if duplicate {
-            return Err(PumpError::DuplicateWindowVisuals);
-        }
+    ) {
         tree.set_window_visuals(token.scope(), visuals);
-        Ok(())
     }
 
     pub(in super::super) fn recompose_component_view(
@@ -1884,12 +1847,12 @@ impl<R: NativeRuntime> Pump<R> {
         changes: &mut ComponentChanges,
         plan: &mut UpdatePlan,
     ) -> Result<(NodeId, Vec<NodeId>), PumpError> {
-        if Self::view_uses_native_tooltip(view.as_kind())
+        if Self::view_uses_native_control(view.as_kind(), MountedKind::ToolTip)
             && !Self::tooltip_implementation_mount_allowed(tree, logical_parent)?
         {
             return Err(PumpError::StructureUnsupported);
         }
-        if Self::view_uses_native_content_dialog(view.as_kind())
+        if Self::view_uses_native_control(view.as_kind(), MountedKind::ContentDialog)
             && !Self::content_dialog_implementation_mount_allowed(tree, logical_parent)?
         {
             return Err(PumpError::StructureUnsupported);
@@ -1915,27 +1878,13 @@ impl<R: NativeRuntime> Pump<R> {
                 let ComponentRender {
                     color_scheme_observation,
                     dependencies,
-                    duplicate_color_scheme_observation: _,
-                    duplicate_window_size_observation: _,
-                    duplicate_window_title,
-                    duplicate_window_visuals,
                     view,
                     window_size_observation,
                     window_title,
                     window_visuals,
                 } = components.view(token, tree.context_snapshot(node)?)?;
-                Self::reconcile_component_window_title(
-                    tree,
-                    token,
-                    duplicate_window_title,
-                    window_title,
-                )?;
-                Self::reconcile_component_window_visuals(
-                    tree,
-                    token,
-                    duplicate_window_visuals,
-                    window_visuals,
-                )?;
+                Self::reconcile_component_window_title(tree, token, window_title);
+                Self::reconcile_component_window_visuals(tree, token, window_visuals);
                 tree.set_window_size_observation(token.scope(), window_size_observation);
                 tree.set_color_scheme_observation(token.scope(), color_scheme_observation);
                 changes.context_reads.insert(token, dependencies);

--- a/crates/libs/reactor/src/core/pump/turn.rs
+++ b/crates/libs/reactor/src/core/pump/turn.rs
@@ -168,18 +168,12 @@ impl<R: NativeRuntime> Pump<R> {
             {
                 let (_, render) = composed_view.take().unwrap();
                 changes.composed.insert(token);
-                Self::reconcile_component_window_title(
-                    &mut candidate,
-                    token,
-                    render.duplicate_window_title,
-                    render.window_title,
-                )?;
+                Self::reconcile_component_window_title(&mut candidate, token, render.window_title);
                 Self::reconcile_component_window_visuals(
                     &mut candidate,
                     token,
-                    render.duplicate_window_visuals,
                     render.window_visuals,
-                )?;
+                );
                 candidate
                     .set_window_size_observation(token.scope(), render.window_size_observation);
                 candidate
@@ -253,12 +247,6 @@ impl<R: NativeRuntime> Pump<R> {
         let render = self
             .components
             .view(token, self.tree.context_snapshot(node)?)?;
-        if render.duplicate_window_title {
-            return Err(PumpError::DuplicateWindowTitle);
-        }
-        if render.duplicate_window_visuals {
-            return Err(PumpError::DuplicateWindowVisuals);
-        }
         let title_matches = match self.tree.window_title() {
             Some(current) if current.owner != token.scope() => {
                 if render.window_title.is_some() {
@@ -316,34 +304,8 @@ impl<R: NativeRuntime> Pump<R> {
         if !window_size_matches || !color_scheme_matches {
             return Ok(LocalComponentUpdate::Fallback(render));
         }
-        let ComponentRender {
-            color_scheme_observation,
-            dependencies,
-            duplicate_color_scheme_observation,
-            duplicate_window_size_observation,
-            duplicate_window_title,
-            duplicate_window_visuals,
-            view,
-            window_size_observation,
-            window_title,
-            window_visuals,
-        } = render;
-        let element = match view.into_kind() {
-            ViewKind::Native(element) => element,
-            kind => {
-                return Ok(LocalComponentUpdate::Fallback(ComponentRender {
-                    color_scheme_observation,
-                    dependencies,
-                    duplicate_color_scheme_observation,
-                    duplicate_window_size_observation,
-                    duplicate_window_title,
-                    duplicate_window_visuals,
-                    view: View::from_kind(kind),
-                    window_size_observation,
-                    window_title,
-                    window_visuals,
-                }));
-            }
+        let ViewKind::Native(element) = render.view.as_kind() else {
+            return Ok(LocalComponentUpdate::Fallback(render));
         };
         if self.tree.kind(native)? != NodeKind::Native(element.kind())
             || !self.tree.children(native)?.is_empty()
@@ -351,18 +313,7 @@ impl<R: NativeRuntime> Pump<R> {
             || self.tree.node_window_title_bar(native).is_some()
             || element.window_title_bar().is_some()
         {
-            return Ok(LocalComponentUpdate::Fallback(ComponentRender {
-                color_scheme_observation,
-                dependencies,
-                duplicate_color_scheme_observation,
-                duplicate_window_size_observation,
-                duplicate_window_title,
-                duplicate_window_visuals,
-                view: View::native(element),
-                window_size_observation,
-                window_title,
-                window_visuals,
-            }));
+            return Ok(LocalComponentUpdate::Fallback(render));
         }
         let mut event_activity_matches = true;
         element.visit_events(&mut |event, active| {
@@ -374,19 +325,14 @@ impl<R: NativeRuntime> Pump<R> {
                 .is_some_and(|state| state.active == active);
         });
         if !event_activity_matches {
-            return Ok(LocalComponentUpdate::Fallback(ComponentRender {
-                color_scheme_observation,
-                dependencies,
-                duplicate_color_scheme_observation,
-                duplicate_window_size_observation,
-                duplicate_window_title,
-                duplicate_window_visuals,
-                view: View::native(element),
-                window_size_observation,
-                window_title,
-                window_visuals,
-            }));
+            return Ok(LocalComponentUpdate::Fallback(render));
         }
+        let ComponentRender {
+            dependencies, view, ..
+        } = render;
+        let ViewKind::Native(element) = view.into_kind() else {
+            unreachable!()
+        };
         let mut plan = UpdatePlan {
             reconcile_observations: self.native_observation_pending,
             ..UpdatePlan::new(self.identity)

--- a/crates/libs/reactor/src/native/winui/content_dialog.rs
+++ b/crates/libs/reactor/src/native/winui/content_dialog.rs
@@ -1,0 +1,409 @@
+use super::*;
+
+#[derive(Default)]
+pub(super) struct ContentDialogScheduler {
+    dialogs: HashMap<NodeId, ContentDialogLifecycle>,
+    next_generation: u64,
+    request_order: u64,
+    subscriptions: HashMap<NodeId, NativeSubscription>,
+}
+
+pub(super) enum ContentDialogAction {
+    None,
+    WaitForRoot(u64),
+    Hide(bindings::ContentDialog),
+}
+
+struct ContentDialogLifecycle {
+    dialog: bindings::ContentDialog,
+    desired_open: bool,
+    generation: u64,
+    pending: bool,
+    queued: bool,
+    request_order: u64,
+    retired: bool,
+    revision: u32,
+    root_loaded: Option<windows_core::EventRevoker>,
+    suppress_callback: bool,
+    xaml_root: Option<XamlRoot>,
+}
+
+#[cfg(feature = "test")]
+#[derive(Debug)]
+pub(crate) struct LiveContentDialogState {
+    pub(crate) desired_open: bool,
+    pub(crate) generation: u64,
+    pub(crate) node: NodeId,
+    pub(crate) pending: bool,
+    pub(crate) queued: bool,
+}
+
+impl ContentDialogScheduler {
+    pub(super) fn contains(&self, node: NodeId) -> bool {
+        self.dialogs.contains_key(&node)
+    }
+
+    pub(super) fn create(&mut self, node: NodeId, dialog: bindings::ContentDialog) {
+        self.next_generation += 1;
+        self.dialogs.insert(
+            node,
+            ContentDialogLifecycle {
+                dialog,
+                desired_open: false,
+                generation: self.next_generation,
+                pending: false,
+                queued: false,
+                request_order: 0,
+                retired: false,
+                revision: 0,
+                root_loaded: None,
+                suppress_callback: false,
+                xaml_root: None,
+            },
+        );
+    }
+
+    pub(super) fn set_open(
+        &mut self,
+        node: NodeId,
+        open: bool,
+        xaml_root: Option<XamlRoot>,
+    ) -> Result<ContentDialogAction, RuntimeError> {
+        let occupied = xaml_root
+            .as_ref()
+            .is_some_and(|root| self.root_occupied(root, Some(node)));
+        let state = self
+            .dialogs
+            .get_mut(&node)
+            .ok_or(RuntimeError::MissingNode(node))?;
+        if state.desired_open == open {
+            return Ok(ContentDialogAction::None);
+        }
+        state.desired_open = open;
+        if open {
+            if let Some(xaml_root) = xaml_root {
+                state.xaml_root = Some(xaml_root.clone());
+                state
+                    .dialog
+                    .cast::<IUIElement>()
+                    .and_then(|dialog| dialog.SetXamlRoot(&xaml_root))
+                    .map_err(native_error)?;
+            }
+            if state.xaml_root.is_none() {
+                self.request_order += 1;
+                state.request_order = self.request_order;
+                return Ok(ContentDialogAction::WaitForRoot(state.generation));
+            }
+            if state.pending || occupied {
+                state.queued = true;
+                self.request_order += 1;
+                state.request_order = self.request_order;
+            } else {
+                show(&state.dialog)?;
+                state.pending = true;
+            }
+        } else {
+            state.queued = false;
+            state.root_loaded = None;
+            if state.pending {
+                state.suppress_callback = true;
+                return Ok(ContentDialogAction::Hide(state.dialog.clone()));
+            }
+        }
+        Ok(ContentDialogAction::None)
+    }
+
+    pub(super) fn set_root_loaded(
+        &mut self,
+        node: NodeId,
+        loaded: windows_core::EventRevoker,
+    ) -> Result<(), RuntimeError> {
+        self.dialogs
+            .get_mut(&node)
+            .ok_or(RuntimeError::MissingNode(node))?
+            .root_loaded = Some(loaded);
+        Ok(())
+    }
+
+    pub(super) fn root_ready(
+        &mut self,
+        node: NodeId,
+        generation: u64,
+        xaml_root: XamlRoot,
+    ) -> Result<(), RuntimeError> {
+        let occupied = self.root_occupied(&xaml_root, Some(node));
+        let Some(state) = self.dialogs.get_mut(&node) else {
+            return Ok(());
+        };
+        if state.generation != generation || !state.desired_open || state.retired {
+            return Ok(());
+        }
+        state.xaml_root = Some(xaml_root.clone());
+        state
+            .dialog
+            .cast::<IUIElement>()
+            .and_then(|dialog| dialog.SetXamlRoot(&xaml_root))
+            .map_err(native_error)?;
+        if occupied {
+            state.queued = true;
+        } else {
+            show(&state.dialog)?;
+            state.pending = true;
+        }
+        Ok(())
+    }
+
+    pub(super) fn has_subscription(&self, node: NodeId) -> bool {
+        self.subscriptions.contains_key(&node)
+    }
+
+    pub(super) fn subscribe(
+        &mut self,
+        node: NodeId,
+        revision: u32,
+        subscription: NativeSubscription,
+    ) -> Result<(), RuntimeError> {
+        self.dialogs
+            .get_mut(&node)
+            .ok_or(RuntimeError::MissingNode(node))?
+            .revision = revision;
+        self.subscriptions.insert(node, subscription);
+        Ok(())
+    }
+
+    pub(super) fn unsubscribe(
+        &mut self,
+        node: NodeId,
+        event: EventId,
+    ) -> Result<bool, RuntimeError> {
+        let Some(state) = self.dialogs.get(&node) else {
+            return Ok(false);
+        };
+        if !state.pending {
+            self.subscriptions
+                .remove(&node)
+                .ok_or(RuntimeError::MissingSubscription(node, event))?;
+        }
+        Ok(true)
+    }
+
+    #[cfg(feature = "test")]
+    pub(super) fn subscription_count(&self) -> usize {
+        self.subscriptions.len()
+    }
+
+    #[cfg(feature = "test")]
+    pub(super) fn states(&self) -> Vec<LiveContentDialogState> {
+        let mut states = self
+            .dialogs
+            .iter()
+            .map(|(node, state)| LiveContentDialogState {
+                desired_open: state.desired_open,
+                generation: state.generation,
+                node: *node,
+                pending: state.pending,
+                queued: state.queued,
+            })
+            .collect::<Vec<_>>();
+        states.sort_unstable_by_key(|state| state.generation);
+        states
+    }
+
+    #[cfg(feature = "test")]
+    pub(super) fn dialog(&self, node: NodeId) -> Result<bindings::ContentDialog, RuntimeError> {
+        Ok(self
+            .dialogs
+            .get(&node)
+            .ok_or(RuntimeError::MissingNode(node))?
+            .dialog
+            .clone())
+    }
+
+    fn root_occupied(&self, root: &XamlRoot, except: Option<NodeId>) -> bool {
+        self.dialogs.iter().any(|(node, state)| {
+            Some(*node) != except
+                && state.pending
+                && state
+                    .xaml_root
+                    .as_ref()
+                    .is_some_and(|current| current == root)
+        })
+    }
+}
+
+pub(super) fn reset(scheduler: &Rc<RefCell<ContentDialogScheduler>>) {
+    let dialogs = {
+        let mut scheduler = scheduler.borrow_mut();
+        let dialogs = scheduler
+            .dialogs
+            .drain()
+            .map(|(_, state)| state)
+            .collect::<Vec<_>>();
+        scheduler.subscriptions.clear();
+        scheduler.request_order = 0;
+        dialogs
+    };
+    for state in dialogs {
+        if state.pending {
+            _ = state.dialog.Hide();
+        }
+    }
+}
+
+pub(super) fn retire(scheduler: &Rc<RefCell<ContentDialogScheduler>>, node: NodeId) {
+    let retain = {
+        let mut scheduler = scheduler.borrow_mut();
+        if let Some(dialog) = scheduler.dialogs.get_mut(&node) {
+            if dialog.pending {
+                dialog.retired = true;
+                true
+            } else {
+                scheduler.dialogs.remove(&node);
+                false
+            }
+        } else {
+            false
+        }
+    };
+    if !retain {
+        scheduler.borrow_mut().subscriptions.remove(&node);
+    }
+}
+
+pub(super) fn closed(
+    scheduler: &Rc<RefCell<ContentDialogScheduler>>,
+    sink: &EventSink,
+    node: NodeId,
+) -> Result<bool, RuntimeError> {
+    let (xaml_root, invoke_callback, retired) = {
+        let mut scheduler = scheduler.borrow_mut();
+        let Some(state) = scheduler.dialogs.get_mut(&node) else {
+            return Ok(false);
+        };
+        if !state.pending {
+            return Ok(false);
+        }
+        state.pending = false;
+        let invoke_callback = !state.suppress_callback;
+        state.suppress_callback = false;
+        (state.xaml_root.clone(), invoke_callback, state.retired)
+    };
+
+    let candidate = if let Some(root) = xaml_root.as_ref() {
+        scheduler
+            .borrow()
+            .dialogs
+            .iter()
+            .filter(|(_, state)| {
+                state.queued
+                    && state.desired_open
+                    && !state.retired
+                    && state
+                        .xaml_root
+                        .as_ref()
+                        .is_some_and(|current| current == root)
+            })
+            .min_by_key(|(_, state)| state.request_order)
+            .map(|(node, state)| (*node, state.generation))
+    } else {
+        None
+    };
+    if let Some((candidate, generation)) = candidate {
+        let callback_sink = sink.clone();
+        let candidate_root = xaml_root.unwrap();
+        let handler = DispatcherQueueHandler::new(move || {
+            if callback_sink.current_identity.get() != Some(callback_sink.identity) {
+                return;
+            }
+            let (candidate, result) = {
+                let mut scheduler = callback_sink.content_dialogs.borrow_mut();
+                if scheduler.root_occupied(&candidate_root, None) {
+                    return;
+                }
+                let candidate = scheduler
+                    .dialogs
+                    .get(&candidate)
+                    .filter(|state| {
+                        state.generation == generation
+                            && state.desired_open
+                            && !state.retired
+                            && !state.pending
+                            && state.queued
+                            && state
+                                .xaml_root
+                                .as_ref()
+                                .is_some_and(|root| root == &candidate_root)
+                    })
+                    .map(|_| candidate)
+                    .or_else(|| {
+                        scheduler
+                            .dialogs
+                            .iter()
+                            .filter(|(_, state)| {
+                                state.desired_open
+                                    && !state.retired
+                                    && !state.pending
+                                    && state.queued
+                                    && state
+                                        .xaml_root
+                                        .as_ref()
+                                        .is_some_and(|root| root == &candidate_root)
+                            })
+                            .min_by_key(|(_, state)| state.request_order)
+                            .map(|(node, _)| *node)
+                    });
+                let Some(candidate) = candidate else {
+                    return;
+                };
+                let state = scheduler.dialogs.get_mut(&candidate).unwrap();
+                state.queued = false;
+                (
+                    candidate,
+                    state.dialog.ShowAsync().map(|_| {
+                        state.pending = true;
+                    }),
+                )
+            };
+            if let Err(error) = result {
+                let revision = callback_sink
+                    .content_dialogs
+                    .borrow()
+                    .dialogs
+                    .get(&candidate)
+                    .map_or(0, |state| state.revision);
+                callback_sink.error(
+                    candidate,
+                    EventId::ContentDialogClosed,
+                    revision,
+                    native_error(error),
+                );
+            }
+        });
+        match sink
+            .dispatcher
+            .TryEnqueueWithPriority(DispatcherQueuePriority::Normal, &handler)
+        {
+            Ok(true) => {}
+            Ok(false) => return Err(RuntimeError::DispatcherRejected),
+            Err(error) => return Err(native_error(error)),
+        }
+    }
+    if retired {
+        scheduler.borrow_mut().dialogs.remove(&node);
+        scheduler.borrow_mut().subscriptions.remove(&node);
+    }
+    Ok(invoke_callback)
+}
+
+fn show(dialog: &bindings::ContentDialog) -> Result<(), RuntimeError> {
+    match dialog.ShowAsync() {
+        Ok(operation) => {
+            drop(operation);
+            Ok(())
+        }
+        // WinUI may return S_OK without an async handle. The Closed event owns completion, so
+        // the runtime does not depend on that handle.
+        Err(error) if error.code().is_ok() => Ok(()),
+        Err(error) => Err(native_error(error)),
+    }
+}

--- a/crates/libs/reactor/src/native/winui/mod.rs
+++ b/crates/libs/reactor/src/native/winui/mod.rs
@@ -47,6 +47,10 @@ mod bindings;
 pub use bindings::*;
 mod app_shim;
 pub use app_shim::*;
+mod content_dialog;
+#[cfg(feature = "test")]
+pub(crate) use content_dialog::LiveContentDialogState;
+use content_dialog::{ContentDialogAction, ContentDialogScheduler};
 mod element_factory;
 #[allow(unused_qualifications)]
 mod generated;
@@ -91,10 +95,7 @@ pub struct WinUiRuntime {
     encoded_image_nodes: Rc<RefCell<HashSet<NodeId>>>,
     feedback: Rc<RefCell<HashMap<(NodeId, EventId), FeedbackExpectation>>>,
     controlled_collection_indices: HashMap<NodeId, i32>,
-    content_dialogs: Rc<RefCell<HashMap<NodeId, ContentDialogLifecycle>>>,
-    content_dialog_request_order: u64,
-    content_dialog_subscriptions: Rc<RefCell<HashMap<NodeId, NativeSubscription>>>,
-    next_content_dialog_generation: u64,
+    content_dialogs: Rc<RefCell<ContentDialogScheduler>>,
     drop_policies: Rc<RefCell<HashMap<NodeId, DragDropPolicy>>>,
     flyouts: HashMap<NodeId, (bindings::Flyout, NodeId)>,
     owned_menus: HashMap<NodeId, NativeOwnedMenu>,
@@ -109,7 +110,7 @@ pub struct WinUiRuntime {
     retained_subtrees: HashMap<NodeId, NativeRetainedSubtree>,
     scheduler: Rc<RefCell<SchedulerState>>,
     image_decode_tickets: HashMap<NodeId, u64>,
-    image_scale_subscriptions: HashMap<(NodeId, u64), ImageScaleSubscriptions>,
+    image_scale_subscriptions: HashMap<(NodeId, u64), XamlRootScaleSubscriptions>,
     swap_chain_panel_subscriptions: HashMap<(NodeId, u64), SwapChainPanelSubscriptions>,
     subscriptions: HashMap<(NodeId, EventId), NativeSubscription>,
     theme_styles: HashMap<(MountedKind, ThemeStyle), Style>,
@@ -127,30 +128,6 @@ pub struct WinUiRuntime {
     pending_application: Option<Application>,
     #[cfg(feature = "test")]
     native_apply_times_us: Vec<f64>,
-}
-
-struct ContentDialogLifecycle {
-    dialog: bindings::ContentDialog,
-    desired_open: bool,
-    generation: u64,
-    pending: bool,
-    queued: bool,
-    request_order: u64,
-    retired: bool,
-    revision: u32,
-    root_loaded: Option<windows_core::EventRevoker>,
-    suppress_callback: bool,
-    xaml_root: Option<XamlRoot>,
-}
-
-#[cfg(feature = "test")]
-#[derive(Debug)]
-pub(crate) struct LiveContentDialogState {
-    pub(crate) desired_open: bool,
-    pub(crate) generation: u64,
-    pub(crate) node: NodeId,
-    pub(crate) pending: bool,
-    pub(crate) queued: bool,
 }
 
 struct WebViewInitialization {
@@ -179,14 +156,13 @@ struct SwapChainPanelSubscriptions {
     _size: windows_core::EventRevoker,
 }
 
-struct ImageScaleSubscriptions {
+struct XamlRootScaleSubscriptions {
     _changed: Rc<RefCell<Option<windows_core::EventRevoker>>>,
     _loaded: windows_core::EventRevoker,
 }
 
 struct CompositionHostSubscriptions {
-    _changed: Rc<RefCell<Option<windows_core::EventRevoker>>>,
-    _loaded: windows_core::EventRevoker,
+    _root: XamlRootScaleSubscriptions,
     _size: windows_core::EventRevoker,
 }
 
@@ -425,19 +401,6 @@ fn build_menu_items(
         output.Append(&native).map_err(native_error)?;
     }
     Ok(())
-}
-
-fn show_content_dialog(dialog: &bindings::ContentDialog) -> Result<(), RuntimeError> {
-    match dialog.ShowAsync() {
-        Ok(operation) => {
-            drop(operation);
-            Ok(())
-        }
-        // WinUI may return S_OK without an async handle. The Closed event owns completion, so
-        // the runtime does not depend on that handle.
-        Err(error) if error.code().is_ok() => Ok(()),
-        Err(error) => Err(native_error(error)),
-    }
 }
 
 fn set_rich_edit_text(control: &bindings::RichEditBox, value: &str) -> Result<(), RuntimeError> {
@@ -696,36 +659,17 @@ impl WinUiRuntime {
 
     #[cfg(feature = "test")]
     pub fn live_event_subscription_count(&self) -> usize {
-        self.subscriptions.len() + self.content_dialog_subscriptions.borrow().len()
+        self.subscriptions.len() + self.content_dialogs.borrow().subscription_count()
     }
 
     #[cfg(feature = "test")]
     pub(crate) fn live_content_dialog_states(&self) -> Vec<LiveContentDialogState> {
-        let mut states = self
-            .content_dialogs
-            .borrow()
-            .iter()
-            .map(|(node, state)| LiveContentDialogState {
-                desired_open: state.desired_open,
-                generation: state.generation,
-                node: *node,
-                pending: state.pending,
-                queued: state.queued,
-            })
-            .collect::<Vec<_>>();
-        states.sort_unstable_by_key(|state| state.generation);
-        states
+        self.content_dialogs.borrow().states()
     }
 
     #[cfg(feature = "test")]
     pub(crate) fn live_hide_content_dialog(&self, node: NodeId) -> Result<(), RuntimeError> {
-        let dialog = self
-            .content_dialogs
-            .borrow()
-            .get(&node)
-            .ok_or(RuntimeError::MissingNode(node))?
-            .dialog
-            .clone();
+        let dialog = self.content_dialogs.borrow().dialog(node)?;
         dialog.Hide().map_err(native_error)
     }
 
@@ -1398,23 +1342,9 @@ impl WinUiRuntime {
                 }
                 let handle = Handle::create(*kind)?;
                 if let Handle::ContentDialog(dialog) = &handle {
-                    self.next_content_dialog_generation += 1;
-                    self.content_dialogs.borrow_mut().insert(
-                        *node,
-                        ContentDialogLifecycle {
-                            dialog: dialog.clone(),
-                            desired_open: false,
-                            generation: self.next_content_dialog_generation,
-                            pending: false,
-                            queued: false,
-                            request_order: 0,
-                            retired: false,
-                            revision: 0,
-                            root_loaded: None,
-                            suppress_callback: false,
-                            xaml_root: None,
-                        },
-                    );
+                    self.content_dialogs
+                        .borrow_mut()
+                        .create(*node, dialog.clone());
                 }
                 self.handles.insert(*node, handle);
             }
@@ -1649,7 +1579,7 @@ impl WinUiRuntime {
                         scale_x: control.CompositionScaleX().unwrap_or(1.0),
                         scale_y: control.CompositionScaleY().unwrap_or(1.0),
                     };
-                    invoke_surface_callback(callback, event);
+                    invoke_callback(callback, event);
                 };
                 emit_metrics(
                     element.ActualWidth().unwrap_or(0.0),
@@ -1663,7 +1593,7 @@ impl WinUiRuntime {
                         if let Some(args) = args.as_ref()
                             && let Ok(value) = args.NewSize()
                         {
-                            invoke_surface_callback(
+                            invoke_callback(
                                 &size_callback,
                                 SwapChainPanelEvent::Metrics {
                                     width: f64::from(value.width),
@@ -1680,7 +1610,7 @@ impl WinUiRuntime {
                 let scale = control
                     .CompositionScaleChanged(move |sender, _| {
                         if let Some(sender) = sender.as_ref() {
-                            invoke_surface_callback(
+                            invoke_callback(
                                 &scale_callback,
                                 SwapChainPanelEvent::Metrics {
                                     width: scale_element.ActualWidth().unwrap_or(0.0),
@@ -1694,7 +1624,7 @@ impl WinUiRuntime {
                     .map_err(native_error)?;
                 let rendering_callback = callback.clone();
                 let rendering = CompositionTarget::Rendering(move |_, _| {
-                    invoke_surface_callback(&rendering_callback, SwapChainPanelEvent::Rendering);
+                    invoke_callback(&rendering_callback, SwapChainPanelEvent::Rendering);
                 })
                 .map_err(native_error)?;
                 self.swap_chain_panel_subscriptions.insert(
@@ -1760,31 +1690,14 @@ impl WinUiRuntime {
                 };
                 let element = control.cast::<UIElement>().map_err(native_error)?;
                 let framework = control.cast::<IFrameworkElement>().map_err(native_error)?;
-                let changed = Rc::new(RefCell::new(None));
                 let sink = self.event_sink()?;
-                observe_image_scale(&element, callback, &changed, &sink)?;
-                let loaded_element = element;
-                let loaded_callback = callback.clone();
-                let loaded_changed = changed.clone();
-                let loaded = framework
-                    .Loaded(move |_, _| {
-                        if let Err(error) = observe_image_scale(
-                            &loaded_element,
-                            &loaded_callback,
-                            &loaded_changed,
-                            &sink,
-                        ) {
-                            sink.enqueue_host(HostEvent::Error(error));
-                        }
-                    })
-                    .map_err(native_error)?;
-                self.image_scale_subscriptions.insert(
-                    (*node, *observation),
-                    ImageScaleSubscriptions {
-                        _changed: changed,
-                        _loaded: loaded,
-                    },
-                );
+                let scale_callback = callback.clone();
+                let subscriptions =
+                    subscribe_xaml_root_scale(&element, &framework, &sink, move |scale| {
+                        invoke_callback(&scale_callback, scale);
+                    })?;
+                self.image_scale_subscriptions
+                    .insert((*node, *observation), subscriptions);
             }
             Command::ObserveCompositionHost {
                 node,
@@ -1805,7 +1718,7 @@ impl WinUiRuntime {
                     .map_err(native_error)?
                     .Compositor()
                     .map_err(native_error)?;
-                invoke_composition_host_callback(
+                invoke_callback(
                     callback,
                     CompositionHostEvent::Ready {
                         compositor: compositor.into(),
@@ -1831,7 +1744,7 @@ impl WinUiRuntime {
                                     return;
                                 }
                             };
-                            invoke_composition_host_callback(
+                            invoke_callback(
                                 &size_callback,
                                 CompositionHostEvent::Metrics {
                                     width: f64::from(value.width),
@@ -1843,31 +1756,22 @@ impl WinUiRuntime {
                     })
                     .map_err(native_error)?;
 
-                let changed = Rc::new(RefCell::new(None));
-                observe_composition_root(&element, &framework, callback, &changed, &sink)?;
-                let loaded_element = element;
-                let loaded_framework = framework;
-                let loaded_callback = callback.clone();
-                let loaded_changed = changed.clone();
-                let loaded = loaded_framework
-                    .clone()
-                    .Loaded(move |_, _| {
-                        if let Err(error) = observe_composition_root(
-                            &loaded_element,
-                            &loaded_framework,
-                            &loaded_callback,
-                            &loaded_changed,
-                            &sink,
-                        ) {
-                            sink.enqueue_host(HostEvent::Error(error));
-                        }
-                    })
-                    .map_err(native_error)?;
+                let scale_callback = callback.clone();
+                let scale_framework = framework.clone();
+                let root = subscribe_xaml_root_scale(&element, &framework, &sink, move |scale| {
+                    invoke_callback(
+                        &scale_callback,
+                        CompositionHostEvent::Metrics {
+                            width: scale_framework.ActualWidth().unwrap_or(0.0),
+                            height: scale_framework.ActualHeight().unwrap_or(0.0),
+                            scale,
+                        },
+                    );
+                })?;
                 self.composition_host_subscriptions.insert(
                     (*node, *observation),
                     CompositionHostSubscriptions {
-                        _changed: changed,
-                        _loaded: loaded,
+                        _root: root,
                         _size: size,
                     },
                 );
@@ -2127,13 +2031,10 @@ impl WinUiRuntime {
                 revision,
             } => {
                 let content_dialog_closed = *event == EventId::ContentDialogClosed
-                    && self.content_dialogs.borrow().contains_key(node);
+                    && self.content_dialogs.borrow().contains(*node);
                 if self.subscriptions.contains_key(&(*node, *event))
                     || content_dialog_closed
-                        && self
-                            .content_dialog_subscriptions
-                            .borrow()
-                            .contains_key(node)
+                        && self.content_dialogs.borrow().has_subscription(*node)
                 {
                     return Err(RuntimeError::DuplicateEvent(*node, *event));
                 }
@@ -2146,27 +2047,18 @@ impl WinUiRuntime {
                 if content_dialog_closed {
                     self.content_dialogs
                         .borrow_mut()
-                        .get_mut(node)
-                        .unwrap()
-                        .revision = *revision;
-                    self.content_dialog_subscriptions
-                        .borrow_mut()
-                        .insert(*node, revoker);
+                        .subscribe(*node, *revision, revoker)?;
                 } else {
                     self.subscriptions.insert((*node, *event), revoker);
                 }
             }
             Command::UnsubscribeEvent { node, event } => {
                 if *event == EventId::ContentDialogClosed
-                    && self.content_dialogs.borrow().contains_key(node)
+                    && self
+                        .content_dialogs
+                        .borrow_mut()
+                        .unsubscribe(*node, *event)?
                 {
-                    let pending = self.content_dialogs.borrow()[node].pending;
-                    if !pending {
-                        self.content_dialog_subscriptions
-                            .borrow_mut()
-                            .remove(node)
-                            .ok_or(RuntimeError::MissingSubscription(*node, *event))?;
-                    }
                     return Ok(());
                 }
                 let revoker = self
@@ -2467,38 +2359,13 @@ impl WinUiRuntime {
                     Err(error) if error.code().is_ok() => None,
                     Err(error) => return Err(native_error(error)),
                 };
-                let occupied = xaml_root.as_ref().is_some_and(|root| {
-                    self.content_dialogs.borrow().iter().any(|(other, state)| {
-                        other != node
-                            && state.pending
-                            && state
-                                .xaml_root
-                                .as_ref()
-                                .is_some_and(|current| current == root)
-                    })
-                });
-                let mut dialogs = self.content_dialogs.borrow_mut();
-                let state = dialogs
-                    .get_mut(node)
-                    .ok_or(RuntimeError::MissingNode(*node))?;
-                if state.desired_open == *open {
-                    return Ok(());
-                }
-                state.desired_open = *open;
-                if *open {
-                    if let Some(xaml_root) = xaml_root {
-                        state.xaml_root = Some(xaml_root.clone());
-                        state
-                            .dialog
-                            .cast::<IUIElement>()
-                            .and_then(|dialog| dialog.SetXamlRoot(&xaml_root))
-                            .map_err(native_error)?;
-                    }
-                    if state.xaml_root.is_none() {
-                        self.content_dialog_request_order += 1;
-                        state.request_order = self.content_dialog_request_order;
-                        let generation = state.generation;
-                        drop(dialogs);
+                let action = self
+                    .content_dialogs
+                    .borrow_mut()
+                    .set_open(*node, *open, xaml_root)?;
+                match action {
+                    ContentDialogAction::None => {}
+                    ContentDialogAction::WaitForRoot(generation) => {
                         let sink = self.event_sink()?;
                         let loaded_owner = owner.unwrap();
                         let owner = loaded_owner
@@ -2523,30 +2390,11 @@ impl WinUiRuntime {
                                 ),
                             })
                             .map_err(native_error)?;
-                        let mut dialogs = self.content_dialogs.borrow_mut();
-                        let state = dialogs
-                            .get_mut(node)
-                            .ok_or(RuntimeError::MissingNode(*node))?;
-                        state.root_loaded = Some(loaded);
-                    } else if state.pending || occupied {
-                        state.queued = true;
-                        self.content_dialog_request_order += 1;
-                        state.request_order = self.content_dialog_request_order;
-                    } else {
-                        show_content_dialog(&state.dialog)?;
-                        state.pending = true;
+                        self.content_dialogs
+                            .borrow_mut()
+                            .set_root_loaded(*node, loaded)?;
                     }
-                } else {
-                    state.queued = false;
-                    state.root_loaded = None;
-                    let hide = if state.pending {
-                        state.suppress_callback = true;
-                        Some(state.dialog.clone())
-                    } else {
-                        None
-                    };
-                    drop(dialogs);
-                    if let Some(dialog) = hide {
+                    ContentDialogAction::Hide(dialog) => {
                         dialog.Hide().map_err(native_error)?;
                     }
                 }
@@ -2599,6 +2447,24 @@ impl WinUiRuntime {
                 .is_some_and(|(application, _)| *application == node)
     }
 
+    fn window_children(
+        &self,
+        node: NodeId,
+    ) -> Result<Option<(&bindings::Grid, UIElementCollection)>, RuntimeError> {
+        if !self.windows.contains_key(&node) {
+            return Ok(None);
+        }
+        let host = self
+            .window_hosts
+            .get(&node)
+            .ok_or(RuntimeError::MissingNode(node))?;
+        let children = host
+            .cast::<IPanel>()
+            .and_then(|host| host.Children())
+            .map_err(native_error)?;
+        Ok(Some((host, children)))
+    }
+
     fn insert_child(
         &mut self,
         parent: NodeId,
@@ -2611,14 +2477,8 @@ impl WinUiRuntime {
             if index != 0 {
                 return Err(RuntimeError::IndexOutOfBounds);
             }
-            let host = self
-                .window_hosts
-                .get(&parent)
-                .ok_or(RuntimeError::MissingNode(parent))?;
-            host.cast::<IPanel>()
-                .and_then(|host| host.Children())
-                .and_then(|children| children.Append(&child))
-                .map_err(native_error)?;
+            let (host, children) = self.window_children(parent)?.unwrap();
+            children.Append(&child).map_err(native_error)?;
             if let Some(visuals) = self.window_visuals.get(&parent) {
                 Self::apply_window_theme(host, visuals.theme)?;
             }
@@ -2914,14 +2774,8 @@ impl WinUiRuntime {
     fn remove_child(&mut self, parent: NodeId, child: NodeId) -> Result<(), RuntimeError> {
         let child_id = child;
         let child = self.ui_element(child)?;
-        if self.windows.contains_key(&parent) {
-            self.window_hosts
-                .get(&parent)
-                .ok_or(RuntimeError::MissingNode(parent))?
-                .cast::<IPanel>()
-                .and_then(|host| host.Children())
-                .and_then(|children| children.Clear())
-                .map_err(native_error)?;
+        if let Some((_, children)) = self.window_children(parent)? {
+            children.Clear().map_err(native_error)?;
             Ok(())
         } else {
             let parent = self
@@ -2940,14 +2794,8 @@ impl WinUiRuntime {
     }
 
     fn reset_children(&mut self, parent: NodeId) -> Result<(), RuntimeError> {
-        if self.windows.contains_key(&parent) {
-            self.window_hosts
-                .get(&parent)
-                .ok_or(RuntimeError::MissingNode(parent))?
-                .cast::<IPanel>()
-                .and_then(|host| host.Children())
-                .and_then(|children| children.Clear())
-                .map_err(native_error)?;
+        if let Some((_, children)) = self.window_children(parent)? {
+            children.Clear().map_err(native_error)?;
             Ok(())
         } else {
             let parent = self
@@ -3130,7 +2978,6 @@ impl WinUiRuntime {
             encoded_image_nodes: Rc::clone(&self.encoded_image_nodes),
             feedback: Rc::clone(&self.feedback),
             content_dialogs: Rc::clone(&self.content_dialogs),
-            content_dialog_subscriptions: Rc::clone(&self.content_dialog_subscriptions),
             pointer_capture: Rc::clone(&self.pointer_capture),
             selection_items: Rc::clone(&self.selection_items),
             dispatcher,
@@ -3212,8 +3059,7 @@ pub struct EventSink {
     drop_policies: Rc<RefCell<HashMap<NodeId, DragDropPolicy>>>,
     encoded_image_nodes: Rc<RefCell<HashSet<NodeId>>>,
     feedback: Rc<RefCell<HashMap<(NodeId, EventId), FeedbackExpectation>>>,
-    content_dialogs: Rc<RefCell<HashMap<NodeId, ContentDialogLifecycle>>>,
-    content_dialog_subscriptions: Rc<RefCell<HashMap<NodeId, NativeSubscription>>>,
+    content_dialogs: Rc<RefCell<ContentDialogScheduler>>,
     pointer_capture: Rc<RefCell<HashMap<NodeId, bool>>>,
     selection_items: Rc<RefCell<Vec<(NodeId, windows_core::IInspectable)>>>,
     dispatcher: DispatcherQueue,
@@ -3342,34 +3188,9 @@ impl EventSink {
         generation: u64,
         xaml_root: XamlRoot,
     ) -> Result<(), RuntimeError> {
-        let occupied = self.content_dialogs.borrow().iter().any(|(other, state)| {
-            *other != node
-                && state.pending
-                && state
-                    .xaml_root
-                    .as_ref()
-                    .is_some_and(|current| current == &xaml_root)
-        });
-        let mut dialogs = self.content_dialogs.borrow_mut();
-        let Some(state) = dialogs.get_mut(&node) else {
-            return Ok(());
-        };
-        if state.generation != generation || !state.desired_open || state.retired {
-            return Ok(());
-        }
-        state.xaml_root = Some(xaml_root.clone());
-        state
-            .dialog
-            .cast::<IUIElement>()
-            .and_then(|dialog| dialog.SetXamlRoot(&xaml_root))
-            .map_err(native_error)?;
-        if occupied {
-            state.queued = true;
-        } else {
-            show_content_dialog(&state.dialog)?;
-            state.pending = true;
-        }
-        Ok(())
+        self.content_dialogs
+            .borrow_mut()
+            .root_ready(node, generation, xaml_root)
     }
 
     pub fn content_dialog_closed(
@@ -3377,126 +3198,7 @@ impl EventSink {
         node: NodeId,
         _revision: u32,
     ) -> Result<bool, RuntimeError> {
-        let (xaml_root, invoke_callback, retired) = {
-            let mut dialogs = self.content_dialogs.borrow_mut();
-            let Some(state) = dialogs.get_mut(&node) else {
-                return Ok(false);
-            };
-            if !state.pending {
-                return Ok(false);
-            }
-            state.pending = false;
-            let invoke_callback = !state.suppress_callback;
-            state.suppress_callback = false;
-            (state.xaml_root.clone(), invoke_callback, state.retired)
-        };
-
-        let candidate = if let Some(root) = xaml_root.as_ref() {
-            self.content_dialogs
-                .borrow()
-                .iter()
-                .filter(|(_, state)| {
-                    state.queued
-                        && state.desired_open
-                        && !state.retired
-                        && state
-                            .xaml_root
-                            .as_ref()
-                            .is_some_and(|current| current == root)
-                })
-                .min_by_key(|(_, state)| state.request_order)
-                .map(|(node, state)| (*node, state.generation))
-        } else {
-            None
-        };
-        if let Some((candidate, generation)) = candidate {
-            let sink = self.clone();
-            let candidate_root = xaml_root.unwrap();
-            let handler = DispatcherQueueHandler::new(move || {
-                if sink.current_identity.get() != Some(sink.identity) {
-                    return;
-                }
-                let (candidate, result) = {
-                    let mut dialogs = sink.content_dialogs.borrow_mut();
-                    if dialogs.iter().any(|(_, state)| {
-                        state.pending
-                            && state
-                                .xaml_root
-                                .as_ref()
-                                .is_some_and(|current| current == &candidate_root)
-                    }) {
-                        return;
-                    }
-                    let candidate = dialogs
-                        .get(&candidate)
-                        .filter(|state| {
-                            state.generation == generation
-                                && state.desired_open
-                                && !state.retired
-                                && !state.pending
-                                && state.queued
-                                && state
-                                    .xaml_root
-                                    .as_ref()
-                                    .is_some_and(|root| root == &candidate_root)
-                        })
-                        .map(|_| candidate)
-                        .or_else(|| {
-                            dialogs
-                                .iter()
-                                .filter(|(_, state)| {
-                                    state.desired_open
-                                        && !state.retired
-                                        && !state.pending
-                                        && state.queued
-                                        && state
-                                            .xaml_root
-                                            .as_ref()
-                                            .is_some_and(|root| root == &candidate_root)
-                                })
-                                .min_by_key(|(_, state)| state.request_order)
-                                .map(|(node, _)| *node)
-                        });
-                    let Some(candidate) = candidate else {
-                        return;
-                    };
-                    let state = dialogs.get_mut(&candidate).unwrap();
-                    state.queued = false;
-                    (
-                        candidate,
-                        state.dialog.ShowAsync().map(|_| {
-                            state.pending = true;
-                        }),
-                    )
-                };
-                if let Err(error) = result {
-                    let revision = sink
-                        .content_dialogs
-                        .borrow()
-                        .get(&candidate)
-                        .map_or(0, |state| state.revision);
-                    sink.error(
-                        candidate,
-                        EventId::ContentDialogClosed,
-                        revision,
-                        native_error(error),
-                    );
-                }
-            });
-            match self
-                .dispatcher
-                .TryEnqueueWithPriority(DispatcherQueuePriority::Normal, &handler)
-            {
-                Ok(true) => {}
-                Ok(false) => return Err(RuntimeError::DispatcherRejected),
-                Err(error) => return Err(native_error(error)),
-            }
-        }
-        if retired {
-            self.content_dialogs.borrow_mut().remove(&node);
-            self.content_dialog_subscriptions.borrow_mut().remove(&node);
-        }
-        Ok(invoke_callback)
+        content_dialog::closed(&self.content_dialogs, self, node)
     }
 
     pub fn selection_item(&self, selected: &windows_core::IInspectable) -> Option<NodeId> {
@@ -4096,19 +3798,7 @@ impl NativeRuntime for WinUiRuntime {
         self.composition_host_subscriptions.clear();
         self.owned_menus.clear();
         self.command_bar_flyouts.clear();
-        let dialogs = self
-            .content_dialogs
-            .borrow_mut()
-            .drain()
-            .map(|(_, state)| state)
-            .collect::<Vec<_>>();
-        self.content_dialog_subscriptions.borrow_mut().clear();
-        self.content_dialog_request_order = 0;
-        for state in dialogs {
-            if state.pending {
-                _ = state.dialog.Hide();
-            }
-        }
+        content_dialog::reset(&self.content_dialogs);
         for (target, (flyout, _)) in self.flyouts.drain() {
             _ = flyout.SetContent(None::<&UIElement>);
             match self.handles.get(&target) {
@@ -4560,23 +4250,7 @@ impl WinUiRuntime {
         if self.resource_override_keys.contains_key(&node) {
             self.clear_resource_overrides(node)?;
         }
-        let retain_dialog = {
-            let mut dialogs = self.content_dialogs.borrow_mut();
-            if let Some(dialog) = dialogs.get_mut(&node) {
-                if dialog.pending {
-                    dialog.retired = true;
-                    true
-                } else {
-                    dialogs.remove(&node);
-                    false
-                }
-            } else {
-                false
-            }
-        };
-        if !retain_dialog {
-            self.content_dialog_subscriptions.borrow_mut().remove(&node);
-        }
+        content_dialog::retire(&self.content_dialogs, node);
         self.selection_owners
             .retain(|child, (parent, _)| *child != node && *parent != node);
         self.selection_items
@@ -4722,32 +4396,66 @@ fn native_error(error: windows_core::Error) -> RuntimeError {
     RuntimeError::Native(error.code().0)
 }
 
-fn invoke_surface_callback(callback: &Callback<SwapChainPanelEvent>, event: SwapChainPanelEvent) {
-    if std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| callback.call(event))).is_err() {
+fn invoke_callback<T>(callback: &Callback<T>, value: T) {
+    if std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| callback.call(value))).is_err() {
         std::process::abort();
     }
 }
 
-fn observe_image_scale(
+fn subscribe_xaml_root_scale<F>(
     element: &UIElement,
-    callback: &Callback<f64>,
+    framework: &IFrameworkElement,
+    sink: &EventSink,
+    callback: F,
+) -> Result<XamlRootScaleSubscriptions, RuntimeError>
+where
+    F: Clone + Fn(f64) + 'static,
+{
+    let changed = Rc::new(RefCell::new(None));
+    observe_xaml_root_scale(element, &changed, sink, callback.clone())?;
+    let loaded_element = element.clone();
+    let loaded_changed = changed.clone();
+    let loaded_sink = sink.clone();
+    let loaded = framework
+        .Loaded(move |_, _| {
+            if let Err(error) = observe_xaml_root_scale(
+                &loaded_element,
+                &loaded_changed,
+                &loaded_sink,
+                callback.clone(),
+            ) {
+                loaded_sink.enqueue_host(HostEvent::Error(error));
+            }
+        })
+        .map_err(native_error)?;
+    Ok(XamlRootScaleSubscriptions {
+        _changed: changed,
+        _loaded: loaded,
+    })
+}
+
+fn observe_xaml_root_scale<F>(
+    element: &UIElement,
     changed: &Rc<RefCell<Option<windows_core::EventRevoker>>>,
     sink: &EventSink,
-) -> Result<(), RuntimeError> {
+    callback: F,
+) -> Result<(), RuntimeError>
+where
+    F: Fn(f64) + 'static,
+{
     let root = match element.XamlRoot() {
         Ok(root) => root,
         Err(error) if error.code().is_ok() => return Ok(()),
         Err(error) => return Err(native_error(error)),
     };
     let scale = root.RasterizationScale().map_err(native_error)?;
-    invoke_image_scale_callback(callback, scale);
-    let changed_callback = callback.clone();
+    callback(scale);
     let changed_sink = sink.clone();
     let revoker = root
         .Changed(move |sender, _| {
             if let Some(sender) = sender.as_ref() {
                 match sender.RasterizationScale() {
-                    Ok(scale) => invoke_image_scale_callback(&changed_callback, scale),
+                    Ok(scale) => callback(scale),
                     Err(error) => {
                         changed_sink.enqueue_host(HostEvent::Error(native_error(error)));
                     }
@@ -4764,68 +4472,6 @@ fn xaml_scale(element: &UIElement) -> Result<f64, RuntimeError> {
         Ok(root) => root.RasterizationScale().map_err(native_error),
         Err(error) if error.code().is_ok() => Ok(1.0),
         Err(error) => Err(native_error(error)),
-    }
-}
-
-fn observe_composition_root(
-    element: &UIElement,
-    framework: &IFrameworkElement,
-    callback: &Callback<CompositionHostEvent>,
-    changed: &Rc<RefCell<Option<windows_core::EventRevoker>>>,
-    sink: &EventSink,
-) -> Result<(), RuntimeError> {
-    let root = match element.XamlRoot() {
-        Ok(root) => root,
-        Err(error) if error.code().is_ok() => return Ok(()),
-        Err(error) => return Err(native_error(error)),
-    };
-    let scale = root.RasterizationScale().map_err(native_error)?;
-    invoke_composition_host_callback(
-        callback,
-        CompositionHostEvent::Metrics {
-            width: framework.ActualWidth().unwrap_or(0.0),
-            height: framework.ActualHeight().unwrap_or(0.0),
-            scale,
-        },
-    );
-    let changed_callback = callback.clone();
-    let changed_framework = framework.clone();
-    let changed_sink = sink.clone();
-    let revoker = root
-        .Changed(move |sender, _| {
-            if let Some(sender) = sender.as_ref() {
-                match sender.RasterizationScale() {
-                    Ok(scale) => invoke_composition_host_callback(
-                        &changed_callback,
-                        CompositionHostEvent::Metrics {
-                            width: changed_framework.ActualWidth().unwrap_or(0.0),
-                            height: changed_framework.ActualHeight().unwrap_or(0.0),
-                            scale,
-                        },
-                    ),
-                    Err(error) => {
-                        changed_sink.enqueue_host(HostEvent::Error(native_error(error)));
-                    }
-                }
-            }
-        })
-        .map_err(native_error)?;
-    changed.replace(Some(revoker));
-    Ok(())
-}
-
-fn invoke_composition_host_callback(
-    callback: &Callback<CompositionHostEvent>,
-    event: CompositionHostEvent,
-) {
-    if std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| callback.call(event))).is_err() {
-        std::process::abort();
-    }
-}
-
-fn invoke_image_scale_callback(callback: &Callback<f64>, scale: f64) {
-    if std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| callback.call(scale))).is_err() {
-        std::process::abort();
     }
 }
 

--- a/crates/tools/reactor/src/generate.rs
+++ b/crates/tools/reactor/src/generate.rs
@@ -2014,33 +2014,7 @@ fn generate_direct_value_validation(
     let Some(validation) = property.validation else {
         return TokenStream::new();
     };
-    let message = match validation {
-        ValueValidation::Finite => {
-            format!(
-                "{} {} must contain finite values",
-                control.name, property.name
-            )
-        }
-        ValueValidation::FiniteNonNegative => format!(
-            "{} {} must contain finite non-negative values",
-            control.name, property.name
-        ),
-        ValueValidation::FinitePositive => {
-            format!(
-                "{} {} must be finite and positive",
-                control.name, property.name
-            )
-        }
-        ValueValidation::NonNegative => {
-            format!("{} {} must be non-negative", control.name, property.name)
-        }
-        ValueValidation::ZeroToFiftyNine => {
-            format!(
-                "{} {} must be between 0 and 59",
-                control.name, property.name
-            )
-        }
-    };
+    let message = value_validation_message(control, property, validation);
     match (validation, property.value.as_str()) {
         (ValueValidation::Finite, "Thickness") => quote! {
             assert!(value.is_finite(), #message);
@@ -2059,33 +2033,7 @@ fn generate_value_validation(
     let Some(validation) = property.validation else {
         return TokenStream::new();
     };
-    let message = match validation {
-        ValueValidation::Finite => {
-            format!(
-                "{} {} must contain finite values",
-                control.name, property.name
-            )
-        }
-        ValueValidation::FiniteNonNegative => format!(
-            "{} {} must contain finite non-negative values",
-            control.name, property.name
-        ),
-        ValueValidation::FinitePositive => {
-            format!(
-                "{} {} must be finite and positive",
-                control.name, property.name
-            )
-        }
-        ValueValidation::NonNegative => {
-            format!("{} {} must be non-negative", control.name, property.name)
-        }
-        ValueValidation::ZeroToFiftyNine => {
-            format!(
-                "{} {} must be between 0 and 59",
-                control.name, property.name
-            )
-        }
-    };
+    let message = value_validation_message(control, property, validation);
     match (validation, property.value.as_str()) {
         (ValueValidation::Finite, "F64") => quote! {
             assert!(
@@ -2138,6 +2086,40 @@ fn generate_value_validation(
     }
 }
 
+fn value_validation_message(
+    control: &ResolvedControl,
+    property: &crate::schema::ResolvedProperty,
+    validation: ValueValidation,
+) -> String {
+    match validation {
+        ValueValidation::Finite => {
+            format!(
+                "{} {} must contain finite values",
+                control.name, property.name
+            )
+        }
+        ValueValidation::FiniteNonNegative => format!(
+            "{} {} must contain finite non-negative values",
+            control.name, property.name
+        ),
+        ValueValidation::FinitePositive => {
+            format!(
+                "{} {} must be finite and positive",
+                control.name, property.name
+            )
+        }
+        ValueValidation::NonNegative => {
+            format!("{} {} must be non-negative", control.name, property.name)
+        }
+        ValueValidation::ZeroToFiftyNine => {
+            format!(
+                "{} {} must be between 0 and 59",
+                control.name, property.name
+            )
+        }
+    }
+}
+
 fn value_equality(
     value: Option<&str>,
     left: &impl quote::ToTokens,
@@ -2160,7 +2142,6 @@ fn generate_descriptors(control: &ResolvedControl) -> TokenStream {
         let field = &property.field;
         let value = &property.value;
         let interface = &property.interface;
-        let clearable = property.clearable;
         let feedback = property
             .feedback
             .as_deref()
@@ -2172,9 +2153,6 @@ fn generate_descriptors(control: &ResolvedControl) -> TokenStream {
                 let value = match value {
                     FeedbackContract::SynchronousExact => "synchronous_exact",
                     FeedbackContract::SynchronousNormalized => "synchronous_normalized",
-                    FeedbackContract::DeferredOrdered => "deferred_ordered",
-                    FeedbackContract::DeferredCoalesced => "deferred_coalesced",
-                    FeedbackContract::Unknown => "unknown",
                 };
                 quote! { Some(#value) }
             },
@@ -2186,7 +2164,7 @@ fn generate_descriptors(control: &ResolvedControl) -> TokenStream {
                 field: #field,
                 value: #value,
                 interface: #interface,
-                clearable: #clearable,
+                clearable: true,
                 feedback: #feedback,
                 feedback_contract: #feedback_contract,
                 observes_feedback: #observes_feedback,
@@ -2413,7 +2391,6 @@ capabilities = ["layout"]
 
 [[control.property]]
 name = "Value"
-clearable = true
 "#;
         let schema = Schema::parse(source).unwrap();
         let metadata = MetadataResolver::load(&workspace_path("crates/tools/reactor/winmd"));

--- a/crates/tools/reactor/src/generate_surface.rs
+++ b/crates/tools/reactor/src/generate_surface.rs
@@ -364,7 +364,6 @@ pub(crate) fn generate(schema: &ResolvedSchema) -> String {
                     quote! { Some(#validation) }
                 },
             );
-            let clearable = property.clearable;
             let theme_style = property.theme_style;
             quote! {
                 PropertySurface {
@@ -373,7 +372,7 @@ pub(crate) fn generate(schema: &ResolvedSchema) -> String {
                     value: #value,
                     adapter: #adapter,
                     validation: #validation,
-                    clearable: #clearable,
+                    clearable: true,
                     theme_style: #theme_style,
                 }
             }

--- a/crates/tools/reactor/src/generate_winui.rs
+++ b/crates/tools/reactor/src/generate_winui.rs
@@ -394,7 +394,6 @@ pub(crate) fn generate(schema: &ResolvedSchema) -> String {
         control
             .properties
             .iter()
-            .filter(|property| property.clearable)
             .map(move |property| generate_clear_property(control, property))
     });
     let events = schema.controls.iter().flat_map(|control| {
@@ -486,7 +485,6 @@ pub(crate) fn generate(schema: &ResolvedSchema) -> String {
                         ))
                     }
                 }),
-                _ => unreachable!(),
             }
         })
     });
@@ -524,7 +522,6 @@ pub(crate) fn generate(schema: &ResolvedSchema) -> String {
                         ))
                     }
                 }),
-                _ => unreachable!(),
             }
         })
     });

--- a/crates/tools/reactor/src/metadata.rs
+++ b/crates/tools/reactor/src/metadata.rs
@@ -471,26 +471,7 @@ impl MetadataResolver {
         add_event: &str,
         property: &str,
     ) -> Option<(String, String, ReadValueConversion)> {
-        // Get the delegate type from the add method's first param.
-        let add_ref = self
-            .lookup
-            .get(&(class_name.to_string(), add_event.to_string()))?;
-        let delegate_type = add_ref.param_types.first()?;
-        // Extract the args class name from the delegate type.
-        let args_class = match delegate_type {
-            // TypedEventHandler<TSender, TArgs> - extract TArgs from generics.
-            Type::ClassName(tn) if tn.generics.len() == 2 => match &tn.generics[1] {
-                Type::ClassName(args_tn) => args_tn.name.clone(),
-                Type::ValueName(args_tn) => args_tn.name.clone(),
-                _ => return None,
-            },
-            // Non-generic delegate - look up args class from Invoke signature.
-            Type::ClassName(tn) => self.delegate_args.get(&tn.name)?.clone(),
-            _ => return None,
-        };
-        // Look up get_{property} on the args class.
-        let getter = format!("get_{property}");
-        let getter_ref = self.lookup.get(&(args_class, getter))?;
+        let getter_ref = self.resolve_event_args_getter(class_name, add_event, property)?;
         let (value, conversion) = self.read_value_for_type(&getter_ref.return_type)?;
         Some((value, getter_ref.interface.full_path(), conversion))
     }
@@ -501,21 +482,7 @@ impl MetadataResolver {
         add_event: &str,
         property: &str,
     ) -> Option<String> {
-        let add_ref = self
-            .lookup
-            .get(&(class_name.to_string(), add_event.to_string()))?;
-        let delegate_type = add_ref.param_types.first()?;
-        let args_class = match delegate_type {
-            Type::ClassName(tn) if tn.generics.len() == 2 => match &tn.generics[1] {
-                Type::ClassName(args_tn) => args_tn.name.clone(),
-                Type::ValueName(args_tn) => args_tn.name.clone(),
-                _ => return None,
-            },
-            Type::ClassName(tn) => self.delegate_args.get(&tn.name)?.clone(),
-            _ => return None,
-        };
-        self.lookup
-            .get(&(args_class, format!("get_{property}")))
+        self.resolve_event_args_getter(class_name, add_event, property)
             .map(|method| method.interface.full_path())
     }
 
@@ -525,21 +492,7 @@ impl MetadataResolver {
         add_event: &str,
         property: &str,
     ) -> Option<String> {
-        let add_ref = self
-            .lookup
-            .get(&(class_name.to_string(), add_event.to_string()))?;
-        let delegate_type = add_ref.param_types.first()?;
-        let args_class = match delegate_type {
-            Type::ClassName(tn) if tn.generics.len() == 2 => match &tn.generics[1] {
-                Type::ClassName(args_tn) => args_tn.name.clone(),
-                Type::ValueName(args_tn) => args_tn.name.clone(),
-                _ => return None,
-            },
-            Type::ClassName(tn) => self.delegate_args.get(&tn.name)?.clone(),
-            _ => return None,
-        };
-        let getter = format!("get_{property}");
-        let getter_ref = self.lookup.get(&(args_class, getter))?;
+        let getter_ref = self.resolve_event_args_getter(class_name, add_event, property)?;
         matches!(getter_ref.return_type, Type::Object).then(|| getter_ref.interface.full_path())
     }
 
@@ -551,6 +504,17 @@ impl MetadataResolver {
         add_event: &str,
         property: &str,
     ) -> Option<String> {
+        let getter_ref = self.resolve_event_args_getter(class_name, add_event, property)?;
+        matches!(getter_ref.return_type, Type::ClassName(_))
+            .then(|| getter_ref.interface.full_path())
+    }
+
+    fn resolve_event_args_getter(
+        &self,
+        class_name: &str,
+        add_event: &str,
+        property: &str,
+    ) -> Option<&MethodRef> {
         let add_ref = self
             .lookup
             .get(&(class_name.to_string(), add_event.to_string()))?;
@@ -565,9 +529,7 @@ impl MetadataResolver {
             _ => return None,
         };
         let getter = format!("get_{property}");
-        let getter_ref = self.lookup.get(&(args_class, getter))?;
-        matches!(getter_ref.return_type, Type::ClassName(_))
-            .then(|| getter_ref.interface.full_path())
+        self.lookup.get(&(args_class, getter))
     }
 
     pub fn resolve_property_read(
@@ -980,6 +942,32 @@ mod tests {
             result.as_deref(),
             Some("I32"),
             "BreadcrumbBar ItemClicked Index should be I32"
+        );
+    }
+
+    #[test]
+    fn resolves_event_args_getter_shapes() {
+        let resolver = MetadataResolver::load(Path::new("winmd"));
+
+        assert!(
+            resolver
+                .resolve_event_args_property_interface("Border", "add_Drop", "DataView")
+                .is_some()
+        );
+        assert!(
+            resolver
+                .resolve_event_args_class_property("TabView", "add_TabCloseRequested", "Tab")
+                .is_some()
+        );
+        assert!(
+            resolver
+                .resolve_event_args_object_property("TreeView", "add_ItemInvoked", "InvokedItem")
+                .is_some()
+        );
+        assert!(
+            resolver
+                .resolve_event_args_class_property("TreeView", "add_ItemInvoked", "InvokedItem")
+                .is_none()
         );
     }
 }

--- a/crates/tools/reactor/src/schema.rs
+++ b/crates/tools/reactor/src/schema.rs
@@ -90,8 +90,6 @@ pub(crate) struct Property {
     #[serde(default)]
     pub(crate) field: Option<String>,
     #[serde(default)]
-    pub(crate) clearable: bool,
-    #[serde(default)]
     pub(crate) theme_style: bool,
     #[serde(default)]
     pub(crate) controlled: Option<String>,
@@ -144,6 +142,271 @@ pub(crate) enum PropertyAdapter {
     SelectionIndex,
 }
 
+#[derive(Clone, Copy)]
+enum PropertyAdapterTargets {
+    Any,
+    Property(&'static str),
+    OneOf(&'static [(&'static str, &'static str)]),
+}
+
+#[derive(Clone, Copy)]
+enum PropertyAdapterMetadata {
+    None,
+    Param(ParamClass),
+    ParamType(&'static str),
+    ValueType(&'static str, bool),
+    SingleField(&'static str, &'static str),
+}
+
+#[derive(Clone, Copy)]
+struct PropertyAdapterContract {
+    targets: PropertyAdapterTargets,
+    metadata: PropertyAdapterMetadata,
+    value: &'static str,
+    copy: bool,
+    requirement: &'static str,
+}
+
+enum PropertyAdapterKind {
+    Property(PropertyAdapterContract),
+    ResourceStyle,
+    EventOnly(&'static str),
+}
+
+impl PropertyAdapter {
+    fn property_kind(self) -> PropertyAdapterKind {
+        use PropertyAdapterMetadata::{None, Param, ParamType, SingleField, ValueType};
+        use PropertyAdapterTargets::{Any, OneOf, Property};
+
+        const BORDER: &str = "Microsoft.UI.Xaml.Controls.Border";
+        const BUTTON: &str = "Microsoft.UI.Xaml.Controls.Button";
+        const GRID: &str = "Microsoft.UI.Xaml.Controls.Grid";
+        const IMAGE: &str = "Microsoft.UI.Xaml.Controls.Image";
+        const IMAGE_ICON: &str = "Microsoft.UI.Xaml.Controls.ImageIcon";
+        const NUMBER_BOX: &str = "Microsoft.UI.Xaml.Controls.NumberBox";
+        const PATH_ICON: &str = "Microsoft.UI.Xaml.Controls.PathIcon";
+        const RATING_CONTROL: &str = "Microsoft.UI.Xaml.Controls.RatingControl";
+        const RICH_EDIT_BOX: &str = "Microsoft.UI.Xaml.Controls.RichEditBox";
+        const RICH_TEXT_BLOCK: &str = "Microsoft.UI.Xaml.Controls.RichTextBlock";
+        const TEXT_BLOCK: &str = "Microsoft.UI.Xaml.Controls.TextBlock";
+        const TIME_PICKER: &str = "Microsoft.UI.Xaml.Controls.TimePicker";
+
+        let property = |targets, metadata, value, copy, requirement| {
+            PropertyAdapterKind::Property(PropertyAdapterContract {
+                targets,
+                metadata,
+                value,
+                copy,
+                requirement,
+            })
+        };
+        match self {
+            Self::ImageUri => property(
+                OneOf(&[(IMAGE, "Source"), (IMAGE_ICON, "Source")]),
+                None,
+                "ImageValue",
+                false,
+                "image_uri requires Image.Source or ImageIcon.Source",
+            ),
+            Self::NumberBoxValue => property(
+                OneOf(&[(NUMBER_BOX, "Value")]),
+                ValueType("F64", true),
+                "OptionalF64",
+                true,
+                "number_box_value requires NumberBox.Value",
+            ),
+            Self::InspectableString => property(
+                Any,
+                Param(ParamClass::IInspectable),
+                "Str",
+                false,
+                "inspectable_string requires an IInspectable property",
+            ),
+            Self::InspectableStringList => property(
+                Any,
+                Param(ParamClass::IInspectable),
+                "StrList",
+                false,
+                "inspectable_string_list requires an IInspectable property",
+            ),
+            Self::ImplicitOpacityTransition => property(
+                OneOf(&[(BORDER, "OpacityTransition")]),
+                None,
+                "Duration",
+                false,
+                "implicit_opacity_transition requires Border.OpacityTransition",
+            ),
+            Self::ImplicitScale => property(
+                OneOf(&[(BORDER, "Scale")]),
+                None,
+                "F64",
+                true,
+                "implicit_scale requires Border.Scale",
+            ),
+            Self::ImplicitScaleTransition => property(
+                OneOf(&[(BORDER, "ScaleTransition")]),
+                None,
+                "Duration",
+                false,
+                "implicit_scale_transition requires Border.ScaleTransition",
+            ),
+            Self::KeyAccelerators => property(
+                OneOf(&[
+                    (BUTTON, "KeyboardAccelerators"),
+                    (GRID, "KeyboardAccelerators"),
+                ]),
+                None,
+                "KeyAccelerators",
+                false,
+                "key_accelerators requires Button.KeyboardAccelerators or Grid.KeyboardAccelerators",
+            ),
+            Self::ClockIdentifier => property(
+                OneOf(&[(TIME_PICKER, "ClockIdentifier")]),
+                None,
+                "Str",
+                false,
+                "clock_identifier requires TimePicker.ClockIdentifier",
+            ),
+            Self::PathData => property(
+                OneOf(&[(PATH_ICON, "Data")]),
+                ParamType("Microsoft.UI.Xaml.Media.Geometry"),
+                "Str",
+                false,
+                "path_data requires PathIcon.Data",
+            ),
+            Self::DropPolicy => property(
+                OneOf(&[(BORDER, "AllowDrop")]),
+                None,
+                "DragDropPolicy",
+                false,
+                "drop_policy requires Border.AllowDrop",
+            ),
+            Self::FontWeight => property(
+                OneOf(&[(TEXT_BLOCK, "FontWeight")]),
+                SingleField("Windows.UI.Text.FontWeight", "weight"),
+                "FontWeight",
+                true,
+                "font_weight requires TextBlock.FontWeight",
+            ),
+            Self::HorizontalContentAlignment => property(
+                OneOf(&[(BUTTON, "HorizontalContentAlignment")]),
+                ValueType("HorizontalAlignment", true),
+                "HorizontalAlignment",
+                true,
+                "horizontal_content_alignment requires Button.HorizontalContentAlignment",
+            ),
+            Self::PointerCapture => property(
+                OneOf(&[(BORDER, "CapturePointerOnPress")]),
+                None,
+                "Bool",
+                true,
+                "pointer_capture requires Border.CapturePointerOnPress",
+            ),
+            Self::RatingValue => property(
+                OneOf(&[(RATING_CONTROL, "Value")]),
+                ValueType("F64", true),
+                "OptionalF64",
+                true,
+                "rating_value requires RatingControl.Value",
+            ),
+            Self::RichEditText => property(
+                OneOf(&[(RICH_EDIT_BOX, "Document")]),
+                None,
+                "Str",
+                false,
+                "rich_edit_text requires RichEditBox.Document",
+            ),
+            Self::RichTextBlocks => property(
+                OneOf(&[(RICH_TEXT_BLOCK, "Blocks")]),
+                None,
+                "RichText",
+                false,
+                "rich_text_blocks requires RichTextBlock.Blocks",
+            ),
+            Self::ResourceOverrides => property(
+                OneOf(&[(BUTTON, "Resources")]),
+                None,
+                "ResourceOverrides",
+                false,
+                "resource_overrides requires Button.Resources",
+            ),
+            Self::Uri => property(
+                Any,
+                ParamType("Windows.Foundation.Uri"),
+                "Str",
+                false,
+                "uri requires a Windows.Foundation.Uri property",
+            ),
+            Self::VerticalContentAlignment => property(
+                OneOf(&[(BUTTON, "VerticalContentAlignment")]),
+                ValueType("VerticalAlignment", true),
+                "VerticalAlignment",
+                true,
+                "vertical_content_alignment requires Button.VerticalContentAlignment",
+            ),
+            Self::SelectionIndex => property(
+                Property("SelectedIndex"),
+                ValueType("I32", true),
+                "SelectionIndex",
+                true,
+                "selection_index requires an I32 SelectedIndex property",
+            ),
+            Self::ResourceStyle => PropertyAdapterKind::ResourceStyle,
+            Self::ContentDialogResult => {
+                PropertyAdapterKind::EventOnly("content_dialog_result is an event-only adapter")
+            }
+            Self::ItemTag => PropertyAdapterKind::EventOnly("item_tag is an event-only adapter"),
+            Self::ItemTags => PropertyAdapterKind::EventOnly("item_tags is an event-only adapter"),
+            Self::TreeNodeContent => {
+                PropertyAdapterKind::EventOnly("tree_node_content is an event-only adapter")
+            }
+            Self::NavigationDisplayMode => {
+                PropertyAdapterKind::EventOnly("navigation_display_mode is an event-only adapter")
+            }
+            Self::PointerEvent => {
+                PropertyAdapterKind::EventOnly("pointer_event is an event-only adapter")
+            }
+            Self::DragInfo | Self::DropData => {
+                PropertyAdapterKind::EventOnly("drag adapters are event-only")
+            }
+        }
+    }
+}
+
+impl PropertyAdapterContract {
+    fn validate(
+        self,
+        control: &str,
+        property: &str,
+        metadata: &MetadataResolver,
+        class: &str,
+        method: &str,
+    ) -> bool {
+        let target_matches = match self.targets {
+            PropertyAdapterTargets::Any => true,
+            PropertyAdapterTargets::Property(expected) => property == expected,
+            PropertyAdapterTargets::OneOf(targets) => targets.contains(&(control, property)),
+        };
+        target_matches
+            && match self.metadata {
+                PropertyAdapterMetadata::None => true,
+                PropertyAdapterMetadata::Param(expected) => {
+                    metadata.classify_param(class, method) == Some(expected)
+                }
+                PropertyAdapterMetadata::ParamType(expected) => {
+                    metadata.param_class_name(class, method).as_deref() == Some(expected)
+                }
+                PropertyAdapterMetadata::ValueType(value, copy) => {
+                    metadata.infer_value_type(class, method) == Some((value.to_string(), copy))
+                }
+                PropertyAdapterMetadata::SingleField(path, field) => {
+                    metadata.single_field_param(class, method)
+                        == Some((path.to_string(), field.to_string()))
+                }
+            }
+    }
+}
+
 #[derive(Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct ResourceStyleVariant {
@@ -166,9 +429,6 @@ pub(crate) enum ValueValidation {
 pub(crate) enum FeedbackContract {
     SynchronousExact,
     SynchronousNormalized,
-    DeferredOrdered,
-    DeferredCoalesced,
-    Unknown,
 }
 
 #[derive(Deserialize)]
@@ -252,7 +512,6 @@ pub(crate) struct ResolvedProperty {
     pub(crate) copy: bool,
     pub(crate) interface: String,
     pub(crate) static_owner: String,
-    pub(crate) clearable: bool,
     pub(crate) feedback: Option<String>,
     pub(crate) feedback_contract: Option<FeedbackContract>,
     pub(crate) clear_feedback: Option<bool>,
@@ -475,19 +734,7 @@ impl Schema {
                     ));
                 }
                 match (feedback.as_ref(), property.feedback_contract) {
-                    (
-                        Some(_),
-                        Some(
-                            FeedbackContract::SynchronousExact
-                            | FeedbackContract::SynchronousNormalized,
-                        ),
-                    ) => {}
-                    (Some(_), Some(_)) => {
-                        return Err(format!(
-                            "{}.{} uses an unsupported feedback contract",
-                            control.type_name, property.name
-                        ));
-                    }
+                    (Some(_), Some(_)) => {}
                     (Some(_), None) => {
                         return Err(format!(
                             "{}.{} needs a feedback contract",
@@ -501,12 +748,6 @@ impl Schema {
                         ));
                     }
                     (None, None) => {}
-                }
-                if !property.clearable {
-                    return Err(format!(
-                        "{}.{} must be clearable until required properties are supported",
-                        control.type_name, property.name
-                    ));
                 }
                 validate_member(
                     &control.type_name,
@@ -580,321 +821,52 @@ impl Schema {
                     ));
                 }
                 let (value, copy) = match property.adapter {
-                    Some(PropertyAdapter::ImageUri) => {
-                        if !matches!(
-                            control.type_name.as_str(),
-                            "Microsoft.UI.Xaml.Controls.Image"
-                                | "Microsoft.UI.Xaml.Controls.ImageIcon"
-                        ) || property.name != "Source"
-                        {
+                    Some(adapter) => match adapter.property_kind() {
+                        PropertyAdapterKind::Property(contract) => {
+                            if !contract.validate(
+                                &control.type_name,
+                                &property.name,
+                                metadata,
+                                &name,
+                                &method,
+                            ) {
+                                return Err(format!(
+                                    "{}.{} {}",
+                                    control.type_name, property.name, contract.requirement
+                                ));
+                            }
+                            (contract.value.to_string(), contract.copy)
+                        }
+                        PropertyAdapterKind::EventOnly(requirement) => {
                             return Err(format!(
-                                "{}.{} image_uri requires Image.Source or ImageIcon.Source",
+                                "{}.{} {requirement}",
                                 control.type_name, property.name
                             ));
                         }
-                        ("ImageValue".to_string(), false)
-                    }
-                    Some(PropertyAdapter::ContentDialogResult) => {
-                        return Err(format!(
-                            "{}.{} content_dialog_result is an event-only adapter",
-                            control.type_name, property.name
-                        ));
-                    }
-                    Some(PropertyAdapter::NumberBoxValue) => {
-                        if control.type_name != "Microsoft.UI.Xaml.Controls.NumberBox"
-                            || property.name != "Value"
-                            || metadata.infer_value_type(&name, &method)
-                                != Some(("F64".to_string(), true))
-                        {
-                            return Err(format!(
-                                "{}.{} number_box_value requires NumberBox.Value",
-                                control.type_name, property.name
-                            ));
+                        PropertyAdapterKind::ResourceStyle => {
+                            if metadata.param_class_name(&name, &method).as_deref()
+                                != Some("Microsoft.UI.Xaml.Style")
+                                || property.variants.is_empty()
+                            {
+                                return Err(format!(
+                                    "{}.{} resource_style requires a Style property and variants",
+                                    control.type_name, property.name
+                                ));
+                            }
+                            let mut names = HashSet::new();
+                            if property
+                                .variants
+                                .iter()
+                                .any(|variant| !names.insert(variant.name.clone()))
+                            {
+                                return Err(format!(
+                                    "{}.{} resource_style has duplicate variants",
+                                    control.type_name, property.name
+                                ));
+                            }
+                            (format!("{}{}", name, property.name), true)
                         }
-                        ("OptionalF64".to_string(), true)
-                    }
-                    Some(PropertyAdapter::InspectableString) => {
-                        if metadata.classify_param(&name, &method) != Some(ParamClass::IInspectable)
-                        {
-                            return Err(format!(
-                                "{}.{} inspectable_string requires an IInspectable property",
-                                control.type_name, property.name
-                            ));
-                        }
-                        ("Str".to_string(), false)
-                    }
-                    Some(PropertyAdapter::InspectableStringList) => {
-                        if metadata.classify_param(&name, &method) != Some(ParamClass::IInspectable)
-                        {
-                            return Err(format!(
-                                "{}.{} inspectable_string_list requires an IInspectable property",
-                                control.type_name, property.name
-                            ));
-                        }
-                        ("StrList".to_string(), false)
-                    }
-                    Some(PropertyAdapter::ImplicitOpacityTransition) => {
-                        if control.type_name != "Microsoft.UI.Xaml.Controls.Border"
-                            || property.name != "OpacityTransition"
-                        {
-                            return Err(format!(
-                                "{}.{} implicit_opacity_transition requires Border.OpacityTransition",
-                                control.type_name, property.name
-                            ));
-                        }
-                        ("Duration".to_string(), false)
-                    }
-                    Some(PropertyAdapter::ImplicitScale) => {
-                        if control.type_name != "Microsoft.UI.Xaml.Controls.Border"
-                            || property.name != "Scale"
-                        {
-                            return Err(format!(
-                                "{}.{} implicit_scale requires Border.Scale",
-                                control.type_name, property.name
-                            ));
-                        }
-                        ("F64".to_string(), true)
-                    }
-                    Some(PropertyAdapter::ImplicitScaleTransition) => {
-                        if control.type_name != "Microsoft.UI.Xaml.Controls.Border"
-                            || property.name != "ScaleTransition"
-                        {
-                            return Err(format!(
-                                "{}.{} implicit_scale_transition requires Border.ScaleTransition",
-                                control.type_name, property.name
-                            ));
-                        }
-                        ("Duration".to_string(), false)
-                    }
-                    Some(PropertyAdapter::KeyAccelerators) => {
-                        if !matches!(
-                            control.type_name.as_str(),
-                            "Microsoft.UI.Xaml.Controls.Button" | "Microsoft.UI.Xaml.Controls.Grid"
-                        ) || property.name != "KeyboardAccelerators"
-                        {
-                            return Err(format!(
-                                "{}.{} key_accelerators requires Button.KeyboardAccelerators or Grid.KeyboardAccelerators",
-                                control.type_name, property.name
-                            ));
-                        }
-                        ("KeyAccelerators".to_string(), false)
-                    }
-                    Some(PropertyAdapter::ClockIdentifier) => {
-                        if control.type_name != "Microsoft.UI.Xaml.Controls.TimePicker"
-                            || property.name != "ClockIdentifier"
-                        {
-                            return Err(format!(
-                                "{}.{} clock_identifier requires TimePicker.ClockIdentifier",
-                                control.type_name, property.name
-                            ));
-                        }
-                        ("Str".to_string(), false)
-                    }
-                    Some(PropertyAdapter::ItemTag) => {
-                        return Err(format!(
-                            "{}.{} item_tag is an event-only adapter",
-                            control.type_name, property.name
-                        ));
-                    }
-                    Some(PropertyAdapter::ItemTags) => {
-                        return Err(format!(
-                            "{}.{} item_tags is an event-only adapter",
-                            control.type_name, property.name
-                        ));
-                    }
-                    Some(PropertyAdapter::TreeNodeContent) => {
-                        return Err(format!(
-                            "{}.{} tree_node_content is an event-only adapter",
-                            control.type_name, property.name
-                        ));
-                    }
-                    Some(PropertyAdapter::PathData) => {
-                        if control.type_name != "Microsoft.UI.Xaml.Controls.PathIcon"
-                            || property.name != "Data"
-                            || metadata.param_class_name(&name, &method).as_deref()
-                                != Some("Microsoft.UI.Xaml.Media.Geometry")
-                        {
-                            return Err(format!(
-                                "{}.{} path_data requires PathIcon.Data",
-                                control.type_name, property.name
-                            ));
-                        }
-                        ("Str".to_string(), false)
-                    }
-                    Some(PropertyAdapter::NavigationDisplayMode) => {
-                        return Err(format!(
-                            "{}.{} navigation_display_mode is an event-only adapter",
-                            control.type_name, property.name
-                        ));
-                    }
-                    Some(PropertyAdapter::PointerEvent) => {
-                        return Err(format!(
-                            "{}.{} pointer_event is an event-only adapter",
-                            control.type_name, property.name
-                        ));
-                    }
-                    Some(PropertyAdapter::DragInfo | PropertyAdapter::DropData) => {
-                        return Err(format!(
-                            "{}.{} drag adapters are event-only",
-                            control.type_name, property.name
-                        ));
-                    }
-                    Some(PropertyAdapter::DropPolicy) => {
-                        if control.type_name != "Microsoft.UI.Xaml.Controls.Border"
-                            || property.name != "AllowDrop"
-                        {
-                            return Err(format!(
-                                "{}.{} drop_policy requires Border.AllowDrop",
-                                control.type_name, property.name
-                            ));
-                        }
-                        ("DragDropPolicy".to_string(), false)
-                    }
-                    Some(PropertyAdapter::FontWeight) => {
-                        if control.type_name != "Microsoft.UI.Xaml.Controls.TextBlock"
-                            || property.name != "FontWeight"
-                            || metadata.single_field_param(&name, &method)
-                                != Some((
-                                    "Windows.UI.Text.FontWeight".to_string(),
-                                    "weight".to_string(),
-                                ))
-                        {
-                            return Err(format!(
-                                "{}.{} font_weight requires TextBlock.FontWeight",
-                                control.type_name, property.name
-                            ));
-                        }
-                        ("FontWeight".to_string(), true)
-                    }
-                    Some(PropertyAdapter::HorizontalContentAlignment) => {
-                        if control.type_name != "Microsoft.UI.Xaml.Controls.Button"
-                            || property.name != "HorizontalContentAlignment"
-                            || metadata.infer_value_type(&name, &method)
-                                != Some(("HorizontalAlignment".to_string(), true))
-                        {
-                            return Err(format!(
-                                "{}.{} horizontal_content_alignment requires Button.HorizontalContentAlignment",
-                                control.type_name, property.name
-                            ));
-                        }
-                        ("HorizontalAlignment".to_string(), true)
-                    }
-                    Some(PropertyAdapter::PointerCapture) => {
-                        if control.type_name != "Microsoft.UI.Xaml.Controls.Border"
-                            || property.name != "CapturePointerOnPress"
-                        {
-                            return Err(format!(
-                                "{}.{} pointer_capture requires Border.CapturePointerOnPress",
-                                control.type_name, property.name
-                            ));
-                        }
-                        ("Bool".to_string(), true)
-                    }
-                    Some(PropertyAdapter::RatingValue) => {
-                        if control.type_name != "Microsoft.UI.Xaml.Controls.RatingControl"
-                            || property.name != "Value"
-                            || metadata.infer_value_type(&name, &method)
-                                != Some(("F64".to_string(), true))
-                        {
-                            return Err(format!(
-                                "{}.{} rating_value requires RatingControl.Value",
-                                control.type_name, property.name
-                            ));
-                        }
-                        ("OptionalF64".to_string(), true)
-                    }
-                    Some(PropertyAdapter::ResourceStyle) => {
-                        if metadata.param_class_name(&name, &method).as_deref()
-                            != Some("Microsoft.UI.Xaml.Style")
-                            || property.variants.is_empty()
-                        {
-                            return Err(format!(
-                                "{}.{} resource_style requires a Style property and variants",
-                                control.type_name, property.name
-                            ));
-                        }
-                        let mut names = HashSet::new();
-                        if property
-                            .variants
-                            .iter()
-                            .any(|variant| !names.insert(variant.name.clone()))
-                        {
-                            return Err(format!(
-                                "{}.{} resource_style has duplicate variants",
-                                control.type_name, property.name
-                            ));
-                        }
-                        (format!("{}{}", name, property.name), true)
-                    }
-                    Some(PropertyAdapter::RichEditText) => {
-                        if control.type_name != "Microsoft.UI.Xaml.Controls.RichEditBox"
-                            || property.name != "Document"
-                        {
-                            return Err(format!(
-                                "{}.{} rich_edit_text requires RichEditBox.Document",
-                                control.type_name, property.name
-                            ));
-                        }
-                        ("Str".to_string(), false)
-                    }
-                    Some(PropertyAdapter::RichTextBlocks) => {
-                        if control.type_name != "Microsoft.UI.Xaml.Controls.RichTextBlock"
-                            || property.name != "Blocks"
-                        {
-                            return Err(format!(
-                                "{}.{} rich_text_blocks requires RichTextBlock.Blocks",
-                                control.type_name, property.name
-                            ));
-                        }
-                        ("RichText".to_string(), false)
-                    }
-                    Some(PropertyAdapter::ResourceOverrides) => {
-                        if control.type_name != "Microsoft.UI.Xaml.Controls.Button"
-                            || property.name != "Resources"
-                        {
-                            return Err(format!(
-                                "{}.{} resource_overrides requires Button.Resources",
-                                control.type_name, property.name
-                            ));
-                        }
-                        ("ResourceOverrides".to_string(), false)
-                    }
-                    Some(PropertyAdapter::Uri) => {
-                        if metadata.param_class_name(&name, &method).as_deref()
-                            != Some("Windows.Foundation.Uri")
-                        {
-                            return Err(format!(
-                                "{}.{} uri requires a Windows.Foundation.Uri property",
-                                control.type_name, property.name
-                            ));
-                        }
-                        ("Str".to_string(), false)
-                    }
-                    Some(PropertyAdapter::VerticalContentAlignment) => {
-                        if control.type_name != "Microsoft.UI.Xaml.Controls.Button"
-                            || property.name != "VerticalContentAlignment"
-                            || metadata.infer_value_type(&name, &method)
-                                != Some(("VerticalAlignment".to_string(), true))
-                        {
-                            return Err(format!(
-                                "{}.{} vertical_content_alignment requires Button.VerticalContentAlignment",
-                                control.type_name, property.name
-                            ));
-                        }
-                        ("VerticalAlignment".to_string(), true)
-                    }
-                    Some(PropertyAdapter::SelectionIndex) => {
-                        if property.name != "SelectedIndex"
-                            || metadata.infer_value_type(&name, &method)
-                                != Some(("I32".to_string(), true))
-                        {
-                            return Err(format!(
-                                "{}.{} selection_index requires an I32 SelectedIndex property",
-                                control.type_name, property.name
-                            ));
-                        }
-                        ("SelectionIndex".to_string(), true)
-                    }
+                    },
                     None if property.theme_style => ("Brush".to_string(), true),
                     None => metadata.infer_value_type(&name, &method).ok_or_else(|| {
                         format!(
@@ -967,7 +939,6 @@ impl Schema {
                     copy,
                     interface: interface.full_path(),
                     static_owner,
-                    clearable: property.clearable,
                     feedback,
                     feedback_contract: property.feedback_contract,
                     clear_feedback: property.clear_feedback,
@@ -2045,7 +2016,6 @@ capabilities = ["layout"]
 
 [[control.property]]
 name = "Text"
-clearable = true
 adapter = "image_uri"
 "#;
         let metadata = MetadataResolver::load(&workspace_path("crates/tools/reactor/winmd"));
@@ -2066,7 +2036,6 @@ capabilities = ["layout"]
 
 [[control.property]]
 name = "Text"
-clearable = true
 adapter = "uri"
 "#;
         let metadata = MetadataResolver::load(&workspace_path("crates/tools/reactor/winmd"));
@@ -2087,7 +2056,6 @@ capabilities = ["layout"]
 
 [[control.property]]
 name = "Text"
-clearable = true
 adapter = "inspectable_string_list"
 "#;
         let metadata = MetadataResolver::load(&workspace_path("crates/tools/reactor/winmd"));
@@ -2125,7 +2093,6 @@ capabilities = ["layout"]
 
 [[control.property]]
 name = "Text"
-clearable = true
 adapter = "{adapter}"
 "#
             );
@@ -2234,7 +2201,6 @@ capabilities = ["layout"]
 
 [[control.property]]
 name = "Text"
-clearable = true
 adapter = "resource_style"
 variants = [{ name = "Accent", resource = "AccentButtonStyle" }]
 "#;
@@ -2463,7 +2429,6 @@ capabilities = ["controlled_text"]
 
 [[control.property]]
 name = "Text"
-clearable = true
 controlled = "Missing"
 feedback_contract = "synchronous_exact"
 "#;
@@ -2485,13 +2450,11 @@ capabilities = ["controlled_text"]
 
 [[control.property]]
 name = "Text"
-clearable = true
 controlled = "TextChanged"
 feedback_contract = "synchronous_exact"
 
 [[control.property]]
 name = "SelectedText"
-clearable = true
 controlled = "TextChanged"
 feedback_contract = "synchronous_exact"
 
@@ -2522,7 +2485,6 @@ capabilities = ["controlled_text"]
 
 [[control.property]]
 name = "Text"
-clearable = true
 controlled = "TextChanged"
 "#;
         let metadata = MetadataResolver::load(&workspace_path("crates/tools/reactor/winmd"));
@@ -2536,7 +2498,7 @@ controlled = "TextChanged"
     }
 
     #[test]
-    fn rejects_unsupported_controlled_feedback_contract() {
+    fn rejects_unknown_feedback_contract() {
         let source = r#"
 [[control]]
 type = "Microsoft.UI.Xaml.Controls.TextBox"
@@ -2544,18 +2506,12 @@ capabilities = ["controlled_text"]
 
 [[control.property]]
 name = "Text"
-clearable = true
 controlled = "TextChanged"
 feedback_contract = "deferred_coalesced"
 "#;
-        let metadata = MetadataResolver::load(&workspace_path("crates/tools/reactor/winmd"));
-        let error = Schema::parse(source)
-            .unwrap()
-            .resolve(&metadata)
-            .err()
-            .unwrap();
+        let error = Schema::parse(source).err().unwrap();
 
-        assert!(error.contains("unsupported feedback contract"));
+        assert!(error.contains("unknown variant `deferred_coalesced`"));
     }
 
     #[test]
@@ -2567,7 +2523,6 @@ capabilities = ["layout"]
 
 [[control.property]]
 name = "Minimum"
-clearable = true
 coerces = "ValueChanged"
 feedback_contract = "synchronous_exact"
 "#;
@@ -2590,13 +2545,11 @@ capabilities = ["layout"]
 
 [[control.property]]
 name = "Minimum"
-clearable = true
 coerces = "ValueChanged"
 feedback_contract = "synchronous_normalized"
 
 [[control.property]]
 name = "Value"
-clearable = true
 controlled = "ValueChanged"
 feedback_contract = "synchronous_exact"
 
@@ -2614,26 +2567,6 @@ property = "NewValue"
         assert!(error.contains(
             "feedback event ValueChanged is coercing and requires synchronous_normalized"
         ));
-    }
-
-    #[test]
-    fn rejects_non_clearable_property_without_required_value_contract() {
-        let source = r#"
-[[control]]
-type = "Microsoft.UI.Xaml.Controls.ProgressBar"
-capabilities = ["layout"]
-
-[[control.property]]
-name = "Value"
-"#;
-        let metadata = MetadataResolver::load(&workspace_path("crates/tools/reactor/winmd"));
-        let error = Schema::parse(source)
-            .unwrap()
-            .resolve(&metadata)
-            .err()
-            .unwrap();
-
-        assert!(error.contains("must be clearable"));
     }
 
     #[test]
@@ -2669,7 +2602,6 @@ capabilities = ["layout"]
 
 [[control.property]]
 name = "IsPaneOpen"
-clearable = true
 
 [[control.event]]
 name = "IsPaneOpenChanged"
@@ -2698,14 +2630,12 @@ capabilities = ["layout"]
 
 [[control.property]]
 name = "IsPaneOpen"
-clearable = true
 controlled = "IsPaneOpenChanged"
 feedback_contract = "synchronous_exact"
 clear_feedback = false
 
 [[control.property]]
 name = "IsSettingsVisible"
-clearable = true
 
 [[control.event]]
 name = "IsPaneOpenChanged"
@@ -2733,7 +2663,6 @@ capabilities = ["layout"]
 
 [[control.property]]
 name = "IsOn"
-clearable = true
 controlled = "Toggled"
 feedback_contract = "synchronous_exact"
 
@@ -2773,7 +2702,6 @@ capabilities = ["layout"]
 
 [[control.property]]
 name = "Text"
-clearable = true
 adapter = "font_weight"
 "#;
         let metadata = MetadataResolver::load(&workspace_path("crates/tools/reactor/winmd"));

--- a/crates/tools/reactor/src/winui.toml
+++ b/crates/tools/reactor/src/winui.toml
@@ -4,38 +4,30 @@ capabilities = ["layout", "text_style"]
 
 [[control.property]]
 name = "Text"
-clearable = true
 
 [[control.property]]
 name = "TextWrapping"
-clearable = true
 
 [[control.property]]
 name = "FontSize"
-clearable = true
 validation = "finite_positive"
 
 [[control.property]]
 name = "FontWeight"
-clearable = true
 adapter = "font_weight"
 
 [[control.property]]
 name = "IsTextSelectionEnabled"
-clearable = true
 
 [[control.property]]
 name = "MaxLines"
-clearable = true
 validation = "non_negative"
 
 [[control.property]]
 name = "TextTrimming"
-clearable = true
 
 [[control.property]]
 name = "Foreground"
-clearable = true
 theme_style = true
 
 
@@ -48,16 +40,13 @@ capabilities = ["layout", "enabled", "content", "focus"]
 
 [[control.property]]
 name = "IsEnabled"
-clearable = true
 
 [[control.property]]
 name = "HorizontalContentAlignment"
-clearable = true
 adapter = "horizontal_content_alignment"
 
 [[control.property]]
 name = "VerticalContentAlignment"
-clearable = true
 adapter = "vertical_content_alignment"
 
 
@@ -65,12 +54,10 @@ adapter = "vertical_content_alignment"
 [[control.property]]
 name = "Resources"
 field = "resource_overrides"
-clearable = true
 adapter = "resource_overrides"
 
 [[control.property]]
 name = "Style"
-clearable = true
 adapter = "resource_style"
 
 variants = [
@@ -83,7 +70,6 @@ variants = [
 [[control.property]]
 name = "KeyboardAccelerators"
 field = "key_accelerators"
-clearable = true
 adapter = "key_accelerators"
 
 [[control.event]]
@@ -95,12 +81,10 @@ capabilities = ["layout", "enabled", "content", "focus"]
 
 [[control.property]]
 name = "NavigateUri"
-clearable = true
 adapter = "uri"
 
 [[control.property]]
 name = "IsEnabled"
-clearable = true
 
 [[control.event]]
 name = "Click"
@@ -111,15 +95,12 @@ capabilities = ["layout", "enabled", "content"]
 
 [[control.property]]
 name = "Delay"
-clearable = true
 
 [[control.property]]
 name = "Interval"
-clearable = true
 
 [[control.property]]
 name = "IsEnabled"
-clearable = true
 
 [[control.event]]
 name = "Click"
@@ -130,27 +111,22 @@ capabilities = ["layout", "content"]
 
 [[control.property]]
 name = "Padding"
-clearable = true
 validation = "finite_non_negative"
 
 [[control.property]]
 name = "BorderThickness"
-clearable = true
 validation = "finite_non_negative"
 
 [[control.property]]
 name = "CornerRadius"
-clearable = true
 validation = "finite_non_negative"
 
 [[control.property]]
 name = "Background"
-clearable = true
 theme_style = true
 
 [[control.property]]
 name = "BorderBrush"
-clearable = true
 theme_style = true
 
 
@@ -161,30 +137,25 @@ theme_style = true
 [[control.property]]
 name = "OpacityTransition"
 field = "opacity_transition"
-clearable = true
 adapter = "implicit_opacity_transition"
 
 [[control.property]]
 name = "Scale"
-clearable = true
 adapter = "implicit_scale"
 validation = "finite_non_negative"
 
 [[control.property]]
 name = "ScaleTransition"
 field = "scale_transition"
-clearable = true
 adapter = "implicit_scale_transition"
 
 [[control.property]]
 name = "CapturePointerOnPress"
-clearable = true
 adapter = "pointer_capture"
 
 [[control.property]]
 name = "AllowDrop"
 field = "drop_policy"
-clearable = true
 adapter = "drop_policy"
 
 [[control.event]]
@@ -241,7 +212,6 @@ capabilities = ["layout"]
 
 [[control.property]]
 name = "ItemsSource"
-clearable = true
 adapter = "inspectable_string_list"
 
 [[control.event]]
@@ -255,11 +225,9 @@ capabilities = ["layout", "children"]
 
 [[control.property]]
 name = "Orientation"
-clearable = true
 
 [[control.property]]
 name = "Spacing"
-clearable = true
 
 [[control]]
 type = "Microsoft.UI.Xaml.Controls.VariableSizedWrapGrid"
@@ -267,17 +235,14 @@ capabilities = ["layout", "children"]
 
 [[control.property]]
 name = "ItemWidth"
-clearable = true
 validation = "finite_positive"
 
 [[control.property]]
 name = "ItemHeight"
-clearable = true
 validation = "finite_positive"
 
 [[control.property]]
 name = "Orientation"
-clearable = true
 
 
 [[control]]
@@ -286,21 +251,17 @@ capabilities = ["layout", "children", "grid_definitions", "reference"]
 
 [[control.property]]
 name = "RowSpacing"
-clearable = true
 
 [[control.property]]
 name = "ColumnSpacing"
-clearable = true
 
 [[control.property]]
 name = "KeyboardAccelerators"
 field = "key_accelerators"
-clearable = true
 adapter = "key_accelerators"
 
 [[control.property]]
 name = "Background"
-clearable = true
 theme_style = true
 
 
@@ -310,39 +271,31 @@ capabilities = ["layout", "enabled", "text_style", "controlled_text", "focus"]
 
 [[control.property]]
 name = "Text"
-clearable = true
 controlled = "TextChanged"
 feedback_contract = "synchronous_exact"
 
 [[control.property]]
 name = "PlaceholderText"
-clearable = true
 
 [[control.property]]
 name = "IsEnabled"
-clearable = true
 
 [[control.property]]
 name = "AcceptsReturn"
-clearable = true
 
 [[control.property]]
 name = "TextWrapping"
-clearable = true
 
 [[control.property]]
 name = "Background"
-clearable = true
 theme_style = true
 
 [[control.property]]
 name = "BorderBrush"
-clearable = true
 theme_style = true
 
 [[control.property]]
 name = "BorderThickness"
-clearable = true
 validation = "finite_non_negative"
 
 [[control.event]]
@@ -358,22 +311,18 @@ capabilities = ["layout", "enabled", "focus"]
 
 [[control.property]]
 name = "Text"
-clearable = true
 controlled = "TextChanged"
 feedback_contract = "synchronous_exact"
 
 [[control.property]]
 name = "ItemsSource"
-clearable = true
 adapter = "inspectable_string_list"
 
 [[control.property]]
 name = "PlaceholderText"
-clearable = true
 
 [[control.property]]
 name = "IsEnabled"
-clearable = true
 
 [[control.event]]
 name = "TextChanged"
@@ -393,21 +342,17 @@ capabilities = ["layout", "enabled", "focus"]
 
 [[control.property]]
 name = "Password"
-clearable = true
 controlled = "PasswordChanged"
 feedback_contract = "synchronous_exact"
 
 [[control.property]]
 name = "PlaceholderText"
-clearable = true
 
 [[control.property]]
 name = "PasswordRevealMode"
-clearable = true
 
 [[control.property]]
 name = "IsEnabled"
-clearable = true
 
 [[control.event]]
 name = "PasswordChanged"
@@ -422,26 +367,22 @@ capabilities = ["layout", "enabled", "focus"]
 
 [[control.property]]
 name = "Minimum"
-clearable = true
 coerces = "ValueChanged"
 feedback_contract = "synchronous_normalized"
 
 [[control.property]]
 name = "Maximum"
-clearable = true
 coerces = "ValueChanged"
 feedback_contract = "synchronous_normalized"
 
 [[control.property]]
 name = "Value"
-clearable = true
 adapter = "number_box_value"
 controlled = "ValueChanged"
 feedback_contract = "synchronous_normalized"
 
 [[control.property]]
 name = "IsEnabled"
-clearable = true
 
 [[control.event]]
 name = "ValueChanged"
@@ -456,34 +397,28 @@ capabilities = ["layout", "enabled", "focus"]
 
 [[control.property]]
 name = "Minimum"
-clearable = true
 coerces = "ValueChanged"
 feedback_contract = "synchronous_normalized"
 
 [[control.property]]
 name = "Maximum"
-clearable = true
 coerces = "ValueChanged"
 feedback_contract = "synchronous_normalized"
 
 [[control.property]]
 name = "Value"
-clearable = true
 controlled = "ValueChanged"
 feedback_contract = "synchronous_normalized"
 
 [[control.property]]
 name = "IsEnabled"
-clearable = true
 
 [[control.property]]
 name = "StepFrequency"
-clearable = true
 validation = "finite_positive"
 
 [[control.property]]
 name = "Orientation"
-clearable = true
 
 
 [[control.event]]
@@ -499,23 +434,18 @@ capabilities = ["layout", "window_title_bar"]
 
 [[control.property]]
 name = "Title"
-clearable = true
 
 [[control.property]]
 name = "Subtitle"
-clearable = true
 
 [[control.property]]
 name = "IsBackButtonVisible"
-clearable = true
 
 [[control.property]]
 name = "IsBackButtonEnabled"
-clearable = true
 
 [[control.property]]
 name = "IsPaneToggleButtonVisible"
-clearable = true
 
 [[control.event]]
 name = "BackRequested"
@@ -535,40 +465,31 @@ capabilities = ["layout", "enabled"]
 
 [[control.property]]
 name = "IsEnabled"
-clearable = true
 
 [[control.property]]
 name = "PaneDisplayMode"
-clearable = true
 
 [[control.property]]
 name = "IsPaneToggleButtonVisible"
-clearable = true
 
 [[control.property]]
 name = "IsBackButtonVisible"
-clearable = true
 
 [[control.property]]
 name = "IsSettingsVisible"
-clearable = true
 
 [[control.property]]
 name = "AlwaysShowHeader"
-clearable = true
 
 [[control.property]]
 name = "PaneTitle"
-clearable = true
 
 [[control.property]]
 name = "OpenPaneLength"
-clearable = true
 validation = "finite_non_negative"
 
 [[control.property]]
 name = "IsPaneOpen"
-clearable = true
 controlled = "IsPaneOpenChanged"
 feedback_contract = "synchronous_exact"
 clear_feedback = true
@@ -617,20 +538,16 @@ capabilities = ["layout"]
 
 [[control.property]]
 name = "Tag"
-clearable = true
 adapter = "inspectable_string"
 
 [[control.property]]
 name = "IsSelected"
-clearable = true
 
 [[control.property]]
 name = "SelectsOnInvoked"
-clearable = true
 
 [[control.property]]
 name = "IsExpanded"
-clearable = true
 
 [[control.slot]]
 name = "Content"
@@ -648,19 +565,15 @@ capabilities = ["layout"]
 
 [[control.property]]
 name = "OpenPaneLength"
-clearable = true
 
 [[control.property]]
 name = "CompactPaneLength"
-clearable = true
 
 [[control.property]]
 name = "DisplayMode"
-clearable = true
 
 [[control.property]]
 name = "IsPaneOpen"
-clearable = true
 controlled = "PaneClosed"
 feedback_contract = "synchronous_exact"
 clear_feedback = false
@@ -681,31 +594,24 @@ capabilities = ["layout", "enabled"]
 
 [[control.property]]
 name = "Minimum"
-clearable = true
 
 [[control.property]]
 name = "Maximum"
-clearable = true
 
 [[control.property]]
 name = "Value"
-clearable = true
 
 [[control.property]]
 name = "IsIndeterminate"
-clearable = true
 
 [[control.property]]
 name = "ShowError"
-clearable = true
 
 [[control.property]]
 name = "ShowPaused"
-clearable = true
 
 [[control.property]]
 name = "IsEnabled"
-clearable = true
 
 [[control]]
 type = "Microsoft.UI.Xaml.Controls.ToggleSwitch"
@@ -713,14 +619,12 @@ capabilities = ["layout", "enabled", "focus"]
 
 [[control.property]]
 name = "IsOn"
-clearable = true
 controlled = "Toggled"
 feedback_contract = "synchronous_exact"
 clear_feedback = false
 
 [[control.property]]
 name = "IsEnabled"
-clearable = true
 
 [[control.event]]
 name = "Toggled"
@@ -741,14 +645,12 @@ capabilities = ["layout", "enabled", "content", "focus"]
 
 [[control.property]]
 name = "IsChecked"
-clearable = true
 controlled = "IsCheckedChanged"
 feedback_contract = "synchronous_exact"
 clear_feedback = false
 
 [[control.property]]
 name = "IsEnabled"
-clearable = true
 
 [[control.event]]
 name = "IsCheckedChanged"
@@ -760,14 +662,12 @@ capabilities = ["layout", "enabled", "content", "focus"]
 
 [[control.property]]
 name = "IsChecked"
-clearable = true
 controlled = "IsCheckedChanged"
 feedback_contract = "synchronous_exact"
 clear_feedback = false
 
 [[control.property]]
 name = "IsEnabled"
-clearable = true
 
 [[control.event]]
 name = "IsCheckedChanged"
@@ -779,18 +679,15 @@ capabilities = ["layout", "enabled", "content", "focus"]
 
 [[control.property]]
 name = "GroupName"
-clearable = true
 
 [[control.property]]
 name = "IsChecked"
-clearable = true
 controlled = "Checked"
 feedback_contract = "synchronous_exact"
 clear_feedback = false
 
 [[control.property]]
 name = "IsEnabled"
-clearable = true
 
 [[control.event]]
 name = "Checked"
@@ -802,19 +699,16 @@ capabilities = ["layout"]
 
 [[control.property]]
 name = "ItemsSource"
-clearable = true
 adapter = "inspectable_string_list"
 
 [[control.property]]
 name = "SelectedIndex"
-clearable = true
 adapter = "selection_index"
 controlled = "SelectionChanged"
 feedback_contract = "synchronous_normalized"
 
 [[control.property]]
 name = "MaxColumns"
-clearable = true
 
 [[control.event]]
 name = "SelectionChanged"
@@ -833,7 +727,6 @@ capabilities = ["layout"]
 
 [[control.property]]
 name = "Value"
-clearable = true
 
 [[control]]
 type = "Microsoft.UI.Xaml.Controls.InfoBar"
@@ -841,23 +734,18 @@ capabilities = ["layout"]
 
 [[control.property]]
 name = "Title"
-clearable = true
 
 [[control.property]]
 name = "Message"
-clearable = true
 
 [[control.property]]
 name = "Severity"
-clearable = true
 
 [[control.property]]
 name = "IsOpen"
-clearable = true
 
 [[control.property]]
 name = "IsClosable"
-clearable = true
 
 [[control.event]]
 name = "Closed"
@@ -868,11 +756,9 @@ capabilities = ["layout"]
 
 [[control.property]]
 name = "DisplayName"
-clearable = true
 
 [[control.property]]
 name = "Initials"
-clearable = true
 
 [[control]]
 type = "Microsoft.UI.Xaml.Controls.ScrollViewer"
@@ -880,11 +766,9 @@ capabilities = ["layout", "content"]
 
 [[control.property]]
 name = "HorizontalScrollBarVisibility"
-clearable = true
 
 [[control.property]]
 name = "VerticalScrollBarVisibility"
-clearable = true
 
 
 
@@ -894,11 +778,9 @@ capabilities = ["layout", "content"]
 
 [[control.property]]
 name = "HorizontalScrollBarVisibility"
-clearable = true
 
 [[control.property]]
 name = "VerticalScrollBarVisibility"
-clearable = true
 
 
 
@@ -908,13 +790,11 @@ capabilities = ["layout", "reference"]
 
 [[control.property]]
 name = "Source"
-clearable = true
 adapter = "image_uri"
 
 
 [[control.property]]
 name = "Stretch"
-clearable = true
 
 [[control.event]]
 name = "ImageOpened"
@@ -930,27 +810,21 @@ capabilities = ["layout", "enabled"]
 
 [[control.property]]
 name = "Minimum"
-clearable = true
 
 [[control.property]]
 name = "Maximum"
-clearable = true
 
 [[control.property]]
 name = "Value"
-clearable = true
 
 [[control.property]]
 name = "IsIndeterminate"
-clearable = true
 
 [[control.property]]
 name = "IsActive"
-clearable = true
 
 [[control.property]]
 name = "IsEnabled"
-clearable = true
 
 [[control]]
 type = "Microsoft.UI.Xaml.Controls.ListBox"
@@ -958,7 +832,6 @@ capabilities = ["layout", "enabled"]
 
 [[control.property]]
 name = "IsEnabled"
-clearable = true
 
 [[control.event]]
 name = "SelectionChanged"
@@ -982,28 +855,23 @@ capabilities = ["layout"]
 
 [[control.property]]
 name = "Fill"
-clearable = true
 theme_style = true
 
 [[control.property]]
 name = "Stroke"
-clearable = true
 theme_style = true
 
 [[control.property]]
 name = "StrokeThickness"
-clearable = true
 validation = "finite_non_negative"
 
 
 [[control.property]]
 name = "RadiusX"
-clearable = true
 validation = "finite_non_negative"
 
 [[control.property]]
 name = "RadiusY"
-clearable = true
 validation = "finite_non_negative"
 
 [[control]]
@@ -1012,17 +880,14 @@ capabilities = ["layout"]
 
 [[control.property]]
 name = "Fill"
-clearable = true
 theme_style = true
 
 [[control.property]]
 name = "Stroke"
-clearable = true
 theme_style = true
 
 [[control.property]]
 name = "StrokeThickness"
-clearable = true
 validation = "finite_non_negative"
 
 
@@ -1032,32 +897,26 @@ capabilities = ["layout"]
 
 [[control.property]]
 name = "Stroke"
-clearable = true
 theme_style = true
 
 [[control.property]]
 name = "StrokeThickness"
-clearable = true
 validation = "finite_non_negative"
 
 [[control.property]]
 name = "X1"
-clearable = true
 validation = "finite"
 
 [[control.property]]
 name = "Y1"
-clearable = true
 validation = "finite"
 
 [[control.property]]
 name = "X2"
-clearable = true
 validation = "finite"
 
 [[control.property]]
 name = "Y2"
-clearable = true
 validation = "finite"
 
 [[control]]
@@ -1066,7 +925,6 @@ capabilities = ["layout"]
 
 [[control.property]]
 name = "Symbol"
-clearable = true
 
 [[control]]
 type = "Microsoft.UI.Xaml.Controls.ImageIcon"
@@ -1074,7 +932,6 @@ capabilities = ["layout"]
 
 [[control.property]]
 name = "Source"
-clearable = true
 adapter = "image_uri"
 
 
@@ -1084,7 +941,6 @@ capabilities = ["layout"]
 
 [[control.property]]
 name = "Glyph"
-clearable = true
 
 [[control]]
 type = "Microsoft.UI.Xaml.Controls.BitmapIcon"
@@ -1092,12 +948,10 @@ capabilities = ["layout"]
 
 [[control.property]]
 name = "UriSource"
-clearable = true
 adapter = "uri"
 
 [[control.property]]
 name = "ShowAsMonochrome"
-clearable = true
 
 [[control]]
 type = "Microsoft.UI.Xaml.Controls.PathIcon"
@@ -1105,7 +959,6 @@ capabilities = ["layout"]
 
 [[control.property]]
 name = "Data"
-clearable = true
 adapter = "path_data"
 
 [[control]]
@@ -1114,12 +967,10 @@ capabilities = ["layout", "content"]
 
 [[control.property]]
 name = "Tag"
-clearable = true
 adapter = "inspectable_string"
 
 [[control.property]]
 name = "IsSelected"
-clearable = true
 
 [[control]]
 type = "Microsoft.UI.Xaml.Controls.RatingControl"
@@ -1127,24 +978,20 @@ capabilities = ["layout", "focus"]
 
 [[control.property]]
 name = "MaxRating"
-clearable = true
 coerces = "ValueChanged"
 feedback_contract = "synchronous_normalized"
 
 [[control.property]]
 name = "Value"
-clearable = true
 adapter = "rating_value"
 controlled = "ValueChanged"
 feedback_contract = "synchronous_normalized"
 
 [[control.property]]
 name = "Caption"
-clearable = true
 
 [[control.property]]
 name = "IsReadOnly"
-clearable = true
 
 [[control.event]]
 name = "ValueChanged"
@@ -1156,7 +1003,6 @@ capabilities = ["layout"]
 
 [[control.property]]
 name = "IsExpanded"
-clearable = true
 controlled = "IsExpandedChanged"
 feedback_contract = "synchronous_exact"
 clear_feedback = false
@@ -1177,27 +1023,22 @@ capabilities = ["layout", "enabled", "focus"]
 
 [[control.property]]
 name = "ItemsSource"
-clearable = true
 adapter = "inspectable_string_list"
 
 [[control.property]]
 name = "SelectedIndex"
-clearable = true
 adapter = "selection_index"
 controlled = "SelectionChanged"
 feedback_contract = "synchronous_exact"
 
 [[control.property]]
 name = "PlaceholderText"
-clearable = true
 
 [[control.property]]
 name = "IsEditable"
-clearable = true
 
 [[control.property]]
 name = "IsEnabled"
-clearable = true
 
 [[control.event]]
 name = "SelectionChanged"
@@ -1212,14 +1053,12 @@ capabilities = ["layout"]
 
 [[control.property]]
 name = "SelectedIndex"
-clearable = true
 adapter = "selection_index"
 controlled = "SelectionChanged"
 feedback_contract = "synchronous_exact"
 
 [[control.property]]
 name = "Title"
-clearable = true
 adapter = "inspectable_string"
 
 [[control.event]]
@@ -1237,7 +1076,6 @@ capabilities = ["layout", "content"]
 
 [[control.property]]
 name = "Header"
-clearable = true
 adapter = "inspectable_string"
 
 [[control]]
@@ -1247,7 +1085,6 @@ capabilities = ["layout"]
 
 [[control.property]]
 name = "SelectedIndex"
-clearable = true
 adapter = "selection_index"
 controlled = "SelectionChanged"
 feedback_contract = "synchronous_exact"
@@ -1286,11 +1123,9 @@ capabilities = ["layout"]
 
 [[control.property]]
 name = "Text"
-clearable = true
 
 [[control.property]]
 name = "IsSelected"
-clearable = true
 
 [[control.slot]]
 name = "Icon"
@@ -1301,18 +1136,15 @@ capabilities = ["layout"]
 
 [[control.property]]
 name = "SelectedIndex"
-clearable = true
 adapter = "selection_index"
 controlled = "SelectionChanged"
 feedback_contract = "synchronous_exact"
 
 [[control.property]]
 name = "CanReorderTabs"
-clearable = true
 
 [[control.property]]
 name = "IsAddTabButtonVisible"
-clearable = true
 
 [[control.event]]
 name = "SelectionChanged"
@@ -1342,16 +1174,13 @@ capabilities = ["layout", "content"]
 
 [[control.property]]
 name = "Header"
-clearable = true
 adapter = "inspectable_string"
 
 [[control.property]]
 name = "IsClosable"
-clearable = true
 
 [[control.property]]
 name = "Tag"
-clearable = true
 adapter = "inspectable_string"
 
 [[control]]
@@ -1360,32 +1189,25 @@ capabilities = ["layout"]
 
 [[control.property]]
 name = "Title"
-clearable = true
 
 [[control.property]]
 name = "Subtitle"
-clearable = true
 
 [[control.property]]
 name = "IsOpen"
-clearable = true
 
 [[control.property]]
 name = "IsLightDismissEnabled"
-clearable = true
 
 [[control.property]]
 name = "PreferredPlacement"
-clearable = true
 
 [[control.property]]
 name = "ActionButtonContent"
-clearable = true
 adapter = "inspectable_string"
 
 [[control.property]]
 name = "CloseButtonContent"
-clearable = true
 adapter = "inspectable_string"
 
 [[control.event]]
@@ -1400,7 +1222,6 @@ capabilities = ["layout", "content", "enabled"]
 
 [[control.property]]
 name = "IsEnabled"
-clearable = true
 
 [[control.event]]
 name = "Click"
@@ -1425,11 +1246,9 @@ capabilities = ["layout", "enabled"]
 
 [[control.property]]
 name = "Label"
-clearable = true
 
 [[control.property]]
 name = "IsEnabled"
-clearable = true
 
 [[control.event]]
 name = "Click"
@@ -1455,7 +1274,6 @@ capabilities = ["layout"]
 
 [[control.property]]
 name = "Title"
-clearable = true
 
 [[control]]
 type = "Microsoft.UI.Xaml.Controls.SplitButton"
@@ -1463,7 +1281,6 @@ capabilities = ["layout", "content", "enabled"]
 
 [[control.property]]
 name = "IsEnabled"
-clearable = true
 
 [[control.event]]
 name = "Click"
@@ -1474,29 +1291,23 @@ capabilities = ["layout", "enabled"]
 
 [[control.property]]
 name = "Color"
-clearable = true
 controlled = "ColorChanged"
 feedback_contract = "synchronous_exact"
 
 [[control.property]]
 name = "IsAlphaEnabled"
-clearable = true
 
 [[control.property]]
 name = "IsHexInputVisible"
-clearable = true
 
 [[control.property]]
 name = "IsColorSliderVisible"
-clearable = true
 
 [[control.property]]
 name = "IsColorChannelTextInputVisible"
-clearable = true
 
 [[control.property]]
 name = "IsEnabled"
-clearable = true
 
 [[control.event]]
 name = "ColorChanged"
@@ -1508,19 +1319,15 @@ capabilities = ["layout", "enabled"]
 
 [[control.property]]
 name = "DayVisible"
-clearable = true
 
 [[control.property]]
 name = "MonthVisible"
-clearable = true
 
 [[control.property]]
 name = "YearVisible"
-clearable = true
 
 [[control.property]]
 name = "IsEnabled"
-clearable = true
 
 [[control.event]]
 name = "SelectedDateChanged"
@@ -1536,16 +1343,13 @@ capabilities = ["layout", "enabled"]
 [[control.property]]
 name = "ClockIdentifier"
 adapter = "clock_identifier"
-clearable = true
 
 [[control.property]]
 name = "MinuteIncrement"
-clearable = true
 validation = "zero_to_fifty_nine"
 
 [[control.property]]
 name = "IsEnabled"
-clearable = true
 
 [[control.event]]
 name = "SelectedTimeChanged"
@@ -1560,19 +1364,15 @@ capabilities = ["layout", "enabled"]
 
 [[control.property]]
 name = "PlaceholderText"
-clearable = true
 
 [[control.property]]
 name = "IsTodayHighlighted"
-clearable = true
 
 [[control.property]]
 name = "IsCalendarOpen"
-clearable = true
 
 [[control.property]]
 name = "IsEnabled"
-clearable = true
 
 [[control.event]]
 name = "DateChanged"
@@ -1593,28 +1393,22 @@ lifecycle = "content_dialog"
 
 [[control.property]]
 name = "Title"
-clearable = true
 adapter = "inspectable_string"
 
 [[control.property]]
 name = "PrimaryButtonText"
-clearable = true
 
 [[control.property]]
 name = "SecondaryButtonText"
-clearable = true
 
 [[control.property]]
 name = "CloseButtonText"
-clearable = true
 
 [[control.property]]
 name = "IsPrimaryButtonEnabled"
-clearable = true
 
 [[control.property]]
 name = "IsSecondaryButtonEnabled"
-clearable = true
 
 [[control.event]]
 name = "Closed"
@@ -1627,15 +1421,12 @@ capabilities = ["layout", "enabled"]
 
 [[control.property]]
 name = "IsTodayHighlighted"
-clearable = true
 
 [[control.property]]
 name = "IsGroupLabelVisible"
-clearable = true
 
 [[control.property]]
 name = "IsEnabled"
-clearable = true
 
 [[control.event]]
 name = "SelectedDatesChanged"
@@ -1647,26 +1438,21 @@ capabilities = ["layout", "enabled"]
 
 [[control.property]]
 name = "SelectedIndex"
-clearable = true
 adapter = "selection_index"
 controlled = "SelectionChanged"
 feedback_contract = "synchronous_exact"
 
 [[control.property]]
 name = "SelectionMode"
-clearable = true
 
 [[control.property]]
 name = "CanDragItems"
-clearable = true
 
 [[control.property]]
 name = "CanReorderItems"
-clearable = true
 
 [[control.property]]
 name = "AllowDrop"
-clearable = true
 
 [[control.event]]
 name = "SelectionChanged"
@@ -1688,7 +1474,6 @@ capabilities = ["layout", "content", "enabled"]
 
 [[control.property]]
 name = "Tag"
-clearable = true
 adapter = "inspectable_string"
 
 [[control]]
@@ -1697,7 +1482,6 @@ capabilities = ["layout", "enabled"]
 
 [[control.property]]
 name = "SelectionMode"
-clearable = true
 
 [[control.event]]
 name = "ItemInvoked"
@@ -1710,22 +1494,18 @@ capabilities = ["layout", "enabled"]
 
 [[control.property]]
 name = "SelectedIndex"
-clearable = true
 adapter = "selection_index"
 controlled = "SelectionChanged"
 feedback_contract = "synchronous_exact"
 
 [[control.property]]
 name = "CanDragItems"
-clearable = true
 
 [[control.property]]
 name = "CanReorderItems"
-clearable = true
 
 [[control.property]]
 name = "AllowDrop"
-clearable = true
 
 [[control.event]]
 name = "DragItemsCompleted"
@@ -1747,7 +1527,6 @@ capabilities = ["layout", "content", "enabled"]
 
 [[control.property]]
 name = "Tag"
-clearable = true
 adapter = "inspectable_string"
 
 [[control]]
@@ -1767,22 +1546,18 @@ capabilities = ["layout", "enabled", "controlled_text", "focus"]
 [[control.property]]
 name = "Document"
 field = "text"
-clearable = true
 controlled = "TextChanged"
 feedback_contract = "synchronous_exact"
 adapter = "rich_edit_text"
 
 [[control.property]]
 name = "PlaceholderText"
-clearable = true
 
 [[control.property]]
 name = "IsReadOnly"
-clearable = true
 
 [[control.property]]
 name = "IsEnabled"
-clearable = true
 
 
 [[control.event]]
@@ -1800,21 +1575,17 @@ capabilities = ["layout", "text_style"]
 [[control.property]]
 name = "Blocks"
 field = "paragraphs"
-clearable = true
 adapter = "rich_text_blocks"
 
 [[control.property]]
 name = "FontSize"
-clearable = true
 validation = "finite_positive"
 
 [[control.property]]
 name = "IsTextSelectionEnabled"
-clearable = true
 
 [[control.property]]
 name = "TextWrapping"
-clearable = true
 
 [[control]]
 type = "Microsoft.UI.Xaml.Controls.Viewbox"
@@ -1822,7 +1593,6 @@ capabilities = ["layout"]
 
 [[control.property]]
 name = "Stretch"
-clearable = true
 
 [[control.slot]]
 name = "Child"


### PR DESCRIPTION
This cleans up a bunch of accumulated complexity in Reactor without changing its generated API or behavior. It removes redundant schema state, simplifies component and window validation, pulls ContentDialog scheduling into a focused module, shares the common XamlRoot observation and native callback plumbing, and consolidates several repetitive generator and metadata-validation paths. The result is less state to carry around, fewer duplicated lifecycle and validation rules, and smaller code paths that are easier to reason about and maintain.