### PR TITLE
`windows-reactor` more simplifications

### DIFF
--- a/crates/libs/reactor/src/core/component.rs
+++ b/crates/libs/reactor/src/core/component.rs
@@ -731,56 +731,64 @@ impl<C: Component> ComponentContext<C> {
     }
 }
 
+#[derive(Default)]
+enum SingleDeclaration<T> {
+    #[default]
+    Empty,
+    Value(T),
+    Duplicate,
+}
+
+impl<T> SingleDeclaration<T> {
+    fn declare(&mut self, value: T) {
+        *self = if matches!(self, Self::Empty) {
+            Self::Value(value)
+        } else {
+            Self::Duplicate
+        };
+    }
+
+    fn resolve<E>(self, duplicate: E) -> Result<Option<T>, E> {
+        match self {
+            Self::Empty => Ok(None),
+            Self::Value(value) => Ok(Some(value)),
+            Self::Duplicate => Err(duplicate),
+        }
+    }
+}
+
 pub struct ViewContext<C: Component> {
     contexts: ContextSnapshot,
-    duplicate_color_scheme_observation: bool,
-    duplicate_window_size_observation: bool,
-    duplicate_window_title: bool,
-    duplicate_window_visuals: bool,
     effects: Rc<RefCell<ComponentEffects>>,
     reads: HashSet<ContextDependency>,
     sender: LocalSender<C::Message>,
-    color_scheme_observation: Option<Callback<ColorScheme>>,
-    window_size_observation: Option<Callback<WindowSize>>,
-    window_title: Option<String>,
-    window_visuals: Option<WindowVisuals>,
+    color_scheme_observation: SingleDeclaration<Callback<ColorScheme>>,
+    window_size_observation: SingleDeclaration<Callback<WindowSize>>,
+    window_title: SingleDeclaration<String>,
+    window_visuals: SingleDeclaration<WindowVisuals>,
 }
 
 impl<C: Component> ViewContext<C> {
     /// Declares a queued color-scheme observation for the owning window.
     pub fn on_color_scheme(&mut self, callback: impl IntoPayloadCallback<ColorScheme>) {
-        if self.color_scheme_observation.is_some() {
-            self.duplicate_color_scheme_observation = true;
-        } else {
-            self.color_scheme_observation = Some(callback.into_payload_callback());
-        }
+        self.color_scheme_observation
+            .declare(callback.into_payload_callback());
     }
 
     /// Declares a queued client-size observation for the owning window.
     pub fn on_window_size(&mut self, callback: impl IntoPayloadCallback<WindowSize>) {
-        if self.window_size_observation.is_some() {
-            self.duplicate_window_size_observation = true;
-        } else {
-            self.window_size_observation = Some(callback.into_payload_callback());
-        }
+        self.window_size_observation
+            .declare(callback.into_payload_callback());
     }
 
     /// Declares the owning window's title for this component publication.
     pub fn window_title(&mut self, title: impl Into<String>) {
-        if self.window_title.is_some() {
-            self.duplicate_window_title = true;
-        } else {
-            self.window_title = Some(title.into());
-        }
+        self.window_title.declare(title.into());
     }
 
     /// Declares the owning window's visual environment for this publication.
     pub fn window_visuals(&mut self, visuals: WindowVisuals) {
-        if self.window_visuals.is_some() {
-            self.duplicate_window_visuals = true;
-        } else {
-            self.window_visuals = Some(visuals);
-        }
+        self.window_visuals.declare(visuals);
     }
 
     pub fn sender(&self) -> LocalSender<C::Message> {
@@ -1332,38 +1340,34 @@ impl ComponentStore {
         ) -> Result<ComponentRender, ComponentStoreError> {
             let mut context = ViewContext {
                 contexts,
-                duplicate_color_scheme_observation: false,
-                duplicate_window_size_observation: false,
-                duplicate_window_title: false,
-                duplicate_window_visuals: false,
                 effects,
                 reads: HashSet::new(),
                 sender,
-                color_scheme_observation: None,
-                window_size_observation: None,
-                window_title: None,
-                window_visuals: None,
+                color_scheme_observation: SingleDeclaration::default(),
+                window_size_observation: SingleDeclaration::default(),
+                window_title: SingleDeclaration::default(),
+                window_visuals: SingleDeclaration::default(),
             };
             let view = component.view(input, &mut context);
-            if context.duplicate_color_scheme_observation {
-                return Err(ComponentStoreError::DuplicateColorSchemeObservation);
-            }
-            if context.duplicate_window_size_observation {
-                return Err(ComponentStoreError::DuplicateWindowSizeObservation);
-            }
-            if context.duplicate_window_title {
-                return Err(ComponentStoreError::DuplicateWindowTitle);
-            }
-            if context.duplicate_window_visuals {
-                return Err(ComponentStoreError::DuplicateWindowVisuals);
-            }
+            let color_scheme_observation = context
+                .color_scheme_observation
+                .resolve(ComponentStoreError::DuplicateColorSchemeObservation)?;
+            let window_size_observation = context
+                .window_size_observation
+                .resolve(ComponentStoreError::DuplicateWindowSizeObservation)?;
+            let window_title = context
+                .window_title
+                .resolve(ComponentStoreError::DuplicateWindowTitle)?;
+            let window_visuals = context
+                .window_visuals
+                .resolve(ComponentStoreError::DuplicateWindowVisuals)?;
             Ok(ComponentRender {
-                color_scheme_observation: context.color_scheme_observation,
+                color_scheme_observation,
                 dependencies: context.reads,
                 view,
-                window_size_observation: context.window_size_observation,
-                window_title: context.window_title,
-                window_visuals: context.window_visuals,
+                window_size_observation,
+                window_title,
+                window_visuals,
             })
         }
 

--- a/crates/libs/reactor/src/core/component_tests.rs
+++ b/crates/libs/reactor/src/core/component_tests.rs
@@ -568,8 +568,10 @@ fn component_factory_creates_with_a_reserved_sender_and_composes() {
     let first = ComponentView::new::<Counter>(2);
     let same = ComponentView::new::<Counter>(2);
     let changed = ComponentView::new::<Counter>(3);
+    let different = ComponentView::new::<Passive>(());
     assert_eq!(first, same);
     assert_ne!(first, changed);
+    assert_ne!(first, different);
 
     let mut store = store();
     let token = first.reserve(&mut store).unwrap();

--- a/crates/libs/reactor/src/core/engine.rs
+++ b/crates/libs/reactor/src/core/engine.rs
@@ -256,18 +256,31 @@ pub struct Tree {
 
 #[derive(Clone, Default)]
 struct WindowDeclarations {
-    color_scheme: Option<WindowObservation<ColorScheme>>,
-    color_scheme_revision: u32,
+    color_scheme: ObservationSlot<ColorScheme>,
     title: Option<Rc<str>>,
     visuals: Option<WindowVisuals>,
-    window_size: Option<WindowObservation<WindowSize>>,
-    window_size_revision: u32,
+    window_size: ObservationSlot<WindowSize>,
 }
 
-#[derive(Clone)]
-struct WindowObservation<T> {
-    callback: Callback<T>,
+#[derive(Clone, Default)]
+struct ObservationSlot<T> {
+    callback: Option<Callback<T>>,
     revision: u32,
+}
+
+impl<T> ObservationSlot<T> {
+    fn get(&self) -> Option<(&Callback<T>, u32)> {
+        self.callback
+            .as_ref()
+            .map(|callback| (callback, self.revision))
+    }
+
+    fn set(&mut self, callback: Option<Callback<T>>) {
+        if callback.is_some() && callback.as_ref() != self.callback.as_ref() {
+            self.revision = self.revision.wrapping_add(1);
+        }
+        self.callback = callback;
+    }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -1096,13 +1109,13 @@ impl Tree {
             self.window_declarations
                 .iter()
                 .filter_map(|(owner, declaration)| {
-                    let observation = declaration.color_scheme.as_ref()?;
+                    let (callback, revision) = declaration.color_scheme.get()?;
                     Some((
                         HostObservationId {
                             owner: *owner,
-                            revision: observation.revision,
+                            revision,
                         },
-                        observation.callback.clone(),
+                        callback.clone(),
                     ))
                 });
         let observation = declarations.next()?;
@@ -1115,7 +1128,7 @@ impl Tree {
         let count = self
             .window_declarations
             .values()
-            .filter(|declaration| declaration.color_scheme.is_some())
+            .filter(|declaration| declaration.color_scheme.get().is_some())
             .count();
         (count <= 1)
             .then(|| self.color_scheme_observation())
@@ -1129,20 +1142,7 @@ impl Tree {
     ) {
         let declarations = Rc::make_mut(&mut self.window_declarations);
         let declaration = declarations.entry(owner).or_default();
-        declaration.color_scheme = callback.map(|callback| {
-            let revision = declaration.color_scheme.as_ref().map_or_else(
-                || declaration.color_scheme_revision.wrapping_add(1),
-                |current| {
-                    if current.callback == callback {
-                        current.revision
-                    } else {
-                        declaration.color_scheme_revision.wrapping_add(1)
-                    }
-                },
-            );
-            declaration.color_scheme_revision = revision;
-            WindowObservation { callback, revision }
-        });
+        declaration.color_scheme.set(callback);
     }
 
     pub(crate) fn window_size_observation(
@@ -1152,13 +1152,13 @@ impl Tree {
             self.window_declarations
                 .iter()
                 .filter_map(|(owner, declaration)| {
-                    let observation = declaration.window_size.as_ref()?;
+                    let (callback, revision) = declaration.window_size.get()?;
                     Some((
                         HostObservationId {
                             owner: *owner,
-                            revision: observation.revision,
+                            revision,
                         },
-                        observation.callback.clone(),
+                        callback.clone(),
                     ))
                 });
         let observation = declarations.next()?;
@@ -1171,7 +1171,7 @@ impl Tree {
         let count = self
             .window_declarations
             .values()
-            .filter(|declaration| declaration.window_size.is_some())
+            .filter(|declaration| declaration.window_size.get().is_some())
             .count();
         (count <= 1)
             .then(|| self.window_size_observation())
@@ -1185,20 +1185,7 @@ impl Tree {
     ) {
         let declarations = Rc::make_mut(&mut self.window_declarations);
         let declaration = declarations.entry(owner).or_default();
-        declaration.window_size = callback.map(|callback| {
-            let revision = declaration.window_size.as_ref().map_or_else(
-                || declaration.window_size_revision.wrapping_add(1),
-                |current| {
-                    if current.callback == callback {
-                        current.revision
-                    } else {
-                        declaration.window_size_revision.wrapping_add(1)
-                    }
-                },
-            );
-            declaration.window_size_revision = revision;
-            WindowObservation { callback, revision }
-        });
+        declaration.window_size.set(callback);
     }
 
     pub(crate) fn remove_window_declarations(&mut self, owner: ScopeId) {

--- a/crates/libs/reactor/src/core/engine.rs
+++ b/crates/libs/reactor/src/core/engine.rs
@@ -46,9 +46,12 @@ enum NodeData {
     NamedSlot(SlotId),
     Tooltip(TooltipPlacement),
     Flyout(FlyoutPlacement),
-    Menu(OwnedMenuKind),
-    CommandBarFlyout,
-    TreeNodes,
+    Menu {
+        kind: OwnedMenuKind,
+        state: OwnedState<Vec<MenuItem>>,
+    },
+    CommandBarFlyout(OwnedState<(Vec<CommandBarCommand>, Vec<CommandBarCommand>)>),
+    TreeNodes(Rc<Vec<TreeNode>>),
     ContentDialog(bool),
     Native(NativeData),
     Virtual(VirtualData),
@@ -86,9 +89,9 @@ impl NodeData {
             Self::NamedSlot(slot) => NodeKind::NamedSlot(*slot),
             Self::Tooltip(placement) => NodeKind::Tooltip(*placement),
             Self::Flyout(placement) => NodeKind::Flyout(*placement),
-            Self::Menu(kind) => NodeKind::Menu(*kind),
-            Self::CommandBarFlyout => NodeKind::CommandBarFlyout,
-            Self::TreeNodes => NodeKind::TreeNodes,
+            Self::Menu { kind, .. } => NodeKind::Menu(*kind),
+            Self::CommandBarFlyout(_) => NodeKind::CommandBarFlyout,
+            Self::TreeNodes(_) => NodeKind::TreeNodes,
             Self::ContentDialog(open) => NodeKind::ContentDialog(*open),
             Self::Native(native) => NodeKind::Native(native.kind),
             Self::Virtual(_) => NodeKind::VirtualCollection,
@@ -150,16 +153,22 @@ impl VirtualData {
 }
 
 #[derive(Clone)]
-struct OwnedState {
+struct OwnedState<T> {
     callback: Callback<String>,
     revision: u32,
-    content: OwnedContent,
+    content: T,
 }
 
-#[derive(Clone)]
-enum OwnedContent {
-    Menu(Vec<MenuItem>),
-    Commands((Vec<CommandBarCommand>, Vec<CommandBarCommand>)),
+impl<T> OwnedState<T> {
+    fn replace(&mut self, callback: Callback<String>, content: T) -> Result<u32, TreeError> {
+        self.revision = self
+            .revision
+            .checked_add(1)
+            .ok_or(TreeError::NotComponent)?;
+        self.callback = callback;
+        self.content = content;
+        Ok(self.revision)
+    }
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -241,8 +250,6 @@ pub struct Tree {
     providers: ProviderStore,
     root: Option<NodeId>,
     owned_attachments: Rc<HashMap<NodeId, (NodeId, NodeId)>>,
-    owned: Rc<HashMap<NodeId, OwnedState>>,
-    tree_nodes: Rc<HashMap<NodeId, Rc<Vec<TreeNode>>>>,
     window_declarations: Rc<HashMap<ScopeId, WindowDeclarations>>,
     window_title_bars: Rc<HashMap<NodeId, WindowTitleBarHeight>>,
 }
@@ -330,8 +337,6 @@ impl Tree {
             providers: ProviderStore::default(),
             root: None,
             owned_attachments: Rc::new(HashMap::new()),
-            owned: Rc::new(HashMap::new()),
-            tree_nodes: Rc::new(HashMap::new()),
             window_declarations: Rc::new(HashMap::new()),
             window_title_bars: Rc::new(HashMap::new()),
         }
@@ -462,16 +467,18 @@ impl Tree {
         kind: OwnedMenuKind,
         menu: Menu,
     ) -> Result<NodeId, TreeError> {
-        let id = self.insert_data(parent, key, NodeData::Menu(kind))?;
-        Rc::make_mut(&mut self.owned).insert(
-            id,
-            OwnedState {
-                callback: menu.on_click,
-                revision: 1,
-                content: OwnedContent::Menu(menu.items),
+        self.insert_data(
+            parent,
+            key,
+            NodeData::Menu {
+                kind,
+                state: OwnedState {
+                    callback: menu.on_click,
+                    revision: 1,
+                    content: menu.items,
+                },
             },
-        );
-        Ok(id)
+        )
     }
 
     pub fn insert_command_bar_flyout(
@@ -480,16 +487,15 @@ impl Tree {
         key: Option<Key>,
         flyout: CommandBarFlyout,
     ) -> Result<NodeId, TreeError> {
-        let id = self.insert_data(parent, key, NodeData::CommandBarFlyout)?;
-        Rc::make_mut(&mut self.owned).insert(
-            id,
-            OwnedState {
+        self.insert_data(
+            parent,
+            key,
+            NodeData::CommandBarFlyout(OwnedState {
                 callback: flyout.on_click,
                 revision: 1,
-                content: OwnedContent::Commands((flyout.primary, flyout.secondary)),
-            },
-        );
-        Ok(id)
+                content: (flyout.primary, flyout.secondary),
+            }),
+        )
     }
 
     pub fn insert_tree_nodes(
@@ -498,16 +504,14 @@ impl Tree {
         key: Option<Key>,
         nodes: Rc<Vec<TreeNode>>,
     ) -> Result<NodeId, TreeError> {
-        let id = self.insert_data(parent, key, NodeData::TreeNodes)?;
-        Rc::make_mut(&mut self.tree_nodes).insert(id, nodes);
-        Ok(id)
+        self.insert_data(parent, key, NodeData::TreeNodes(nodes))
     }
 
     pub fn tree_nodes(&self, id: NodeId) -> Result<&Rc<Vec<TreeNode>>, TreeError> {
-        if !matches!(&self.arena.get(id)?.data, NodeData::TreeNodes) {
-            return Err(TreeError::NotComponent);
+        match &self.arena.get(id)?.data {
+            NodeData::TreeNodes(nodes) => Ok(nodes),
+            _ => Err(TreeError::NotComponent),
         }
-        self.tree_nodes.get(&id).ok_or(TreeError::NotComponent)
     }
 
     pub fn update_tree_nodes(
@@ -515,47 +519,36 @@ impl Tree {
         id: NodeId,
         nodes: Rc<Vec<TreeNode>>,
     ) -> Result<(), TreeError> {
-        if !matches!(&self.arena.get(id)?.data, NodeData::TreeNodes) {
-            return Err(TreeError::NotComponent);
+        match &mut self.arena.get_mut(id)?.data {
+            NodeData::TreeNodes(current) => {
+                *current = nodes;
+                Ok(())
+            }
+            _ => Err(TreeError::NotComponent),
         }
-        Rc::make_mut(&mut self.tree_nodes).insert(id, nodes);
-        Ok(())
     }
 
     pub fn owned_revision(&self, id: NodeId) -> Result<u32, TreeError> {
-        let node = self.arena.get(id)?;
-        if !matches!(&node.data, NodeData::Menu(_) | NodeData::CommandBarFlyout) {
-            return Err(TreeError::NotComponent);
+        match &self.arena.get(id)?.data {
+            NodeData::Menu { state, .. } => Ok(state.revision),
+            NodeData::CommandBarFlyout(state) => Ok(state.revision),
+            _ => Err(TreeError::NotComponent),
         }
-        self.owned
-            .get(&id)
-            .map(|owned| owned.revision)
-            .ok_or(TreeError::NotComponent)
     }
 
     pub fn owned_callback(&self, id: NodeId) -> Result<&Callback<String>, TreeError> {
-        self.arena.get(id)?;
-        self.owned
-            .get(&id)
-            .map(|owned| &owned.callback)
-            .ok_or(TreeError::NotComponent)
+        match &self.arena.get(id)?.data {
+            NodeData::Menu { state, .. } => Ok(&state.callback),
+            NodeData::CommandBarFlyout(state) => Ok(&state.callback),
+            _ => Err(TreeError::NotComponent),
+        }
     }
 
     pub fn update_menu(&mut self, id: NodeId, menu: Menu) -> Result<u32, TreeError> {
-        let node = self.arena.get_mut(id)?;
-        if !matches!(&node.data, NodeData::Menu(_)) {
-            return Err(TreeError::NotComponent);
+        match &mut self.arena.get_mut(id)?.data {
+            NodeData::Menu { state, .. } => state.replace(menu.on_click, menu.items),
+            _ => Err(TreeError::NotComponent),
         }
-        let owned = Rc::make_mut(&mut self.owned)
-            .get_mut(&id)
-            .ok_or(TreeError::NotComponent)?;
-        owned.revision = owned
-            .revision
-            .checked_add(1)
-            .ok_or(TreeError::NotComponent)?;
-        owned.callback = menu.on_click;
-        owned.content = OwnedContent::Menu(menu.items);
-        Ok(owned.revision)
     }
 
     pub fn update_command_bar_flyout(
@@ -563,20 +556,12 @@ impl Tree {
         id: NodeId,
         flyout: CommandBarFlyout,
     ) -> Result<u32, TreeError> {
-        let node = self.arena.get_mut(id)?;
-        if !matches!(&node.data, NodeData::CommandBarFlyout) {
-            return Err(TreeError::NotComponent);
+        match &mut self.arena.get_mut(id)?.data {
+            NodeData::CommandBarFlyout(state) => {
+                state.replace(flyout.on_click, (flyout.primary, flyout.secondary))
+            }
+            _ => Err(TreeError::NotComponent),
         }
-        let owned = Rc::make_mut(&mut self.owned)
-            .get_mut(&id)
-            .ok_or(TreeError::NotComponent)?;
-        owned.revision = owned
-            .revision
-            .checked_add(1)
-            .ok_or(TreeError::NotComponent)?;
-        owned.callback = flyout.on_click;
-        owned.content = OwnedContent::Commands((flyout.primary, flyout.secondary));
-        Ok(owned.revision)
     }
 
     pub fn set_kind(&mut self, id: NodeId, kind: NodeKind) -> Result<(), TreeError> {
@@ -590,7 +575,7 @@ impl Tree {
                 *current = placement;
                 Ok(())
             }
-            (NodeData::Menu(current), NodeKind::Menu(kind)) => {
+            (NodeData::Menu { kind: current, .. }, NodeKind::Menu(kind)) => {
                 *current = kind;
                 Ok(())
             }
@@ -607,10 +592,9 @@ impl Tree {
     }
 
     pub fn owned_menu(&self, id: NodeId) -> Result<&[MenuItem], TreeError> {
-        self.arena.get(id)?;
-        match &self.owned.get(&id).ok_or(TreeError::NotComponent)?.content {
-            OwnedContent::Menu(items) => Ok(items),
-            OwnedContent::Commands(_) => Err(TreeError::NotComponent),
+        match &self.arena.get(id)?.data {
+            NodeData::Menu { state, .. } => Ok(&state.content),
+            _ => Err(TreeError::NotComponent),
         }
     }
 
@@ -618,10 +602,9 @@ impl Tree {
         &self,
         id: NodeId,
     ) -> Result<&(Vec<CommandBarCommand>, Vec<CommandBarCommand>), TreeError> {
-        self.arena.get(id)?;
-        match &self.owned.get(&id).ok_or(TreeError::NotComponent)?.content {
-            OwnedContent::Commands(commands) => Ok(commands),
-            OwnedContent::Menu(_) => Err(TreeError::NotComponent),
+        match &self.arena.get(id)?.data {
+            NodeData::CommandBarFlyout(state) => Ok(&state.content),
+            _ => Err(TreeError::NotComponent),
         }
     }
 
@@ -1306,12 +1289,6 @@ impl Tree {
             }
             if matches!(&node.data, NodeData::Tooltip(_) | NodeData::Flyout(_)) {
                 Rc::make_mut(&mut self.owned_attachments).remove(&id);
-            }
-            if matches!(&node.data, NodeData::Menu(_) | NodeData::CommandBarFlyout) {
-                Rc::make_mut(&mut self.owned).remove(&id);
-            }
-            if matches!(&node.data, NodeData::TreeNodes) {
-                Rc::make_mut(&mut self.tree_nodes).remove(&id);
             }
             retired.push((id, kind));
         }

--- a/crates/libs/reactor/src/core/engine_tests.rs
+++ b/crates/libs/reactor/src/core/engine_tests.rs
@@ -103,6 +103,68 @@ fn candidate_tree_clones_component_identity_without_component_state() {
 }
 
 #[test]
+fn candidate_tree_clones_owned_node_payloads_on_write() {
+    let mut tree = Tree::new();
+    let root = tree.insert(None, NodeKind::Application).unwrap();
+    let menu = Menu::new([MenuItem::item("old", "Old")], |_| {});
+    let menu_callback = menu.on_click.clone();
+    let menu_node = tree
+        .insert_menu(Some(root), None, OwnedMenuKind::ButtonFlyout, menu)
+        .unwrap();
+    let flyout = CommandBarFlyout::new([CommandBarCommand::button("old", "Old")], [], |_| {});
+    let flyout_callback = flyout.on_click.clone();
+    let flyout_node = tree
+        .insert_command_bar_flyout(Some(root), None, flyout)
+        .unwrap();
+    let tree_node = tree
+        .insert_tree_nodes(Some(root), None, Rc::new(vec![TreeNode::new("old", "Old")]))
+        .unwrap();
+
+    let mut candidate = tree.clone();
+    candidate
+        .update_menu(menu_node, Menu::new([MenuItem::item("new", "New")], |_| {}))
+        .unwrap();
+    candidate
+        .update_command_bar_flyout(
+            flyout_node,
+            CommandBarFlyout::new([CommandBarCommand::button("new", "New")], [], |_| {}),
+        )
+        .unwrap();
+    candidate
+        .update_tree_nodes(tree_node, Rc::new(vec![TreeNode::new("new", "New")]))
+        .unwrap();
+
+    assert_eq!(tree.owned_revision(menu_node), Ok(1));
+    assert_eq!(tree.owned_revision(flyout_node), Ok(1));
+    assert_eq!(tree.owned_callback(menu_node), Ok(&menu_callback));
+    assert_eq!(tree.owned_callback(flyout_node), Ok(&flyout_callback));
+    assert_eq!(
+        tree.owned_menu(menu_node).unwrap()[0].key(),
+        &Key::from("old")
+    );
+    assert_eq!(
+        tree.owned_commands(flyout_node).unwrap().0[0].key(),
+        &Key::from("old")
+    );
+    assert_eq!(tree.tree_nodes(tree_node).unwrap()[0].key, Key::from("old"));
+
+    assert_eq!(candidate.owned_revision(menu_node), Ok(2));
+    assert_eq!(candidate.owned_revision(flyout_node), Ok(2));
+    assert_eq!(
+        candidate.owned_menu(menu_node).unwrap()[0].key(),
+        &Key::from("new")
+    );
+    assert_eq!(
+        candidate.owned_commands(flyout_node).unwrap().0[0].key(),
+        &Key::from("new")
+    );
+    assert_eq!(
+        candidate.tree_nodes(tree_node).unwrap()[0].key,
+        Key::from("new")
+    );
+}
+
+#[test]
 fn rejects_second_root() {
     let mut tree = Tree::new();
     tree.insert(None, NodeKind::Application).unwrap();

--- a/crates/libs/reactor/src/core/engine_tests.rs
+++ b/crates/libs/reactor/src/core/engine_tests.rs
@@ -8,6 +8,31 @@ fn identity() -> WindowToken {
 }
 use std::collections::{HashMap, HashSet};
 
+#[test]
+fn observation_slot_preserves_and_advances_revisions() {
+    let first = Callback::new(|_: ()| {});
+    let second = Callback::new(|_: ()| {});
+    let mut slot = ObservationSlot::default();
+
+    assert!(slot.get().is_none());
+    slot.set(Some(first.clone()));
+    assert_eq!(slot.get(), Some((&first, 1)));
+    slot.set(Some(first.clone()));
+    assert_eq!(slot.get(), Some((&first, 1)));
+    slot.set(Some(second.clone()));
+    assert_eq!(slot.get(), Some((&second, 2)));
+    slot.set(None);
+    assert!(slot.get().is_none());
+    assert_eq!(slot.revision, 2);
+    slot.set(None);
+    assert_eq!(slot.revision, 2);
+    slot.set(Some(second.clone()));
+    assert_eq!(slot.get(), Some((&second, 3)));
+    slot.revision = u32::MAX;
+    slot.set(Some(first.clone()));
+    assert_eq!(slot.get(), Some((&first, 0)));
+}
+
 struct Rng(u64);
 
 impl Rng {

--- a/crates/libs/reactor/src/core/pump/mod.rs
+++ b/crates/libs/reactor/src/core/pump/mod.rs
@@ -176,7 +176,7 @@ impl<R: NativeRuntime> Pump<R> {
             plan,
             FrontendChanges::Element(desired),
             next_version,
-            CandidateFailureStage::PlanningDiscard,
+            PlanningFailure::Discard,
         )?;
         self.application = Some(application);
         self.window = Some(window);
@@ -210,7 +210,7 @@ impl<R: NativeRuntime> Pump<R> {
         let (root, native_roots) = match mounted {
             Ok(mounted) => mounted,
             Err(error) => {
-                self.fail_component_candidate(&changes, CandidateFailureStage::PlanningDiscard);
+                self.fail_component_candidate(&changes, PlanningFailure::Discard);
                 return Err(error);
             }
         };
@@ -225,7 +225,7 @@ impl<R: NativeRuntime> Pump<R> {
                 });
             }
             _ => {
-                self.fail_component_candidate(&changes, CandidateFailureStage::PlanningDiscard);
+                self.fail_component_candidate(&changes, PlanningFailure::Discard);
                 return Err(PumpError::StructureUnsupported);
             }
         }
@@ -234,7 +234,7 @@ impl<R: NativeRuntime> Pump<R> {
             changes,
             next_version,
             plan,
-            planning_failure: CandidateFailureStage::PlanningDiscard,
+            planning_failure: PlanningFailure::Discard,
             root,
             tree: candidate,
             window,
@@ -268,18 +268,18 @@ impl<R: NativeRuntime> Pump<R> {
             &mut changes,
             &mut plan,
         ) {
-            self.fail_component_candidate(&changes, CandidateFailureStage::PlanningRearm);
+            self.fail_component_candidate(&changes, PlanningFailure::Rearm);
             return Err(error);
         }
         let window = self.window.ok_or(PumpError::NotMounted)?;
         let candidate_root = match candidate.children(window) {
             Ok([candidate_root]) => *candidate_root,
             Ok(_) => {
-                self.fail_component_candidate(&changes, CandidateFailureStage::PlanningRearm);
+                self.fail_component_candidate(&changes, PlanningFailure::Rearm);
                 return Err(PumpError::StructureUnsupported);
             }
             Err(error) => {
-                self.fail_component_candidate(&changes, CandidateFailureStage::PlanningRearm);
+                self.fail_component_candidate(&changes, PlanningFailure::Rearm);
                 return Err(error.into());
             }
         };
@@ -327,7 +327,7 @@ impl<R: NativeRuntime> Pump<R> {
             plan,
             FrontendChanges::Element(desired_element),
             next_version,
-            CandidateFailureStage::PlanningDiscard,
+            PlanningFailure::Discard,
         )
     }
 
@@ -649,7 +649,7 @@ impl<R: NativeRuntime> Pump<R> {
             changes,
             next_version,
             plan,
-            planning_failure: CandidateFailureStage::PlanningRearm,
+            planning_failure: PlanningFailure::Rearm,
             root: candidate_root,
             tree: candidate,
             window,

--- a/crates/libs/reactor/src/core/pump/native_work.rs
+++ b/crates/libs/reactor/src/core/pump/native_work.rs
@@ -653,7 +653,7 @@ impl<R: NativeRuntime> Pump<R> {
             for queued in consumed.into_iter().rev() {
                 self.realizations.push_front(queued);
             }
-            self.fail_component_candidate(&changes, CandidateFailureStage::PlanningDiscard);
+            self.fail_component_candidate(&changes, PlanningFailure::Discard);
             return Err(error);
         }
         let has_work = !plan.commands.is_empty()
@@ -696,7 +696,7 @@ impl<R: NativeRuntime> Pump<R> {
             changes,
             next_version: self.version,
             plan,
-            planning_failure: CandidateFailureStage::PlanningDiscard,
+            planning_failure: PlanningFailure::Discard,
             root,
             tree: candidate,
             window,

--- a/crates/libs/reactor/src/core/pump/plan.rs
+++ b/crates/libs/reactor/src/core/pump/plan.rs
@@ -36,12 +36,9 @@ pub(super) struct ComponentChanges {
 }
 
 #[derive(Clone, Copy)]
-pub(super) enum CandidateFailureStage {
-    PlanningDiscard,
-    PlanningRearm,
-    EffectPreparation,
-    NativeApply,
-    Publication,
+pub(super) enum PlanningFailure {
+    Discard,
+    Rearm,
 }
 
 pub(super) enum LocalComponentUpdate {
@@ -64,7 +61,7 @@ pub(super) struct ComponentCandidate {
     pub(super) changes: ComponentChanges,
     pub(super) next_version: u64,
     pub(super) plan: UpdatePlan,
-    pub(super) planning_failure: CandidateFailureStage,
+    pub(super) planning_failure: PlanningFailure,
     pub(super) root: NodeId,
     pub(super) tree: Tree,
     pub(super) window: NodeId,

--- a/crates/libs/reactor/src/core/pump/planner/view.rs
+++ b/crates/libs/reactor/src/core/pump/planner/view.rs
@@ -45,6 +45,27 @@ struct ChildListTarget {
     slot: Option<SlotId>,
 }
 
+struct KeyedChildReconciliation {
+    old_keys: Vec<Key>,
+    new_keys: Vec<Key>,
+    operations: Vec<KeyedOperation<Key>>,
+    nodes: HashMap<Key, NodeId>,
+}
+
+impl KeyedChildReconciliation {
+    fn order(&self) -> Result<Vec<NodeId>, PumpError> {
+        self.new_keys
+            .iter()
+            .map(|key| {
+                self.nodes
+                    .get(key)
+                    .copied()
+                    .ok_or(PumpError::StructureUnsupported)
+            })
+            .collect()
+    }
+}
+
 impl<R: NativeRuntime> Pump<R> {
     pub(in super::super) fn reconcile_planned_view(
         tree: &mut Tree,
@@ -670,35 +691,11 @@ impl<R: NativeRuntime> Pump<R> {
         if target.slot.is_some() && requires_sync {
             return Err(PumpError::StructureUnsupported);
         }
-        let old_keys = current
-            .iter()
-            .map(|child| {
-                tree.key(*child)?
-                    .cloned()
-                    .ok_or(PumpError::StructureUnsupported)
-            })
-            .collect::<Result<Vec<_>, PumpError>>()?;
-        let new_keys = desired
-            .iter()
-            .map(|child| child.key().clone())
-            .collect::<Vec<_>>();
-        let operations = diff(&old_keys, &new_keys)
-            .map_err(|KeyedError::DuplicateKey(key)| PumpError::DuplicateKey(key))?;
-        let new_key_set = new_keys.iter().cloned().collect::<HashSet<_>>();
-        let mut nodes = old_keys
-            .iter()
-            .cloned()
-            .zip(current.iter().copied())
-            .collect::<HashMap<_, _>>();
-
-        for (key, child) in old_keys.iter().zip(current.iter().copied()) {
-            if !new_key_set.contains(key) {
-                Self::collect_retired_components(tree, child, components, changes)?;
-                Self::retire_planned_subtree(tree, child, plan)?;
-            }
-        }
+        let mut reconciliation = Self::begin_keyed_child_reconciliation(
+            tree, current, desired, components, changes, plan,
+        )?;
         for child in desired {
-            if let Some(child_node) = nodes.get(child.key()).copied() {
+            if let Some(child_node) = reconciliation.nodes.get(child.key()).copied() {
                 let old_roots = Self::native_roots(tree, child_node)?;
                 let reconciled = Self::reconcile_planned_view(
                     tree,
@@ -715,12 +712,12 @@ impl<R: NativeRuntime> Pump<R> {
                 }
                 requires_sync |= invalid_roots;
                 if reconciled != child_node {
-                    nodes.insert(child.key().clone(), reconciled);
+                    reconciliation.nodes.insert(child.key().clone(), reconciled);
                 }
             }
         }
         for child in desired {
-            if !nodes.contains_key(child.key()) {
+            if !reconciliation.nodes.contains_key(child.key()) {
                 let (child_node, native) = Self::mount_planned_view(
                     tree,
                     Some(target.logical_parent),
@@ -734,22 +731,13 @@ impl<R: NativeRuntime> Pump<R> {
                     return Err(PumpError::StructureUnsupported);
                 }
                 requires_sync |= native.len() != 1;
-                nodes.insert(child.key().clone(), child_node);
+                reconciliation.nodes.insert(child.key().clone(), child_node);
             }
         }
 
-        let order = new_keys
-            .iter()
-            .map(|key| {
-                nodes
-                    .get(key)
-                    .copied()
-                    .ok_or(PumpError::StructureUnsupported)
-            })
-            .collect::<Result<Vec<_>, _>>()?;
-        tree.set_children(target.logical_parent, order)?;
+        tree.set_children(target.logical_parent, reconciliation.order()?)?;
         let new_native = Self::native_children(tree, target.logical_parent)?;
-        let dense = super::is_dense_keyed_update(&operations);
+        let dense = super::is_dense_keyed_update(&reconciliation.operations);
         if (requires_sync || dense) && old_native != new_native {
             plan.synchronize_children(target.native_parent, target.slot, new_native);
         } else if !requires_sync {
@@ -757,9 +745,9 @@ impl<R: NativeRuntime> Pump<R> {
                 tree,
                 target.native_parent,
                 target.slot,
-                old_keys,
-                operations,
-                &nodes,
+                reconciliation.old_keys,
+                reconciliation.operations,
+                &reconciliation.nodes,
                 plan,
             )?;
         }
@@ -1157,6 +1145,49 @@ impl<R: NativeRuntime> Pump<R> {
         Ok(node)
     }
 
+    fn begin_keyed_child_reconciliation(
+        tree: &mut Tree,
+        current: Vec<NodeId>,
+        desired: &[KeyedView],
+        components: &mut ComponentStore,
+        changes: &mut ComponentChanges,
+        plan: &mut UpdatePlan,
+    ) -> Result<KeyedChildReconciliation, PumpError> {
+        let old_keys = current
+            .iter()
+            .map(|child| {
+                tree.key(*child)?
+                    .cloned()
+                    .ok_or(PumpError::StructureUnsupported)
+            })
+            .collect::<Result<Vec<_>, PumpError>>()?;
+        let new_keys = desired
+            .iter()
+            .map(|child| child.key().clone())
+            .collect::<Vec<_>>();
+        let operations = diff(&old_keys, &new_keys)
+            .map_err(|KeyedError::DuplicateKey(key)| PumpError::DuplicateKey(key))?;
+        let new_key_set = new_keys.iter().cloned().collect::<HashSet<_>>();
+        let nodes = old_keys
+            .iter()
+            .cloned()
+            .zip(current.iter().copied())
+            .collect::<HashMap<_, _>>();
+
+        for (key, child) in old_keys.iter().zip(current) {
+            if !new_key_set.contains(key) {
+                Self::collect_retired_components(tree, child, components, changes)?;
+                Self::retire_planned_subtree(tree, child, plan)?;
+            }
+        }
+        Ok(KeyedChildReconciliation {
+            old_keys,
+            new_keys,
+            operations,
+            nodes,
+        })
+    }
+
     fn reconcile_fragment(
         tree: &mut Tree,
         node: NodeId,
@@ -1167,36 +1198,11 @@ impl<R: NativeRuntime> Pump<R> {
     ) -> Result<(), PumpError> {
         let old_native = Self::native_roots(tree, node)?;
         let current = tree.children(node)?.to_vec();
-        let old_keys = current
-            .iter()
-            .map(|child| {
-                tree.key(*child)?
-                    .cloned()
-                    .ok_or(PumpError::StructureUnsupported)
-            })
-            .collect::<Result<Vec<_>, PumpError>>()?;
-        let new_keys = children
-            .iter()
-            .map(|child| child.key().clone())
-            .collect::<Vec<_>>();
-        diff(&old_keys, &new_keys)
-            .map_err(|KeyedError::DuplicateKey(key)| PumpError::DuplicateKey(key))?;
-
-        let new_key_set = new_keys.iter().cloned().collect::<HashSet<_>>();
-        let mut nodes = old_keys
-            .iter()
-            .cloned()
-            .zip(current.iter().copied())
-            .collect::<HashMap<_, _>>();
-        for (key, child) in old_keys.iter().zip(current) {
-            if !new_key_set.contains(key) {
-                Self::collect_retired_components(tree, child, components, changes)?;
-                Self::retire_planned_subtree(tree, child, plan)?;
-            }
-        }
-        let mut order = Vec::with_capacity(children.len());
+        let mut reconciliation = Self::begin_keyed_child_reconciliation(
+            tree, current, children, components, changes, plan,
+        )?;
         for child in children {
-            let child_node = if let Some(child_node) = nodes.get(child.key()).copied() {
+            if let Some(child_node) = reconciliation.nodes.get(child.key()).copied() {
                 let reconciled = Self::reconcile_planned_view(
                     tree,
                     child_node,
@@ -1205,8 +1211,7 @@ impl<R: NativeRuntime> Pump<R> {
                     changes,
                     plan,
                 )?;
-                nodes.insert(child.key().clone(), reconciled);
-                reconciled
+                reconciliation.nodes.insert(child.key().clone(), reconciled);
             } else {
                 let mounted = Self::mount_planned_view(
                     tree,
@@ -1218,12 +1223,10 @@ impl<R: NativeRuntime> Pump<R> {
                     plan,
                 )?
                 .0;
-                nodes.insert(child.key().clone(), mounted);
-                mounted
-            };
-            order.push(child_node);
+                reconciliation.nodes.insert(child.key().clone(), mounted);
+            }
         }
-        tree.set_children(node, order)?;
+        tree.set_children(node, reconciliation.order()?)?;
 
         let new_native = Self::native_roots(tree, node)?;
         if old_native != new_native {

--- a/crates/libs/reactor/src/core/pump/publish.rs
+++ b/crates/libs/reactor/src/core/pump/publish.rs
@@ -11,33 +11,25 @@ impl<R: NativeRuntime> Pump<R> {
     pub(super) fn fail_component_candidate(
         &mut self,
         changes: &ComponentChanges,
-        stage: CandidateFailureStage,
+        failure: PlanningFailure,
     ) {
-        if matches!(stage, CandidateFailureStage::PlanningRearm) {
+        if matches!(failure, PlanningFailure::Rearm) {
             self.planning_dirty.extend(changes.touched.iter().copied());
         }
         Self::remove_reservations(&mut self.components, &changes.reserved);
-        if matches!(
-            stage,
-            CandidateFailureStage::EffectPreparation
-                | CandidateFailureStage::NativeApply
-                | CandidateFailureStage::Publication
-        ) {
-            self.fail_stop();
+    }
+
+    fn fail_frontend_planning(&mut self, changes: &FrontendChanges, failure: PlanningFailure) {
+        if let FrontendChanges::Component(changes) = changes {
+            self.fail_component_candidate(changes, failure);
         }
     }
 
-    fn fail_frontend_candidate(&mut self, changes: &FrontendChanges, stage: CandidateFailureStage) {
+    pub(super) fn abort_frontend_candidate(&mut self, changes: &FrontendChanges) {
         if let FrontendChanges::Component(changes) = changes {
-            self.fail_component_candidate(changes, stage);
-        } else if matches!(
-            stage,
-            CandidateFailureStage::EffectPreparation
-                | CandidateFailureStage::NativeApply
-                | CandidateFailureStage::Publication
-        ) {
-            self.fail_stop();
+            Self::remove_reservations(&mut self.components, &changes.reserved);
         }
+        self.fail_stop();
     }
 
     pub(super) fn apply_native_commands(&mut self, commands: &[Command]) -> Result<(), PumpError> {
@@ -68,7 +60,7 @@ impl<R: NativeRuntime> Pump<R> {
         plan: UpdatePlan,
         mut changes: FrontendChanges,
         next_version: u64,
-        planning_failure: CandidateFailureStage,
+        planning_failure: PlanningFailure,
     ) -> Result<(), PumpError> {
         let commits_window_close = plan
             .post_publish_commands
@@ -76,7 +68,7 @@ impl<R: NativeRuntime> Pump<R> {
             .any(|command| matches!(command, Command::CloseWindow { .. }));
         if let Err(error) = self.validate_candidate_references(&candidate, &plan.reference_commits)
         {
-            self.fail_frontend_candidate(&changes, planning_failure);
+            self.fail_frontend_planning(&changes, planning_failure);
             return Err(error);
         }
         let prepared = match &mut changes {
@@ -88,27 +80,27 @@ impl<R: NativeRuntime> Pump<R> {
             FrontendChanges::Element(_) => Ok(()),
         };
         if let Err(error) = prepared {
-            self.fail_frontend_candidate(&changes, CandidateFailureStage::EffectPreparation);
+            self.abort_frontend_candidate(&changes);
             return Err(error);
         }
 
         if let Err(error) = self.apply_native_commands(&plan.commands) {
-            self.fail_frontend_candidate(&changes, CandidateFailureStage::NativeApply);
+            self.abort_frontend_candidate(&changes);
             return Err(error);
         }
 
         if let Err(error) = self.commit_candidate_properties(&mut candidate, &plan.commits) {
-            self.fail_frontend_candidate(&changes, CandidateFailureStage::Publication);
+            self.abort_frontend_candidate(&changes);
             return Err(error);
         }
         if let Err(error) =
             self.commit_candidate_references(&mut candidate, &plan.reference_commits)
         {
-            self.fail_frontend_candidate(&changes, CandidateFailureStage::Publication);
+            self.abort_frontend_candidate(&changes);
             return Err(error);
         }
         if let Err(error) = self.publish_frontend(candidate, &changes, &plan.reference_commits) {
-            self.fail_frontend_candidate(&changes, CandidateFailureStage::Publication);
+            self.abort_frontend_candidate(&changes);
             return Err(error);
         }
         self.diagnostics.extend(plan.diagnostics);

--- a/crates/libs/reactor/src/core/pump/tests/failure_policy.rs
+++ b/crates/libs/reactor/src/core/pump/tests/failure_policy.rs
@@ -20,7 +20,7 @@ fn planning_discard_removes_reservations_without_rearming_or_poison() {
     let mut pump = Pump::new(RecordingRuntime::default());
     let (changes, token) = candidate_with_reservation(&mut pump);
 
-    pump.fail_component_candidate(&changes, CandidateFailureStage::PlanningDiscard);
+    pump.fail_component_candidate(&changes, PlanningFailure::Discard);
 
     assert!(pump.components.publish(token).is_err());
     assert!(pump.planning_dirty.is_empty());
@@ -32,7 +32,7 @@ fn planning_rearm_removes_reservations_and_retains_touched_scopes() {
     let mut pump = Pump::new(RecordingRuntime::default());
     let (changes, token) = candidate_with_reservation(&mut pump);
 
-    pump.fail_component_candidate(&changes, CandidateFailureStage::PlanningRearm);
+    pump.fail_component_candidate(&changes, PlanningFailure::Rearm);
 
     assert!(pump.components.publish(token).is_err());
     assert!(pump.planning_dirty.contains(&token));
@@ -40,21 +40,15 @@ fn planning_rearm_removes_reservations_and_retains_touched_scopes() {
 }
 
 #[test]
-fn post_planning_failures_remove_reservations_and_fail_stop() {
-    for stage in [
-        CandidateFailureStage::EffectPreparation,
-        CandidateFailureStage::NativeApply,
-        CandidateFailureStage::Publication,
-    ] {
-        let mut pump = Pump::new(RecordingRuntime::default());
-        let (changes, token) = candidate_with_reservation(&mut pump);
+fn post_planning_abort_removes_reservations_and_fail_stops() {
+    let mut pump = Pump::new(RecordingRuntime::default());
+    let (changes, token) = candidate_with_reservation(&mut pump);
 
-        pump.fail_component_candidate(&changes, stage);
+    pump.abort_frontend_candidate(&FrontendChanges::Component(changes));
 
-        assert!(pump.components.publish(token).is_err());
-        assert!(pump.poisoned());
-        pump.dirty_components.insert(token);
-        pump.native_observation_pending = true;
-        assert!(!pump.native_work_pending());
-    }
+    assert!(pump.components.publish(token).is_err());
+    assert!(pump.poisoned());
+    pump.dirty_components.insert(token);
+    pump.native_observation_pending = true;
+    assert!(!pump.native_work_pending());
 }

--- a/crates/libs/reactor/src/core/pump/tests/window_observations.rs
+++ b/crates/libs/reactor/src/core/pump/tests/window_observations.rs
@@ -224,6 +224,32 @@ fn duplicate_host_observation_is_rejected() {
     );
 }
 
+struct DuplicateColorSchemeObservation;
+
+impl Component for DuplicateColorSchemeObservation {
+    type Message = ();
+    type Input = ();
+
+    fn create(_input: &(), _context: &ComponentContext<Self>) -> Self {
+        Self
+    }
+
+    fn view(&self, _input: &(), context: &mut ViewContext<Self>) -> View {
+        context.on_color_scheme(|_| ());
+        context.on_color_scheme(|_| ());
+        View::empty()
+    }
+}
+
+#[test]
+fn duplicate_color_scheme_observation_is_rejected() {
+    let mut pump = Pump::new(RecordingRuntime::default());
+    assert_eq!(
+        pump.mount_view(View::component::<DuplicateColorSchemeObservation>(())),
+        Err(PumpError::DuplicateColorSchemeObservation)
+    );
+}
+
 struct ObservationChild;
 
 impl Component for ObservationChild {

--- a/crates/libs/reactor/src/core/pump/turn.rs
+++ b/crates/libs/reactor/src/core/pump/turn.rs
@@ -115,7 +115,7 @@ impl<R: NativeRuntime> Pump<R> {
                             token,
                         },
                         next_version,
-                        CandidateFailureStage::PlanningRearm,
+                        PlanningFailure::Rearm,
                     )?;
                     self.planning_dirty.remove(&token);
                     self.dirty_components.clear();
@@ -159,7 +159,7 @@ impl<R: NativeRuntime> Pump<R> {
                 if changes.retired.contains(&token) {
                     continue;
                 }
-                self.fail_component_candidate(&changes, CandidateFailureStage::PlanningRearm);
+                self.fail_component_candidate(&changes, PlanningFailure::Rearm);
                 return Err(PumpError::StructureUnsupported);
             };
             let result = if composed_view
@@ -198,7 +198,7 @@ impl<R: NativeRuntime> Pump<R> {
                 )
             };
             if let Err(error) = result {
-                self.fail_component_candidate(&changes, CandidateFailureStage::PlanningRearm);
+                self.fail_component_candidate(&changes, PlanningFailure::Rearm);
                 return Err(error);
             }
         }

--- a/crates/libs/reactor/src/core/scheduler.rs
+++ b/crates/libs/reactor/src/core/scheduler.rs
@@ -54,10 +54,11 @@ impl SchedulerState {
             self.pending
                 .map_or(priority, |current| current.max(priority)),
         );
+        let pending = self.pending.unwrap();
         match self.phase {
-            SchedulerPhase::Idle => self.schedule(priority),
-            SchedulerPhase::Scheduled(scheduled) if priority > scheduled.priority => {
-                self.schedule(priority)
+            SchedulerPhase::Idle => self.schedule(pending),
+            SchedulerPhase::Scheduled(scheduled) if pending > scheduled.priority => {
+                self.schedule(pending)
             }
             SchedulerPhase::Scheduled(_) | SchedulerPhase::Dispatching => ScheduleAction::None,
             SchedulerPhase::Closing => ScheduleAction::Closed,
@@ -174,6 +175,21 @@ mod tests {
         state.enqueue_failed(ticket);
 
         let ScheduleAction::Enqueue(retry) = state.request(WorkPriority::Normal) else {
+            panic!("expected retry");
+        };
+        assert_eq!(retry.priority, WorkPriority::Normal);
+    }
+
+    #[test]
+    fn lower_priority_request_does_not_downgrade_retained_work() {
+        let mut state = SchedulerState::new();
+        let ScheduleAction::Enqueue(ticket) = state.request(WorkPriority::Normal) else {
+            panic!("expected enqueue");
+        };
+
+        state.enqueue_failed(ticket);
+
+        let ScheduleAction::Enqueue(retry) = state.request(WorkPriority::Low) else {
             panic!("expected retry");
         };
         assert_eq!(retry.priority, WorkPriority::Normal);

--- a/crates/libs/reactor/src/native/winui/content_dialog.rs
+++ b/crates/libs/reactor/src/native/winui/content_dialog.rs
@@ -5,7 +5,6 @@ pub(super) struct ContentDialogScheduler {
     dialogs: HashMap<NodeId, ContentDialogLifecycle>,
     next_generation: u64,
     request_order: u64,
-    subscriptions: HashMap<NodeId, NativeSubscription>,
 }
 
 pub(super) enum ContentDialogAction {
@@ -24,6 +23,7 @@ struct ContentDialogLifecycle {
     retired: bool,
     revision: u32,
     root_loaded: Option<windows_core::EventRevoker>,
+    subscription: Option<NativeSubscription>,
     suppress_callback: bool,
     xaml_root: Option<XamlRoot>,
 }
@@ -57,6 +57,7 @@ impl ContentDialogScheduler {
                 retired: false,
                 revision: 0,
                 root_loaded: None,
+                subscription: None,
                 suppress_callback: false,
                 xaml_root: None,
             },
@@ -149,7 +150,9 @@ impl ContentDialogScheduler {
     }
 
     pub(super) fn has_subscription(&self, node: NodeId) -> bool {
-        self.subscriptions.contains_key(&node)
+        self.dialogs
+            .get(&node)
+            .is_some_and(|state| state.subscription.is_some())
     }
 
     pub(super) fn subscribe(
@@ -158,11 +161,12 @@ impl ContentDialogScheduler {
         revision: u32,
         subscription: NativeSubscription,
     ) -> Result<(), RuntimeError> {
-        self.dialogs
+        let state = self
+            .dialogs
             .get_mut(&node)
-            .ok_or(RuntimeError::MissingNode(node))?
-            .revision = revision;
-        self.subscriptions.insert(node, subscription);
+            .ok_or(RuntimeError::MissingNode(node))?;
+        state.revision = revision;
+        state.subscription = Some(subscription);
         Ok(())
     }
 
@@ -171,12 +175,13 @@ impl ContentDialogScheduler {
         node: NodeId,
         event: EventId,
     ) -> Result<bool, RuntimeError> {
-        let Some(state) = self.dialogs.get(&node) else {
+        let Some(state) = self.dialogs.get_mut(&node) else {
             return Ok(false);
         };
         if !state.pending {
-            self.subscriptions
-                .remove(&node)
+            state
+                .subscription
+                .take()
                 .ok_or(RuntimeError::MissingSubscription(node, event))?;
         }
         Ok(true)
@@ -184,7 +189,10 @@ impl ContentDialogScheduler {
 
     #[cfg(feature = "test")]
     pub(super) fn subscription_count(&self) -> usize {
-        self.subscriptions.len()
+        self.dialogs
+            .values()
+            .filter(|state| state.subscription.is_some())
+            .count()
     }
 
     #[cfg(feature = "test")]
@@ -278,17 +286,21 @@ impl ContentDialogScheduler {
 }
 
 pub(super) fn reset(scheduler: &Rc<RefCell<ContentDialogScheduler>>) {
-    let dialogs = {
+    let (dialogs, subscriptions) = {
         let mut scheduler = scheduler.borrow_mut();
-        let dialogs = scheduler
+        let mut dialogs = scheduler
             .dialogs
             .drain()
             .map(|(_, state)| state)
             .collect::<Vec<_>>();
-        scheduler.subscriptions.clear();
+        let subscriptions = dialogs
+            .iter_mut()
+            .filter_map(|state| state.subscription.take())
+            .collect::<Vec<_>>();
         scheduler.request_order = 0;
-        dialogs
+        (dialogs, subscriptions)
     };
+    drop(subscriptions);
     for state in dialogs {
         if state.pending {
             _ = state.dialog.Hide();
@@ -297,23 +309,20 @@ pub(super) fn reset(scheduler: &Rc<RefCell<ContentDialogScheduler>>) {
 }
 
 pub(super) fn retire(scheduler: &Rc<RefCell<ContentDialogScheduler>>, node: NodeId) {
-    let retain = {
+    let removed = {
         let mut scheduler = scheduler.borrow_mut();
         if let Some(dialog) = scheduler.dialogs.get_mut(&node) {
             if dialog.pending {
                 dialog.retired = true;
-                true
+                None
             } else {
-                scheduler.dialogs.remove(&node);
-                false
+                scheduler.dialogs.remove(&node)
             }
         } else {
-            false
+            None
         }
     };
-    if !retain {
-        scheduler.borrow_mut().subscriptions.remove(&node);
-    }
+    drop(removed);
 }
 
 pub(super) fn closed(
@@ -379,8 +388,8 @@ pub(super) fn closed(
         }
     }
     if retired {
-        scheduler.borrow_mut().dialogs.remove(&node);
-        scheduler.borrow_mut().subscriptions.remove(&node);
+        let removed = scheduler.borrow_mut().dialogs.remove(&node);
+        drop(removed);
     }
     Ok(invoke_callback)
 }

--- a/crates/libs/reactor/src/native/winui/content_dialog.rs
+++ b/crates/libs/reactor/src/native/winui/content_dialog.rs
@@ -90,17 +90,13 @@ impl ContentDialogScheduler {
                     .map_err(native_error)?;
             }
             if state.xaml_root.is_none() {
-                self.request_order += 1;
-                state.request_order = self.request_order;
+                Self::assign_request_order(&mut self.request_order, state);
                 return Ok(ContentDialogAction::WaitForRoot(state.generation));
             }
             if state.pending || occupied {
-                state.queued = true;
-                self.request_order += 1;
-                state.request_order = self.request_order;
+                Self::enqueue(&mut self.request_order, state);
             } else {
-                show(&state.dialog)?;
-                state.pending = true;
+                Self::show_now(state)?;
             }
         } else {
             state.queued = false;
@@ -147,8 +143,7 @@ impl ContentDialogScheduler {
         if occupied {
             state.queued = true;
         } else {
-            show(&state.dialog)?;
-            state.pending = true;
+            Self::show_now(state)?;
         }
         Ok(())
     }
@@ -229,6 +224,57 @@ impl ContentDialogScheduler {
                     .is_some_and(|current| current == root)
         })
     }
+
+    fn next_queued(
+        &self,
+        root: &XamlRoot,
+        preferred: Option<(NodeId, u64)>,
+    ) -> Option<(NodeId, u64)> {
+        preferred
+            .and_then(|(node, generation)| {
+                self.dialogs
+                    .get(&node)
+                    .filter(|state| {
+                        state.generation == generation && Self::eligible_for_root(state, root)
+                    })
+                    .map(|_| (node, generation))
+            })
+            .or_else(|| {
+                self.dialogs
+                    .iter()
+                    .filter(|(_, state)| Self::eligible_for_root(state, root))
+                    .min_by_key(|(_, state)| state.request_order)
+                    .map(|(node, state)| (*node, state.generation))
+            })
+    }
+
+    fn eligible_for_root(state: &ContentDialogLifecycle, root: &XamlRoot) -> bool {
+        state.desired_open
+            && !state.retired
+            && !state.pending
+            && state.queued
+            && state
+                .xaml_root
+                .as_ref()
+                .is_some_and(|current| current == root)
+    }
+
+    fn assign_request_order(request_order: &mut u64, state: &mut ContentDialogLifecycle) {
+        *request_order += 1;
+        state.request_order = *request_order;
+    }
+
+    fn enqueue(request_order: &mut u64, state: &mut ContentDialogLifecycle) {
+        state.queued = true;
+        Self::assign_request_order(request_order, state);
+    }
+
+    fn show_now(state: &mut ContentDialogLifecycle) -> Result<(), RuntimeError> {
+        state.queued = false;
+        show(&state.dialog)?;
+        state.pending = true;
+        Ok(())
+    }
 }
 
 pub(super) fn reset(scheduler: &Rc<RefCell<ContentDialogScheduler>>) {
@@ -289,25 +335,9 @@ pub(super) fn closed(
         (state.xaml_root.clone(), invoke_callback, state.retired)
     };
 
-    let candidate = if let Some(root) = xaml_root.as_ref() {
-        scheduler
-            .borrow()
-            .dialogs
-            .iter()
-            .filter(|(_, state)| {
-                state.queued
-                    && state.desired_open
-                    && !state.retired
-                    && state
-                        .xaml_root
-                        .as_ref()
-                        .is_some_and(|current| current == root)
-            })
-            .min_by_key(|(_, state)| state.request_order)
-            .map(|(node, state)| (*node, state.generation))
-    } else {
-        None
-    };
+    let candidate = xaml_root
+        .as_ref()
+        .and_then(|root| scheduler.borrow().next_queued(root, None));
     if let Some((candidate, generation)) = candidate {
         let callback_sink = sink.clone();
         let candidate_root = xaml_root.unwrap();
@@ -321,48 +351,13 @@ pub(super) fn closed(
                     return;
                 }
                 let candidate = scheduler
-                    .dialogs
-                    .get(&candidate)
-                    .filter(|state| {
-                        state.generation == generation
-                            && state.desired_open
-                            && !state.retired
-                            && !state.pending
-                            && state.queued
-                            && state
-                                .xaml_root
-                                .as_ref()
-                                .is_some_and(|root| root == &candidate_root)
-                    })
-                    .map(|_| candidate)
-                    .or_else(|| {
-                        scheduler
-                            .dialogs
-                            .iter()
-                            .filter(|(_, state)| {
-                                state.desired_open
-                                    && !state.retired
-                                    && !state.pending
-                                    && state.queued
-                                    && state
-                                        .xaml_root
-                                        .as_ref()
-                                        .is_some_and(|root| root == &candidate_root)
-                            })
-                            .min_by_key(|(_, state)| state.request_order)
-                            .map(|(node, _)| *node)
-                    });
+                    .next_queued(&candidate_root, Some((candidate, generation)))
+                    .map(|(node, _)| node);
                 let Some(candidate) = candidate else {
                     return;
                 };
                 let state = scheduler.dialogs.get_mut(&candidate).unwrap();
-                state.queued = false;
-                (
-                    candidate,
-                    state.dialog.ShowAsync().map(|_| {
-                        state.pending = true;
-                    }),
-                )
+                (candidate, ContentDialogScheduler::show_now(state))
             };
             if let Err(error) = result {
                 let revision = callback_sink
@@ -371,12 +366,7 @@ pub(super) fn closed(
                     .dialogs
                     .get(&candidate)
                     .map_or(0, |state| state.revision);
-                callback_sink.error(
-                    candidate,
-                    EventId::ContentDialogClosed,
-                    revision,
-                    native_error(error),
-                );
+                callback_sink.error(candidate, EventId::ContentDialogClosed, revision, error);
             }
         });
         match sink

--- a/crates/libs/reactor/src/native/winui/framework.rs
+++ b/crates/libs/reactor/src/native/winui/framework.rs
@@ -4,22 +4,6 @@ use crate::{
     VerticalAlignment as ReactorVerticalAlignment,
 };
 
-pub(super) fn is_common(property: PropertyId) -> bool {
-    matches!(
-        property,
-        PropertyId::Width
-            | PropertyId::Height
-            | PropertyId::MinWidth
-            | PropertyId::MaxWidth
-            | PropertyId::MinHeight
-            | PropertyId::MaxHeight
-            | PropertyId::Opacity
-            | PropertyId::HorizontalAlignment
-            | PropertyId::VerticalAlignment
-            | PropertyId::Margin
-    )
-}
-
 pub(super) fn set(
     element: &UIElement,
     property: PropertyId,

--- a/crates/libs/reactor/src/native/winui/grid.rs
+++ b/crates/libs/reactor/src/native/winui/grid.rs
@@ -1,31 +1,6 @@
 use super::*;
 use crate::GridLength as ReactorGridLength;
 
-pub(super) fn is_attached(property: PropertyId) -> bool {
-    matches!(
-        property,
-        PropertyId::GridRow
-            | PropertyId::GridColumn
-            | PropertyId::GridRowSpan
-            | PropertyId::GridColumnSpan
-            | PropertyId::RelativeAlignLeft
-            | PropertyId::RelativeAlignTop
-            | PropertyId::RelativeAlignRight
-            | PropertyId::RelativeAlignBottom
-            | PropertyId::RelativeAlignHorizontalCenter
-            | PropertyId::RelativeAlignVerticalCenter
-            | PropertyId::CanvasLeft
-            | PropertyId::CanvasTop
-            | PropertyId::AutomationName
-            | PropertyId::AutomationId
-            | PropertyId::AutomationHeadingLevel
-    )
-}
-
-pub(super) fn is_definitions(property: PropertyId) -> bool {
-    matches!(property, PropertyId::GridRows | PropertyId::GridColumns)
-}
-
 pub(super) fn set_attached(
     element: &UIElement,
     property: PropertyId,

--- a/crates/libs/reactor/src/native/winui/mod.rs
+++ b/crates/libs/reactor/src/native/winui/mod.rs
@@ -175,7 +175,6 @@ pub struct WinUiRuntime {
     pointer_capture: Rc<RefCell<HashMap<NodeId, bool>>>,
     resource_override_keys: HashMap<NodeId, HashSet<String>>,
     command_bar_flyouts: HashMap<NodeId, NativeCommandBarFlyout>,
-    composition_host_subscriptions: HashMap<(NodeId, u64), CompositionHostSubscriptions>,
     identity: Rc<Cell<Option<WindowToken>>>,
     selection_items: Rc<RefCell<Vec<(NodeId, windows_core::IInspectable)>>>,
     selection_owners: HashMap<NodeId, (NodeId, SlotId)>,
@@ -183,8 +182,7 @@ pub struct WinUiRuntime {
     retained_subtrees: HashMap<NodeId, NativeRetainedSubtree>,
     scheduler: Rc<RefCell<SchedulerState>>,
     image_decode_tickets: HashMap<NodeId, u64>,
-    image_scale_subscriptions: HashMap<(NodeId, u64), XamlRootScaleSubscriptions>,
-    swap_chain_panel_subscriptions: HashMap<(NodeId, u64), SwapChainPanelSubscriptions>,
+    observation_subscriptions: HashMap<(NodeId, u64), ObservationSubscription>,
     subscriptions: HashMap<(NodeId, EventId), NativeSubscription>,
     theme_styles: HashMap<(MountedKind, ThemeStyle), Style>,
     virtuals: HashMap<NodeId, element_factory::VirtualHandle>,
@@ -223,20 +221,24 @@ fn complete_webview_initialization(
     }
 }
 
-struct SwapChainPanelSubscriptions {
-    _rendering: windows_core::EventRevoker,
-    _scale: windows_core::EventRevoker,
-    _size: windows_core::EventRevoker,
-}
-
 struct XamlRootScaleSubscriptions {
     _changed: Rc<RefCell<Option<windows_core::EventRevoker>>>,
     _loaded: windows_core::EventRevoker,
 }
 
-struct CompositionHostSubscriptions {
-    _root: XamlRootScaleSubscriptions,
-    _size: windows_core::EventRevoker,
+enum ObservationSubscription {
+    SwapChainPanel {
+        _rendering: windows_core::EventRevoker,
+        _scale: windows_core::EventRevoker,
+        _size: windows_core::EventRevoker,
+    },
+    ImageScale {
+        _root: XamlRootScaleSubscriptions,
+    },
+    CompositionHost {
+        _root: XamlRootScaleSubscriptions,
+        _size: windows_core::EventRevoker,
+    },
 }
 
 struct NativeRetainedSubtree {
@@ -1680,9 +1682,9 @@ impl WinUiRuntime {
                     invoke_callback(&rendering_callback, SwapChainPanelEvent::Rendering);
                 })
                 .map_err(native_error)?;
-                self.swap_chain_panel_subscriptions.insert(
+                self.observation_subscriptions.insert(
                     (*node, *observation),
-                    SwapChainPanelSubscriptions {
+                    ObservationSubscription::SwapChainPanel {
                         _rendering: rendering,
                         _scale: scale,
                         _size: size,
@@ -1749,8 +1751,12 @@ impl WinUiRuntime {
                     subscribe_xaml_root_scale(&element, &framework, &sink, move |scale| {
                         invoke_callback(&scale_callback, scale);
                     })?;
-                self.image_scale_subscriptions
-                    .insert((*node, *observation), subscriptions);
+                self.observation_subscriptions.insert(
+                    (*node, *observation),
+                    ObservationSubscription::ImageScale {
+                        _root: subscriptions,
+                    },
+                );
             }
             Command::ObserveCompositionHost {
                 node,
@@ -1821,19 +1827,17 @@ impl WinUiRuntime {
                         },
                     );
                 })?;
-                self.composition_host_subscriptions.insert(
+                self.observation_subscriptions.insert(
                     (*node, *observation),
-                    CompositionHostSubscriptions {
+                    ObservationSubscription::CompositionHost {
                         _root: root,
                         _size: size,
                     },
                 );
             }
             Command::RevokeObservation { node, observation } => {
-                let key = (*node, *observation);
-                self.swap_chain_panel_subscriptions.remove(&key);
-                self.image_scale_subscriptions.remove(&key);
-                self.composition_host_subscriptions.remove(&key);
+                self.observation_subscriptions
+                    .remove(&(*node, *observation));
             }
             Command::SetCompositionChildVisual {
                 node,
@@ -3592,9 +3596,7 @@ impl NativeRuntime for WinUiRuntime {
         self.subscriptions.clear();
         self.encoded_image_nodes.borrow_mut().clear();
         self.image_decode_tickets.clear();
-        self.swap_chain_panel_subscriptions.clear();
-        self.image_scale_subscriptions.clear();
-        self.composition_host_subscriptions.clear();
+        self.observation_subscriptions.clear();
         self.owned_menus.clear();
         self.command_bar_flyouts.clear();
         content_dialog::reset(&self.content_dialogs);
@@ -4034,14 +4036,10 @@ impl WinUiRuntime {
             Err(RuntimeError::MissingNode(node)),
         );
         self.controlled_collection_indices.remove(&node);
-        self.composition_host_subscriptions
+        self.observation_subscriptions
             .retain(|(subscription_node, _), _| *subscription_node != node);
         self.drop_policies.borrow_mut().remove(&node);
         self.pointer_capture.borrow_mut().remove(&node);
-        self.image_scale_subscriptions
-            .retain(|(subscription_node, _), _| *subscription_node != node);
-        self.swap_chain_panel_subscriptions
-            .retain(|(subscription_node, _), _| *subscription_node != node);
         if self.resource_override_keys.contains_key(&node) {
             self.clear_resource_overrides(node)?;
         }

--- a/crates/libs/reactor/src/native/winui/mod.rs
+++ b/crates/libs/reactor/src/native/winui/mod.rs
@@ -58,6 +58,79 @@ pub use generated::*;
 mod framework;
 mod grid;
 
+enum PropertyTarget<'a> {
+    Framework(UIElement),
+    Attached(UIElement),
+    GridDefinitions(&'a Handle),
+    Generated(&'a Handle),
+}
+
+impl<'a> PropertyTarget<'a> {
+    fn resolve(
+        runtime: &'a WinUiRuntime,
+        node: NodeId,
+        property: PropertyId,
+    ) -> Result<Self, RuntimeError> {
+        Ok(match property {
+            PropertyId::Width
+            | PropertyId::Height
+            | PropertyId::MinWidth
+            | PropertyId::MaxWidth
+            | PropertyId::MinHeight
+            | PropertyId::MaxHeight
+            | PropertyId::Opacity
+            | PropertyId::HorizontalAlignment
+            | PropertyId::VerticalAlignment
+            | PropertyId::Margin => Self::Framework(runtime.ui_element(node)?),
+            PropertyId::GridRow
+            | PropertyId::GridColumn
+            | PropertyId::GridRowSpan
+            | PropertyId::GridColumnSpan
+            | PropertyId::RelativeAlignLeft
+            | PropertyId::RelativeAlignTop
+            | PropertyId::RelativeAlignRight
+            | PropertyId::RelativeAlignBottom
+            | PropertyId::RelativeAlignHorizontalCenter
+            | PropertyId::RelativeAlignVerticalCenter
+            | PropertyId::CanvasLeft
+            | PropertyId::CanvasTop
+            | PropertyId::AutomationName
+            | PropertyId::AutomationId
+            | PropertyId::AutomationHeadingLevel => Self::Attached(runtime.ui_element(node)?),
+            PropertyId::GridRows | PropertyId::GridColumns => Self::GridDefinitions(
+                runtime
+                    .handles
+                    .get(&node)
+                    .ok_or(RuntimeError::MissingNode(node))?,
+            ),
+            _ => Self::Generated(
+                runtime
+                    .handles
+                    .get(&node)
+                    .ok_or(RuntimeError::MissingNode(node))?,
+            ),
+        })
+    }
+
+    fn set(&self, property: PropertyId, value: &PropertyValue) -> Result<(), RuntimeError> {
+        match self {
+            Self::Framework(element) => framework::set(element, property, value),
+            Self::Attached(element) => grid::set_attached(element, property, value),
+            Self::GridDefinitions(handle) => grid::set_definitions(handle, property, value),
+            Self::Generated(handle) => set_property(handle, property, value),
+        }
+    }
+
+    fn clear(&self, property: PropertyId) -> Result<(), RuntimeError> {
+        match self {
+            Self::Framework(element) => framework::clear(element, property),
+            Self::Attached(element) => grid::clear_attached(element, property),
+            Self::GridDefinitions(handle) => grid::clear_definitions(handle, property),
+            Self::Generated(handle) => clear_property(handle, property),
+        }
+    }
+}
+
 pub enum NativeSubscription {
     Event {
         _revoker: windows_core::EventRevoker,
@@ -1829,18 +1902,7 @@ impl WinUiRuntime {
                         _ => Err(RuntimeError::UnsupportedKind),
                     };
                 }
-                let element = (framework::is_common(*property) || grid::is_attached(*property))
-                    .then(|| self.ui_element(*node))
-                    .transpose()?;
-                let handle = if element.is_none() {
-                    Some(
-                        self.handles
-                            .get(node)
-                            .ok_or(RuntimeError::MissingNode(*node))?,
-                    )
-                } else {
-                    None
-                };
+                let target = PropertyTarget::resolve(self, *node, *property)?;
                 let feedback = expected_feedback(*property, Some(value));
                 let selection_owner = self
                     .selection_owners
@@ -1888,19 +1950,8 @@ impl WinUiRuntime {
                                 }),
                             _ => Err(RuntimeError::UnsupportedKind),
                         }
-                    } else if let Some(element) = element {
-                        if framework::is_common(*property) {
-                            framework::set(&element, *property, value)
-                        } else {
-                            grid::set_attached(&element, *property, value)
-                        }
                     } else {
-                        let handle = handle.unwrap();
-                        if grid::is_definitions(*property) {
-                            grid::set_definitions(handle, *property, value)
-                        } else {
-                            set_property(handle, *property, value)
-                        }
+                        target.set(*property, value)
                     };
                     let observation =
                         feedback_event.and_then(|event| {
@@ -1944,18 +1995,7 @@ impl WinUiRuntime {
                 if *property == PropertyId::ButtonResources {
                     return self.clear_resource_overrides(*node);
                 }
-                let element = (framework::is_common(*property) || grid::is_attached(*property))
-                    .then(|| self.ui_element(*node))
-                    .transpose()?;
-                let handle = if element.is_none() {
-                    Some(
-                        self.handles
-                            .get(node)
-                            .ok_or(RuntimeError::MissingNode(*node))?,
-                    )
-                } else {
-                    None
-                };
+                let target = PropertyTarget::resolve(self, *node, *property)?;
                 let feedback = expected_feedback(*property, None);
                 let selection_owner = self
                     .selection_owners
@@ -1981,19 +2021,8 @@ impl WinUiRuntime {
                             .map_err(native_error)?;
                         self.drop_policies.borrow_mut().remove(node);
                         Ok(())
-                    } else if let Some(element) = element {
-                        if framework::is_common(*property) {
-                            framework::clear(&element, *property)
-                        } else {
-                            grid::clear_attached(&element, *property)
-                        }
                     } else {
-                        let handle = handle.unwrap();
-                        if grid::is_definitions(*property) {
-                            grid::clear_definitions(handle, *property)
-                        } else {
-                            clear_property(handle, *property)
-                        }
+                        target.clear(*property)
                     };
                     if let Some(event) = feedback_event {
                         self.feedback.borrow_mut().remove(&(*node, event));

--- a/crates/tests/libs/reactor_selftest/src/fixtures.rs
+++ b/crates/tests/libs/reactor_selftest/src/fixtures.rs
@@ -8,8 +8,10 @@ use windows::UI::Input::Preview::Injection::{
     InjectedInputMouseInfo, InjectedInputMouseOptions, InputInjector,
 };
 use windows::Win32::winuser::{
-    BringWindowToTop, ClientToScreen, GetClientRect, GetSystemMetrics, SM_CXVIRTUALSCREEN,
-    SM_CYVIRTUALSCREEN, SM_XVIRTUALSCREEN, SM_YVIRTUALSCREEN, SetForegroundWindow,
+    BringWindowToTop, ClientToScreen, GetClientRect, GetMonitorInfoW, GetSystemMetrics,
+    GetWindowRect, MONITOR_DEFAULTTONEAREST, MONITORINFO, MonitorFromWindow, SM_CXVIRTUALSCREEN,
+    SM_CYVIRTUALSCREEN, SM_XVIRTUALSCREEN, SM_YVIRTUALSCREEN, SWP_NOSIZE, SWP_NOZORDER,
+    SetForegroundWindow, SetWindowPos,
 };
 use windows::Win32::{HWND, POINT, RECT};
 use windows_canvas::{CanvasImageSource, ColorF, GpuDevice, animated_canvas};
@@ -443,6 +445,9 @@ fn inject_pointer_stage(
     injector: &InputInjector,
 ) -> Result<(), String> {
     let hwnd = HWND(handle as *mut _);
+    if stage == PointerStage::Move {
+        fit_window_to_work_area(hwnd)?;
+    }
     unsafe {
         let _ = SetForegroundWindow(hwnd);
         let _ = BringWindowToTop(hwnd);
@@ -495,6 +500,38 @@ fn inject_pointer_stage(
         ),
     };
     inject_at(injector, x, y, options).map_err(|error| error.to_string())
+}
+
+fn fit_window_to_work_area(hwnd: HWND) -> Result<(), String> {
+    let mut window = RECT::default();
+    if !unsafe { GetWindowRect(hwnd, &mut window) }.as_bool() {
+        return Err("could not read the pointer fixture window rect".to_string());
+    }
+    let monitor = unsafe { MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST as u32) };
+    let mut monitor_info = MONITORINFO {
+        cbSize: size_of::<MONITORINFO>() as u32,
+        ..Default::default()
+    };
+    if !unsafe { GetMonitorInfoW(monitor, &mut monitor_info) }.as_bool() {
+        return Err("could not read the pointer fixture monitor work area".to_string());
+    }
+
+    let width = window.right - window.left;
+    let height = window.bottom - window.top;
+    let work = monitor_info.rcWork;
+    let x = window
+        .left
+        .clamp(work.left, (work.right - width).max(work.left));
+    let y = window
+        .top
+        .clamp(work.top, (work.bottom - height).max(work.top));
+    if (x != window.left || y != window.top)
+        && !unsafe { SetWindowPos(hwnd, None, x, y, 0, 0, (SWP_NOSIZE | SWP_NOZORDER) as u32) }
+            .as_bool()
+    {
+        return Err("could not move the pointer fixture into the monitor work area".to_string());
+    }
+    Ok(())
 }
 
 fn client_screen_point(hwnd: HWND, x_fraction: f64, y_fraction: f64) -> Result<(i32, i32), String> {

--- a/crates/tests/libs/reactor_selftest/src/fixtures.rs
+++ b/crates/tests/libs/reactor_selftest/src/fixtures.rs
@@ -447,10 +447,27 @@ fn inject_pointer_stage(
         let _ = SetForegroundWindow(hwnd);
         let _ = BringWindowToTop(hwnd);
     }
+    if stage == PointerStage::Move {
+        let (x, y) = virtual_screen_origin();
+        inject_at(
+            injector,
+            x,
+            y,
+            InjectedInputMouseOptions::Move | InjectedInputMouseOptions::MoveNoCoalesce,
+        )
+        .map_err(|error| error.to_string())?;
+        inject_at(
+            injector,
+            x,
+            y,
+            InjectedInputMouseOptions::LeftUp | InjectedInputMouseOptions::RightUp,
+        )
+        .map_err(|error| error.to_string())?;
+    }
     let ((x, y), options) = match stage {
         PointerStage::Move => (
             client_screen_point(hwnd, 0.5, 0.1)?,
-            InjectedInputMouseOptions::Move,
+            InjectedInputMouseOptions::Move | InjectedInputMouseOptions::MoveNoCoalesce,
         ),
         PointerStage::LeftDown => (
             client_screen_point(hwnd, 0.5, 0.1)?,
@@ -458,7 +475,7 @@ fn inject_pointer_stage(
         ),
         PointerStage::MoveOutside => (
             client_screen_point(hwnd, 0.5, 0.75)?,
-            InjectedInputMouseOptions::Move,
+            InjectedInputMouseOptions::Move | InjectedInputMouseOptions::MoveNoCoalesce,
         ),
         PointerStage::LeftUp => (
             client_screen_point(hwnd, 0.5, 0.75)?,
@@ -472,7 +489,10 @@ fn inject_pointer_stage(
             client_screen_point(hwnd, 0.5, 0.1)?,
             InjectedInputMouseOptions::RightUp,
         ),
-        PointerStage::Exit => (virtual_screen_origin(), InjectedInputMouseOptions::Move),
+        PointerStage::Exit => (
+            virtual_screen_origin(),
+            InjectedInputMouseOptions::Move | InjectedInputMouseOptions::MoveNoCoalesce,
+        ),
     };
     inject_at(injector, x, y, options).map_err(|error| error.to_string())
 }

--- a/crates/tools/reactor/src/generate.rs
+++ b/crates/tools/reactor/src/generate.rs
@@ -135,7 +135,7 @@ pub(crate) fn generate(schema: &ResolvedSchema) -> String {
         control
             .slots
             .iter()
-            .filter(|slot| matches!(slot.shape, crate::schema::SlotShape::Collection))
+            .filter(|slot| matches!(&slot.shape, crate::schema::SlotShape::Collection(_)))
             .map(move |slot| {
                 let slot = ident(&format!("{}{}", control.name, slot.name));
                 quote! { SlotId::#slot }
@@ -2191,7 +2191,7 @@ fn generate_descriptors(control: &ResolvedControl) -> TokenStream {
         let id = ident(&format!("{}{}", control.name, slot.name));
         let name = &slot.name;
         let interface = &slot.interface;
-        let (target, collection) = match slot.shape {
+        let (target, collection) = match &slot.shape {
             crate::schema::SlotShape::Single(crate::schema::SlotTarget::Inspectable) => {
                 ("inspectable", false)
             }
@@ -2201,7 +2201,7 @@ fn generate_descriptors(control: &ResolvedControl) -> TokenStream {
             crate::schema::SlotShape::Single(crate::schema::SlotTarget::UiElement) => {
                 ("ui_element", false)
             }
-            crate::schema::SlotShape::Collection => ("inspectable", true),
+            crate::schema::SlotShape::Collection(_) => ("inspectable", true),
         };
         quote! {
             SlotDescriptor {
@@ -2289,7 +2289,7 @@ fn generate_control(control: &ResolvedControl) -> TokenStream {
     let collection_slots = control
         .slots
         .iter()
-        .filter(|slot| matches!(slot.shape, crate::schema::SlotShape::Collection))
+        .filter(|slot| matches!(&slot.shape, crate::schema::SlotShape::Collection(_)))
         .collect::<Vec<_>>();
     let controlled_indices = control
         .properties

--- a/crates/tools/reactor/src/generate_surface.rs
+++ b/crates/tools/reactor/src/generate_surface.rs
@@ -230,7 +230,7 @@ pub(crate) fn generate(schema: &ResolvedSchema) -> String {
                     .map(|selection| selection.item.as_str())
                     .or_else(|| slot.item_controls.first().map(String::as_str))
                     .or_else(|| {
-                        slot.collection_item.as_deref().and_then(|item| {
+                        slot.shape.collection_item().and_then(|item| {
                             schema
                                 .controls
                                 .iter()
@@ -245,31 +245,31 @@ pub(crate) fn generate(schema: &ResolvedSchema) -> String {
                         quote! { #item::new().width(80.0) },
                     )
                 } else {
-                    let target = match slot.shape {
-                        SlotShape::Single(target) => target,
-                        SlotShape::Collection => SlotTarget::UiElement,
+                    let target = match &slot.shape {
+                        SlotShape::Single(target) => *target,
+                        SlotShape::Collection(_) => SlotTarget::UiElement,
                     };
                     (
                         structural_child(target, "surface a", false),
                         structural_child(target, "surface b", true),
                     )
                 };
-                let initial = match slot.shape {
+                let initial = match &slot.shape {
                     SlotShape::Single(_) => quote! {
                         #control_name::new().slot(#slot_type::#slot_name, #initial_child)
                     },
-                    SlotShape::Collection => quote! {
+                    SlotShape::Collection(_) => quote! {
                         #control_name::new().collection_slot(
                             #slot_type::#slot_name,
                             [KeyedView::new("surface", #initial_child)],
                         )
                     },
                 };
-                let alternate = match slot.shape {
+                let alternate = match &slot.shape {
                     SlotShape::Single(_) => quote! {
                         #control_name::new().slot(#slot_type::#slot_name, #alternate_child)
                     },
-                    SlotShape::Collection => quote! {
+                    SlotShape::Collection(_) => quote! {
                         #control_name::new().collection_slot(
                             #slot_type::#slot_name,
                             [KeyedView::new("surface", #alternate_child)],

--- a/crates/tools/reactor/src/generate_winui.rs
+++ b/crates/tools/reactor/src/generate_winui.rs
@@ -236,13 +236,6 @@ pub(crate) fn generate_control_bindings_filter(schema: &ResolvedSchema) -> Strin
                 entries.insert("Microsoft::UI::Xaml::IDragOperationDeferral::Complete".to_string());
                 entries.insert("Windows::Storage::IStorageItem::{get_Name, get_Path}".to_string());
             }
-            if let EventPayloadSource::SenderItemTags {
-                interface,
-                property,
-            } = &event.source
-            {
-                entries.insert(format!("{}::get_{}", filter_path(interface), property));
-            }
         }
         if let Some(selection) = &control.selection {
             entries.insert(format!(
@@ -2330,6 +2323,23 @@ mod tests {
         let source = include_str!("winui.toml");
         let metadata = MetadataResolver::load(&workspace_path("crates/tools/reactor/winmd"));
         Schema::parse(source).unwrap().resolve(&metadata).unwrap()
+    }
+
+    #[test]
+    fn item_tags_payload_adds_its_sender_getter_to_the_bindings_filter() {
+        let source = r#"
+[[control]]
+type = "Microsoft.UI.Xaml.Controls.TabView"
+
+[[control.event]]
+name = "TabItemsChanged"
+adapter = "item_tags"
+"#;
+        let metadata = MetadataResolver::load(&workspace_path("crates/tools/reactor/winmd"));
+        let schema = Schema::parse(source).unwrap().resolve(&metadata).unwrap();
+        let filter = generate_control_bindings_filter(&schema);
+
+        assert!(filter.contains("Microsoft::UI::Xaml::Controls::ITabView::get_TabItems"));
     }
 
     #[test]

--- a/crates/tools/reactor/src/generate_winui.rs
+++ b/crates/tools/reactor/src/generate_winui.rs
@@ -2,6 +2,7 @@ use proc_macro2::{Ident, Span, TokenStream};
 use quote::quote;
 use std::collections::BTreeSet;
 
+use crate::metadata::CollectionType;
 use crate::schema::{
     EventPayloadConversion, EventPayloadSource, EventSubscription, FeedbackContract,
     PropertyAdapter, ResolvedControl, ResolvedEvent, ResolvedProperty, ResolvedSchema, Role,
@@ -256,9 +257,9 @@ pub(crate) fn generate_control_bindings_filter(schema: &ResolvedSchema) -> Strin
             ));
         }
         for slot in &control.slots {
-            let accessor = match slot.shape {
+            let accessor = match &slot.shape {
                 SlotShape::Single(_) => "put",
-                SlotShape::Collection => "get",
+                SlotShape::Collection(_) => "get",
             };
             entries.insert(format!(
                 "{}::{}_{}",
@@ -366,21 +367,21 @@ pub(crate) fn generate(schema: &ResolvedSchema) -> String {
         control
             .slots
             .iter()
-            .filter(|slot| matches!(slot.shape, SlotShape::Single(_)))
+            .filter(|slot| matches!(&slot.shape, SlotShape::Single(_)))
             .map(move |slot| generate_set_slot(control, slot))
     });
     let collection_slots = schema.controls.iter().flat_map(|control| {
         control
             .slots
             .iter()
-            .filter(|slot| matches!(slot.shape, SlotShape::Collection))
+            .filter(|slot| matches!(&slot.shape, SlotShape::Collection(_)))
             .map(move |slot| generate_slot_collection(control, slot))
     });
     let collection_items = schema
         .controls
         .iter()
         .flat_map(|control| &control.slots)
-        .filter_map(|slot| slot.collection_item.as_deref())
+        .filter_map(|slot| slot.shape.collection_item())
         .collect::<BTreeSet<_>>();
     let collection_variants = collection_items.iter().map(|item| {
         let variant = ident(item.rsplit('.').next().unwrap());
@@ -896,30 +897,33 @@ fn generate_slot_collection(
                 .map_err(native_error)
         }
     };
-    let get = if slot.collection_cast {
-        quote! {
-            #get?
-                .cast::<windows_collections::IVector<windows_core::IInspectable>>()
-                .map_err(native_error)
+    let collection = match &slot.shape {
+        SlotShape::Collection(CollectionType::InspectableVector) => {
+            quote! { SlotCollection::Inspectable(#get?) }
         }
-    } else {
-        get
-    };
-    let get = if slot.collection_observable {
-        let item = path_ident(slot.collection_item.as_deref().unwrap());
-        quote! {
-            #get?
-                .cast::<windows_collections::IVector<bindings::#item>>()
-                .map_err(native_error)
+        SlotShape::Collection(CollectionType::ItemCollection) => quote! {
+            SlotCollection::Inspectable(
+                #get?
+                    .cast::<windows_collections::IVector<windows_core::IInspectable>>()
+                    .map_err(native_error)?
+            )
+        },
+        SlotShape::Collection(CollectionType::TypedVector(item)) => {
+            let variant = ident(item.rsplit('.').next().unwrap());
+            quote! { SlotCollection::#variant(#get?) }
         }
-    } else {
-        get
-    };
-    let collection = if let Some(item) = slot.collection_item.as_deref() {
-        let variant = ident(item.rsplit('.').next().unwrap());
-        quote! { SlotCollection::#variant(#get?) }
-    } else {
-        quote! { SlotCollection::Inspectable(#get?) }
+        SlotShape::Collection(CollectionType::ObservableVector(item)) => {
+            let variant = ident(item.rsplit('.').next().unwrap());
+            let item = path_ident(item);
+            quote! {
+                SlotCollection::#variant(
+                    #get?
+                        .cast::<windows_collections::IVector<bindings::#item>>()
+                        .map_err(native_error)?
+                )
+            }
+        }
+        SlotShape::Single(_) => unreachable!(),
     };
     quote! { (Handle::#control_name(control), SlotId::#slot_id) => Ok(#collection) }
 }
@@ -929,10 +933,10 @@ fn generate_set_slot(control: &ResolvedControl, slot: &crate::schema::ResolvedSl
     let slot_id = ident(&format!("{}{}", control.name, slot.name));
     let interface = path_ident(&slot.interface);
     let setter = ident(&format!("Set{}", slot.name));
-    let SlotShape::Single(target) = slot.shape else {
+    let SlotShape::Single(target) = &slot.shape else {
         unreachable!()
     };
-    let value = match target {
+    let value = match *target {
         SlotTarget::IconElement => quote! {
             match child {
                 Some(child) => {

--- a/crates/tools/reactor/src/generate_winui.rs
+++ b/crates/tools/reactor/src/generate_winui.rs
@@ -112,38 +112,20 @@ pub(crate) fn generate_control_bindings_filter(schema: &ResolvedSchema) -> Strin
                 | Some(PropertyAdapter::VerticalContentAlignment)
                 | None => {}
             }
-            if !matches!(
-                property.adapter,
-                Some(
-                    PropertyAdapter::ResourceStyle
-                        | PropertyAdapter::RichEditText
-                        | PropertyAdapter::RichTextBlocks
-                        | PropertyAdapter::PointerCapture
-                        | PropertyAdapter::DropPolicy
-                        | PropertyAdapter::KeyAccelerators
-                        | PropertyAdapter::ResourceOverrides
-                )
-            ) {
+            if property
+                .adapter
+                .is_none_or(|adapter| adapter.capabilities().uses_property_setter)
+            {
                 entries.insert(format!(
                     "{}::put_{}",
                     filter_path(&property.interface),
                     property.name
                 ));
             }
-            if !matches!(
-                property.adapter,
-                Some(
-                    PropertyAdapter::ImplicitOpacityTransition
-                        | PropertyAdapter::ImplicitScale
-                        | PropertyAdapter::ImplicitScaleTransition
-                        | PropertyAdapter::RichEditText
-                        | PropertyAdapter::RichTextBlocks
-                        | PropertyAdapter::PointerCapture
-                        | PropertyAdapter::DropPolicy
-                        | PropertyAdapter::KeyAccelerators
-                        | PropertyAdapter::ResourceOverrides
-                )
-            ) {
+            if property
+                .adapter
+                .is_none_or(|adapter| adapter.capabilities().uses_dependency_property)
+            {
                 entries.insert(format!(
                     "{}::{}Property",
                     filter_path(&property.static_owner),

--- a/crates/tools/reactor/src/metadata.rs
+++ b/crates/tools/reactor/src/metadata.rs
@@ -52,6 +52,14 @@ pub enum ParamClass {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CollectionType {
+    InspectableVector,
+    ItemCollection,
+    TypedVector(String),
+    ObservableVector(String),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ReadValueConversion {
     Identity,
     Field(String),
@@ -702,57 +710,34 @@ impl MetadataResolver {
         Some(format!("{}.{}", name.namespace, name.name))
     }
 
-    pub fn returns_inspectable_vector(&self, class_name: &str, method_name: &str) -> bool {
-        let Some(mref) = self
-            .lookup
-            .get(&(class_name.to_string(), method_name.to_string()))
-        else {
-            return false;
-        };
-        matches!(
-            &mref.return_type,
-            Type::ClassName(name)
-                if name.namespace == "Windows.Foundation.Collections"
-                    && name.name == "IVector`1"
-                    && name.generics.as_slice() == [Type::Object]
-        )
-    }
-
-    pub fn return_vector_element_class_name(
+    pub fn classify_collection(
         &self,
         class_name: &str,
         method_name: &str,
-    ) -> Option<String> {
+    ) -> Option<CollectionType> {
         let method = self
             .lookup
             .get(&(class_name.to_string(), method_name.to_string()))?;
-        let Type::ClassName(vector) = &method.return_type else {
+        let Type::ClassName(name) = &method.return_type else {
             return None;
         };
-        if vector.namespace != "Windows.Foundation.Collections"
-            || !matches!(vector.name.as_str(), "IVector`1" | "IObservableVector`1")
-        {
+        if name.namespace == "Microsoft.UI.Xaml.Controls" && name.name == "ItemCollection" {
+            return Some(CollectionType::ItemCollection);
+        }
+        if name.namespace != "Windows.Foundation.Collections" {
             return None;
         }
-        let Type::ClassName(element) = vector.generics.first()? else {
-            return None;
-        };
-        Some(format!("{}.{}", element.namespace, element.name))
-    }
-
-    pub fn returns_observable_vector(&self, class_name: &str, method_name: &str) -> bool {
-        let Some(method) = self
-            .lookup
-            .get(&(class_name.to_string(), method_name.to_string()))
-        else {
-            return false;
-        };
-        matches!(
-            &method.return_type,
-            Type::ClassName(name)
-                if name.namespace == "Windows.Foundation.Collections"
-                    && name.name == "IObservableVector`1"
-        )
+        match (name.name.as_str(), name.generics.first()?) {
+            ("IVector`1", Type::Object) => Some(CollectionType::InspectableVector),
+            ("IVector`1", Type::ClassName(item)) => Some(CollectionType::TypedVector(format!(
+                "{}.{}",
+                item.namespace, item.name
+            ))),
+            ("IObservableVector`1", Type::ClassName(item)) => Some(
+                CollectionType::ObservableVector(format!("{}.{}", item.namespace, item.name)),
+            ),
+            _ => None,
+        }
     }
 
     pub fn returns_object(&self, class_name: &str, method_name: &str) -> bool {
@@ -826,17 +811,24 @@ mod tests {
         let resolver = MetadataResolver::load(Path::new("winmd"));
 
         assert_eq!(
-            resolver
-                .return_class_name("ListBox", "get_Items")
-                .as_deref(),
-            Some("Microsoft.UI.Xaml.Controls.ItemCollection")
+            resolver.classify_collection("ListBox", "get_Items"),
+            Some(CollectionType::ItemCollection)
         );
-        assert!(resolver.returns_inspectable_vector("NavigationView", "get_MenuItems"));
         assert_eq!(
-            resolver
-                .return_vector_element_class_name("SelectorBar", "get_Items")
-                .as_deref(),
-            Some("Microsoft.UI.Xaml.Controls.SelectorBarItem")
+            resolver.classify_collection("NavigationView", "get_MenuItems"),
+            Some(CollectionType::InspectableVector)
+        );
+        assert_eq!(
+            resolver.classify_collection("SelectorBar", "get_Items"),
+            Some(CollectionType::TypedVector(
+                "Microsoft.UI.Xaml.Controls.SelectorBarItem".to_string()
+            ))
+        );
+        assert_eq!(
+            resolver.classify_collection("CommandBar", "get_PrimaryCommands"),
+            Some(CollectionType::ObservableVector(
+                "Microsoft.UI.Xaml.Controls.ICommandBarElement".to_string()
+            ))
         );
     }
 

--- a/crates/tools/reactor/src/schema.rs
+++ b/crates/tools/reactor/src/schema.rs
@@ -1,5 +1,5 @@
 use crate::helpers::to_snake_case;
-use crate::metadata::{MetadataResolver, ParamClass, ReadValueConversion};
+use crate::metadata::{CollectionType, MetadataResolver, ParamClass, ReadValueConversion};
 use serde::Deserialize;
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
@@ -600,9 +600,6 @@ pub(crate) struct ResolvedSlot {
     pub(crate) name: String,
     pub(crate) interface: String,
     pub(crate) shape: SlotShape,
-    pub(crate) collection_cast: bool,
-    pub(crate) collection_observable: bool,
-    pub(crate) collection_item: Option<String>,
     pub(crate) item_controls: Vec<String>,
 }
 
@@ -620,10 +617,23 @@ pub(crate) struct ResolvedSelection {
     pub(crate) payload_inspectable: bool,
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 pub(crate) enum SlotShape {
     Single(SlotTarget),
-    Collection,
+    Collection(CollectionType),
+}
+
+impl SlotShape {
+    pub(crate) fn collection_item(&self) -> Option<&str> {
+        match self {
+            Self::Collection(CollectionType::TypedVector(item))
+            | Self::Collection(CollectionType::ObservableVector(item)) => Some(item),
+            Self::Single(_)
+            | Self::Collection(
+                CollectionType::InspectableVector | CollectionType::ItemCollection,
+            ) => None,
+        }
+    }
 }
 
 #[derive(Debug, Eq, PartialEq)]
@@ -1563,27 +1573,16 @@ impl Schema {
                         }
                     )
                 })?;
-                let collection_cast = slot.collection
-                    && !metadata.returns_inspectable_vector(&name, &method)
-                    && metadata.return_class_name(&name, &method).as_deref()
-                        == Some("Microsoft.UI.Xaml.Controls.ItemCollection");
-                let collection_item = slot
-                    .collection
-                    .then(|| metadata.return_vector_element_class_name(&name, &method))
-                    .flatten();
-                if slot.collection
-                    && !collection_cast
-                    && collection_item.is_none()
-                    && !metadata.returns_inspectable_vector(&name, &method)
-                {
-                    return Err(format!(
-                        "{}.{} collection slot must return IVector<IInspectable>, a typed class \
-                         vector, or ItemCollection",
-                        control.type_name, slot.name
-                    ));
-                }
                 let shape = if slot.collection {
-                    SlotShape::Collection
+                    SlotShape::Collection(metadata.classify_collection(&name, &method).ok_or_else(
+                        || {
+                            format!(
+                                "{}.{} collection slot must return IVector<IInspectable>, a typed \
+                                 class vector, or ItemCollection",
+                                control.type_name, slot.name
+                            )
+                        },
+                    )?)
                 } else {
                     match metadata.classify_param(&name, &method) {
                         Some(ParamClass::IInspectable) => {
@@ -1619,10 +1618,6 @@ impl Schema {
                     name: slot.name,
                     interface: interface.full_path(),
                     shape,
-                    collection_cast,
-                    collection_observable: slot.collection
-                        && metadata.returns_observable_vector(&name, &method),
-                    collection_item,
                     item_controls: slot.item_controls,
                 });
             }
@@ -1822,7 +1817,7 @@ fn validate_selections(controls: &[ResolvedControl]) -> Result<(), String> {
                     control.type_name, selection.slot
                 )
             })?;
-        if !matches!(slot.shape, SlotShape::Collection) {
+        if !matches!(&slot.shape, SlotShape::Collection(_)) {
             return Err(format!(
                 "{} selection slot {} is not a collection",
                 control.type_name, selection.slot

--- a/crates/tools/reactor/src/schema.rs
+++ b/crates/tools/reactor/src/schema.rs
@@ -143,6 +143,12 @@ pub(crate) enum PropertyAdapter {
 }
 
 #[derive(Clone, Copy)]
+pub(crate) struct PropertyAdapterCapabilities {
+    pub(crate) uses_dependency_property: bool,
+    pub(crate) uses_property_setter: bool,
+}
+
+#[derive(Clone, Copy)]
 enum PropertyAdapterTargets {
     Any,
     Property(&'static str),
@@ -174,6 +180,53 @@ enum PropertyAdapterKind {
 }
 
 impl PropertyAdapter {
+    pub(crate) fn capabilities(self) -> PropertyAdapterCapabilities {
+        match self {
+            Self::ResourceStyle => PropertyAdapterCapabilities {
+                uses_dependency_property: true,
+                uses_property_setter: false,
+            },
+            Self::DropPolicy
+            | Self::KeyAccelerators
+            | Self::PointerCapture
+            | Self::ResourceOverrides
+            | Self::RichEditText
+            | Self::RichTextBlocks => PropertyAdapterCapabilities {
+                uses_dependency_property: false,
+                uses_property_setter: false,
+            },
+            Self::ImplicitOpacityTransition
+            | Self::ImplicitScale
+            | Self::ImplicitScaleTransition => PropertyAdapterCapabilities {
+                uses_dependency_property: false,
+                uses_property_setter: true,
+            },
+            Self::ClockIdentifier
+            | Self::ContentDialogResult
+            | Self::DragInfo
+            | Self::DropData
+            | Self::FontWeight
+            | Self::HorizontalContentAlignment
+            | Self::ImageUri
+            | Self::InspectableString
+            | Self::InspectableStringList
+            | Self::ItemTag
+            | Self::ItemTags
+            | Self::NavigationDisplayMode
+            | Self::NumberBoxValue
+            | Self::PathData
+            | Self::PointerEvent
+            | Self::RatingValue
+            | Self::SelectionIndex
+            | Self::TreeNodeContent
+            | Self::Uri
+            | Self::VerticalContentAlignment => PropertyAdapterCapabilities {
+                uses_dependency_property: true,
+                uses_property_setter: true,
+            },
+        }
+    }
+
     fn property_kind(self) -> PropertyAdapterKind {
         use PropertyAdapterMetadata::{None, Param, ParamType, SingleField, ValueType};
         use PropertyAdapterTargets::{Any, OneOf, Property};


### PR DESCRIPTION
This tightens up the Reactor internals after the recent architecture work: it fixes scheduler priority retention after an enqueue failure, simplifies candidate failure handling and ContentDialog scheduling, consolidates keyed reconciliation, property routing, node payloads, observation state, and declaration/subscription bookkeeping, and replaces correlated collection metadata fields with an explicit typed shape. It also adds focused state-transition coverage and stabilizes the live pointer fixture when Windows cascades its window behind the taskbar, while preserving generated Reactor output.