### PR TITLE
`windows-bindgen` floating point equality generation

### DIFF
--- a/crates/libs/bindgen/src/types/cpp_handle.rs
+++ b/crates/libs/bindgen/src/types/cpp_handle.rs
@@ -56,10 +56,15 @@ impl Config<'_> {
             // Arch-divergent handles are separate rows; each emitted item needs its own gate.
             let arches = write_arches(def);
             let arches = quote! { #arches #cfg };
+            let derives = if ty.is_eq(self.reader) {
+                quote! { #[derive(Clone, Copy, Debug, PartialEq, Eq, Default)] }
+            } else {
+                quote! { #[derive(Clone, Copy, Debug, PartialEq, Default)] }
+            };
             quote! {
                 #arches
                 #[repr(transparent)]
-                #[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+                #derives
                 pub struct #name(pub #ty_name);
             }
         }

--- a/crates/tests/libs/bindgen/expected/handle_float.rs
+++ b/crates/tests/libs/bindgen/expected/handle_float.rs
@@ -1,0 +1,12 @@
+#[repr(transparent)]
+#[derive(Clone, Copy, Debug, PartialEq, Default)]
+pub struct Double(pub f64);
+#[repr(transparent)]
+#[derive(Clone, Copy, Debug, PartialEq, Default)]
+pub struct Float(pub f32);
+#[repr(transparent)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+pub struct Handle(pub *mut core::ffi::c_void);
+#[repr(transparent)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+pub struct Integer(pub i32);

--- a/crates/tests/libs/bindgen/input/handle_float.rdl
+++ b/crates/tests/libs/bindgen/input/handle_float.rdl
@@ -1,0 +1,8 @@
+//! --filter Test --flat
+#[win32]
+mod Test {
+    type Float = f32;
+    type Double = f64;
+    type Integer = i32;
+    type Handle = *mut void;
+}


### PR DESCRIPTION
This update fixes `windows-bindgen` generating invalid `Eq` implementations for native typedefs backed by `f32` or `f64`. These wrappers now use the existing type-aware `Eq` check, preserving `PartialEq` while omitting `Eq` for floating-point types and leaving integer and pointer typedefs unchanged. It also adds regression coverage for both floating-point types.