### PR TITLE
`windows-bindgen` explicit compose option

### DIFF
--- a/crates/libs/bindgen/src/cli.rs
+++ b/crates/libs/bindgen/src/cli.rs
@@ -25,6 +25,7 @@ use super::*;
 /// - `--extern`: Uses extern declarations with `--sys`.
 /// - `--minimal`: Omits class wrappers, inherited forwarders, and handle wrappers.
 /// - `--implement`: Emits implementation traits for selected WinRT interfaces.
+/// - `--compose`: Selects minimal-mode WinRT class composition targets.
 /// - `--dead-code`: Emits `pub(crate)` items for dead-code analysis.
 /// - `--etc`: Reads arguments from command files.
 /// - `--filter-file`: Reads filters from text files.
@@ -83,6 +84,7 @@ where
     let mut kind = ArgKind::None;
     let mut has_output = false;
     let mut implement = None::<Vec<String>>;
+    let mut compose = None::<Vec<String>>;
 
     for arg in args {
         if arg.starts_with('-') {
@@ -119,6 +121,10 @@ where
                     implement.get_or_insert_with(Vec::new);
                     kind = ArgKind::Implement;
                 }
+                "--compose" => {
+                    compose.get_or_insert_with(Vec::new);
+                    kind = ArgKind::Compose;
+                }
                 _ => panic!("invalid option `{arg}`"),
             },
             ArgKind::Output => {
@@ -145,6 +151,9 @@ where
             ArgKind::Implement => {
                 implement.as_mut().unwrap().push(arg.clone());
             }
+            ArgKind::Compose => {
+                compose.as_mut().unwrap().push(arg.clone());
+            }
             ArgKind::Rustfmt => {
                 builder.rustfmt(&arg);
             }
@@ -157,6 +166,10 @@ where
         } else {
             builder.implements(implement);
         }
+    }
+    if let Some(compose) = compose {
+        assert!(!compose.is_empty(), "`--compose` requires a class name");
+        builder.composes(compose);
     }
 
     builder.write();
@@ -171,6 +184,7 @@ enum ArgKind {
     Rustfmt,
     Derive,
     Implement,
+    Compose,
 }
 
 #[track_caller]

--- a/crates/libs/bindgen/src/config.rs
+++ b/crates/libs/bindgen/src/config.rs
@@ -53,6 +53,16 @@ impl Config<'_> {
         }
     }
 
+    /// Returns whether a class is an explicit minimal-mode composition target.
+    pub fn should_compose(&self, name: TypeName) -> bool {
+        self.bindgen.compose.iter().any(|target| {
+            target
+                .strip_prefix(name.namespace())
+                .and_then(|name| name.strip_prefix('.'))
+                == Some(name.name())
+        })
+    }
+
     /// Minimal bindings emit `RuntimeType::NAME` only for implemented interfaces.
     pub fn emit_runtime_name(&self, name: TypeName) -> bool {
         !self.bindgen.style.is_minimal() || self.should_implement(name, false)

--- a/crates/libs/bindgen/src/lib.rs
+++ b/crates/libs/bindgen/src/lib.rs
@@ -88,6 +88,7 @@ pub struct Bindgen {
     output: PathBuf,
     derive: Vec<String>,
     implement: Option<Vec<String>>,
+    compose: Vec<String>,
     rustfmt: Option<String>,
     layout: Layout,
     style: Style,
@@ -374,6 +375,32 @@ impl Bindgen {
         self
     }
 
+    /// Selects a composable WinRT class as a minimal-mode composition target.
+    ///
+    /// The class and its composable factory methods must also be selected by a filter.
+    #[track_caller]
+    pub fn compose(&mut self, name: &str) -> &mut Self {
+        assert!(
+            name.rsplit_once('.')
+                .is_some_and(|(namespace, name)| !namespace.is_empty() && !name.is_empty()),
+            "`compose` requires a fully qualified class name"
+        );
+        self.compose.push(name.to_string());
+        self
+    }
+
+    /// Selects multiple composable WinRT classes as minimal-mode composition targets.
+    pub fn composes<I, S>(&mut self, names: I) -> &mut Self
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        for name in names {
+            self.compose(name.as_ref());
+        }
+        self
+    }
+
     /// Generate raw or sys-style Rust bindings.
     ///
     /// Mutually exclusive with [`Bindgen::minimal`]; panics if `minimal` was
@@ -431,6 +458,10 @@ impl Bindgen {
         assert!(
             !self.output.as_os_str().is_empty(),
             "output is required (call `.output()` or pass `--out`)"
+        );
+        assert!(
+            self.compose.is_empty() || self.style.is_minimal(),
+            "`compose` requires `minimal`"
         );
 
         let mut include: Vec<&str> = vec![];
@@ -606,12 +637,57 @@ impl Bindgen {
             self_generics: Vec::new(),
             prunable: std::sync::Arc::new(BTreeSet::new()),
         };
+        let filter_config = Config {
+            implement: None,
+            ..config.clone()
+        };
+
+        for target in &self.compose {
+            let class = composition_target(reader, target);
+            assert!(
+                types.contains_key(&class.type_name()),
+                "composition target `{target}` is not selected by the filter"
+            );
+            assert!(
+                class
+                    .required_interfaces(reader)
+                    .iter()
+                    .filter(|interface| interface.kind == InterfaceKind::Composable)
+                    .filter(|interface| types.contains_key(&interface.def.type_name()))
+                    .any(|interface| interface
+                        .get_methods(&filter_config)
+                        .iter()
+                        .any(|method| matches!(method, MethodOrName::Method(_)))),
+                "composition target `{target}` has no composable factory method selected by the \
+                 filter"
+            );
+        }
 
         let tree = TypeTree::new(&types);
         report_timing(&self.output, "planning", phase.elapsed());
         config.write(tree);
         report_timing(&self.output, "total", total.elapsed());
     }
+}
+
+#[track_caller]
+fn composition_target(reader: &Reader, target: &str) -> Class {
+    let (namespace, name) = target.rsplit_once('.').unwrap();
+    let class = reader
+        .with_full_name(namespace, name)
+        .find_map(|ty| match ty {
+            Type::Class(class) => Some(class),
+            _ => None,
+        })
+        .unwrap_or_else(|| panic!("composition target `{target}` is not a WinRT class"));
+    assert!(
+        class
+            .required_interfaces(reader)
+            .iter()
+            .any(|interface| interface.kind == InterfaceKind::Composable),
+        "composition target `{target}` is not composable"
+    );
+    class
 }
 
 fn default_reader() -> &'static Reader {
@@ -818,6 +894,22 @@ mod tests {
         let mut builder = Bindgen::new();
         builder.implements(std::iter::empty::<&str>());
         assert_eq!(builder.implement, None);
+    }
+
+    #[test]
+    fn composition_selection() {
+        let mut builder = Bindgen::new();
+        builder
+            .compose("Test.First")
+            .composes(["Test.Second", "Other.Third"]);
+        assert_eq!(
+            builder.compose,
+            vec![
+                "Test.First".to_string(),
+                "Test.Second".to_string(),
+                "Other.Third".to_string()
+            ]
+        );
     }
 
     #[test]

--- a/crates/libs/bindgen/src/types/class.rs
+++ b/crates/libs/bindgen/src/types/class.rs
@@ -70,25 +70,7 @@ impl Class {
             // (needed for static caching). Instance methods live on their interfaces.
             let mut method_names = MethodNames::new();
 
-            // Minimal mode emits `compose()` only for implemented/overridable interfaces.
-            let needs_compose = config.implement.is_some_and(|imp| {
-                required_interfaces
-                    .iter()
-                    .any(|i| imp.matches(i.def.type_name()))
-                    || self
-                        .def
-                        .attributes()
-                        .filter(|a| a.name() == "OverridableAttribute")
-                        .any(|a| {
-                            a.value().iter().any(|(_, arg)| {
-                                if let Value::TypeName(tn) = arg {
-                                    imp.matches_str(&tn.namespace, &tn.name)
-                                } else {
-                                    false
-                                }
-                            })
-                        })
-            });
+            let needs_compose = config.should_compose(type_name);
 
             for interface in required_interfaces
                 .iter()

--- a/crates/libs/bindgen/src/types/method.rs
+++ b/crates/libs/bindgen/src/types/method.rs
@@ -1031,7 +1031,8 @@ impl Method {
                     quote! {}
                 };
 
-                // Minimal subclassing emits `compose()` instead of non-aggregating `new()`.
+                // An explicit minimal composition target emits `compose()` instead of the
+                // non-aggregating `new()`.
                 let suppress_new = emit_compose && config.bindgen.style.is_minimal();
                 let new = if !suppress_new {
                     quote! {

--- a/crates/tests/libs/bindgen/expected/minimal_compose_target.rs
+++ b/crates/tests/libs/bindgen/expected/minimal_compose_target.rs
@@ -1,0 +1,256 @@
+#[repr(transparent)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Base(windows_core::IUnknown);
+windows_core::imp::interface_hierarchy!(
+    Base,
+    windows_core::IUnknown,
+    windows_core::IInspectable,
+    IOverrides
+);
+impl Base {
+    pub fn compose<T>(compose: T) -> windows_core::Result<Self>
+    where
+        T: windows_core::Compose,
+    {
+        Self::IBaseFactory(|this| unsafe {
+            let (derived__, base__) = windows_core::Compose::compose(compose);
+            let mut result__ = core::mem::zeroed();
+            (windows_core::Interface::vtable(this).CreateInstance)(
+                windows_core::Interface::as_raw(this),
+                core::mem::transmute_copy(&derived__),
+                base__ as *mut _ as _,
+                &mut result__,
+            )
+            .ok()?;
+            let _ = &derived__;
+            windows_core::Type::from_abi(result__)
+        })
+    }
+    fn IBaseFactory<R, F: FnOnce(&IBaseFactory) -> windows_core::Result<R>>(
+        callback: F,
+    ) -> windows_core::Result<R> {
+        static SHARED: windows_core::imp::FactoryCache<Base, IBaseFactory> =
+            windows_core::imp::FactoryCache::new();
+        SHARED.call(callback)
+    }
+}
+impl windows_core::RuntimeType for Base {
+    const SIGNATURE: windows_core::imp::ConstBuffer =
+        windows_core::imp::ConstBuffer::for_class::<Self, IOverrides>();
+}
+unsafe impl windows_core::Interface for Base {
+    type Vtable = <IOverrides as windows_core::Interface>::Vtable;
+    const IID: windows_core::GUID = <IOverrides as windows_core::Interface>::IID;
+}
+impl core::ops::Deref for Base {
+    type Target = IOverrides;
+    fn deref(&self) -> &Self::Target {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl windows_core::RuntimeName for Base {
+    const NAME: &'static str = "Test.Base";
+}
+#[repr(transparent)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Derived(windows_core::IUnknown);
+windows_core::imp::interface_hierarchy!(
+    Derived,
+    windows_core::IUnknown,
+    windows_core::IInspectable,
+    IDerived
+);
+windows_core::imp::required_hierarchy!(Derived, Base);
+impl Derived {
+    pub fn new() -> windows_core::Result<Self> {
+        Self::IDerivedFactory(|this| unsafe {
+            let mut result__ = core::mem::zeroed();
+            (windows_core::Interface::vtable(this).CreateInstance)(
+                windows_core::Interface::as_raw(this),
+                core::ptr::null_mut(),
+                core::ptr::null_mut(),
+                &mut result__,
+            )
+            .and_then(|| windows_core::Type::from_abi(result__))
+        })
+    }
+    fn IDerivedFactory<R, F: FnOnce(&IDerivedFactory) -> windows_core::Result<R>>(
+        callback: F,
+    ) -> windows_core::Result<R> {
+        static SHARED: windows_core::imp::FactoryCache<Derived, IDerivedFactory> =
+            windows_core::imp::FactoryCache::new();
+        SHARED.call(callback)
+    }
+}
+impl windows_core::RuntimeType for Derived {
+    const SIGNATURE: windows_core::imp::ConstBuffer =
+        windows_core::imp::ConstBuffer::for_class::<Self, IDerived>();
+}
+unsafe impl windows_core::Interface for Derived {
+    type Vtable = <IDerived as windows_core::Interface>::Vtable;
+    const IID: windows_core::GUID = <IDerived as windows_core::Interface>::IID;
+}
+impl core::ops::Deref for Derived {
+    type Target = IDerived;
+    fn deref(&self) -> &Self::Target {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl windows_core::RuntimeName for Derived {
+    const NAME: &'static str = "Test.Derived";
+}
+windows_core::imp::define_interface!(
+    IBaseFactory,
+    IBaseFactory_Vtbl,
+    0xb2b35536_fcb0_54c1_9424_0abe7fedee40
+);
+impl windows_core::RuntimeType for IBaseFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer =
+        windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
+windows_core::imp::interface_hierarchy!(
+    IBaseFactory,
+    windows_core::IUnknown,
+    windows_core::IInspectable
+);
+impl IBaseFactory {
+    pub fn CreateInstance<P0>(
+        &self,
+        outer: P0,
+        inner: &mut Option<windows_core::IInspectable>,
+    ) -> windows_core::Result<Base>
+    where
+        P0: windows_core::Param<windows_core::IInspectable>,
+    {
+        unsafe {
+            let mut result__ = core::mem::zeroed();
+            (windows_core::Interface::vtable(self).CreateInstance)(
+                windows_core::Interface::as_raw(self),
+                outer.param().abi(),
+                inner as *mut _ as _,
+                &mut result__,
+            )
+            .and_then(|| windows_core::Type::from_abi(result__))
+        }
+    }
+}
+#[repr(C)]
+pub struct IBaseFactory_Vtbl {
+    pub base__: windows_core::IInspectable_Vtbl,
+    pub CreateInstance: unsafe extern "system" fn(
+        *mut core::ffi::c_void,
+        *mut core::ffi::c_void,
+        *mut *mut core::ffi::c_void,
+        *mut *mut core::ffi::c_void,
+    ) -> windows_core::HRESULT,
+}
+windows_core::imp::define_interface!(
+    IDerived,
+    IDerived_Vtbl,
+    0x23cf7109_3cfc_56a0_88cb_06d8fd320cc6
+);
+impl windows_core::RuntimeType for IDerived {
+    const SIGNATURE: windows_core::imp::ConstBuffer =
+        windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
+windows_core::imp::interface_hierarchy!(
+    IDerived,
+    windows_core::IUnknown,
+    windows_core::IInspectable
+);
+#[repr(C)]
+pub struct IDerived_Vtbl {
+    pub base__: windows_core::IInspectable_Vtbl,
+}
+windows_core::imp::define_interface!(
+    IDerivedFactory,
+    IDerivedFactory_Vtbl,
+    0xa04ab497_ffe5_53d3_a6ad_1bfb9db8c9a1
+);
+impl windows_core::RuntimeType for IDerivedFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer =
+        windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
+windows_core::imp::interface_hierarchy!(
+    IDerivedFactory,
+    windows_core::IUnknown,
+    windows_core::IInspectable
+);
+impl IDerivedFactory {
+    pub fn CreateInstance<P0>(
+        &self,
+        outer: P0,
+        inner: &mut Option<windows_core::IInspectable>,
+    ) -> windows_core::Result<Derived>
+    where
+        P0: windows_core::Param<windows_core::IInspectable>,
+    {
+        unsafe {
+            let mut result__ = core::mem::zeroed();
+            (windows_core::Interface::vtable(self).CreateInstance)(
+                windows_core::Interface::as_raw(self),
+                outer.param().abi(),
+                inner as *mut _ as _,
+                &mut result__,
+            )
+            .and_then(|| windows_core::Type::from_abi(result__))
+        }
+    }
+}
+#[repr(C)]
+pub struct IDerivedFactory_Vtbl {
+    pub base__: windows_core::IInspectable_Vtbl,
+    pub CreateInstance: unsafe extern "system" fn(
+        *mut core::ffi::c_void,
+        *mut core::ffi::c_void,
+        *mut *mut core::ffi::c_void,
+        *mut *mut core::ffi::c_void,
+    ) -> windows_core::HRESULT,
+}
+windows_core::imp::define_interface!(
+    IOverrides,
+    IOverrides_Vtbl,
+    0x8952afe3_c320_51da_92db_224e61ab57d1
+);
+impl windows_core::RuntimeType for IOverrides {
+    const SIGNATURE: windows_core::imp::ConstBuffer =
+        windows_core::imp::ConstBuffer::for_interface::<Self>();
+    const NAME: windows_core::imp::ConstBuffer =
+        windows_core::imp::ConstBuffer::from_slice(b"Test.IOverrides");
+}
+windows_core::imp::interface_hierarchy!(
+    IOverrides,
+    windows_core::IUnknown,
+    windows_core::IInspectable
+);
+impl windows_core::RuntimeName for IOverrides {
+    const NAME: &'static str = "Test.IOverrides";
+}
+pub trait IOverrides_Impl: windows_core::IUnknownImpl {
+    fn OnSomething(&self) -> windows_core::Result<()>;
+}
+impl IOverrides_Vtbl {
+    pub const fn new<Identity: IOverrides_Impl, const OFFSET: isize>() -> Self {
+        unsafe extern "system" fn OnSomething<Identity: IOverrides_Impl, const OFFSET: isize>(
+            this: *mut core::ffi::c_void,
+        ) -> windows_core::HRESULT {
+            unsafe {
+                let this: &Identity =
+                    &*((this as *const *const ()).offset(OFFSET) as *const Identity);
+                IOverrides_Impl::OnSomething(this).into()
+            }
+        }
+        Self {
+            base__: windows_core::IInspectable_Vtbl::new::<Identity, IOverrides, OFFSET>(),
+            OnSomething: OnSomething::<Identity, OFFSET>,
+        }
+    }
+    pub fn matches(iid: &windows_core::GUID) -> bool {
+        iid == &<IOverrides as windows_core::Interface>::IID
+    }
+}
+#[repr(C)]
+pub struct IOverrides_Vtbl {
+    pub base__: windows_core::IInspectable_Vtbl,
+    pub OnSomething: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
+}

--- a/crates/tests/libs/bindgen/input/minimal_compose_target.rdl
+++ b/crates/tests/libs/bindgen/input/minimal_compose_target.rdl
@@ -1,0 +1,39 @@
+//! --filter Test.Base::CreateInstance --filter Test.Derived::CreateInstance
+//! --implement Test.IOverrides --compose Test.Base --minimal --flat
+#[winrt]
+mod Windows {
+    mod Foundation {
+        mod Metadata {
+            #[repr(i32)]
+            enum CompositionType {
+                Protected = 1,
+                Public = 2,
+            }
+            attribute ComposableAttribute {
+                fn(factory_type: Type, composition_type: CompositionType, version: u32);
+            }
+        }
+    }
+}
+#[winrt]
+mod Test {
+    #[Windows::Foundation::Metadata::Composable(IBaseFactory, Public, 1)]
+    class Base {
+        IOverrides,
+    }
+    interface IOverrides {
+        fn OnSomething(&self);
+    }
+    interface IBaseFactory {
+        fn CreateInstance(&self, outer: Object, inner: &mut Object) -> Base;
+    }
+
+    #[Windows::Foundation::Metadata::Composable(IDerivedFactory, Public, 1)]
+    class Derived: Base {
+        IDerived,
+    }
+    interface IDerived {}
+    interface IDerivedFactory {
+        fn CreateInstance(&self, outer: Object, inner: &mut Object) -> Derived;
+    }
+}

--- a/crates/tests/libs/bindgen/tests/errors.rs
+++ b/crates/tests/libs/bindgen/tests/errors.rs
@@ -45,6 +45,54 @@ fn conflicting_styles_panic() {
     ]);
 }
 
+#[test]
+#[should_panic(expected = "`compose` requires `minimal`")]
+fn compose_without_minimal_panics() {
+    windows_bindgen::builder()
+        .output("unused.rs")
+        .filter("GetTickCount")
+        .compose("Test.Class")
+        .write();
+}
+
+#[test]
+#[should_panic(expected = "`compose` requires a fully qualified class name")]
+fn unqualified_compose_target_panics() {
+    windows_bindgen::builder().compose("Class");
+}
+
+#[test]
+#[should_panic(expected = "`--compose` requires a class name")]
+fn missing_compose_target_panics() {
+    windows_bindgen::bindgen(["--compose", "--minimal"]);
+}
+
+#[test]
+#[should_panic(
+    expected = "composition target `Test.Base` has no composable factory method selected by the \
+                filter"
+)]
+fn implemented_factory_does_not_select_composition_factory() {
+    let scratch = std::path::Path::new(env!("OUT_DIR")).join("compose_filter");
+    std::fs::create_dir_all(&scratch).unwrap();
+    let winmd = scratch.join("out.winmd");
+    windows_rdl::reader()
+        .input("input/minimal_compose_target.rdl")
+        .output(&winmd)
+        .write()
+        .unwrap();
+
+    windows_bindgen::builder()
+        .input(winmd)
+        .output(scratch.join("out.rs"))
+        .filter("Test.Base")
+        .implement("Test.IBaseFactory")
+        .compose("Test.Base")
+        .minimal()
+        .flat()
+        .write();
+}
+
 fn author_variadic(name: &str) -> (String, String) {
     let scratch = std::path::Path::new(env!("OUT_DIR")).join(name);
     std::fs::create_dir_all(&scratch).unwrap();

--- a/crates/tools/reactor/src/main.rs
+++ b/crates/tools/reactor/src/main.rs
@@ -69,6 +69,7 @@ fn main() {
             "Microsoft.UI.Xaml.IApplicationOverrides",
             "Microsoft.UI.Xaml.Markup.IXamlMetadataProvider",
         ])
+        .compose("Microsoft.UI.Xaml.Application")
         .minimal()
         .dead_code()
         .flat()

--- a/docs/crates/windows-bindgen.md
+++ b/docs/crates/windows-bindgen.md
@@ -113,6 +113,10 @@ Style:
   A class `CreateInstance` filter retains only the constructor factory method it needs. Use minimal
   style for small binding sets. `windows-canvas` and `windows-reactor` use it. It is mutually
   exclusive with `--sys`.
+- `--compose Namespace.Class` or `.compose("Namespace.Class")` marks an explicitly filtered,
+  composable WinRT class as a minimal-mode composition target. It emits `compose()` instead of the
+  factory's non-aggregating `new()`. Composition targets are independent of `--implement`, which
+  selects interface implementation traits.
 
 WinRT event accessors are always collapsed into an `Event` wrapper. This applies to all styles and
 layouts. See [Event accessors](#event-accessors).
@@ -323,6 +327,11 @@ dependencies do not add hierarchy edges to unrelated types.
 An interface selected as a shell can still supply `_Impl` scaffolding through `--implement`.
 Implementation closure retains every method signature needed by the ABI without emitting callable
 wrappers. Select the whole interface as well when the same binding must call and implement it.
+
+Minimal composable bindings also require an explicit class target. Select the class's composable
+factory method with `--filter`, select the override interfaces with `--implement`, and select the
+class itself with `--compose`. This avoids treating every class that inherits an implemented
+override interface as a composition target.
 
 For broad filters and package generation, `TypeMap::filter` scans namespaces from the top down. This
 is used for full namespace and package output.


### PR DESCRIPTION
This separates WinRT interface implementation from class composition in `windows-bindgen`, so `--implement` now only controls which implementation traits are generated while the new minimal-mode `--compose` option explicitly identifies the class being composed. This fixes cases where implementing an inherited override interface could accidentally make unrelated composable classes expose `compose()` and lose `new()`. `windows-reactor` now explicitly composes `Application`, while `windows-canvas`, `windows-webview`, and `windows-composition` remain unchanged because they do not subclass WinRT classes, and all other generated output remains unchanged.

Fixes: #4843
