### PR TITLE
Add NavigationView footer menu items

### DIFF
--- a/crates/libs/reactor/public-api.txt
+++ b/crates/libs/reactor/public-api.txt
@@ -29,10 +29,6 @@ pub windows_reactor::AcceleratorKey::Up
 pub enum windows_reactor::AcceleratorModifiers
 pub windows_reactor::AcceleratorModifiers::Control
 pub windows_reactor::AcceleratorModifiers::None
-#[non_exhaustive] #[repr(u8)] pub enum windows_reactor::AppBarButtonSlot
-pub windows_reactor::AppBarButtonSlot::Icon
-#[non_exhaustive] #[repr(u8)] pub enum windows_reactor::AutoSuggestBoxSlot
-pub windows_reactor::AutoSuggestBoxSlot::Header
 pub enum windows_reactor::AutomationHeadingLevel
 pub windows_reactor::AutomationHeadingLevel::Level1
 pub windows_reactor::AutomationHeadingLevel::Level2
@@ -55,13 +51,9 @@ pub windows_reactor::ButtonStyle::Accent
 pub windows_reactor::ButtonStyle::Default
 pub windows_reactor::ButtonStyle::Subtle
 pub windows_reactor::ButtonStyle::TextLink
-#[non_exhaustive] #[repr(u8)] pub enum windows_reactor::CalendarDatePickerSlot
-pub windows_reactor::CalendarDatePickerSlot::Header
 pub enum windows_reactor::ColorScheme
 pub windows_reactor::ColorScheme::Dark
 pub windows_reactor::ColorScheme::Light
-#[non_exhaustive] #[repr(u8)] pub enum windows_reactor::ComboBoxSlot
-pub windows_reactor::ComboBoxSlot::Header
 pub enum windows_reactor::CommandBarCommand
 pub windows_reactor::CommandBarCommand::Button
 pub windows_reactor::CommandBarCommand::Button::enabled: bool
@@ -74,9 +66,6 @@ impl windows_reactor::CommandBarCommand
 pub fn windows_reactor::CommandBarCommand::button(impl core::convert::Into<windows_reactor::Key>, impl core::convert::Into<alloc::string::String>) -> Self
 pub fn windows_reactor::CommandBarCommand::button_with_icon(impl core::convert::Into<windows_reactor::Key>, impl core::convert::Into<alloc::string::String>, windows_reactor::Symbol) -> Self
 pub fn windows_reactor::CommandBarCommand::separator(impl core::convert::Into<windows_reactor::Key>) -> Self
-#[non_exhaustive] #[repr(u8)] pub enum windows_reactor::CommandBarSlot
-pub windows_reactor::CommandBarSlot::PrimaryCommands
-pub windows_reactor::CommandBarSlot::SecondaryCommands
 #[repr(u8)] pub enum windows_reactor::ComponentTaskStatus
 pub windows_reactor::ComponentTaskStatus::Cancelled
 pub windows_reactor::ComponentTaskStatus::Delivered
@@ -97,8 +86,6 @@ pub windows_reactor::CompositionHostEvent::Ready::width: f64
 pub windows_reactor::ContentDialogResult::None
 pub windows_reactor::ContentDialogResult::Primary
 pub windows_reactor::ContentDialogResult::Secondary
-#[non_exhaustive] #[repr(u8)] pub enum windows_reactor::DatePickerSlot
-pub windows_reactor::DatePickerSlot::Header
 pub enum windows_reactor::DragDropOperation
 pub windows_reactor::DragDropOperation::Copy
 pub windows_reactor::DragDropOperation::Link
@@ -111,11 +98,6 @@ pub enum windows_reactor::DroppedData
 pub windows_reactor::DroppedData::StorageItems(alloc::vec::Vec<windows_reactor::DroppedStorageItem>)
 pub windows_reactor::DroppedData::Text(alloc::string::String)
 pub windows_reactor::DroppedData::Unsupported
-#[non_exhaustive] #[repr(u8)] pub enum windows_reactor::ExpanderSlot
-pub windows_reactor::ExpanderSlot::Content
-pub windows_reactor::ExpanderSlot::Header
-#[non_exhaustive] #[repr(u8)] pub enum windows_reactor::FlipViewSlot
-pub windows_reactor::FlipViewSlot::Items
 pub enum windows_reactor::FlyoutPlacement
 pub windows_reactor::FlyoutPlacement::Auto
 pub windows_reactor::FlyoutPlacement::Bottom
@@ -139,8 +121,6 @@ impl windows_reactor::GridLength
 pub const windows_reactor::GridLength::STAR: Self
 impl core::cmp::PartialEq for windows_reactor::GridLength
 pub fn windows_reactor::GridLength::eq(&self, &Self) -> bool
-#[non_exhaustive] #[repr(u8)] pub enum windows_reactor::GridViewSlot
-pub windows_reactor::GridViewSlot::Items
 pub enum windows_reactor::HorizontalAlignment
 pub windows_reactor::HorizontalAlignment::Center
 pub windows_reactor::HorizontalAlignment::Left
@@ -154,17 +134,11 @@ pub windows_reactor::InfoBarSeverity::Warning
 pub enum windows_reactor::IntegrationError
 pub windows_reactor::IntegrationError::Native(i32)
 pub windows_reactor::IntegrationError::Unavailable
-#[non_exhaustive] #[repr(u8)] pub enum windows_reactor::ListBoxSlot
-pub windows_reactor::ListBoxSlot::Items
 #[non_exhaustive] pub enum windows_reactor::ListViewSelectionMode
 pub windows_reactor::ListViewSelectionMode::Extended
 pub windows_reactor::ListViewSelectionMode::Multiple
 pub windows_reactor::ListViewSelectionMode::None
 pub windows_reactor::ListViewSelectionMode::Single
-#[non_exhaustive] #[repr(u8)] pub enum windows_reactor::ListViewSlot
-pub windows_reactor::ListViewSlot::Items
-#[non_exhaustive] #[repr(u8)] pub enum windows_reactor::MenuBarSlot
-pub windows_reactor::MenuBarSlot::Items
 pub enum windows_reactor::MenuItem
 pub windows_reactor::MenuItem::Item
 pub windows_reactor::MenuItem::Item::enabled: bool
@@ -189,35 +163,19 @@ pub enum windows_reactor::NavigationViewDisplayMode
 pub windows_reactor::NavigationViewDisplayMode::Compact
 pub windows_reactor::NavigationViewDisplayMode::Expanded
 pub windows_reactor::NavigationViewDisplayMode::Minimal
-#[non_exhaustive] #[repr(u8)] pub enum windows_reactor::NavigationViewItemSlot
-pub windows_reactor::NavigationViewItemSlot::Content
-pub windows_reactor::NavigationViewItemSlot::Icon
-pub windows_reactor::NavigationViewItemSlot::MenuItems
 #[non_exhaustive] pub enum windows_reactor::NavigationViewPaneDisplayMode
 pub windows_reactor::NavigationViewPaneDisplayMode::Auto
 pub windows_reactor::NavigationViewPaneDisplayMode::Left
 pub windows_reactor::NavigationViewPaneDisplayMode::LeftCompact
 pub windows_reactor::NavigationViewPaneDisplayMode::LeftMinimal
 pub windows_reactor::NavigationViewPaneDisplayMode::Top
-#[non_exhaustive] #[repr(u8)] pub enum windows_reactor::NavigationViewSlot
-pub windows_reactor::NavigationViewSlot::Content
-pub windows_reactor::NavigationViewSlot::Header
-pub windows_reactor::NavigationViewSlot::MenuItems
-pub windows_reactor::NavigationViewSlot::PaneCustomContent
-pub windows_reactor::NavigationViewSlot::PaneFooter
-#[non_exhaustive] #[repr(u8)] pub enum windows_reactor::NumberBoxSlot
-pub windows_reactor::NumberBoxSlot::Header
 #[non_exhaustive] pub enum windows_reactor::Orientation
 pub windows_reactor::Orientation::Horizontal
 pub windows_reactor::Orientation::Vertical
-#[non_exhaustive] #[repr(u8)] pub enum windows_reactor::PasswordBoxSlot
-pub windows_reactor::PasswordBoxSlot::Header
 #[non_exhaustive] pub enum windows_reactor::PasswordRevealMode
 pub windows_reactor::PasswordRevealMode::Hidden
 pub windows_reactor::PasswordRevealMode::Peek
 pub windows_reactor::PasswordRevealMode::Visible
-#[non_exhaustive] #[repr(u8)] pub enum windows_reactor::PivotSlot
-pub windows_reactor::PivotSlot::Items
 pub enum windows_reactor::PumpDiagnostic
 pub windows_reactor::PumpDiagnostic::VirtualRowRootCount
 pub windows_reactor::PumpDiagnostic::VirtualRowRootCount::actual: usize
@@ -225,8 +183,6 @@ pub windows_reactor::PumpDiagnostic::VirtualRowRootCount::collection: windows_re
 pub windows_reactor::PumpDiagnostic::VirtualRowRootCount::key: windows_reactor::Key
 pub windows_reactor::PumpDiagnostic::WindowOpenRejected
 pub windows_reactor::PumpDiagnostic::WindowOpenRejected::error: windows_reactor::core::runtime::RuntimeError
-#[non_exhaustive] #[repr(u8)] pub enum windows_reactor::RadioButtonsSlot
-pub windows_reactor::RadioButtonsSlot::Header
 pub enum windows_reactor::ResourceValue
 pub windows_reactor::ResourceValue::Color(windows_reactor::Color)
 pub windows_reactor::ResourceValue::CornerRadius(windows_reactor::CornerRadius)
@@ -237,8 +193,6 @@ impl core::convert::From<windows_reactor::CornerRadius> for windows_reactor::Res
 pub fn windows_reactor::ResourceValue::from(windows_reactor::CornerRadius) -> Self
 impl core::convert::From<windows_reactor::Thickness> for windows_reactor::ResourceValue
 pub fn windows_reactor::ResourceValue::from(windows_reactor::Thickness) -> Self
-#[non_exhaustive] #[repr(u8)] pub enum windows_reactor::RichEditBoxSlot
-pub windows_reactor::RichEditBoxSlot::Header
 pub enum windows_reactor::RichTextInline
 pub windows_reactor::RichTextInline::Hyperlink(windows_reactor::RichTextHyperlink)
 pub windows_reactor::RichTextInline::LineBreak
@@ -252,20 +206,11 @@ pub windows_reactor::ScrollBarVisibility::Visible
 pub windows_reactor::ScrollingScrollBarVisibility::Auto
 pub windows_reactor::ScrollingScrollBarVisibility::Hidden
 pub windows_reactor::ScrollingScrollBarVisibility::Visible
-#[non_exhaustive] #[repr(u8)] pub enum windows_reactor::SelectorBarItemSlot
-pub windows_reactor::SelectorBarItemSlot::Icon
-#[non_exhaustive] #[repr(u8)] pub enum windows_reactor::SelectorBarSlot
-pub windows_reactor::SelectorBarSlot::Items
-#[non_exhaustive] #[repr(u8)] pub enum windows_reactor::SliderSlot
-pub windows_reactor::SliderSlot::Header
 #[non_exhaustive] pub enum windows_reactor::SplitViewDisplayMode
 pub windows_reactor::SplitViewDisplayMode::CompactInline
 pub windows_reactor::SplitViewDisplayMode::CompactOverlay
 pub windows_reactor::SplitViewDisplayMode::Inline
 pub windows_reactor::SplitViewDisplayMode::Overlay
-#[non_exhaustive] #[repr(u8)] pub enum windows_reactor::SplitViewSlot
-pub windows_reactor::SplitViewSlot::Content
-pub windows_reactor::SplitViewSlot::Pane
 #[non_exhaustive] pub enum windows_reactor::Stretch
 pub windows_reactor::Stretch::Fill
 pub windows_reactor::Stretch::None
@@ -477,8 +422,6 @@ pub windows_reactor::Symbol::ZeroBars
 pub windows_reactor::Symbol::Zoom
 pub windows_reactor::Symbol::ZoomIn
 pub windows_reactor::Symbol::ZoomOut
-#[non_exhaustive] #[repr(u8)] pub enum windows_reactor::TabViewSlot
-pub windows_reactor::TabViewSlot::TabItems
 #[non_exhaustive] pub enum windows_reactor::TeachingTipPlacementMode
 pub windows_reactor::TeachingTipPlacementMode::Auto
 pub windows_reactor::TeachingTipPlacementMode::Bottom
@@ -494,8 +437,6 @@ pub windows_reactor::TeachingTipPlacementMode::RightTop
 pub windows_reactor::TeachingTipPlacementMode::Top
 pub windows_reactor::TeachingTipPlacementMode::TopLeft
 pub windows_reactor::TeachingTipPlacementMode::TopRight
-#[non_exhaustive] #[repr(u8)] pub enum windows_reactor::TextBoxSlot
-pub windows_reactor::TextBoxSlot::Header
 #[non_exhaustive] pub enum windows_reactor::TextTrimming
 pub windows_reactor::TextTrimming::CharacterEllipsis
 pub windows_reactor::TextTrimming::Clip
@@ -516,15 +457,6 @@ pub windows_reactor::ThemeBrush::SystemCritical
 pub windows_reactor::ThemeBrush::SystemCriticalBackground
 impl core::convert::From<windows_reactor::ThemeBrush> for windows_reactor::Brush
 pub fn windows_reactor::Brush::from(windows_reactor::ThemeBrush) -> Self
-#[non_exhaustive] #[repr(u8)] pub enum windows_reactor::TimePickerSlot
-pub windows_reactor::TimePickerSlot::Header
-#[non_exhaustive] #[repr(u8)] pub enum windows_reactor::TitleBarSlot
-pub windows_reactor::TitleBarSlot::Content
-pub windows_reactor::TitleBarSlot::RightHeader
-#[non_exhaustive] #[repr(u8)] pub enum windows_reactor::ToggleSwitchSlot
-pub windows_reactor::ToggleSwitchSlot::Header
-pub windows_reactor::ToggleSwitchSlot::OffContent
-pub windows_reactor::ToggleSwitchSlot::OnContent
 pub enum windows_reactor::TooltipPlacement
 pub windows_reactor::TooltipPlacement::Bottom
 pub windows_reactor::TooltipPlacement::Left
@@ -540,8 +472,6 @@ pub windows_reactor::VerticalAlignment::Bottom
 pub windows_reactor::VerticalAlignment::Center
 pub windows_reactor::VerticalAlignment::Stretch
 pub windows_reactor::VerticalAlignment::Top
-#[non_exhaustive] #[repr(u8)] pub enum windows_reactor::ViewboxSlot
-pub windows_reactor::ViewboxSlot::Child
 pub enum windows_reactor::WindowBackdrop
 pub windows_reactor::WindowBackdrop::Acrylic
 pub windows_reactor::WindowBackdrop::Mica
@@ -561,6 +491,7 @@ pub fn windows_reactor::App::run_component<C: windows_reactor::Component>(<C as 
 pub fn windows_reactor::App::run_windows<I>(I) -> windows_result::Result<()> where I: core::iter::traits::collect::IntoIterator<Item = windows_reactor::View>
 pub struct windows_reactor::AppBarButton
 impl windows_reactor::AppBarButton
+pub fn windows_reactor::AppBarButton::icon(self, impl core::convert::Into<windows_reactor::View>) -> Self
 pub fn windows_reactor::AppBarButton::is_enabled(self, impl core::convert::Into<core::option::Option<bool>>) -> Self
 pub fn windows_reactor::AppBarButton::label(self, impl core::convert::Into<alloc::string::String>) -> Self
 pub fn windows_reactor::AppBarButton::label_optional<T>(self, core::option::Option<T>) -> Self where T: core::convert::Into<alloc::string::String>
@@ -581,11 +512,6 @@ pub fn windows_reactor::AppBarButton::min_width(self, impl core::convert::Into<c
 pub fn windows_reactor::AppBarButton::opacity(self, impl core::convert::Into<core::option::Option<f64>>) -> Self where Self: core::marker::Sized
 pub fn windows_reactor::AppBarButton::vertical_alignment(self, impl core::convert::Into<core::option::Option<windows_reactor::VerticalAlignment>>) -> Self where Self: core::marker::Sized
 pub fn windows_reactor::AppBarButton::width(self, impl core::convert::Into<core::option::Option<f64>>) -> Self where Self: core::marker::Sized
-impl windows_reactor::SlotsControl for windows_reactor::AppBarButton
-pub type windows_reactor::AppBarButton::Slot = windows_reactor::AppBarButtonSlot
-pub fn windows_reactor::AppBarButton::collection_slot<T>(self, Self::Slot, impl core::iter::traits::collect::IntoIterator<Item = T>) -> windows_reactor::View where T: core::convert::Into<windows_reactor::KeyedView>
-pub fn windows_reactor::AppBarButton::slot(self, Self::Slot, impl core::convert::Into<windows_reactor::View>) -> windows_reactor::View
-pub fn windows_reactor::AppBarButton::slots(self, impl core::iter::traits::collect::IntoIterator<Item = windows_reactor::SlotView<Self::Slot>>) -> windows_reactor::View
 pub struct windows_reactor::AppBarSeparator
 impl windows_reactor::AppBarSeparator
 pub fn windows_reactor::AppBarSeparator::new() -> Self
@@ -607,6 +533,7 @@ pub fn windows_reactor::AppBarSeparator::width(self, impl core::convert::Into<co
 pub struct windows_reactor::AutoSuggestBox
 impl windows_reactor::AutoSuggestBox
 pub fn windows_reactor::AutoSuggestBox::element_ref(self, &windows_reactor::ElementRef<Self>) -> Self
+pub fn windows_reactor::AutoSuggestBox::header(self, impl core::convert::Into<windows_reactor::View>) -> Self
 pub fn windows_reactor::AutoSuggestBox::is_enabled(self, impl core::convert::Into<core::option::Option<bool>>) -> Self
 pub fn windows_reactor::AutoSuggestBox::items_source<I, S>(self, I) -> Self where I: core::iter::traits::collect::IntoIterator<Item = S>, S: core::convert::Into<alloc::string::String>
 pub fn windows_reactor::AutoSuggestBox::items_source_optional<I, S>(self, core::option::Option<I>) -> Self where I: core::iter::traits::collect::IntoIterator<Item = S>, S: core::convert::Into<alloc::string::String>
@@ -634,11 +561,6 @@ pub fn windows_reactor::AutoSuggestBox::opacity(self, impl core::convert::Into<c
 pub fn windows_reactor::AutoSuggestBox::vertical_alignment(self, impl core::convert::Into<core::option::Option<windows_reactor::VerticalAlignment>>) -> Self where Self: core::marker::Sized
 pub fn windows_reactor::AutoSuggestBox::width(self, impl core::convert::Into<core::option::Option<f64>>) -> Self where Self: core::marker::Sized
 impl windows_reactor::ReferenceControl for windows_reactor::AutoSuggestBox
-impl windows_reactor::SlotsControl for windows_reactor::AutoSuggestBox
-pub type windows_reactor::AutoSuggestBox::Slot = windows_reactor::AutoSuggestBoxSlot
-pub fn windows_reactor::AutoSuggestBox::collection_slot<T>(self, Self::Slot, impl core::iter::traits::collect::IntoIterator<Item = T>) -> windows_reactor::View where T: core::convert::Into<windows_reactor::KeyedView>
-pub fn windows_reactor::AutoSuggestBox::slot(self, Self::Slot, impl core::convert::Into<windows_reactor::View>) -> windows_reactor::View
-pub fn windows_reactor::AutoSuggestBox::slots(self, impl core::iter::traits::collect::IntoIterator<Item = windows_reactor::SlotView<Self::Slot>>) -> windows_reactor::View
 pub struct windows_reactor::BitmapIcon
 impl windows_reactor::BitmapIcon
 pub fn windows_reactor::BitmapIcon::new() -> Self
@@ -759,6 +681,7 @@ pub fn windows_reactor::Button::width(self, impl core::convert::Into<core::optio
 impl windows_reactor::ReferenceControl for windows_reactor::Button
 pub struct windows_reactor::CalendarDatePicker
 impl windows_reactor::CalendarDatePicker
+pub fn windows_reactor::CalendarDatePicker::header(self, impl core::convert::Into<windows_reactor::View>) -> Self
 pub fn windows_reactor::CalendarDatePicker::is_calendar_open(self, impl core::convert::Into<core::option::Option<bool>>) -> Self
 pub fn windows_reactor::CalendarDatePicker::is_enabled(self, impl core::convert::Into<core::option::Option<bool>>) -> Self
 pub fn windows_reactor::CalendarDatePicker::is_today_highlighted(self, impl core::convert::Into<core::option::Option<bool>>) -> Self
@@ -781,11 +704,6 @@ pub fn windows_reactor::CalendarDatePicker::min_width(self, impl core::convert::
 pub fn windows_reactor::CalendarDatePicker::opacity(self, impl core::convert::Into<core::option::Option<f64>>) -> Self where Self: core::marker::Sized
 pub fn windows_reactor::CalendarDatePicker::vertical_alignment(self, impl core::convert::Into<core::option::Option<windows_reactor::VerticalAlignment>>) -> Self where Self: core::marker::Sized
 pub fn windows_reactor::CalendarDatePicker::width(self, impl core::convert::Into<core::option::Option<f64>>) -> Self where Self: core::marker::Sized
-impl windows_reactor::SlotsControl for windows_reactor::CalendarDatePicker
-pub type windows_reactor::CalendarDatePicker::Slot = windows_reactor::CalendarDatePickerSlot
-pub fn windows_reactor::CalendarDatePicker::collection_slot<T>(self, Self::Slot, impl core::iter::traits::collect::IntoIterator<Item = T>) -> windows_reactor::View where T: core::convert::Into<windows_reactor::KeyedView>
-pub fn windows_reactor::CalendarDatePicker::slot(self, Self::Slot, impl core::convert::Into<windows_reactor::View>) -> windows_reactor::View
-pub fn windows_reactor::CalendarDatePicker::slots(self, impl core::iter::traits::collect::IntoIterator<Item = windows_reactor::SlotView<Self::Slot>>) -> windows_reactor::View
 pub struct windows_reactor::CalendarView
 impl windows_reactor::CalendarView
 pub fn windows_reactor::CalendarView::is_enabled(self, impl core::convert::Into<core::option::Option<bool>>) -> Self
@@ -913,6 +831,7 @@ pub fn windows_reactor::ColorPicker::width(self, impl core::convert::Into<core::
 pub struct windows_reactor::ComboBox
 impl windows_reactor::ComboBox
 pub fn windows_reactor::ComboBox::element_ref(self, &windows_reactor::ElementRef<Self>) -> Self
+pub fn windows_reactor::ComboBox::header(self, impl core::convert::Into<windows_reactor::View>) -> Self
 pub fn windows_reactor::ComboBox::is_editable(self, impl core::convert::Into<core::option::Option<bool>>) -> Self
 pub fn windows_reactor::ComboBox::is_enabled(self, impl core::convert::Into<core::option::Option<bool>>) -> Self
 pub fn windows_reactor::ComboBox::items_source<I, S>(self, I) -> Self where I: core::iter::traits::collect::IntoIterator<Item = S>, S: core::convert::Into<alloc::string::String>
@@ -939,14 +858,11 @@ pub fn windows_reactor::ComboBox::opacity(self, impl core::convert::Into<core::o
 pub fn windows_reactor::ComboBox::vertical_alignment(self, impl core::convert::Into<core::option::Option<windows_reactor::VerticalAlignment>>) -> Self where Self: core::marker::Sized
 pub fn windows_reactor::ComboBox::width(self, impl core::convert::Into<core::option::Option<f64>>) -> Self where Self: core::marker::Sized
 impl windows_reactor::ReferenceControl for windows_reactor::ComboBox
-impl windows_reactor::SlotsControl for windows_reactor::ComboBox
-pub type windows_reactor::ComboBox::Slot = windows_reactor::ComboBoxSlot
-pub fn windows_reactor::ComboBox::collection_slot<T>(self, Self::Slot, impl core::iter::traits::collect::IntoIterator<Item = T>) -> windows_reactor::View where T: core::convert::Into<windows_reactor::KeyedView>
-pub fn windows_reactor::ComboBox::slot(self, Self::Slot, impl core::convert::Into<windows_reactor::View>) -> windows_reactor::View
-pub fn windows_reactor::ComboBox::slots(self, impl core::iter::traits::collect::IntoIterator<Item = windows_reactor::SlotView<Self::Slot>>) -> windows_reactor::View
 pub struct windows_reactor::CommandBar
 impl windows_reactor::CommandBar
 pub fn windows_reactor::CommandBar::new() -> Self
+pub fn windows_reactor::CommandBar::primary_commands<T>(self, impl core::iter::traits::collect::IntoIterator<Item = T>) -> Self where T: core::convert::Into<windows_reactor::KeyedView>
+pub fn windows_reactor::CommandBar::secondary_commands<T>(self, impl core::iter::traits::collect::IntoIterator<Item = T>) -> Self where T: core::convert::Into<windows_reactor::KeyedView>
 impl windows_reactor::CommandBar
 pub fn windows_reactor::CommandBar::owned_commands(self, impl core::iter::traits::collect::IntoIterator<Item = windows_reactor::CommandBarCommand>, impl core::iter::traits::collect::IntoIterator<Item = windows_reactor::CommandBarCommand>, impl windows_reactor::IntoPayloadCallback<alloc::string::String>) -> windows_reactor::View
 impl core::convert::From<windows_reactor::CommandBar> for windows_reactor::View
@@ -964,11 +880,6 @@ pub fn windows_reactor::CommandBar::min_width(self, impl core::convert::Into<cor
 pub fn windows_reactor::CommandBar::opacity(self, impl core::convert::Into<core::option::Option<f64>>) -> Self where Self: core::marker::Sized
 pub fn windows_reactor::CommandBar::vertical_alignment(self, impl core::convert::Into<core::option::Option<windows_reactor::VerticalAlignment>>) -> Self where Self: core::marker::Sized
 pub fn windows_reactor::CommandBar::width(self, impl core::convert::Into<core::option::Option<f64>>) -> Self where Self: core::marker::Sized
-impl windows_reactor::SlotsControl for windows_reactor::CommandBar
-pub type windows_reactor::CommandBar::Slot = windows_reactor::CommandBarSlot
-pub fn windows_reactor::CommandBar::collection_slot<T>(self, Self::Slot, impl core::iter::traits::collect::IntoIterator<Item = T>) -> windows_reactor::View where T: core::convert::Into<windows_reactor::KeyedView>
-pub fn windows_reactor::CommandBar::slot(self, Self::Slot, impl core::convert::Into<windows_reactor::View>) -> windows_reactor::View
-pub fn windows_reactor::CommandBar::slots(self, impl core::iter::traits::collect::IntoIterator<Item = windows_reactor::SlotView<Self::Slot>>) -> windows_reactor::View
 pub struct windows_reactor::CommandBarFlyout
 impl windows_reactor::CommandBarFlyout
 pub fn windows_reactor::CommandBarFlyout::new(impl core::iter::traits::collect::IntoIterator<Item = windows_reactor::CommandBarCommand>, impl core::iter::traits::collect::IntoIterator<Item = windows_reactor::CommandBarCommand>, impl windows_reactor::IntoPayloadCallback<alloc::string::String>) -> Self
@@ -1038,6 +949,7 @@ pub fn windows_reactor::CornerRadius::default() -> Self
 pub struct windows_reactor::DatePicker
 impl windows_reactor::DatePicker
 pub fn windows_reactor::DatePicker::day_visible(self, impl core::convert::Into<core::option::Option<bool>>) -> Self
+pub fn windows_reactor::DatePicker::header(self, impl core::convert::Into<windows_reactor::View>) -> Self
 pub fn windows_reactor::DatePicker::is_enabled(self, impl core::convert::Into<core::option::Option<bool>>) -> Self
 pub fn windows_reactor::DatePicker::month_visible(self, impl core::convert::Into<core::option::Option<bool>>) -> Self
 pub fn windows_reactor::DatePicker::new() -> Self
@@ -1058,11 +970,6 @@ pub fn windows_reactor::DatePicker::min_width(self, impl core::convert::Into<cor
 pub fn windows_reactor::DatePicker::opacity(self, impl core::convert::Into<core::option::Option<f64>>) -> Self where Self: core::marker::Sized
 pub fn windows_reactor::DatePicker::vertical_alignment(self, impl core::convert::Into<core::option::Option<windows_reactor::VerticalAlignment>>) -> Self where Self: core::marker::Sized
 pub fn windows_reactor::DatePicker::width(self, impl core::convert::Into<core::option::Option<f64>>) -> Self where Self: core::marker::Sized
-impl windows_reactor::SlotsControl for windows_reactor::DatePicker
-pub type windows_reactor::DatePicker::Slot = windows_reactor::DatePickerSlot
-pub fn windows_reactor::DatePicker::collection_slot<T>(self, Self::Slot, impl core::iter::traits::collect::IntoIterator<Item = T>) -> windows_reactor::View where T: core::convert::Into<windows_reactor::KeyedView>
-pub fn windows_reactor::DatePicker::slot(self, Self::Slot, impl core::convert::Into<windows_reactor::View>) -> windows_reactor::View
-pub fn windows_reactor::DatePicker::slots(self, impl core::iter::traits::collect::IntoIterator<Item = windows_reactor::SlotView<Self::Slot>>) -> windows_reactor::View
 pub struct windows_reactor::DragDropAction
 pub windows_reactor::DragDropAction::caption: core::option::Option<alloc::string::String>
 pub windows_reactor::DragDropAction::operation: windows_reactor::DragDropOperation
@@ -1181,6 +1088,8 @@ pub fn windows_reactor::ExitTransition::duration(self) -> core::time::Duration
 pub fn windows_reactor::ExitTransition::fade(core::time::Duration) -> Self
 pub struct windows_reactor::Expander
 impl windows_reactor::Expander
+pub fn windows_reactor::Expander::content(self, impl core::convert::Into<windows_reactor::View>) -> Self
+pub fn windows_reactor::Expander::header(self, impl core::convert::Into<windows_reactor::View>) -> Self
 pub fn windows_reactor::Expander::is_expanded(self, impl core::convert::Into<core::option::Option<bool>>) -> Self
 pub fn windows_reactor::Expander::new() -> Self
 pub fn windows_reactor::Expander::on_is_expanded_changed(self, impl windows_reactor::IntoPayloadCallback<bool>) -> Self
@@ -1199,13 +1108,9 @@ pub fn windows_reactor::Expander::min_width(self, impl core::convert::Into<core:
 pub fn windows_reactor::Expander::opacity(self, impl core::convert::Into<core::option::Option<f64>>) -> Self where Self: core::marker::Sized
 pub fn windows_reactor::Expander::vertical_alignment(self, impl core::convert::Into<core::option::Option<windows_reactor::VerticalAlignment>>) -> Self where Self: core::marker::Sized
 pub fn windows_reactor::Expander::width(self, impl core::convert::Into<core::option::Option<f64>>) -> Self where Self: core::marker::Sized
-impl windows_reactor::SlotsControl for windows_reactor::Expander
-pub type windows_reactor::Expander::Slot = windows_reactor::ExpanderSlot
-pub fn windows_reactor::Expander::collection_slot<T>(self, Self::Slot, impl core::iter::traits::collect::IntoIterator<Item = T>) -> windows_reactor::View where T: core::convert::Into<windows_reactor::KeyedView>
-pub fn windows_reactor::Expander::slot(self, Self::Slot, impl core::convert::Into<windows_reactor::View>) -> windows_reactor::View
-pub fn windows_reactor::Expander::slots(self, impl core::iter::traits::collect::IntoIterator<Item = windows_reactor::SlotView<Self::Slot>>) -> windows_reactor::View
 pub struct windows_reactor::FlipView
 impl windows_reactor::FlipView
+pub fn windows_reactor::FlipView::items<T>(self, impl core::iter::traits::collect::IntoIterator<Item = T>) -> Self where T: core::convert::Into<windows_reactor::KeyedView>
 pub fn windows_reactor::FlipView::new() -> Self
 pub fn windows_reactor::FlipView::on_selection_changed(self, impl windows_reactor::IntoPayloadCallback<core::option::Option<usize>>) -> Self
 pub fn windows_reactor::FlipView::selected_index(self, impl core::convert::Into<core::option::Option<usize>>) -> Self
@@ -1224,11 +1129,6 @@ pub fn windows_reactor::FlipView::min_width(self, impl core::convert::Into<core:
 pub fn windows_reactor::FlipView::opacity(self, impl core::convert::Into<core::option::Option<f64>>) -> Self where Self: core::marker::Sized
 pub fn windows_reactor::FlipView::vertical_alignment(self, impl core::convert::Into<core::option::Option<windows_reactor::VerticalAlignment>>) -> Self where Self: core::marker::Sized
 pub fn windows_reactor::FlipView::width(self, impl core::convert::Into<core::option::Option<f64>>) -> Self where Self: core::marker::Sized
-impl windows_reactor::SlotsControl for windows_reactor::FlipView
-pub type windows_reactor::FlipView::Slot = windows_reactor::FlipViewSlot
-pub fn windows_reactor::FlipView::collection_slot<T>(self, Self::Slot, impl core::iter::traits::collect::IntoIterator<Item = T>) -> windows_reactor::View where T: core::convert::Into<windows_reactor::KeyedView>
-pub fn windows_reactor::FlipView::slot(self, Self::Slot, impl core::convert::Into<windows_reactor::View>) -> windows_reactor::View
-pub fn windows_reactor::FlipView::slots(self, impl core::iter::traits::collect::IntoIterator<Item = windows_reactor::SlotView<Self::Slot>>) -> windows_reactor::View
 pub struct windows_reactor::Flyout
 impl windows_reactor::Flyout
 pub fn windows_reactor::Flyout::placement(self, windows_reactor::FlyoutPlacement) -> Self
@@ -1308,6 +1208,7 @@ impl windows_reactor::GridView
 pub fn windows_reactor::GridView::allow_drop(self, impl core::convert::Into<core::option::Option<bool>>) -> Self
 pub fn windows_reactor::GridView::can_drag_items(self, impl core::convert::Into<core::option::Option<bool>>) -> Self
 pub fn windows_reactor::GridView::can_reorder_items(self, impl core::convert::Into<core::option::Option<bool>>) -> Self
+pub fn windows_reactor::GridView::items<T>(self, impl core::iter::traits::collect::IntoIterator<Item = T>) -> Self where T: core::convert::Into<windows_reactor::KeyedView>
 pub fn windows_reactor::GridView::new() -> Self
 pub fn windows_reactor::GridView::on_reordered(self, impl windows_reactor::IntoPayloadCallback<alloc::vec::Vec<alloc::string::String>>) -> Self
 pub fn windows_reactor::GridView::on_selection_changed(self, impl windows_reactor::IntoPayloadCallback<core::option::Option<usize>>) -> Self
@@ -1327,11 +1228,6 @@ pub fn windows_reactor::GridView::min_width(self, impl core::convert::Into<core:
 pub fn windows_reactor::GridView::opacity(self, impl core::convert::Into<core::option::Option<f64>>) -> Self where Self: core::marker::Sized
 pub fn windows_reactor::GridView::vertical_alignment(self, impl core::convert::Into<core::option::Option<windows_reactor::VerticalAlignment>>) -> Self where Self: core::marker::Sized
 pub fn windows_reactor::GridView::width(self, impl core::convert::Into<core::option::Option<f64>>) -> Self where Self: core::marker::Sized
-impl windows_reactor::SlotsControl for windows_reactor::GridView
-pub type windows_reactor::GridView::Slot = windows_reactor::GridViewSlot
-pub fn windows_reactor::GridView::collection_slot<T>(self, Self::Slot, impl core::iter::traits::collect::IntoIterator<Item = T>) -> windows_reactor::View where T: core::convert::Into<windows_reactor::KeyedView>
-pub fn windows_reactor::GridView::slot(self, Self::Slot, impl core::convert::Into<windows_reactor::View>) -> windows_reactor::View
-pub fn windows_reactor::GridView::slots(self, impl core::iter::traits::collect::IntoIterator<Item = windows_reactor::SlotView<Self::Slot>>) -> windows_reactor::View
 pub struct windows_reactor::GridViewItem
 impl windows_reactor::GridViewItem
 pub fn windows_reactor::GridViewItem::new() -> Self
@@ -1548,6 +1444,7 @@ pub fn windows_reactor::Line::width(self, impl core::convert::Into<core::option:
 pub struct windows_reactor::ListBox
 impl windows_reactor::ListBox
 pub fn windows_reactor::ListBox::is_enabled(self, impl core::convert::Into<core::option::Option<bool>>) -> Self
+pub fn windows_reactor::ListBox::items<T>(self, impl core::iter::traits::collect::IntoIterator<Item = T>) -> Self where T: core::convert::Into<windows_reactor::KeyedView>
 pub fn windows_reactor::ListBox::new() -> Self
 pub fn windows_reactor::ListBox::on_selected_tag_changed(self, impl windows_reactor::IntoPayloadCallback<core::option::Option<alloc::string::String>>) -> Self
 impl core::convert::From<windows_reactor::ListBox> for windows_reactor::View
@@ -1565,11 +1462,6 @@ pub fn windows_reactor::ListBox::min_width(self, impl core::convert::Into<core::
 pub fn windows_reactor::ListBox::opacity(self, impl core::convert::Into<core::option::Option<f64>>) -> Self where Self: core::marker::Sized
 pub fn windows_reactor::ListBox::vertical_alignment(self, impl core::convert::Into<core::option::Option<windows_reactor::VerticalAlignment>>) -> Self where Self: core::marker::Sized
 pub fn windows_reactor::ListBox::width(self, impl core::convert::Into<core::option::Option<f64>>) -> Self where Self: core::marker::Sized
-impl windows_reactor::SlotsControl for windows_reactor::ListBox
-pub type windows_reactor::ListBox::Slot = windows_reactor::ListBoxSlot
-pub fn windows_reactor::ListBox::collection_slot<T>(self, Self::Slot, impl core::iter::traits::collect::IntoIterator<Item = T>) -> windows_reactor::View where T: core::convert::Into<windows_reactor::KeyedView>
-pub fn windows_reactor::ListBox::slot(self, Self::Slot, impl core::convert::Into<windows_reactor::View>) -> windows_reactor::View
-pub fn windows_reactor::ListBox::slots(self, impl core::iter::traits::collect::IntoIterator<Item = windows_reactor::SlotView<Self::Slot>>) -> windows_reactor::View
 pub struct windows_reactor::ListBoxItem
 impl windows_reactor::ListBoxItem
 pub fn windows_reactor::ListBoxItem::is_selected(self, impl core::convert::Into<core::option::Option<bool>>) -> Self
@@ -1598,6 +1490,7 @@ impl windows_reactor::ListView
 pub fn windows_reactor::ListView::allow_drop(self, impl core::convert::Into<core::option::Option<bool>>) -> Self
 pub fn windows_reactor::ListView::can_drag_items(self, impl core::convert::Into<core::option::Option<bool>>) -> Self
 pub fn windows_reactor::ListView::can_reorder_items(self, impl core::convert::Into<core::option::Option<bool>>) -> Self
+pub fn windows_reactor::ListView::items<T>(self, impl core::iter::traits::collect::IntoIterator<Item = T>) -> Self where T: core::convert::Into<windows_reactor::KeyedView>
 pub fn windows_reactor::ListView::new() -> Self
 pub fn windows_reactor::ListView::on_reordered(self, impl windows_reactor::IntoPayloadCallback<alloc::vec::Vec<alloc::string::String>>) -> Self
 pub fn windows_reactor::ListView::on_selection_changed(self, impl windows_reactor::IntoPayloadCallback<core::option::Option<usize>>) -> Self
@@ -1618,11 +1511,6 @@ pub fn windows_reactor::ListView::min_width(self, impl core::convert::Into<core:
 pub fn windows_reactor::ListView::opacity(self, impl core::convert::Into<core::option::Option<f64>>) -> Self where Self: core::marker::Sized
 pub fn windows_reactor::ListView::vertical_alignment(self, impl core::convert::Into<core::option::Option<windows_reactor::VerticalAlignment>>) -> Self where Self: core::marker::Sized
 pub fn windows_reactor::ListView::width(self, impl core::convert::Into<core::option::Option<f64>>) -> Self where Self: core::marker::Sized
-impl windows_reactor::SlotsControl for windows_reactor::ListView
-pub type windows_reactor::ListView::Slot = windows_reactor::ListViewSlot
-pub fn windows_reactor::ListView::collection_slot<T>(self, Self::Slot, impl core::iter::traits::collect::IntoIterator<Item = T>) -> windows_reactor::View where T: core::convert::Into<windows_reactor::KeyedView>
-pub fn windows_reactor::ListView::slot(self, Self::Slot, impl core::convert::Into<windows_reactor::View>) -> windows_reactor::View
-pub fn windows_reactor::ListView::slots(self, impl core::iter::traits::collect::IntoIterator<Item = windows_reactor::SlotView<Self::Slot>>) -> windows_reactor::View
 pub struct windows_reactor::ListViewItem
 impl windows_reactor::ListViewItem
 pub fn windows_reactor::ListViewItem::new() -> Self
@@ -1657,6 +1545,7 @@ impl windows_reactor::Menu
 pub fn windows_reactor::Menu::new(impl core::iter::traits::collect::IntoIterator<Item = windows_reactor::MenuItem>, impl windows_reactor::IntoPayloadCallback<alloc::string::String>) -> Self
 pub struct windows_reactor::MenuBar
 impl windows_reactor::MenuBar
+pub fn windows_reactor::MenuBar::items<T>(self, impl core::iter::traits::collect::IntoIterator<Item = T>) -> Self where T: core::convert::Into<windows_reactor::KeyedView>
 pub fn windows_reactor::MenuBar::new() -> Self
 impl core::convert::From<windows_reactor::MenuBar> for windows_reactor::View
 pub fn windows_reactor::View::from(windows_reactor::MenuBar) -> Self
@@ -1673,11 +1562,6 @@ pub fn windows_reactor::MenuBar::min_width(self, impl core::convert::Into<core::
 pub fn windows_reactor::MenuBar::opacity(self, impl core::convert::Into<core::option::Option<f64>>) -> Self where Self: core::marker::Sized
 pub fn windows_reactor::MenuBar::vertical_alignment(self, impl core::convert::Into<core::option::Option<windows_reactor::VerticalAlignment>>) -> Self where Self: core::marker::Sized
 pub fn windows_reactor::MenuBar::width(self, impl core::convert::Into<core::option::Option<f64>>) -> Self where Self: core::marker::Sized
-impl windows_reactor::SlotsControl for windows_reactor::MenuBar
-pub type windows_reactor::MenuBar::Slot = windows_reactor::MenuBarSlot
-pub fn windows_reactor::MenuBar::collection_slot<T>(self, Self::Slot, impl core::iter::traits::collect::IntoIterator<Item = T>) -> windows_reactor::View where T: core::convert::Into<windows_reactor::KeyedView>
-pub fn windows_reactor::MenuBar::slot(self, Self::Slot, impl core::convert::Into<windows_reactor::View>) -> windows_reactor::View
-pub fn windows_reactor::MenuBar::slots(self, impl core::iter::traits::collect::IntoIterator<Item = windows_reactor::SlotView<Self::Slot>>) -> windows_reactor::View
 pub struct windows_reactor::MenuBarItem
 impl windows_reactor::MenuBarItem
 pub fn windows_reactor::MenuBarItem::new() -> Self
@@ -1701,17 +1585,23 @@ pub fn windows_reactor::MenuBarItem::width(self, impl core::convert::Into<core::
 pub struct windows_reactor::NavigationView
 impl windows_reactor::NavigationView
 pub fn windows_reactor::NavigationView::always_show_header(self, impl core::convert::Into<core::option::Option<bool>>) -> Self
+pub fn windows_reactor::NavigationView::content(self, impl core::convert::Into<windows_reactor::View>) -> Self
+pub fn windows_reactor::NavigationView::footer_menu_items<T>(self, impl core::iter::traits::collect::IntoIterator<Item = T>) -> Self where T: core::convert::Into<windows_reactor::KeyedView>
+pub fn windows_reactor::NavigationView::header(self, impl core::convert::Into<windows_reactor::View>) -> Self
 pub fn windows_reactor::NavigationView::is_back_button_visible(self, impl core::convert::Into<core::option::Option<windows_reactor::NavigationViewBackButtonVisible>>) -> Self
 pub fn windows_reactor::NavigationView::is_enabled(self, impl core::convert::Into<core::option::Option<bool>>) -> Self
 pub fn windows_reactor::NavigationView::is_pane_open(self, impl core::convert::Into<core::option::Option<bool>>) -> Self
 pub fn windows_reactor::NavigationView::is_pane_toggle_button_visible(self, impl core::convert::Into<core::option::Option<bool>>) -> Self
 pub fn windows_reactor::NavigationView::is_settings_visible(self, impl core::convert::Into<core::option::Option<bool>>) -> Self
+pub fn windows_reactor::NavigationView::menu_items<T>(self, impl core::iter::traits::collect::IntoIterator<Item = T>) -> Self where T: core::convert::Into<windows_reactor::KeyedView>
 pub fn windows_reactor::NavigationView::new() -> Self
 pub fn windows_reactor::NavigationView::on_display_mode_changed(self, impl windows_reactor::IntoPayloadCallback<windows_reactor::NavigationViewDisplayMode>) -> Self
 pub fn windows_reactor::NavigationView::on_is_pane_open_changed(self, impl windows_reactor::IntoPayloadCallback<bool>) -> Self
 pub fn windows_reactor::NavigationView::on_selected_tag_changed(self, impl windows_reactor::IntoPayloadCallback<core::option::Option<alloc::string::String>>) -> Self
 pub fn windows_reactor::NavigationView::open_pane_length(self, impl core::convert::Into<core::option::Option<f64>>) -> Self
+pub fn windows_reactor::NavigationView::pane_custom_content(self, impl core::convert::Into<windows_reactor::View>) -> Self
 pub fn windows_reactor::NavigationView::pane_display_mode(self, impl core::convert::Into<core::option::Option<windows_reactor::NavigationViewPaneDisplayMode>>) -> Self
+pub fn windows_reactor::NavigationView::pane_footer(self, impl core::convert::Into<windows_reactor::View>) -> Self
 pub fn windows_reactor::NavigationView::pane_title(self, impl core::convert::Into<alloc::string::String>) -> Self
 pub fn windows_reactor::NavigationView::pane_title_optional<T>(self, core::option::Option<T>) -> Self where T: core::convert::Into<alloc::string::String>
 impl core::convert::From<windows_reactor::NavigationView> for windows_reactor::View
@@ -1729,15 +1619,13 @@ pub fn windows_reactor::NavigationView::min_width(self, impl core::convert::Into
 pub fn windows_reactor::NavigationView::opacity(self, impl core::convert::Into<core::option::Option<f64>>) -> Self where Self: core::marker::Sized
 pub fn windows_reactor::NavigationView::vertical_alignment(self, impl core::convert::Into<core::option::Option<windows_reactor::VerticalAlignment>>) -> Self where Self: core::marker::Sized
 pub fn windows_reactor::NavigationView::width(self, impl core::convert::Into<core::option::Option<f64>>) -> Self where Self: core::marker::Sized
-impl windows_reactor::SlotsControl for windows_reactor::NavigationView
-pub type windows_reactor::NavigationView::Slot = windows_reactor::NavigationViewSlot
-pub fn windows_reactor::NavigationView::collection_slot<T>(self, Self::Slot, impl core::iter::traits::collect::IntoIterator<Item = T>) -> windows_reactor::View where T: core::convert::Into<windows_reactor::KeyedView>
-pub fn windows_reactor::NavigationView::slot(self, Self::Slot, impl core::convert::Into<windows_reactor::View>) -> windows_reactor::View
-pub fn windows_reactor::NavigationView::slots(self, impl core::iter::traits::collect::IntoIterator<Item = windows_reactor::SlotView<Self::Slot>>) -> windows_reactor::View
 pub struct windows_reactor::NavigationViewItem
 impl windows_reactor::NavigationViewItem
+pub fn windows_reactor::NavigationViewItem::content(self, impl core::convert::Into<windows_reactor::View>) -> Self
+pub fn windows_reactor::NavigationViewItem::icon(self, impl core::convert::Into<windows_reactor::View>) -> Self
 pub fn windows_reactor::NavigationViewItem::is_expanded(self, impl core::convert::Into<core::option::Option<bool>>) -> Self
 pub fn windows_reactor::NavigationViewItem::is_selected(self, impl core::convert::Into<core::option::Option<bool>>) -> Self
+pub fn windows_reactor::NavigationViewItem::menu_items<T>(self, impl core::iter::traits::collect::IntoIterator<Item = T>) -> Self where T: core::convert::Into<windows_reactor::KeyedView>
 pub fn windows_reactor::NavigationViewItem::new() -> Self
 pub fn windows_reactor::NavigationViewItem::selects_on_invoked(self, impl core::convert::Into<core::option::Option<bool>>) -> Self
 pub fn windows_reactor::NavigationViewItem::tag(self, impl core::convert::Into<alloc::string::String>) -> Self
@@ -1757,14 +1645,10 @@ pub fn windows_reactor::NavigationViewItem::min_width(self, impl core::convert::
 pub fn windows_reactor::NavigationViewItem::opacity(self, impl core::convert::Into<core::option::Option<f64>>) -> Self where Self: core::marker::Sized
 pub fn windows_reactor::NavigationViewItem::vertical_alignment(self, impl core::convert::Into<core::option::Option<windows_reactor::VerticalAlignment>>) -> Self where Self: core::marker::Sized
 pub fn windows_reactor::NavigationViewItem::width(self, impl core::convert::Into<core::option::Option<f64>>) -> Self where Self: core::marker::Sized
-impl windows_reactor::SlotsControl for windows_reactor::NavigationViewItem
-pub type windows_reactor::NavigationViewItem::Slot = windows_reactor::NavigationViewItemSlot
-pub fn windows_reactor::NavigationViewItem::collection_slot<T>(self, Self::Slot, impl core::iter::traits::collect::IntoIterator<Item = T>) -> windows_reactor::View where T: core::convert::Into<windows_reactor::KeyedView>
-pub fn windows_reactor::NavigationViewItem::slot(self, Self::Slot, impl core::convert::Into<windows_reactor::View>) -> windows_reactor::View
-pub fn windows_reactor::NavigationViewItem::slots(self, impl core::iter::traits::collect::IntoIterator<Item = windows_reactor::SlotView<Self::Slot>>) -> windows_reactor::View
 pub struct windows_reactor::NumberBox
 impl windows_reactor::NumberBox
 pub fn windows_reactor::NumberBox::element_ref(self, &windows_reactor::ElementRef<Self>) -> Self
+pub fn windows_reactor::NumberBox::header(self, impl core::convert::Into<windows_reactor::View>) -> Self
 pub fn windows_reactor::NumberBox::is_enabled(self, impl core::convert::Into<core::option::Option<bool>>) -> Self
 pub fn windows_reactor::NumberBox::maximum(self, impl core::convert::Into<core::option::Option<f64>>) -> Self
 pub fn windows_reactor::NumberBox::minimum(self, impl core::convert::Into<core::option::Option<f64>>) -> Self
@@ -1788,14 +1672,10 @@ pub fn windows_reactor::NumberBox::opacity(self, impl core::convert::Into<core::
 pub fn windows_reactor::NumberBox::vertical_alignment(self, impl core::convert::Into<core::option::Option<windows_reactor::VerticalAlignment>>) -> Self where Self: core::marker::Sized
 pub fn windows_reactor::NumberBox::width(self, impl core::convert::Into<core::option::Option<f64>>) -> Self where Self: core::marker::Sized
 impl windows_reactor::ReferenceControl for windows_reactor::NumberBox
-impl windows_reactor::SlotsControl for windows_reactor::NumberBox
-pub type windows_reactor::NumberBox::Slot = windows_reactor::NumberBoxSlot
-pub fn windows_reactor::NumberBox::collection_slot<T>(self, Self::Slot, impl core::iter::traits::collect::IntoIterator<Item = T>) -> windows_reactor::View where T: core::convert::Into<windows_reactor::KeyedView>
-pub fn windows_reactor::NumberBox::slot(self, Self::Slot, impl core::convert::Into<windows_reactor::View>) -> windows_reactor::View
-pub fn windows_reactor::NumberBox::slots(self, impl core::iter::traits::collect::IntoIterator<Item = windows_reactor::SlotView<Self::Slot>>) -> windows_reactor::View
 pub struct windows_reactor::PasswordBox
 impl windows_reactor::PasswordBox
 pub fn windows_reactor::PasswordBox::element_ref(self, &windows_reactor::ElementRef<Self>) -> Self
+pub fn windows_reactor::PasswordBox::header(self, impl core::convert::Into<windows_reactor::View>) -> Self
 pub fn windows_reactor::PasswordBox::is_enabled(self, impl core::convert::Into<core::option::Option<bool>>) -> Self
 pub fn windows_reactor::PasswordBox::new() -> Self
 pub fn windows_reactor::PasswordBox::on_password_changed(self, impl windows_reactor::IntoPayloadCallback<alloc::string::String>) -> Self
@@ -1821,11 +1701,6 @@ pub fn windows_reactor::PasswordBox::opacity(self, impl core::convert::Into<core
 pub fn windows_reactor::PasswordBox::vertical_alignment(self, impl core::convert::Into<core::option::Option<windows_reactor::VerticalAlignment>>) -> Self where Self: core::marker::Sized
 pub fn windows_reactor::PasswordBox::width(self, impl core::convert::Into<core::option::Option<f64>>) -> Self where Self: core::marker::Sized
 impl windows_reactor::ReferenceControl for windows_reactor::PasswordBox
-impl windows_reactor::SlotsControl for windows_reactor::PasswordBox
-pub type windows_reactor::PasswordBox::Slot = windows_reactor::PasswordBoxSlot
-pub fn windows_reactor::PasswordBox::collection_slot<T>(self, Self::Slot, impl core::iter::traits::collect::IntoIterator<Item = T>) -> windows_reactor::View where T: core::convert::Into<windows_reactor::KeyedView>
-pub fn windows_reactor::PasswordBox::slot(self, Self::Slot, impl core::convert::Into<windows_reactor::View>) -> windows_reactor::View
-pub fn windows_reactor::PasswordBox::slots(self, impl core::iter::traits::collect::IntoIterator<Item = windows_reactor::SlotView<Self::Slot>>) -> windows_reactor::View
 pub struct windows_reactor::PathIcon
 impl windows_reactor::PathIcon
 pub fn windows_reactor::PathIcon::data(self, impl core::convert::Into<alloc::string::String>) -> Self
@@ -1870,6 +1745,7 @@ pub fn windows_reactor::PersonPicture::vertical_alignment(self, impl core::conve
 pub fn windows_reactor::PersonPicture::width(self, impl core::convert::Into<core::option::Option<f64>>) -> Self where Self: core::marker::Sized
 pub struct windows_reactor::Pivot
 impl windows_reactor::Pivot
+pub fn windows_reactor::Pivot::items<T>(self, impl core::iter::traits::collect::IntoIterator<Item = T>) -> Self where T: core::convert::Into<windows_reactor::KeyedView>
 pub fn windows_reactor::Pivot::new() -> Self
 pub fn windows_reactor::Pivot::on_selection_changed(self, impl windows_reactor::IntoPayloadCallback<core::option::Option<usize>>) -> Self
 pub fn windows_reactor::Pivot::selected_index(self, impl core::convert::Into<core::option::Option<usize>>) -> Self
@@ -1890,11 +1766,6 @@ pub fn windows_reactor::Pivot::min_width(self, impl core::convert::Into<core::op
 pub fn windows_reactor::Pivot::opacity(self, impl core::convert::Into<core::option::Option<f64>>) -> Self where Self: core::marker::Sized
 pub fn windows_reactor::Pivot::vertical_alignment(self, impl core::convert::Into<core::option::Option<windows_reactor::VerticalAlignment>>) -> Self where Self: core::marker::Sized
 pub fn windows_reactor::Pivot::width(self, impl core::convert::Into<core::option::Option<f64>>) -> Self where Self: core::marker::Sized
-impl windows_reactor::SlotsControl for windows_reactor::Pivot
-pub type windows_reactor::Pivot::Slot = windows_reactor::PivotSlot
-pub fn windows_reactor::Pivot::collection_slot<T>(self, Self::Slot, impl core::iter::traits::collect::IntoIterator<Item = T>) -> windows_reactor::View where T: core::convert::Into<windows_reactor::KeyedView>
-pub fn windows_reactor::Pivot::slot(self, Self::Slot, impl core::convert::Into<windows_reactor::View>) -> windows_reactor::View
-pub fn windows_reactor::Pivot::slots(self, impl core::iter::traits::collect::IntoIterator<Item = windows_reactor::SlotView<Self::Slot>>) -> windows_reactor::View
 pub struct windows_reactor::PivotItem
 impl windows_reactor::PivotItem
 pub fn windows_reactor::PivotItem::header(self, impl core::convert::Into<alloc::string::String>) -> Self
@@ -2005,6 +1876,7 @@ pub fn windows_reactor::RadioButton::width(self, impl core::convert::Into<core::
 impl windows_reactor::ReferenceControl for windows_reactor::RadioButton
 pub struct windows_reactor::RadioButtons
 impl windows_reactor::RadioButtons
+pub fn windows_reactor::RadioButtons::header(self, impl core::convert::Into<windows_reactor::View>) -> Self
 pub fn windows_reactor::RadioButtons::items_source<I, S>(self, I) -> Self where I: core::iter::traits::collect::IntoIterator<Item = S>, S: core::convert::Into<alloc::string::String>
 pub fn windows_reactor::RadioButtons::items_source_optional<I, S>(self, core::option::Option<I>) -> Self where I: core::iter::traits::collect::IntoIterator<Item = S>, S: core::convert::Into<alloc::string::String>
 pub fn windows_reactor::RadioButtons::max_columns(self, impl core::convert::Into<core::option::Option<i32>>) -> Self
@@ -2026,11 +1898,6 @@ pub fn windows_reactor::RadioButtons::min_width(self, impl core::convert::Into<c
 pub fn windows_reactor::RadioButtons::opacity(self, impl core::convert::Into<core::option::Option<f64>>) -> Self where Self: core::marker::Sized
 pub fn windows_reactor::RadioButtons::vertical_alignment(self, impl core::convert::Into<core::option::Option<windows_reactor::VerticalAlignment>>) -> Self where Self: core::marker::Sized
 pub fn windows_reactor::RadioButtons::width(self, impl core::convert::Into<core::option::Option<f64>>) -> Self where Self: core::marker::Sized
-impl windows_reactor::SlotsControl for windows_reactor::RadioButtons
-pub type windows_reactor::RadioButtons::Slot = windows_reactor::RadioButtonsSlot
-pub fn windows_reactor::RadioButtons::collection_slot<T>(self, Self::Slot, impl core::iter::traits::collect::IntoIterator<Item = T>) -> windows_reactor::View where T: core::convert::Into<windows_reactor::KeyedView>
-pub fn windows_reactor::RadioButtons::slot(self, Self::Slot, impl core::convert::Into<windows_reactor::View>) -> windows_reactor::View
-pub fn windows_reactor::RadioButtons::slots(self, impl core::iter::traits::collect::IntoIterator<Item = windows_reactor::SlotView<Self::Slot>>) -> windows_reactor::View
 pub struct windows_reactor::RatingControl
 impl windows_reactor::RatingControl
 pub fn windows_reactor::RatingControl::caption(self, impl core::convert::Into<alloc::string::String>) -> Self
@@ -2135,6 +2002,7 @@ pub fn windows_reactor::ResourceOverrides::set(self, impl core::convert::Into<al
 pub struct windows_reactor::RichEditBox
 impl windows_reactor::RichEditBox
 pub fn windows_reactor::RichEditBox::element_ref(self, &windows_reactor::ElementRef<Self>) -> Self
+pub fn windows_reactor::RichEditBox::header(self, impl core::convert::Into<windows_reactor::View>) -> Self
 pub fn windows_reactor::RichEditBox::is_enabled(self, impl core::convert::Into<core::option::Option<bool>>) -> Self
 pub fn windows_reactor::RichEditBox::is_read_only(self, impl core::convert::Into<core::option::Option<bool>>) -> Self
 pub fn windows_reactor::RichEditBox::new() -> Self
@@ -2160,11 +2028,6 @@ pub fn windows_reactor::RichEditBox::opacity(self, impl core::convert::Into<core
 pub fn windows_reactor::RichEditBox::vertical_alignment(self, impl core::convert::Into<core::option::Option<windows_reactor::VerticalAlignment>>) -> Self where Self: core::marker::Sized
 pub fn windows_reactor::RichEditBox::width(self, impl core::convert::Into<core::option::Option<f64>>) -> Self where Self: core::marker::Sized
 impl windows_reactor::ReferenceControl for windows_reactor::RichEditBox
-impl windows_reactor::SlotsControl for windows_reactor::RichEditBox
-pub type windows_reactor::RichEditBox::Slot = windows_reactor::RichEditBoxSlot
-pub fn windows_reactor::RichEditBox::collection_slot<T>(self, Self::Slot, impl core::iter::traits::collect::IntoIterator<Item = T>) -> windows_reactor::View where T: core::convert::Into<windows_reactor::KeyedView>
-pub fn windows_reactor::RichEditBox::slot(self, Self::Slot, impl core::convert::Into<windows_reactor::View>) -> windows_reactor::View
-pub fn windows_reactor::RichEditBox::slots(self, impl core::iter::traits::collect::IntoIterator<Item = windows_reactor::SlotView<Self::Slot>>) -> windows_reactor::View
 pub struct windows_reactor::RichText
 impl windows_reactor::RichText
 pub fn windows_reactor::RichText::new(impl core::iter::traits::collect::IntoIterator<Item = windows_reactor::RichTextParagraph>) -> Self
@@ -2249,6 +2112,7 @@ pub fn windows_reactor::ScrollViewer::vertical_alignment(self, impl core::conver
 pub fn windows_reactor::ScrollViewer::width(self, impl core::convert::Into<core::option::Option<f64>>) -> Self where Self: core::marker::Sized
 pub struct windows_reactor::SelectorBar
 impl windows_reactor::SelectorBar
+pub fn windows_reactor::SelectorBar::items<T>(self, impl core::iter::traits::collect::IntoIterator<Item = T>) -> Self where T: core::convert::Into<windows_reactor::KeyedView>
 pub fn windows_reactor::SelectorBar::new() -> Self
 pub fn windows_reactor::SelectorBar::on_selected_text_changed(self, impl windows_reactor::IntoPayloadCallback<core::option::Option<alloc::string::String>>) -> Self
 impl core::convert::From<windows_reactor::SelectorBar> for windows_reactor::View
@@ -2266,13 +2130,9 @@ pub fn windows_reactor::SelectorBar::min_width(self, impl core::convert::Into<co
 pub fn windows_reactor::SelectorBar::opacity(self, impl core::convert::Into<core::option::Option<f64>>) -> Self where Self: core::marker::Sized
 pub fn windows_reactor::SelectorBar::vertical_alignment(self, impl core::convert::Into<core::option::Option<windows_reactor::VerticalAlignment>>) -> Self where Self: core::marker::Sized
 pub fn windows_reactor::SelectorBar::width(self, impl core::convert::Into<core::option::Option<f64>>) -> Self where Self: core::marker::Sized
-impl windows_reactor::SlotsControl for windows_reactor::SelectorBar
-pub type windows_reactor::SelectorBar::Slot = windows_reactor::SelectorBarSlot
-pub fn windows_reactor::SelectorBar::collection_slot<T>(self, Self::Slot, impl core::iter::traits::collect::IntoIterator<Item = T>) -> windows_reactor::View where T: core::convert::Into<windows_reactor::KeyedView>
-pub fn windows_reactor::SelectorBar::slot(self, Self::Slot, impl core::convert::Into<windows_reactor::View>) -> windows_reactor::View
-pub fn windows_reactor::SelectorBar::slots(self, impl core::iter::traits::collect::IntoIterator<Item = windows_reactor::SlotView<Self::Slot>>) -> windows_reactor::View
 pub struct windows_reactor::SelectorBarItem
 impl windows_reactor::SelectorBarItem
+pub fn windows_reactor::SelectorBarItem::icon(self, impl core::convert::Into<windows_reactor::View>) -> Self
 pub fn windows_reactor::SelectorBarItem::is_selected(self, impl core::convert::Into<core::option::Option<bool>>) -> Self
 pub fn windows_reactor::SelectorBarItem::new() -> Self
 pub fn windows_reactor::SelectorBarItem::text(self, impl core::convert::Into<alloc::string::String>) -> Self
@@ -2292,14 +2152,10 @@ pub fn windows_reactor::SelectorBarItem::min_width(self, impl core::convert::Int
 pub fn windows_reactor::SelectorBarItem::opacity(self, impl core::convert::Into<core::option::Option<f64>>) -> Self where Self: core::marker::Sized
 pub fn windows_reactor::SelectorBarItem::vertical_alignment(self, impl core::convert::Into<core::option::Option<windows_reactor::VerticalAlignment>>) -> Self where Self: core::marker::Sized
 pub fn windows_reactor::SelectorBarItem::width(self, impl core::convert::Into<core::option::Option<f64>>) -> Self where Self: core::marker::Sized
-impl windows_reactor::SlotsControl for windows_reactor::SelectorBarItem
-pub type windows_reactor::SelectorBarItem::Slot = windows_reactor::SelectorBarItemSlot
-pub fn windows_reactor::SelectorBarItem::collection_slot<T>(self, Self::Slot, impl core::iter::traits::collect::IntoIterator<Item = T>) -> windows_reactor::View where T: core::convert::Into<windows_reactor::KeyedView>
-pub fn windows_reactor::SelectorBarItem::slot(self, Self::Slot, impl core::convert::Into<windows_reactor::View>) -> windows_reactor::View
-pub fn windows_reactor::SelectorBarItem::slots(self, impl core::iter::traits::collect::IntoIterator<Item = windows_reactor::SlotView<Self::Slot>>) -> windows_reactor::View
 pub struct windows_reactor::Slider
 impl windows_reactor::Slider
 pub fn windows_reactor::Slider::element_ref(self, &windows_reactor::ElementRef<Self>) -> Self
+pub fn windows_reactor::Slider::header(self, impl core::convert::Into<windows_reactor::View>) -> Self
 pub fn windows_reactor::Slider::is_enabled(self, impl core::convert::Into<core::option::Option<bool>>) -> Self
 pub fn windows_reactor::Slider::maximum(self, impl core::convert::Into<core::option::Option<f64>>) -> Self
 pub fn windows_reactor::Slider::minimum(self, impl core::convert::Into<core::option::Option<f64>>) -> Self
@@ -2325,15 +2181,6 @@ pub fn windows_reactor::Slider::opacity(self, impl core::convert::Into<core::opt
 pub fn windows_reactor::Slider::vertical_alignment(self, impl core::convert::Into<core::option::Option<windows_reactor::VerticalAlignment>>) -> Self where Self: core::marker::Sized
 pub fn windows_reactor::Slider::width(self, impl core::convert::Into<core::option::Option<f64>>) -> Self where Self: core::marker::Sized
 impl windows_reactor::ReferenceControl for windows_reactor::Slider
-impl windows_reactor::SlotsControl for windows_reactor::Slider
-pub type windows_reactor::Slider::Slot = windows_reactor::SliderSlot
-pub fn windows_reactor::Slider::collection_slot<T>(self, Self::Slot, impl core::iter::traits::collect::IntoIterator<Item = T>) -> windows_reactor::View where T: core::convert::Into<windows_reactor::KeyedView>
-pub fn windows_reactor::Slider::slot(self, Self::Slot, impl core::convert::Into<windows_reactor::View>) -> windows_reactor::View
-pub fn windows_reactor::Slider::slots(self, impl core::iter::traits::collect::IntoIterator<Item = windows_reactor::SlotView<Self::Slot>>) -> windows_reactor::View
-pub struct windows_reactor::SlotView<S>
-impl<S> windows_reactor::SlotView<S>
-pub fn windows_reactor::SlotView<S>::collection<T>(S, impl core::iter::traits::collect::IntoIterator<Item = T>) -> Self where T: core::convert::Into<windows_reactor::KeyedView>
-pub fn windows_reactor::SlotView<S>::new(S, impl core::convert::Into<windows_reactor::View>) -> Self
 pub struct windows_reactor::SplitButton
 impl windows_reactor::SplitButton
 pub fn windows_reactor::SplitButton::is_enabled(self, impl core::convert::Into<core::option::Option<bool>>) -> Self
@@ -2359,11 +2206,13 @@ pub fn windows_reactor::SplitButton::width(self, impl core::convert::Into<core::
 pub struct windows_reactor::SplitView
 impl windows_reactor::SplitView
 pub fn windows_reactor::SplitView::compact_pane_length(self, impl core::convert::Into<core::option::Option<f64>>) -> Self
+pub fn windows_reactor::SplitView::content(self, impl core::convert::Into<windows_reactor::View>) -> Self
 pub fn windows_reactor::SplitView::display_mode(self, impl core::convert::Into<core::option::Option<windows_reactor::SplitViewDisplayMode>>) -> Self
 pub fn windows_reactor::SplitView::is_pane_open(self, impl core::convert::Into<core::option::Option<bool>>) -> Self
 pub fn windows_reactor::SplitView::new() -> Self
 pub fn windows_reactor::SplitView::on_pane_closed(self, impl windows_reactor::IntoPayloadCallback<bool>) -> Self
 pub fn windows_reactor::SplitView::open_pane_length(self, impl core::convert::Into<core::option::Option<f64>>) -> Self
+pub fn windows_reactor::SplitView::pane(self, impl core::convert::Into<windows_reactor::View>) -> Self
 impl core::convert::From<windows_reactor::SplitView> for windows_reactor::View
 pub fn windows_reactor::View::from(windows_reactor::SplitView) -> Self
 impl windows_reactor::LayoutControl for windows_reactor::SplitView
@@ -2379,11 +2228,6 @@ pub fn windows_reactor::SplitView::min_width(self, impl core::convert::Into<core
 pub fn windows_reactor::SplitView::opacity(self, impl core::convert::Into<core::option::Option<f64>>) -> Self where Self: core::marker::Sized
 pub fn windows_reactor::SplitView::vertical_alignment(self, impl core::convert::Into<core::option::Option<windows_reactor::VerticalAlignment>>) -> Self where Self: core::marker::Sized
 pub fn windows_reactor::SplitView::width(self, impl core::convert::Into<core::option::Option<f64>>) -> Self where Self: core::marker::Sized
-impl windows_reactor::SlotsControl for windows_reactor::SplitView
-pub type windows_reactor::SplitView::Slot = windows_reactor::SplitViewSlot
-pub fn windows_reactor::SplitView::collection_slot<T>(self, Self::Slot, impl core::iter::traits::collect::IntoIterator<Item = T>) -> windows_reactor::View where T: core::convert::Into<windows_reactor::KeyedView>
-pub fn windows_reactor::SplitView::slot(self, Self::Slot, impl core::convert::Into<windows_reactor::View>) -> windows_reactor::View
-pub fn windows_reactor::SplitView::slots(self, impl core::iter::traits::collect::IntoIterator<Item = windows_reactor::SlotView<Self::Slot>>) -> windows_reactor::View
 pub struct windows_reactor::StackPanel
 impl windows_reactor::StackPanel
 pub fn windows_reactor::StackPanel::new() -> Self
@@ -2456,6 +2300,7 @@ pub fn windows_reactor::TabView::on_close_requested(self, impl windows_reactor::
 pub fn windows_reactor::TabView::on_reordered(self, impl windows_reactor::IntoPayloadCallback<alloc::vec::Vec<alloc::string::String>>) -> Self
 pub fn windows_reactor::TabView::on_selection_changed(self, impl windows_reactor::IntoPayloadCallback<core::option::Option<usize>>) -> Self
 pub fn windows_reactor::TabView::selected_index(self, impl core::convert::Into<core::option::Option<usize>>) -> Self
+pub fn windows_reactor::TabView::tab_items<T>(self, impl core::iter::traits::collect::IntoIterator<Item = T>) -> Self where T: core::convert::Into<windows_reactor::KeyedView>
 impl core::convert::From<windows_reactor::TabView> for windows_reactor::View
 pub fn windows_reactor::View::from(windows_reactor::TabView) -> Self
 impl windows_reactor::LayoutControl for windows_reactor::TabView
@@ -2471,11 +2316,6 @@ pub fn windows_reactor::TabView::min_width(self, impl core::convert::Into<core::
 pub fn windows_reactor::TabView::opacity(self, impl core::convert::Into<core::option::Option<f64>>) -> Self where Self: core::marker::Sized
 pub fn windows_reactor::TabView::vertical_alignment(self, impl core::convert::Into<core::option::Option<windows_reactor::VerticalAlignment>>) -> Self where Self: core::marker::Sized
 pub fn windows_reactor::TabView::width(self, impl core::convert::Into<core::option::Option<f64>>) -> Self where Self: core::marker::Sized
-impl windows_reactor::SlotsControl for windows_reactor::TabView
-pub type windows_reactor::TabView::Slot = windows_reactor::TabViewSlot
-pub fn windows_reactor::TabView::collection_slot<T>(self, Self::Slot, impl core::iter::traits::collect::IntoIterator<Item = T>) -> windows_reactor::View where T: core::convert::Into<windows_reactor::KeyedView>
-pub fn windows_reactor::TabView::slot(self, Self::Slot, impl core::convert::Into<windows_reactor::View>) -> windows_reactor::View
-pub fn windows_reactor::TabView::slots(self, impl core::iter::traits::collect::IntoIterator<Item = windows_reactor::SlotView<Self::Slot>>) -> windows_reactor::View
 pub struct windows_reactor::TabViewItem
 impl windows_reactor::TabViewItem
 pub fn windows_reactor::TabViewItem::header(self, impl core::convert::Into<alloc::string::String>) -> Self
@@ -2570,6 +2410,7 @@ pub fn windows_reactor::TextBox::border_brush_optional<T>(self, core::option::Op
 pub fn windows_reactor::TextBox::border_thickness(self, impl core::convert::Into<windows_reactor::Thickness>) -> Self
 pub fn windows_reactor::TextBox::border_thickness_optional<T>(self, core::option::Option<T>) -> Self where T: core::convert::Into<windows_reactor::Thickness>
 pub fn windows_reactor::TextBox::element_ref(self, &windows_reactor::ElementRef<Self>) -> Self
+pub fn windows_reactor::TextBox::header(self, impl core::convert::Into<windows_reactor::View>) -> Self
 pub fn windows_reactor::TextBox::is_enabled(self, impl core::convert::Into<core::option::Option<bool>>) -> Self
 pub fn windows_reactor::TextBox::new() -> Self
 pub fn windows_reactor::TextBox::on_text_changed(self, impl windows_reactor::IntoPayloadCallback<alloc::string::String>) -> Self
@@ -2595,11 +2436,6 @@ pub fn windows_reactor::TextBox::opacity(self, impl core::convert::Into<core::op
 pub fn windows_reactor::TextBox::vertical_alignment(self, impl core::convert::Into<core::option::Option<windows_reactor::VerticalAlignment>>) -> Self where Self: core::marker::Sized
 pub fn windows_reactor::TextBox::width(self, impl core::convert::Into<core::option::Option<f64>>) -> Self where Self: core::marker::Sized
 impl windows_reactor::ReferenceControl for windows_reactor::TextBox
-impl windows_reactor::SlotsControl for windows_reactor::TextBox
-pub type windows_reactor::TextBox::Slot = windows_reactor::TextBoxSlot
-pub fn windows_reactor::TextBox::collection_slot<T>(self, Self::Slot, impl core::iter::traits::collect::IntoIterator<Item = T>) -> windows_reactor::View where T: core::convert::Into<windows_reactor::KeyedView>
-pub fn windows_reactor::TextBox::slot(self, Self::Slot, impl core::convert::Into<windows_reactor::View>) -> windows_reactor::View
-pub fn windows_reactor::TextBox::slots(self, impl core::iter::traits::collect::IntoIterator<Item = windows_reactor::SlotView<Self::Slot>>) -> windows_reactor::View
 pub struct windows_reactor::Thickness(_)
 impl windows_reactor::Thickness
 pub fn windows_reactor::Thickness::bottom(&self) -> f64
@@ -2621,6 +2457,7 @@ pub struct windows_reactor::TimePicker
 impl windows_reactor::TimePicker
 pub fn windows_reactor::TimePicker::clock_identifier(self, impl core::convert::Into<alloc::string::String>) -> Self
 pub fn windows_reactor::TimePicker::clock_identifier_optional<T>(self, core::option::Option<T>) -> Self where T: core::convert::Into<alloc::string::String>
+pub fn windows_reactor::TimePicker::header(self, impl core::convert::Into<windows_reactor::View>) -> Self
 pub fn windows_reactor::TimePicker::is_enabled(self, impl core::convert::Into<core::option::Option<bool>>) -> Self
 pub fn windows_reactor::TimePicker::minute_increment(self, impl core::convert::Into<core::option::Option<i32>>) -> Self
 pub fn windows_reactor::TimePicker::new() -> Self
@@ -2640,13 +2477,9 @@ pub fn windows_reactor::TimePicker::min_width(self, impl core::convert::Into<cor
 pub fn windows_reactor::TimePicker::opacity(self, impl core::convert::Into<core::option::Option<f64>>) -> Self where Self: core::marker::Sized
 pub fn windows_reactor::TimePicker::vertical_alignment(self, impl core::convert::Into<core::option::Option<windows_reactor::VerticalAlignment>>) -> Self where Self: core::marker::Sized
 pub fn windows_reactor::TimePicker::width(self, impl core::convert::Into<core::option::Option<f64>>) -> Self where Self: core::marker::Sized
-impl windows_reactor::SlotsControl for windows_reactor::TimePicker
-pub type windows_reactor::TimePicker::Slot = windows_reactor::TimePickerSlot
-pub fn windows_reactor::TimePicker::collection_slot<T>(self, Self::Slot, impl core::iter::traits::collect::IntoIterator<Item = T>) -> windows_reactor::View where T: core::convert::Into<windows_reactor::KeyedView>
-pub fn windows_reactor::TimePicker::slot(self, Self::Slot, impl core::convert::Into<windows_reactor::View>) -> windows_reactor::View
-pub fn windows_reactor::TimePicker::slots(self, impl core::iter::traits::collect::IntoIterator<Item = windows_reactor::SlotView<Self::Slot>>) -> windows_reactor::View
 pub struct windows_reactor::TitleBar
 impl windows_reactor::TitleBar
+pub fn windows_reactor::TitleBar::content(self, impl core::convert::Into<windows_reactor::View>) -> Self
 pub fn windows_reactor::TitleBar::is_back_button_enabled(self, impl core::convert::Into<core::option::Option<bool>>) -> Self
 pub fn windows_reactor::TitleBar::is_back_button_visible(self, impl core::convert::Into<core::option::Option<bool>>) -> Self
 pub fn windows_reactor::TitleBar::is_pane_toggle_button_visible(self, impl core::convert::Into<core::option::Option<bool>>) -> Self
@@ -2654,6 +2487,7 @@ pub fn windows_reactor::TitleBar::new() -> Self
 pub fn windows_reactor::TitleBar::on_back_requested(self, impl windows_reactor::IntoUnitCallback) -> Self
 pub fn windows_reactor::TitleBar::on_pane_toggle_requested(self, impl windows_reactor::IntoUnitCallback) -> Self
 pub fn windows_reactor::TitleBar::preferred_height(self, windows_reactor::WindowTitleBarHeight) -> Self
+pub fn windows_reactor::TitleBar::right_header(self, impl core::convert::Into<windows_reactor::View>) -> Self
 pub fn windows_reactor::TitleBar::subtitle(self, impl core::convert::Into<alloc::string::String>) -> Self
 pub fn windows_reactor::TitleBar::subtitle_optional<T>(self, core::option::Option<T>) -> Self where T: core::convert::Into<alloc::string::String>
 pub fn windows_reactor::TitleBar::title(self, impl core::convert::Into<alloc::string::String>) -> Self
@@ -2673,11 +2507,6 @@ pub fn windows_reactor::TitleBar::min_width(self, impl core::convert::Into<core:
 pub fn windows_reactor::TitleBar::opacity(self, impl core::convert::Into<core::option::Option<f64>>) -> Self where Self: core::marker::Sized
 pub fn windows_reactor::TitleBar::vertical_alignment(self, impl core::convert::Into<core::option::Option<windows_reactor::VerticalAlignment>>) -> Self where Self: core::marker::Sized
 pub fn windows_reactor::TitleBar::width(self, impl core::convert::Into<core::option::Option<f64>>) -> Self where Self: core::marker::Sized
-impl windows_reactor::SlotsControl for windows_reactor::TitleBar
-pub type windows_reactor::TitleBar::Slot = windows_reactor::TitleBarSlot
-pub fn windows_reactor::TitleBar::collection_slot<T>(self, Self::Slot, impl core::iter::traits::collect::IntoIterator<Item = T>) -> windows_reactor::View where T: core::convert::Into<windows_reactor::KeyedView>
-pub fn windows_reactor::TitleBar::slot(self, Self::Slot, impl core::convert::Into<windows_reactor::View>) -> windows_reactor::View
-pub fn windows_reactor::TitleBar::slots(self, impl core::iter::traits::collect::IntoIterator<Item = windows_reactor::SlotView<Self::Slot>>) -> windows_reactor::View
 pub struct windows_reactor::ToggleButton
 impl windows_reactor::ToggleButton
 pub fn windows_reactor::ToggleButton::element_ref(self, &windows_reactor::ElementRef<Self>) -> Self
@@ -2707,9 +2536,12 @@ impl windows_reactor::ReferenceControl for windows_reactor::ToggleButton
 pub struct windows_reactor::ToggleSwitch
 impl windows_reactor::ToggleSwitch
 pub fn windows_reactor::ToggleSwitch::element_ref(self, &windows_reactor::ElementRef<Self>) -> Self
+pub fn windows_reactor::ToggleSwitch::header(self, impl core::convert::Into<windows_reactor::View>) -> Self
 pub fn windows_reactor::ToggleSwitch::is_enabled(self, impl core::convert::Into<core::option::Option<bool>>) -> Self
 pub fn windows_reactor::ToggleSwitch::is_on(self, impl core::convert::Into<core::option::Option<bool>>) -> Self
 pub fn windows_reactor::ToggleSwitch::new() -> Self
+pub fn windows_reactor::ToggleSwitch::off_content(self, impl core::convert::Into<windows_reactor::View>) -> Self
+pub fn windows_reactor::ToggleSwitch::on_content(self, impl core::convert::Into<windows_reactor::View>) -> Self
 pub fn windows_reactor::ToggleSwitch::on_toggled(self, impl windows_reactor::IntoPayloadCallback<bool>) -> Self
 impl core::convert::From<windows_reactor::ToggleSwitch> for windows_reactor::View
 pub fn windows_reactor::View::from(windows_reactor::ToggleSwitch) -> Self
@@ -2728,11 +2560,6 @@ pub fn windows_reactor::ToggleSwitch::opacity(self, impl core::convert::Into<cor
 pub fn windows_reactor::ToggleSwitch::vertical_alignment(self, impl core::convert::Into<core::option::Option<windows_reactor::VerticalAlignment>>) -> Self where Self: core::marker::Sized
 pub fn windows_reactor::ToggleSwitch::width(self, impl core::convert::Into<core::option::Option<f64>>) -> Self where Self: core::marker::Sized
 impl windows_reactor::ReferenceControl for windows_reactor::ToggleSwitch
-impl windows_reactor::SlotsControl for windows_reactor::ToggleSwitch
-pub type windows_reactor::ToggleSwitch::Slot = windows_reactor::ToggleSwitchSlot
-pub fn windows_reactor::ToggleSwitch::collection_slot<T>(self, Self::Slot, impl core::iter::traits::collect::IntoIterator<Item = T>) -> windows_reactor::View where T: core::convert::Into<windows_reactor::KeyedView>
-pub fn windows_reactor::ToggleSwitch::slot(self, Self::Slot, impl core::convert::Into<windows_reactor::View>) -> windows_reactor::View
-pub fn windows_reactor::ToggleSwitch::slots(self, impl core::iter::traits::collect::IntoIterator<Item = windows_reactor::SlotView<Self::Slot>>) -> windows_reactor::View
 pub struct windows_reactor::Tooltip
 impl windows_reactor::Tooltip
 pub fn windows_reactor::Tooltip::placement(self, windows_reactor::TooltipPlacement) -> Self
@@ -2970,6 +2797,7 @@ pub fn windows_reactor::ViewContext<C>::window_title(&mut self, impl core::conve
 pub fn windows_reactor::ViewContext<C>::window_visuals(&mut self, windows_reactor::WindowVisuals)
 pub struct windows_reactor::Viewbox
 impl windows_reactor::Viewbox
+pub fn windows_reactor::Viewbox::child(self, impl core::convert::Into<windows_reactor::View>) -> Self
 pub fn windows_reactor::Viewbox::new() -> Self
 pub fn windows_reactor::Viewbox::stretch(self, impl core::convert::Into<core::option::Option<windows_reactor::Stretch>>) -> Self
 impl core::convert::From<windows_reactor::Viewbox> for windows_reactor::View
@@ -2987,11 +2815,6 @@ pub fn windows_reactor::Viewbox::min_width(self, impl core::convert::Into<core::
 pub fn windows_reactor::Viewbox::opacity(self, impl core::convert::Into<core::option::Option<f64>>) -> Self where Self: core::marker::Sized
 pub fn windows_reactor::Viewbox::vertical_alignment(self, impl core::convert::Into<core::option::Option<windows_reactor::VerticalAlignment>>) -> Self where Self: core::marker::Sized
 pub fn windows_reactor::Viewbox::width(self, impl core::convert::Into<core::option::Option<f64>>) -> Self where Self: core::marker::Sized
-impl windows_reactor::SlotsControl for windows_reactor::Viewbox
-pub type windows_reactor::Viewbox::Slot = windows_reactor::ViewboxSlot
-pub fn windows_reactor::Viewbox::collection_slot<T>(self, Self::Slot, impl core::iter::traits::collect::IntoIterator<Item = T>) -> windows_reactor::View where T: core::convert::Into<windows_reactor::KeyedView>
-pub fn windows_reactor::Viewbox::slot(self, Self::Slot, impl core::convert::Into<windows_reactor::View>) -> windows_reactor::View
-pub fn windows_reactor::Viewbox::slots(self, impl core::iter::traits::collect::IntoIterator<Item = windows_reactor::SlotView<Self::Slot>>) -> windows_reactor::View
 pub struct windows_reactor::VirtualSource
 impl windows_reactor::VirtualSource
 pub fn windows_reactor::VirtualSource::is_empty(&self) -> bool
@@ -4235,156 +4058,6 @@ pub fn T::relative_align_left(self) -> Self
 pub fn T::relative_align_right(self) -> Self
 pub fn T::relative_align_top(self) -> Self
 pub fn T::relative_align_vertical_center(self) -> Self
-pub trait windows_reactor::SlotsControl: sealed::NativeControl + sealed::SlotIndex<Self::Slot> + core::marker::Sized
-pub type windows_reactor::SlotsControl::Slot: core::marker::Copy
-pub fn windows_reactor::SlotsControl::collection_slot<T>(self, Self::Slot, impl core::iter::traits::collect::IntoIterator<Item = T>) -> windows_reactor::View where T: core::convert::Into<windows_reactor::KeyedView>
-pub fn windows_reactor::SlotsControl::slot(self, Self::Slot, impl core::convert::Into<windows_reactor::View>) -> windows_reactor::View
-pub fn windows_reactor::SlotsControl::slots(self, impl core::iter::traits::collect::IntoIterator<Item = windows_reactor::SlotView<Self::Slot>>) -> windows_reactor::View
-impl windows_reactor::SlotsControl for windows_reactor::AppBarButton
-pub type windows_reactor::AppBarButton::Slot = windows_reactor::AppBarButtonSlot
-pub fn windows_reactor::AppBarButton::collection_slot<T>(self, Self::Slot, impl core::iter::traits::collect::IntoIterator<Item = T>) -> windows_reactor::View where T: core::convert::Into<windows_reactor::KeyedView>
-pub fn windows_reactor::AppBarButton::slot(self, Self::Slot, impl core::convert::Into<windows_reactor::View>) -> windows_reactor::View
-pub fn windows_reactor::AppBarButton::slots(self, impl core::iter::traits::collect::IntoIterator<Item = windows_reactor::SlotView<Self::Slot>>) -> windows_reactor::View
-impl windows_reactor::SlotsControl for windows_reactor::AutoSuggestBox
-pub type windows_reactor::AutoSuggestBox::Slot = windows_reactor::AutoSuggestBoxSlot
-pub fn windows_reactor::AutoSuggestBox::collection_slot<T>(self, Self::Slot, impl core::iter::traits::collect::IntoIterator<Item = T>) -> windows_reactor::View where T: core::convert::Into<windows_reactor::KeyedView>
-pub fn windows_reactor::AutoSuggestBox::slot(self, Self::Slot, impl core::convert::Into<windows_reactor::View>) -> windows_reactor::View
-pub fn windows_reactor::AutoSuggestBox::slots(self, impl core::iter::traits::collect::IntoIterator<Item = windows_reactor::SlotView<Self::Slot>>) -> windows_reactor::View
-impl windows_reactor::SlotsControl for windows_reactor::CalendarDatePicker
-pub type windows_reactor::CalendarDatePicker::Slot = windows_reactor::CalendarDatePickerSlot
-pub fn windows_reactor::CalendarDatePicker::collection_slot<T>(self, Self::Slot, impl core::iter::traits::collect::IntoIterator<Item = T>) -> windows_reactor::View where T: core::convert::Into<windows_reactor::KeyedView>
-pub fn windows_reactor::CalendarDatePicker::slot(self, Self::Slot, impl core::convert::Into<windows_reactor::View>) -> windows_reactor::View
-pub fn windows_reactor::CalendarDatePicker::slots(self, impl core::iter::traits::collect::IntoIterator<Item = windows_reactor::SlotView<Self::Slot>>) -> windows_reactor::View
-impl windows_reactor::SlotsControl for windows_reactor::ComboBox
-pub type windows_reactor::ComboBox::Slot = windows_reactor::ComboBoxSlot
-pub fn windows_reactor::ComboBox::collection_slot<T>(self, Self::Slot, impl core::iter::traits::collect::IntoIterator<Item = T>) -> windows_reactor::View where T: core::convert::Into<windows_reactor::KeyedView>
-pub fn windows_reactor::ComboBox::slot(self, Self::Slot, impl core::convert::Into<windows_reactor::View>) -> windows_reactor::View
-pub fn windows_reactor::ComboBox::slots(self, impl core::iter::traits::collect::IntoIterator<Item = windows_reactor::SlotView<Self::Slot>>) -> windows_reactor::View
-impl windows_reactor::SlotsControl for windows_reactor::CommandBar
-pub type windows_reactor::CommandBar::Slot = windows_reactor::CommandBarSlot
-pub fn windows_reactor::CommandBar::collection_slot<T>(self, Self::Slot, impl core::iter::traits::collect::IntoIterator<Item = T>) -> windows_reactor::View where T: core::convert::Into<windows_reactor::KeyedView>
-pub fn windows_reactor::CommandBar::slot(self, Self::Slot, impl core::convert::Into<windows_reactor::View>) -> windows_reactor::View
-pub fn windows_reactor::CommandBar::slots(self, impl core::iter::traits::collect::IntoIterator<Item = windows_reactor::SlotView<Self::Slot>>) -> windows_reactor::View
-impl windows_reactor::SlotsControl for windows_reactor::DatePicker
-pub type windows_reactor::DatePicker::Slot = windows_reactor::DatePickerSlot
-pub fn windows_reactor::DatePicker::collection_slot<T>(self, Self::Slot, impl core::iter::traits::collect::IntoIterator<Item = T>) -> windows_reactor::View where T: core::convert::Into<windows_reactor::KeyedView>
-pub fn windows_reactor::DatePicker::slot(self, Self::Slot, impl core::convert::Into<windows_reactor::View>) -> windows_reactor::View
-pub fn windows_reactor::DatePicker::slots(self, impl core::iter::traits::collect::IntoIterator<Item = windows_reactor::SlotView<Self::Slot>>) -> windows_reactor::View
-impl windows_reactor::SlotsControl for windows_reactor::Expander
-pub type windows_reactor::Expander::Slot = windows_reactor::ExpanderSlot
-pub fn windows_reactor::Expander::collection_slot<T>(self, Self::Slot, impl core::iter::traits::collect::IntoIterator<Item = T>) -> windows_reactor::View where T: core::convert::Into<windows_reactor::KeyedView>
-pub fn windows_reactor::Expander::slot(self, Self::Slot, impl core::convert::Into<windows_reactor::View>) -> windows_reactor::View
-pub fn windows_reactor::Expander::slots(self, impl core::iter::traits::collect::IntoIterator<Item = windows_reactor::SlotView<Self::Slot>>) -> windows_reactor::View
-impl windows_reactor::SlotsControl for windows_reactor::FlipView
-pub type windows_reactor::FlipView::Slot = windows_reactor::FlipViewSlot
-pub fn windows_reactor::FlipView::collection_slot<T>(self, Self::Slot, impl core::iter::traits::collect::IntoIterator<Item = T>) -> windows_reactor::View where T: core::convert::Into<windows_reactor::KeyedView>
-pub fn windows_reactor::FlipView::slot(self, Self::Slot, impl core::convert::Into<windows_reactor::View>) -> windows_reactor::View
-pub fn windows_reactor::FlipView::slots(self, impl core::iter::traits::collect::IntoIterator<Item = windows_reactor::SlotView<Self::Slot>>) -> windows_reactor::View
-impl windows_reactor::SlotsControl for windows_reactor::GridView
-pub type windows_reactor::GridView::Slot = windows_reactor::GridViewSlot
-pub fn windows_reactor::GridView::collection_slot<T>(self, Self::Slot, impl core::iter::traits::collect::IntoIterator<Item = T>) -> windows_reactor::View where T: core::convert::Into<windows_reactor::KeyedView>
-pub fn windows_reactor::GridView::slot(self, Self::Slot, impl core::convert::Into<windows_reactor::View>) -> windows_reactor::View
-pub fn windows_reactor::GridView::slots(self, impl core::iter::traits::collect::IntoIterator<Item = windows_reactor::SlotView<Self::Slot>>) -> windows_reactor::View
-impl windows_reactor::SlotsControl for windows_reactor::ListBox
-pub type windows_reactor::ListBox::Slot = windows_reactor::ListBoxSlot
-pub fn windows_reactor::ListBox::collection_slot<T>(self, Self::Slot, impl core::iter::traits::collect::IntoIterator<Item = T>) -> windows_reactor::View where T: core::convert::Into<windows_reactor::KeyedView>
-pub fn windows_reactor::ListBox::slot(self, Self::Slot, impl core::convert::Into<windows_reactor::View>) -> windows_reactor::View
-pub fn windows_reactor::ListBox::slots(self, impl core::iter::traits::collect::IntoIterator<Item = windows_reactor::SlotView<Self::Slot>>) -> windows_reactor::View
-impl windows_reactor::SlotsControl for windows_reactor::ListView
-pub type windows_reactor::ListView::Slot = windows_reactor::ListViewSlot
-pub fn windows_reactor::ListView::collection_slot<T>(self, Self::Slot, impl core::iter::traits::collect::IntoIterator<Item = T>) -> windows_reactor::View where T: core::convert::Into<windows_reactor::KeyedView>
-pub fn windows_reactor::ListView::slot(self, Self::Slot, impl core::convert::Into<windows_reactor::View>) -> windows_reactor::View
-pub fn windows_reactor::ListView::slots(self, impl core::iter::traits::collect::IntoIterator<Item = windows_reactor::SlotView<Self::Slot>>) -> windows_reactor::View
-impl windows_reactor::SlotsControl for windows_reactor::MenuBar
-pub type windows_reactor::MenuBar::Slot = windows_reactor::MenuBarSlot
-pub fn windows_reactor::MenuBar::collection_slot<T>(self, Self::Slot, impl core::iter::traits::collect::IntoIterator<Item = T>) -> windows_reactor::View where T: core::convert::Into<windows_reactor::KeyedView>
-pub fn windows_reactor::MenuBar::slot(self, Self::Slot, impl core::convert::Into<windows_reactor::View>) -> windows_reactor::View
-pub fn windows_reactor::MenuBar::slots(self, impl core::iter::traits::collect::IntoIterator<Item = windows_reactor::SlotView<Self::Slot>>) -> windows_reactor::View
-impl windows_reactor::SlotsControl for windows_reactor::NavigationView
-pub type windows_reactor::NavigationView::Slot = windows_reactor::NavigationViewSlot
-pub fn windows_reactor::NavigationView::collection_slot<T>(self, Self::Slot, impl core::iter::traits::collect::IntoIterator<Item = T>) -> windows_reactor::View where T: core::convert::Into<windows_reactor::KeyedView>
-pub fn windows_reactor::NavigationView::slot(self, Self::Slot, impl core::convert::Into<windows_reactor::View>) -> windows_reactor::View
-pub fn windows_reactor::NavigationView::slots(self, impl core::iter::traits::collect::IntoIterator<Item = windows_reactor::SlotView<Self::Slot>>) -> windows_reactor::View
-impl windows_reactor::SlotsControl for windows_reactor::NavigationViewItem
-pub type windows_reactor::NavigationViewItem::Slot = windows_reactor::NavigationViewItemSlot
-pub fn windows_reactor::NavigationViewItem::collection_slot<T>(self, Self::Slot, impl core::iter::traits::collect::IntoIterator<Item = T>) -> windows_reactor::View where T: core::convert::Into<windows_reactor::KeyedView>
-pub fn windows_reactor::NavigationViewItem::slot(self, Self::Slot, impl core::convert::Into<windows_reactor::View>) -> windows_reactor::View
-pub fn windows_reactor::NavigationViewItem::slots(self, impl core::iter::traits::collect::IntoIterator<Item = windows_reactor::SlotView<Self::Slot>>) -> windows_reactor::View
-impl windows_reactor::SlotsControl for windows_reactor::NumberBox
-pub type windows_reactor::NumberBox::Slot = windows_reactor::NumberBoxSlot
-pub fn windows_reactor::NumberBox::collection_slot<T>(self, Self::Slot, impl core::iter::traits::collect::IntoIterator<Item = T>) -> windows_reactor::View where T: core::convert::Into<windows_reactor::KeyedView>
-pub fn windows_reactor::NumberBox::slot(self, Self::Slot, impl core::convert::Into<windows_reactor::View>) -> windows_reactor::View
-pub fn windows_reactor::NumberBox::slots(self, impl core::iter::traits::collect::IntoIterator<Item = windows_reactor::SlotView<Self::Slot>>) -> windows_reactor::View
-impl windows_reactor::SlotsControl for windows_reactor::PasswordBox
-pub type windows_reactor::PasswordBox::Slot = windows_reactor::PasswordBoxSlot
-pub fn windows_reactor::PasswordBox::collection_slot<T>(self, Self::Slot, impl core::iter::traits::collect::IntoIterator<Item = T>) -> windows_reactor::View where T: core::convert::Into<windows_reactor::KeyedView>
-pub fn windows_reactor::PasswordBox::slot(self, Self::Slot, impl core::convert::Into<windows_reactor::View>) -> windows_reactor::View
-pub fn windows_reactor::PasswordBox::slots(self, impl core::iter::traits::collect::IntoIterator<Item = windows_reactor::SlotView<Self::Slot>>) -> windows_reactor::View
-impl windows_reactor::SlotsControl for windows_reactor::Pivot
-pub type windows_reactor::Pivot::Slot = windows_reactor::PivotSlot
-pub fn windows_reactor::Pivot::collection_slot<T>(self, Self::Slot, impl core::iter::traits::collect::IntoIterator<Item = T>) -> windows_reactor::View where T: core::convert::Into<windows_reactor::KeyedView>
-pub fn windows_reactor::Pivot::slot(self, Self::Slot, impl core::convert::Into<windows_reactor::View>) -> windows_reactor::View
-pub fn windows_reactor::Pivot::slots(self, impl core::iter::traits::collect::IntoIterator<Item = windows_reactor::SlotView<Self::Slot>>) -> windows_reactor::View
-impl windows_reactor::SlotsControl for windows_reactor::RadioButtons
-pub type windows_reactor::RadioButtons::Slot = windows_reactor::RadioButtonsSlot
-pub fn windows_reactor::RadioButtons::collection_slot<T>(self, Self::Slot, impl core::iter::traits::collect::IntoIterator<Item = T>) -> windows_reactor::View where T: core::convert::Into<windows_reactor::KeyedView>
-pub fn windows_reactor::RadioButtons::slot(self, Self::Slot, impl core::convert::Into<windows_reactor::View>) -> windows_reactor::View
-pub fn windows_reactor::RadioButtons::slots(self, impl core::iter::traits::collect::IntoIterator<Item = windows_reactor::SlotView<Self::Slot>>) -> windows_reactor::View
-impl windows_reactor::SlotsControl for windows_reactor::RichEditBox
-pub type windows_reactor::RichEditBox::Slot = windows_reactor::RichEditBoxSlot
-pub fn windows_reactor::RichEditBox::collection_slot<T>(self, Self::Slot, impl core::iter::traits::collect::IntoIterator<Item = T>) -> windows_reactor::View where T: core::convert::Into<windows_reactor::KeyedView>
-pub fn windows_reactor::RichEditBox::slot(self, Self::Slot, impl core::convert::Into<windows_reactor::View>) -> windows_reactor::View
-pub fn windows_reactor::RichEditBox::slots(self, impl core::iter::traits::collect::IntoIterator<Item = windows_reactor::SlotView<Self::Slot>>) -> windows_reactor::View
-impl windows_reactor::SlotsControl for windows_reactor::SelectorBar
-pub type windows_reactor::SelectorBar::Slot = windows_reactor::SelectorBarSlot
-pub fn windows_reactor::SelectorBar::collection_slot<T>(self, Self::Slot, impl core::iter::traits::collect::IntoIterator<Item = T>) -> windows_reactor::View where T: core::convert::Into<windows_reactor::KeyedView>
-pub fn windows_reactor::SelectorBar::slot(self, Self::Slot, impl core::convert::Into<windows_reactor::View>) -> windows_reactor::View
-pub fn windows_reactor::SelectorBar::slots(self, impl core::iter::traits::collect::IntoIterator<Item = windows_reactor::SlotView<Self::Slot>>) -> windows_reactor::View
-impl windows_reactor::SlotsControl for windows_reactor::SelectorBarItem
-pub type windows_reactor::SelectorBarItem::Slot = windows_reactor::SelectorBarItemSlot
-pub fn windows_reactor::SelectorBarItem::collection_slot<T>(self, Self::Slot, impl core::iter::traits::collect::IntoIterator<Item = T>) -> windows_reactor::View where T: core::convert::Into<windows_reactor::KeyedView>
-pub fn windows_reactor::SelectorBarItem::slot(self, Self::Slot, impl core::convert::Into<windows_reactor::View>) -> windows_reactor::View
-pub fn windows_reactor::SelectorBarItem::slots(self, impl core::iter::traits::collect::IntoIterator<Item = windows_reactor::SlotView<Self::Slot>>) -> windows_reactor::View
-impl windows_reactor::SlotsControl for windows_reactor::Slider
-pub type windows_reactor::Slider::Slot = windows_reactor::SliderSlot
-pub fn windows_reactor::Slider::collection_slot<T>(self, Self::Slot, impl core::iter::traits::collect::IntoIterator<Item = T>) -> windows_reactor::View where T: core::convert::Into<windows_reactor::KeyedView>
-pub fn windows_reactor::Slider::slot(self, Self::Slot, impl core::convert::Into<windows_reactor::View>) -> windows_reactor::View
-pub fn windows_reactor::Slider::slots(self, impl core::iter::traits::collect::IntoIterator<Item = windows_reactor::SlotView<Self::Slot>>) -> windows_reactor::View
-impl windows_reactor::SlotsControl for windows_reactor::SplitView
-pub type windows_reactor::SplitView::Slot = windows_reactor::SplitViewSlot
-pub fn windows_reactor::SplitView::collection_slot<T>(self, Self::Slot, impl core::iter::traits::collect::IntoIterator<Item = T>) -> windows_reactor::View where T: core::convert::Into<windows_reactor::KeyedView>
-pub fn windows_reactor::SplitView::slot(self, Self::Slot, impl core::convert::Into<windows_reactor::View>) -> windows_reactor::View
-pub fn windows_reactor::SplitView::slots(self, impl core::iter::traits::collect::IntoIterator<Item = windows_reactor::SlotView<Self::Slot>>) -> windows_reactor::View
-impl windows_reactor::SlotsControl for windows_reactor::TabView
-pub type windows_reactor::TabView::Slot = windows_reactor::TabViewSlot
-pub fn windows_reactor::TabView::collection_slot<T>(self, Self::Slot, impl core::iter::traits::collect::IntoIterator<Item = T>) -> windows_reactor::View where T: core::convert::Into<windows_reactor::KeyedView>
-pub fn windows_reactor::TabView::slot(self, Self::Slot, impl core::convert::Into<windows_reactor::View>) -> windows_reactor::View
-pub fn windows_reactor::TabView::slots(self, impl core::iter::traits::collect::IntoIterator<Item = windows_reactor::SlotView<Self::Slot>>) -> windows_reactor::View
-impl windows_reactor::SlotsControl for windows_reactor::TextBox
-pub type windows_reactor::TextBox::Slot = windows_reactor::TextBoxSlot
-pub fn windows_reactor::TextBox::collection_slot<T>(self, Self::Slot, impl core::iter::traits::collect::IntoIterator<Item = T>) -> windows_reactor::View where T: core::convert::Into<windows_reactor::KeyedView>
-pub fn windows_reactor::TextBox::slot(self, Self::Slot, impl core::convert::Into<windows_reactor::View>) -> windows_reactor::View
-pub fn windows_reactor::TextBox::slots(self, impl core::iter::traits::collect::IntoIterator<Item = windows_reactor::SlotView<Self::Slot>>) -> windows_reactor::View
-impl windows_reactor::SlotsControl for windows_reactor::TimePicker
-pub type windows_reactor::TimePicker::Slot = windows_reactor::TimePickerSlot
-pub fn windows_reactor::TimePicker::collection_slot<T>(self, Self::Slot, impl core::iter::traits::collect::IntoIterator<Item = T>) -> windows_reactor::View where T: core::convert::Into<windows_reactor::KeyedView>
-pub fn windows_reactor::TimePicker::slot(self, Self::Slot, impl core::convert::Into<windows_reactor::View>) -> windows_reactor::View
-pub fn windows_reactor::TimePicker::slots(self, impl core::iter::traits::collect::IntoIterator<Item = windows_reactor::SlotView<Self::Slot>>) -> windows_reactor::View
-impl windows_reactor::SlotsControl for windows_reactor::TitleBar
-pub type windows_reactor::TitleBar::Slot = windows_reactor::TitleBarSlot
-pub fn windows_reactor::TitleBar::collection_slot<T>(self, Self::Slot, impl core::iter::traits::collect::IntoIterator<Item = T>) -> windows_reactor::View where T: core::convert::Into<windows_reactor::KeyedView>
-pub fn windows_reactor::TitleBar::slot(self, Self::Slot, impl core::convert::Into<windows_reactor::View>) -> windows_reactor::View
-pub fn windows_reactor::TitleBar::slots(self, impl core::iter::traits::collect::IntoIterator<Item = windows_reactor::SlotView<Self::Slot>>) -> windows_reactor::View
-impl windows_reactor::SlotsControl for windows_reactor::ToggleSwitch
-pub type windows_reactor::ToggleSwitch::Slot = windows_reactor::ToggleSwitchSlot
-pub fn windows_reactor::ToggleSwitch::collection_slot<T>(self, Self::Slot, impl core::iter::traits::collect::IntoIterator<Item = T>) -> windows_reactor::View where T: core::convert::Into<windows_reactor::KeyedView>
-pub fn windows_reactor::ToggleSwitch::slot(self, Self::Slot, impl core::convert::Into<windows_reactor::View>) -> windows_reactor::View
-pub fn windows_reactor::ToggleSwitch::slots(self, impl core::iter::traits::collect::IntoIterator<Item = windows_reactor::SlotView<Self::Slot>>) -> windows_reactor::View
-impl windows_reactor::SlotsControl for windows_reactor::Viewbox
-pub type windows_reactor::Viewbox::Slot = windows_reactor::ViewboxSlot
-pub fn windows_reactor::Viewbox::collection_slot<T>(self, Self::Slot, impl core::iter::traits::collect::IntoIterator<Item = T>) -> windows_reactor::View where T: core::convert::Into<windows_reactor::KeyedView>
-pub fn windows_reactor::Viewbox::slot(self, Self::Slot, impl core::convert::Into<windows_reactor::View>) -> windows_reactor::View
-pub fn windows_reactor::Viewbox::slots(self, impl core::iter::traits::collect::IntoIterator<Item = windows_reactor::SlotView<Self::Slot>>) -> windows_reactor::View
 pub trait windows_reactor::TooltipExt: core::convert::Into<windows_reactor::View> + core::marker::Sized
 pub fn windows_reactor::TooltipExt::tooltip(self, impl core::convert::Into<alloc::string::String>) -> windows_reactor::View
 pub fn windows_reactor::TooltipExt::tooltip_with(self, windows_reactor::Tooltip) -> windows_reactor::View

--- a/crates/libs/reactor/src/app.rs
+++ b/crates/libs/reactor/src/app.rs
@@ -266,23 +266,20 @@ impl ComponentLoop {
                 ListView::new()
                     .selected_index(None)
                     .on_selection_changed(move |value| callback.set(value == Some(1)))
-                    .collection_slot(
-                        ListViewSlot::Items,
-                        [
-                            KeyedView::new(
-                                "first",
-                                ListViewItem::new()
-                                    .tag("first")
-                                    .content(TextBlock::new().text("First")),
-                            ),
-                            KeyedView::new(
-                                "second",
-                                ListViewItem::new()
-                                    .tag("second")
-                                    .content(TextBlock::new().text("Second")),
-                            ),
-                        ],
-                    ),
+                    .items([
+                        KeyedView::new(
+                            "first",
+                            ListViewItem::new()
+                                .tag("first")
+                                .content(TextBlock::new().text("First")),
+                        ),
+                        KeyedView::new(
+                            "second",
+                            ListViewItem::new()
+                                .tag("second")
+                                .content(TextBlock::new().text("Second")),
+                        ),
+                    ]),
                 "selection index",
                 observed,
                 |runtime, node| {
@@ -665,26 +662,23 @@ impl LivePump for ComponentLoop {
         let selected_callback = Rc::clone(&selected);
         let list = ListBox::new()
             .on_selected_tag_changed(move |tag| *selected_callback.borrow_mut() = tag)
-            .slots([SlotView::collection(
-                ListBoxSlot::Items,
-                [
-                    KeyedView::new(
-                        "one",
-                        ListBoxItem::new()
-                            .tag("one")
-                            .is_selected(true)
-                            .content(TextBlock::new().text("One")),
-                    ),
-                    KeyedView::new(
-                        "two",
-                        ListBoxItem::new()
-                            .tag("two")
-                            .is_selected(false)
-                            .content(TextBlock::new().text("Two")),
-                    ),
-                ],
-            )]);
-        if self.pump.update_view(list).is_err() || self.pump.dispatch_events() != Ok(0) {
+            .items([
+                KeyedView::new(
+                    "one",
+                    ListBoxItem::new()
+                        .tag("one")
+                        .is_selected(true)
+                        .content(TextBlock::new().text("One")),
+                ),
+                KeyedView::new(
+                    "two",
+                    ListBoxItem::new()
+                        .tag("two")
+                        .is_selected(false)
+                        .content(TextBlock::new().text("Two")),
+                ),
+            ]);
+        if self.pump.update_view(list.into()).is_err() || self.pump.dispatch_events() != Ok(0) {
             eprintln!("controlled selection feedback failed");
             return false;
         }

--- a/crates/libs/reactor/src/core/pump/native_work.rs
+++ b/crates/libs/reactor/src/core/pump/native_work.rs
@@ -401,23 +401,22 @@ impl<R: NativeRuntime> Pump<R> {
         selection: SelectionDescriptor,
         selected_item: Option<NodeId>,
     ) -> bool {
-        let Some(slot) = self
-            .tree
-            .children(owner)
-            .iter()
-            .copied()
-            .find(|child| self.tree.kind(*child) == NodeKind::NamedSlot(selection.slot))
-        else {
-            return false;
-        };
         let mut items = Vec::new();
-        for child in self.tree.children(slot).to_vec() {
-            let mut roots = Vec::new();
-            Self::collect_native_roots(&self.tree, child, &mut roots);
-            if let [item] = roots.as_slice()
-                && self.tree.kind(*item) == NodeKind::Native(selection.item)
-            {
-                items.push(*item);
+        for slot in self.tree.children(owner).to_vec() {
+            let NodeKind::NamedSlot(slot_id) = self.tree.kind(slot) else {
+                continue;
+            };
+            if !selection.slots.contains(&slot_id) {
+                continue;
+            }
+            for child in self.tree.children(slot).to_vec() {
+                let mut roots = Vec::new();
+                Self::collect_native_roots(&self.tree, child, &mut roots);
+                if let [item] = roots.as_slice()
+                    && self.tree.kind(*item) == NodeKind::Native(selection.item)
+                {
+                    items.push(*item);
+                }
             }
         }
         let mut changed = false;

--- a/crates/libs/reactor/src/core/pump/tests/content_dialogs.rs
+++ b/crates/libs/reactor/src/core/pump/tests/content_dialogs.rs
@@ -567,9 +567,7 @@ fn rejects_direct_native_and_nested_overlay_ownership() {
 
     let mut named_slot = Pump::new(RecordingRuntime::default());
     assert_eq!(
-        named_slot.mount_view(
-            SplitView::new().slots([SlotView::new(SplitViewSlot::Content, dialog(false),)])
-        ),
+        named_slot.mount_view(SplitView::new().content(dialog(false)).into()),
         Err(PumpError::StructureUnsupported)
     );
 }

--- a/crates/libs/reactor/src/core/pump/tests/events_controlled_feedback.rs
+++ b/crates/libs/reactor/src/core/pump/tests/events_controlled_feedback.rs
@@ -29,35 +29,37 @@ fn navigation_selection_observes_item_state_and_preserves_missing_tags() {
     let selected_capture = Rc::clone(&selected);
     let view = NavigationView::new()
         .on_selected_tag_changed(move |tag| selected_capture.borrow_mut().push(tag))
-        .slots([SlotView::collection(
-            NavigationViewSlot::MenuItems,
-            [
-                KeyedView::new("empty", NavigationViewItem::new().tag("").is_selected(true)),
-                KeyedView::new(
-                    "home",
-                    NavigationViewItem::new().tag("home").is_selected(false),
-                ),
-            ],
+        .menu_items([KeyedView::new(
+            "empty",
+            NavigationViewItem::new().tag("").is_selected(true),
+        )])
+        .footer_menu_items([KeyedView::new(
+            "home",
+            NavigationViewItem::new().tag("home").is_selected(false),
         )]);
     let mut pump = Pump::new(RecordingRuntime::default());
-    pump.mount_view(view.clone()).unwrap();
+    pump.mount_view(view.clone().into()).unwrap();
     let navigation = pump.root().unwrap();
     let revision = pump
         .event_revision(navigation, EventId::NavigationViewSelectionChanged)
         .unwrap();
-    let items = pump
+    let menu_item = pump
         .runtime()
         .node(navigation)
         .unwrap()
-        .slot_children(SlotId::NavigationViewMenuItems)
-        .to_vec();
+        .slot_children(SlotId::NavigationViewMenuItems)[0];
+    let footer_item = pump
+        .runtime()
+        .node(navigation)
+        .unwrap()
+        .slot_children(SlotId::NavigationViewFooterMenuItems)[0];
 
     pump.queue_event(QueuedEvent::new(
         navigation,
         EventId::NavigationViewSelectionChanged,
         revision,
         EventPayload::SelectionChange(SelectionChange {
-            item: Some(items[1]),
+            item: Some(footer_item),
             tag: Some("home".into()),
         }),
     ));
@@ -65,21 +67,21 @@ fn navigation_selection_observes_item_state_and_preserves_missing_tags() {
     assert_eq!(&*selected.borrow(), &[Some("home".into())]);
     assert_eq!(
         pump.tree
-            .native(items[0])
+            .native(menu_item)
             .properties
             .get(&PropertyId::NavigationViewItemIsSelected),
         Some(&Some(PropertyValue::Bool(false)))
     );
     assert_eq!(
         pump.tree
-            .native(items[1])
+            .native(footer_item)
             .properties
             .get(&PropertyId::NavigationViewItemIsSelected),
         Some(&Some(PropertyValue::Bool(true)))
     );
 
     let batches = pump.runtime().commands().len();
-    pump.update_view(view).unwrap();
+    pump.update_view(view.into()).unwrap();
     let commands = pump.runtime().commands()[batches..]
         .iter()
         .flatten()
@@ -103,7 +105,7 @@ fn navigation_selection_observes_item_state_and_preserves_missing_tags() {
     ));
     assert_eq!(pump.dispatch_events(), Ok(1));
     assert_eq!(&*selected.borrow(), &[Some("home".into()), None]);
-    assert!(items.iter().all(|item| {
+    assert!([menu_item, footer_item].iter().all(|item| {
         pump.tree
             .native(*item)
             .properties
@@ -113,13 +115,14 @@ fn navigation_selection_observes_item_state_and_preserves_missing_tags() {
 
     let mut passive = Pump::new(RecordingRuntime::default());
     passive
-        .mount_view(NavigationView::new().slots([SlotView::collection(
-            NavigationViewSlot::MenuItems,
-            [KeyedView::new(
-                "home",
-                NavigationViewItem::new().tag("home").is_selected(false),
-            )],
-        )]))
+        .mount_view(
+            NavigationView::new()
+                .menu_items([KeyedView::new(
+                    "home",
+                    NavigationViewItem::new().tag("home").is_selected(false),
+                )])
+                .into(),
+        )
         .unwrap();
     let navigation = passive.root().unwrap();
     let item = passive
@@ -151,13 +154,14 @@ fn navigation_selection_observes_item_state_and_preserves_missing_tags() {
 
     let mut uncontrolled = Pump::new(RecordingRuntime::default());
     uncontrolled
-        .mount_view(NavigationView::new().slots([SlotView::collection(
-            NavigationViewSlot::MenuItems,
-            [KeyedView::new(
-                "native",
-                NavigationViewItem::new().tag("native"),
-            )],
-        )]))
+        .mount_view(
+            NavigationView::new()
+                .menu_items([KeyedView::new(
+                    "native",
+                    NavigationViewItem::new().tag("native"),
+                )])
+                .into(),
+        )
         .unwrap();
     let navigation = uncontrolled.root().unwrap();
     let item = uncontrolled
@@ -211,13 +215,11 @@ fn navigation_selection_observes_item_state_and_preserves_missing_tags() {
         .mount_view(
             NavigationView::new()
                 .on_selected_tag_changed(|_| {})
-                .slots([SlotView::collection(
-                    NavigationViewSlot::MenuItems,
-                    [
-                        KeyedView::new("first", View::component::<Item>(("first", true))),
-                        KeyedView::new("second", View::component::<Item>(("second", false))),
-                    ],
-                )]),
+                .menu_items([
+                    KeyedView::new("first", View::component::<Item>(("first", true))),
+                    KeyedView::new("second", View::component::<Item>(("second", false))),
+                ])
+                .into(),
         )
         .unwrap();
     let navigation = nested.root().unwrap();
@@ -1522,13 +1524,11 @@ fn tab_view_routes_selected_index_feedback() {
         TabView::new()
             .selected_index(0)
             .on_selection_changed(move |index| capture.set(index))
-            .slots([SlotView::collection(
-                TabViewSlot::TabItems,
-                [
-                    KeyedView::new("a", TabViewItem::new().header("A").tag("a")),
-                    KeyedView::new("b", TabViewItem::new().header("B").tag("b")),
-                ],
-            )]),
+            .tab_items([
+                KeyedView::new("a", TabViewItem::new().header("A").tag("a")),
+                KeyedView::new("b", TabViewItem::new().header("B").tag("b")),
+            ])
+            .into(),
     )
     .unwrap();
     let root = pump.root().unwrap();
@@ -1555,13 +1555,11 @@ fn tab_view_close_requested_routes_key_string() {
     pump.mount_view(
         TabView::new()
             .on_close_requested(move |key: String| *capture.borrow_mut() = key)
-            .slots([SlotView::collection(
-                TabViewSlot::TabItems,
-                [
-                    KeyedView::new("first", TabViewItem::new().header("First").tag("first")),
-                    KeyedView::new("second", TabViewItem::new().header("Second").tag("second")),
-                ],
-            )]),
+            .tab_items([
+                KeyedView::new("first", TabViewItem::new().header("First").tag("first")),
+                KeyedView::new("second", TabViewItem::new().header("Second").tag("second")),
+            ])
+            .into(),
     )
     .unwrap();
     let root = pump.root().unwrap();
@@ -1589,10 +1587,8 @@ fn tab_view_add_button_click_routes_unit() {
         TabView::new()
             .is_add_tab_button_visible(true)
             .on_add_tab_button_click(move || capture.set(true))
-            .slots([SlotView::collection(
-                TabViewSlot::TabItems,
-                [KeyedView::new("tab", TabViewItem::new().header("Tab"))],
-            )]),
+            .tab_items([KeyedView::new("tab", TabViewItem::new().header("Tab"))])
+            .into(),
     )
     .unwrap();
     let root = pump.root().unwrap();
@@ -1621,13 +1617,11 @@ fn tab_view_reorder_routes_item_tags() {
             .on_reordered(move |order: Vec<String>| {
                 *capture.borrow_mut() = order;
             })
-            .slots([SlotView::collection(
-                TabViewSlot::TabItems,
-                [
-                    KeyedView::new("first", TabViewItem::new().header("First").tag("first")),
-                    KeyedView::new("second", TabViewItem::new().header("Second").tag("second")),
-                ],
-            )]),
+            .tab_items([
+                KeyedView::new("first", TabViewItem::new().header("First").tag("first")),
+                KeyedView::new("second", TabViewItem::new().header("Second").tag("second")),
+            ])
+            .into(),
     )
     .unwrap();
     let root = pump.root().unwrap();
@@ -1855,13 +1849,11 @@ fn list_and_grid_views_route_selection_and_reordered_tags() {
             .on_reordered(move |items: Vec<String>| {
                 *reordered_capture.borrow_mut() = items;
             })
-            .slots([SlotView::collection(
-                ListViewSlot::Items,
-                [
-                    KeyedView::new("a", ListViewItem::new().tag("a")),
-                    KeyedView::new("b", ListViewItem::new().tag("b")),
-                ],
-            )]),
+            .items([
+                KeyedView::new("a", ListViewItem::new().tag("a")),
+                KeyedView::new("b", ListViewItem::new().tag("b")),
+            ])
+            .into(),
     )
     .unwrap();
     let root = list.root().unwrap();
@@ -1895,13 +1887,11 @@ fn list_and_grid_views_route_selection_and_reordered_tags() {
             .on_reordered(move |items: Vec<String>| {
                 *capture.borrow_mut() = items;
             })
-            .slots([SlotView::collection(
-                GridViewSlot::Items,
-                [
-                    KeyedView::new("x", GridViewItem::new().tag("x")),
-                    KeyedView::new("y", GridViewItem::new().tag("y")),
-                ],
-            )]),
+            .items([
+                KeyedView::new("x", GridViewItem::new().tag("x")),
+                KeyedView::new("y", GridViewItem::new().tag("y")),
+            ])
+            .into(),
     )
     .unwrap();
     let root = grid.root().unwrap();
@@ -1973,14 +1963,12 @@ fn tab_view_collection_preserves_identity_through_reorder() {
     pump.mount_view(
         TabView::new()
             .selected_index(0)
-            .slots([SlotView::collection(
-                TabViewSlot::TabItems,
-                [
-                    KeyedView::new("a", TabViewItem::new().header("A").tag("a")),
-                    KeyedView::new("b", TabViewItem::new().header("B").tag("b")),
-                    KeyedView::new("c", TabViewItem::new().header("C").tag("c")),
-                ],
-            )]),
+            .tab_items([
+                KeyedView::new("a", TabViewItem::new().header("A").tag("a")),
+                KeyedView::new("b", TabViewItem::new().header("B").tag("b")),
+                KeyedView::new("c", TabViewItem::new().header("C").tag("c")),
+            ])
+            .into(),
     )
     .unwrap();
     let root = pump.root().unwrap();
@@ -1995,14 +1983,12 @@ fn tab_view_collection_preserves_identity_through_reorder() {
     pump.update_view(
         TabView::new()
             .selected_index(0)
-            .slots([SlotView::collection(
-                TabViewSlot::TabItems,
-                [
-                    KeyedView::new("c", TabViewItem::new().header("C").tag("c")),
-                    KeyedView::new("a", TabViewItem::new().header("A").tag("a")),
-                    KeyedView::new("b", TabViewItem::new().header("B").tag("b")),
-                ],
-            )]),
+            .tab_items([
+                KeyedView::new("c", TabViewItem::new().header("C").tag("c")),
+                KeyedView::new("a", TabViewItem::new().header("A").tag("a")),
+                KeyedView::new("b", TabViewItem::new().header("B").tag("b")),
+            ])
+            .into(),
     )
     .unwrap();
     let reordered_children: Vec<_> = pump

--- a/crates/libs/reactor/src/core/pump/tests/slots.rs
+++ b/crates/libs/reactor/src/core/pump/tests/slots.rs
@@ -6,34 +6,33 @@ use std::collections::HashSet;
 use std::rc::Rc;
 
 fn navigation(content: Option<View>, header: Option<View>) -> View {
-    let mut slots = Vec::new();
+    let mut view = NavigationView::new();
     if let Some(content) = content {
-        slots.push(SlotView::new(NavigationViewSlot::Content, content));
+        view = view.content(content);
     }
     if let Some(header) = header {
-        slots.push(SlotView::new(NavigationViewSlot::Header, header));
+        view = view.header(header);
     }
-    NavigationView::new().slots(slots)
+    view.into()
 }
 
 fn split_view(content: Option<View>, pane: Option<View>) -> View {
-    let mut slots = Vec::new();
-    if let Some(pane) = pane {
-        slots.push(SlotView::new(SplitViewSlot::Pane, pane));
-    }
-    if let Some(content) = content {
-        slots.push(SlotView::new(SplitViewSlot::Content, content));
-    }
-    SplitView::new()
+    let mut view = SplitView::new()
         .open_pane_length(280.0)
         .compact_pane_length(48.0)
         .display_mode(SplitViewDisplayMode::CompactInline)
-        .is_pane_open(true)
-        .slots(slots)
+        .is_pane_open(true);
+    if let Some(pane) = pane {
+        view = view.pane(pane);
+    }
+    if let Some(content) = content {
+        view = view.content(content);
+    }
+    view.into()
 }
 
 fn navigation_menu(items: impl IntoIterator<Item = KeyedView>) -> View {
-    NavigationView::new().collection_slot(NavigationViewSlot::MenuItems, items)
+    NavigationView::new().menu_items(items).into()
 }
 
 #[test]
@@ -110,6 +109,7 @@ fn split_view_properties_and_ui_element_slots_follow_generated_paths() {
     );
 
     pump.update_view(split_view(None, None)).unwrap();
+    let root = pump.root().unwrap();
     let recorded = pump.runtime().node(root).unwrap();
     assert_eq!(recorded.slot(SlotId::SplitViewPane), None);
     assert_eq!(recorded.slot(SlotId::SplitViewContent), None);
@@ -153,17 +153,13 @@ fn navigation_view_sets_display_mode_before_initial_pane_state() {
 #[test]
 fn navigation_view_third_slot_uses_the_shared_slot_path() {
     let mut pump = Pump::new(RecordingRuntime::default());
-    pump.mount_view(NavigationView::new().slots([
-        SlotView::new(
-            NavigationViewSlot::Content,
-            TextBlock::new().text("content"),
-        ),
-        SlotView::new(NavigationViewSlot::Header, TextBlock::new().text("header")),
-        SlotView::new(
-            NavigationViewSlot::PaneCustomContent,
-            StackPanel::new().children((Button::new(),)),
-        ),
-    ]))
+    pump.mount_view(
+        NavigationView::new()
+            .content(TextBlock::new().text("content"))
+            .header(TextBlock::new().text("header"))
+            .pane_custom_content(StackPanel::new().children((Button::new(),)))
+            .into(),
+    )
     .unwrap();
     let root = pump.root().unwrap();
     let recorded = pump.runtime().node(root).unwrap();
@@ -180,17 +176,11 @@ fn navigation_view_third_slot_uses_the_shared_slot_path() {
 #[test]
 fn navigation_item_content_and_typed_icon_slots_update_independently() {
     let view = |icon| {
-        let mut slots = vec![SlotView::new(
-            NavigationViewItemSlot::Content,
-            TextBlock::new().text("Home"),
-        )];
+        let mut item = NavigationViewItem::new().content(TextBlock::new().text("Home"));
         if icon {
-            slots.push(SlotView::new(
-                NavigationViewItemSlot::Icon,
-                SymbolIcon::new().symbol(Symbol::Home),
-            ));
+            item = item.icon(SymbolIcon::new().symbol(Symbol::Home));
         }
-        NavigationViewItem::new().slots(slots)
+        item.into()
     };
     let mut pump = Pump::new(RecordingRuntime::default());
     pump.mount_view(view(true)).unwrap();
@@ -236,20 +226,18 @@ fn selector_bar_uses_keyed_typed_items_and_icon_slots() {
         KeyedView::new(
             text,
             if icon {
-                item.slots([SlotView::new(
-                    SelectorBarItemSlot::Icon,
-                    SymbolIcon::new().symbol(Symbol::Favorite),
-                )])
+                item.icon(SymbolIcon::new().symbol(Symbol::Favorite))
             } else {
-                item.into()
+                item
             },
         )
     };
     let mut pump = Pump::new(RecordingRuntime::default());
-    pump.mount_view(SelectorBar::new().slots([SlotView::collection(
-        SelectorBarSlot::Items,
-        [item("Recent", false), item("Favorites", true)],
-    )]))
+    pump.mount_view(
+        SelectorBar::new()
+            .items([item("Recent", false), item("Favorites", true)])
+            .into(),
+    )
     .unwrap();
 
     let root = pump.root().unwrap();
@@ -284,17 +272,13 @@ fn keyed_collection_slot_mounts_updates_reorders_and_removes_items() {
             NavigationViewItem::new()
                 .tag("home")
                 .is_selected(true)
-                .slots([SlotView::new(
-                    NavigationViewItemSlot::Content,
-                    TextBlock::new().text("Home"),
-                )]),
+                .content(TextBlock::new().text("Home")),
         ),
         KeyedView::new(
             "text",
-            NavigationViewItem::new().tag("text").slots([SlotView::new(
-                NavigationViewItemSlot::Content,
-                TextBlock::new().text("Text input"),
-            )]),
+            NavigationViewItem::new()
+                .tag("text")
+                .content(TextBlock::new().text("Text input")),
         ),
     ]))
     .unwrap();
@@ -328,19 +312,13 @@ fn keyed_collection_slot_mounts_updates_reorders_and_removes_items() {
             NavigationViewItem::new()
                 .tag("text")
                 .is_selected(true)
-                .slots([SlotView::new(
-                    NavigationViewItemSlot::Content,
-                    TextBlock::new().text("Text entry"),
-                )]),
+                .content(TextBlock::new().text("Text entry")),
         ),
         KeyedView::new(
             "numeric",
             NavigationViewItem::new()
                 .tag("numeric")
-                .slots([SlotView::new(
-                    NavigationViewItemSlot::Content,
-                    TextBlock::new().text("Numeric input"),
-                )]),
+                .content(TextBlock::new().text("Numeric input")),
         ),
     ]))
     .unwrap();
@@ -375,10 +353,9 @@ fn collection_slot_pure_reorder_moves_retained_items() {
         navigation_menu(order.iter().map(|tag| {
             KeyedView::new(
                 *tag,
-                NavigationViewItem::new().tag(*tag).slots([SlotView::new(
-                    NavigationViewItemSlot::Content,
-                    TextBlock::new().text(*tag),
-                )]),
+                NavigationViewItem::new()
+                    .tag(*tag)
+                    .content(TextBlock::new().text(*tag)),
             )
         }))
     };
@@ -492,10 +469,9 @@ fn dense_collection_slot_reorder_preserves_item_identity() {
         navigation_menu(labels.iter().map(|label| {
             KeyedView::new(
                 label.clone(),
-                NavigationViewItem::new().tag(label).slots([SlotView::new(
-                    NavigationViewItemSlot::Content,
-                    TextBlock::new().text(label),
-                )]),
+                NavigationViewItem::new()
+                    .tag(label)
+                    .content(TextBlock::new().text(label)),
             )
         }))
     };
@@ -534,17 +510,8 @@ fn dense_collection_slot_reorder_preserves_item_identity() {
 }
 
 #[test]
-fn collection_slots_reject_single_views_and_multiple_native_roots() {
+fn collection_slots_reject_multiple_native_roots() {
     let mut pump = Pump::new(RecordingRuntime::default());
-    assert_eq!(
-        pump.mount_view(NavigationView::new().slots([SlotView::new(
-            NavigationViewSlot::MenuItems,
-            NavigationViewItem::new(),
-        )])),
-        Err(PumpError::StructureUnsupported)
-    );
-    assert!(pump.root().is_none());
-
     assert_eq!(
         pump.mount_view(navigation_menu([KeyedView::new(
             "multiple",
@@ -582,13 +549,54 @@ fn collection_slots_reject_single_views_and_multiple_native_roots() {
 }
 
 #[test]
-fn single_slots_reject_collection_content() {
+fn malformed_slot_content_is_rejected() {
+    let mut single_collection = Pump::new(RecordingRuntime::default());
+    assert_eq!(
+        single_collection.mount_view(View::slotted(
+            NavigationView::new().into(),
+            Rc::new(vec![SlottedView {
+                slot: SlotId::NavigationViewMenuItems,
+                content: SlotContent::Single(NavigationViewItem::new().into()),
+            }]),
+        )),
+        Err(PumpError::StructureUnsupported)
+    );
+    assert!(single_collection.root().is_none());
+
+    let mut collection_single = Pump::new(RecordingRuntime::default());
+    assert_eq!(
+        collection_single.mount_view(View::slotted(
+            NavigationView::new().into(),
+            Rc::new(vec![SlottedView {
+                slot: SlotId::NavigationViewContent,
+                content: SlotContent::Collection(Rc::new(vec![KeyedView::new(
+                    "content",
+                    TextBlock::new(),
+                )])),
+            }]),
+        )),
+        Err(PumpError::StructureUnsupported)
+    );
+    assert!(collection_single.root().is_none());
+}
+
+#[test]
+fn malformed_duplicate_slots_are_rejected() {
     let mut pump = Pump::new(RecordingRuntime::default());
     assert_eq!(
-        pump.mount_view(NavigationView::new().slots([SlotView::collection(
-            NavigationViewSlot::Content,
-            [KeyedView::new("content", TextBlock::new())],
-        )])),
+        pump.mount_view(View::slotted(
+            NavigationView::new().into(),
+            Rc::new(vec![
+                SlottedView {
+                    slot: SlotId::NavigationViewContent,
+                    content: SlotContent::Single(TextBlock::new().into()),
+                },
+                SlottedView {
+                    slot: SlotId::NavigationViewContent,
+                    content: SlotContent::Single(Button::new().into()),
+                },
+            ]),
+        )),
         Err(PumpError::StructureUnsupported)
     );
     assert!(pump.root().is_none());
@@ -664,19 +672,29 @@ fn named_slots_mount_update_replace_and_clear_independently() {
 }
 
 #[test]
-fn named_slot_rejects_duplicate_assignments_and_multiple_native_roots() {
-    let duplicate = NavigationView::new().slots([
-        SlotView::new(NavigationViewSlot::Content, View::native(TextBlock::new())),
-        SlotView::new(NavigationViewSlot::Content, View::native(Button::new())),
-    ]);
+fn named_slot_last_assignment_wins_and_multiple_native_roots_are_rejected() {
     let mut pump = Pump::new(RecordingRuntime::default());
+    pump.mount_view(
+        NavigationView::new()
+            .content(TextBlock::new())
+            .content(Button::new())
+            .into(),
+    )
+    .unwrap();
+    let root = pump.root().unwrap();
+    let content = pump
+        .runtime()
+        .node(root)
+        .unwrap()
+        .slot(SlotId::NavigationViewContent)
+        .unwrap();
     assert_eq!(
-        pump.mount_view(duplicate),
-        Err(PumpError::StructureUnsupported)
+        pump.tree.kind(content),
+        NodeKind::Native(MountedKind::Button)
     );
-    assert!(pump.root().is_none());
 
     let multiple = View::fragment((TextBlock::new(), Button::new()));
+    let mut pump = Pump::new(RecordingRuntime::default());
     assert_eq!(
         pump.mount_view(navigation(Some(multiple), None)),
         Err(PumpError::StructureUnsupported)

--- a/crates/libs/reactor/src/core/pump/tests/window_title_bars.rs
+++ b/crates/libs/reactor/src/core/pump/tests/window_title_bars.rs
@@ -27,14 +27,13 @@ impl Component for TitleBarComponent {
         let title_bar = TitleBar::new()
             .title("Title")
             .preferred_height(input.height);
-        let title_bar = title_bar.slots(std::iter::empty::<SlotView<TitleBarSlot>>());
         if input.duplicate {
             return StackPanel::new().children((title_bar, TitleBar::new()));
         }
         if input.nested {
             Border::new().content(title_bar)
         } else {
-            title_bar
+            title_bar.into()
         }
     }
 }
@@ -68,6 +67,35 @@ fn direct_element_updates_reconcile_title_bar_declarations() {
 
     pump.update(TextBlock::new().into()).unwrap();
     assert_eq!(pump.runtime().window_title_bar(window), None);
+}
+
+#[test]
+fn title_bar_named_content_preserves_the_active_title_bar() {
+    let mut pump = Pump::new(RecordingRuntime::default());
+    pump.mount(TitleBar::new().into()).unwrap();
+    let window = pump.window.unwrap();
+    let (title_bar, _) = pump.runtime().window_title_bar(window).unwrap();
+
+    pump.update(
+        TitleBar::new()
+            .content(TextBlock::new().text("content"))
+            .into(),
+    )
+    .unwrap();
+    assert_eq!(
+        pump.runtime()
+            .window_title_bar(window)
+            .map(|(node, _)| node),
+        Some(title_bar)
+    );
+
+    pump.update(TitleBar::new().into()).unwrap();
+    assert_eq!(
+        pump.runtime()
+            .window_title_bar(window)
+            .map(|(node, _)| node),
+        Some(title_bar)
+    );
 }
 
 #[test]

--- a/crates/libs/reactor/src/element.rs
+++ b/crates/libs/reactor/src/element.rs
@@ -331,10 +331,6 @@ pub(crate) mod sealed {
         }
     }
 
-    pub(crate) trait SlotIndex<S> {
-        fn slot_index(slot: S) -> u8;
-    }
-
     pub trait StaticViews {
         fn into_positioned(self) -> Vec<super::KeyedView>;
     }
@@ -778,10 +774,7 @@ impl CommandBarCommand {
                         let _ = callback.call(clicked.clone());
                     });
                 let view = match icon {
-                    Some(icon) => button.slots([SlotView::new(
-                        AppBarButtonSlot::Icon,
-                        SymbolIcon::new().symbol(icon),
-                    )]),
+                    Some(icon) => button.icon(SymbolIcon::new().symbol(icon)).into(),
                     None => button.into(),
                 };
                 KeyedView { key, view }
@@ -802,20 +795,17 @@ impl CommandBar {
         on_click: impl IntoPayloadCallback<String>,
     ) -> View {
         let on_click = on_click.into_payload_callback();
-        self.slots([
-            SlotView::collection(
-                CommandBarSlot::PrimaryCommands,
-                primary
-                    .into_iter()
-                    .map(|command| command.into_keyed_view(&on_click)),
-            ),
-            SlotView::collection(
-                CommandBarSlot::SecondaryCommands,
-                secondary
-                    .into_iter()
-                    .map(|command| command.into_keyed_view(&on_click)),
-            ),
-        ])
+        self.primary_commands(
+            primary
+                .into_iter()
+                .map(|command| command.into_keyed_view(&on_click)),
+        )
+        .secondary_commands(
+            secondary
+                .into_iter()
+                .map(|command| command.into_keyed_view(&on_click)),
+        )
+        .into()
     }
 }
 
@@ -1031,46 +1021,16 @@ impl View {
         })
     }
 
+    pub(crate) fn slotted(control: Element, slots: Rc<Vec<SlottedView>>) -> Self {
+        Self(ViewKind::Slots { control, slots })
+    }
+
     pub(crate) fn as_kind(&self) -> &ViewKind {
         &self.0
     }
 
     pub(crate) fn into_kind(self) -> ViewKind {
         self.0
-    }
-}
-
-/// Content assigned to one typed control slot.
-#[derive(Clone, Debug, PartialEq)]
-pub struct SlotView<S> {
-    slot: S,
-    content: SlotContent,
-}
-
-impl<S> SlotView<S> {
-    /// Creates a slot containing one view.
-    pub fn new(slot: S, view: impl Into<View>) -> Self {
-        Self {
-            slot,
-            content: SlotContent::Single(view.into()),
-        }
-    }
-
-    /// Creates a collection slot whose children are reconciled by key.
-    pub fn collection<T>(slot: S, children: impl IntoIterator<Item = T>) -> Self
-    where
-        T: Into<KeyedView>,
-    {
-        Self {
-            slot,
-            content: SlotContent::Collection(Rc::new(
-                children.into_iter().map(Into::into).collect(),
-            )),
-        }
-    }
-
-    fn into_parts(self) -> (S, SlotContent) {
-        (self.slot, self.content)
     }
 }
 
@@ -1084,6 +1044,19 @@ pub(crate) enum SlotContent {
 pub(crate) struct SlottedView {
     pub(crate) slot: SlotId,
     pub(crate) content: SlotContent,
+}
+
+pub(crate) fn set_control_slot(
+    slots: &mut Option<Rc<Vec<SlottedView>>>,
+    slot: SlotId,
+    content: SlotContent,
+) {
+    let slots = Rc::make_mut(slots.get_or_insert_with(|| Rc::new(Vec::new())));
+    if let Some(existing) = slots.iter_mut().find(|existing| existing.slot == slot) {
+        existing.content = content;
+    } else {
+        slots.push(SlottedView { slot, content });
+    }
 }
 
 impl From<Element> for View {
@@ -2444,46 +2417,6 @@ pub trait ChildrenControl: sealed::NativeControl + Sized {
         View(ViewKind::Children {
             control: sealed::NativeControl::into_element(self),
             children: Rc::new(children.into_iter().map(Into::into).collect()),
-        })
-    }
-}
-
-/// Assigns single views or keyed collections to a control's typed slots.
-#[allow(private_bounds)]
-pub trait SlotsControl: sealed::NativeControl + sealed::SlotIndex<Self::Slot> + Sized {
-    type Slot: Copy;
-
-    fn slot(self, slot: Self::Slot, view: impl Into<View>) -> View {
-        self.slots([SlotView::new(slot, view)])
-    }
-
-    fn collection_slot<T>(self, slot: Self::Slot, children: impl IntoIterator<Item = T>) -> View
-    where
-        T: Into<KeyedView>,
-    {
-        self.slots([SlotView::collection(slot, children)])
-    }
-
-    fn slots(self, slots: impl IntoIterator<Item = SlotView<Self::Slot>>) -> View {
-        let control = sealed::NativeControl::into_element(self);
-        let kind = control.kind();
-        let slots = slots
-            .into_iter()
-            .map(|slot| {
-                let (slot, content) = slot.into_parts();
-                SlottedView {
-                    slot: slot_id(
-                        kind,
-                        <Self as sealed::SlotIndex<Self::Slot>>::slot_index(slot),
-                    )
-                    .unwrap(),
-                    content,
-                }
-            })
-            .collect();
-        View(ViewKind::Slots {
-            control,
-            slots: Rc::new(slots),
         })
     }
 }

--- a/crates/libs/reactor/src/generated.rs
+++ b/crates/libs/reactor/src/generated.rs
@@ -1253,6 +1253,7 @@ pub mod public {
         on_text_changed: Option<Callback<String>>,
         reference: Option<NativeElementRef>,
         element_state: Option<std::rc::Rc<ElementState>>,
+        slots: Option<std::rc::Rc<Vec<SlottedView>>>,
     }
     impl TextBox {
         pub fn new() -> Self {
@@ -1348,6 +1349,14 @@ pub mod public {
             self.on_text_changed = Some(callback.into_payload_callback());
             self
         }
+        pub fn header(mut self, view: impl Into<View>) -> Self {
+            set_control_slot(
+                &mut self.slots,
+                SlotId::TextBoxHeader,
+                SlotContent::Single(view.into()),
+            );
+            self
+        }
     }
     impl sealed::Sealed for TextBox {}
     impl sealed::NativeControl for TextBox {
@@ -1364,20 +1373,6 @@ pub mod public {
     }
     impl LayoutControl for TextBox {}
     impl FocusControl for TextBox {}
-    #[non_exhaustive]
-    #[repr(u8)]
-    #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-    pub enum TextBoxSlot {
-        Header,
-    }
-    impl sealed::SlotIndex<TextBoxSlot> for TextBox {
-        fn slot_index(slot: TextBoxSlot) -> u8 {
-            slot as u8
-        }
-    }
-    impl SlotsControl for TextBox {
-        type Slot = TextBoxSlot;
-    }
     #[derive(Clone, Debug, Default, PartialEq)]
     pub struct AutoSuggestBox {
         text: Property<String>,
@@ -1387,6 +1382,7 @@ pub mod public {
         events: Option<std::rc::Rc<AutoSuggestBoxEvents>>,
         reference: Option<NativeElementRef>,
         element_state: Option<std::rc::Rc<ElementState>>,
+        slots: Option<std::rc::Rc<Vec<SlottedView>>>,
     }
     impl AutoSuggestBox {
         pub fn new() -> Self {
@@ -1459,6 +1455,14 @@ pub mod public {
             .on_suggestion_chosen = Some(callback.into_payload_callback());
             self
         }
+        pub fn header(mut self, view: impl Into<View>) -> Self {
+            set_control_slot(
+                &mut self.slots,
+                SlotId::AutoSuggestBoxHeader,
+                SlotContent::Single(view.into()),
+            );
+            self
+        }
     }
     impl sealed::Sealed for AutoSuggestBox {}
     impl sealed::NativeControl for AutoSuggestBox {
@@ -1475,20 +1479,6 @@ pub mod public {
     }
     impl LayoutControl for AutoSuggestBox {}
     impl FocusControl for AutoSuggestBox {}
-    #[non_exhaustive]
-    #[repr(u8)]
-    #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-    pub enum AutoSuggestBoxSlot {
-        Header,
-    }
-    impl sealed::SlotIndex<AutoSuggestBoxSlot> for AutoSuggestBox {
-        fn slot_index(slot: AutoSuggestBoxSlot) -> u8 {
-            slot as u8
-        }
-    }
-    impl SlotsControl for AutoSuggestBox {
-        type Slot = AutoSuggestBoxSlot;
-    }
     #[derive(Clone, Debug, Default, PartialEq)]
     pub struct PasswordBox {
         password: Property<String>,
@@ -1498,6 +1488,7 @@ pub mod public {
         on_password_changed: Option<Callback<String>>,
         reference: Option<NativeElementRef>,
         element_state: Option<std::rc::Rc<ElementState>>,
+        slots: Option<std::rc::Rc<Vec<SlottedView>>>,
     }
     impl PasswordBox {
         pub fn new() -> Self {
@@ -1546,6 +1537,14 @@ pub mod public {
             self.on_password_changed = Some(callback.into_payload_callback());
             self
         }
+        pub fn header(mut self, view: impl Into<View>) -> Self {
+            set_control_slot(
+                &mut self.slots,
+                SlotId::PasswordBoxHeader,
+                SlotContent::Single(view.into()),
+            );
+            self
+        }
     }
     impl sealed::Sealed for PasswordBox {}
     impl sealed::NativeControl for PasswordBox {
@@ -1562,20 +1561,6 @@ pub mod public {
     }
     impl LayoutControl for PasswordBox {}
     impl FocusControl for PasswordBox {}
-    #[non_exhaustive]
-    #[repr(u8)]
-    #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-    pub enum PasswordBoxSlot {
-        Header,
-    }
-    impl sealed::SlotIndex<PasswordBoxSlot> for PasswordBox {
-        fn slot_index(slot: PasswordBoxSlot) -> u8 {
-            slot as u8
-        }
-    }
-    impl SlotsControl for PasswordBox {
-        type Slot = PasswordBoxSlot;
-    }
     #[derive(Clone, Debug, Default, PartialEq)]
     pub struct NumberBox {
         minimum: Property<f64>,
@@ -1585,6 +1570,7 @@ pub mod public {
         on_value_changed: Option<Callback<Option<f64>>>,
         reference: Option<NativeElementRef>,
         element_state: Option<std::rc::Rc<ElementState>>,
+        slots: Option<std::rc::Rc<Vec<SlottedView>>>,
     }
     impl NumberBox {
         pub fn new() -> Self {
@@ -1618,6 +1604,14 @@ pub mod public {
             self.on_value_changed = Some(callback.into_payload_callback());
             self
         }
+        pub fn header(mut self, view: impl Into<View>) -> Self {
+            set_control_slot(
+                &mut self.slots,
+                SlotId::NumberBoxHeader,
+                SlotContent::Single(view.into()),
+            );
+            self
+        }
     }
     impl sealed::Sealed for NumberBox {}
     impl sealed::NativeControl for NumberBox {
@@ -1634,20 +1628,6 @@ pub mod public {
     }
     impl LayoutControl for NumberBox {}
     impl FocusControl for NumberBox {}
-    #[non_exhaustive]
-    #[repr(u8)]
-    #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-    pub enum NumberBoxSlot {
-        Header,
-    }
-    impl sealed::SlotIndex<NumberBoxSlot> for NumberBox {
-        fn slot_index(slot: NumberBoxSlot) -> u8 {
-            slot as u8
-        }
-    }
-    impl SlotsControl for NumberBox {
-        type Slot = NumberBoxSlot;
-    }
     #[derive(Clone, Debug, Default, PartialEq)]
     pub struct Slider {
         minimum: Property<f64>,
@@ -1659,6 +1639,7 @@ pub mod public {
         on_value_changed: Option<Callback<f64>>,
         reference: Option<NativeElementRef>,
         element_state: Option<std::rc::Rc<ElementState>>,
+        slots: Option<std::rc::Rc<Vec<SlottedView>>>,
     }
     impl Slider {
         pub fn new() -> Self {
@@ -1708,6 +1689,14 @@ pub mod public {
             self.on_value_changed = Some(callback.into_payload_callback());
             self
         }
+        pub fn header(mut self, view: impl Into<View>) -> Self {
+            set_control_slot(
+                &mut self.slots,
+                SlotId::SliderHeader,
+                SlotContent::Single(view.into()),
+            );
+            self
+        }
     }
     impl sealed::Sealed for Slider {}
     impl sealed::NativeControl for Slider {
@@ -1724,20 +1713,6 @@ pub mod public {
     }
     impl LayoutControl for Slider {}
     impl FocusControl for Slider {}
-    #[non_exhaustive]
-    #[repr(u8)]
-    #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-    pub enum SliderSlot {
-        Header,
-    }
-    impl sealed::SlotIndex<SliderSlot> for Slider {
-        fn slot_index(slot: SliderSlot) -> u8 {
-            slot as u8
-        }
-    }
-    impl SlotsControl for Slider {
-        type Slot = SliderSlot;
-    }
     #[derive(Clone, Debug, Default, PartialEq)]
     pub struct TitleBar {
         title: Property<String>,
@@ -1748,6 +1723,7 @@ pub mod public {
         events: Option<std::rc::Rc<TitleBarEvents>>,
         element_state: Option<std::rc::Rc<ElementState>>,
         preferred_height: WindowTitleBarHeight,
+        slots: Option<std::rc::Rc<Vec<SlottedView>>>,
     }
     impl TitleBar {
         pub fn new() -> Self {
@@ -1810,6 +1786,22 @@ pub mod public {
             .on_pane_toggle_requested = Some(callback.into_unit_callback());
             self
         }
+        pub fn content(mut self, view: impl Into<View>) -> Self {
+            set_control_slot(
+                &mut self.slots,
+                SlotId::TitleBarContent,
+                SlotContent::Single(view.into()),
+            );
+            self
+        }
+        pub fn right_header(mut self, view: impl Into<View>) -> Self {
+            set_control_slot(
+                &mut self.slots,
+                SlotId::TitleBarRightHeader,
+                SlotContent::Single(view.into()),
+            );
+            self
+        }
     }
     impl sealed::Sealed for TitleBar {}
     impl sealed::NativeControl for TitleBar {
@@ -1823,21 +1815,6 @@ pub mod public {
         }
     }
     impl LayoutControl for TitleBar {}
-    #[non_exhaustive]
-    #[repr(u8)]
-    #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-    pub enum TitleBarSlot {
-        Content,
-        RightHeader,
-    }
-    impl sealed::SlotIndex<TitleBarSlot> for TitleBar {
-        fn slot_index(slot: TitleBarSlot) -> u8 {
-            slot as u8
-        }
-    }
-    impl SlotsControl for TitleBar {
-        type Slot = TitleBarSlot;
-    }
     #[derive(Clone, Debug, Default, PartialEq)]
     pub struct NavigationView {
         is_enabled: Property<bool>,
@@ -1851,6 +1828,7 @@ pub mod public {
         is_pane_open: Property<bool>,
         events: Option<std::rc::Rc<NavigationViewEvents>>,
         element_state: Option<std::rc::Rc<ElementState>>,
+        slots: Option<std::rc::Rc<Vec<SlottedView>>>,
     }
     impl NavigationView {
         pub fn new() -> Self {
@@ -1949,6 +1927,64 @@ pub mod public {
             .on_selected_tag_changed = Some(callback.into_payload_callback());
             self
         }
+        pub fn content(mut self, view: impl Into<View>) -> Self {
+            set_control_slot(
+                &mut self.slots,
+                SlotId::NavigationViewContent,
+                SlotContent::Single(view.into()),
+            );
+            self
+        }
+        pub fn header(mut self, view: impl Into<View>) -> Self {
+            set_control_slot(
+                &mut self.slots,
+                SlotId::NavigationViewHeader,
+                SlotContent::Single(view.into()),
+            );
+            self
+        }
+        pub fn pane_custom_content(mut self, view: impl Into<View>) -> Self {
+            set_control_slot(
+                &mut self.slots,
+                SlotId::NavigationViewPaneCustomContent,
+                SlotContent::Single(view.into()),
+            );
+            self
+        }
+        pub fn pane_footer(mut self, view: impl Into<View>) -> Self {
+            set_control_slot(
+                &mut self.slots,
+                SlotId::NavigationViewPaneFooter,
+                SlotContent::Single(view.into()),
+            );
+            self
+        }
+        pub fn menu_items<T>(mut self, children: impl IntoIterator<Item = T>) -> Self
+        where
+            T: Into<KeyedView>,
+        {
+            set_control_slot(
+                &mut self.slots,
+                SlotId::NavigationViewMenuItems,
+                SlotContent::Collection(std::rc::Rc::new(
+                    children.into_iter().map(Into::into).collect(),
+                )),
+            );
+            self
+        }
+        pub fn footer_menu_items<T>(mut self, children: impl IntoIterator<Item = T>) -> Self
+        where
+            T: Into<KeyedView>,
+        {
+            set_control_slot(
+                &mut self.slots,
+                SlotId::NavigationViewFooterMenuItems,
+                SlotContent::Collection(std::rc::Rc::new(
+                    children.into_iter().map(Into::into).collect(),
+                )),
+            );
+            self
+        }
     }
     impl sealed::Sealed for NavigationView {}
     impl sealed::NativeControl for NavigationView {
@@ -1962,24 +1998,6 @@ pub mod public {
         }
     }
     impl LayoutControl for NavigationView {}
-    #[non_exhaustive]
-    #[repr(u8)]
-    #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-    pub enum NavigationViewSlot {
-        Content,
-        Header,
-        PaneCustomContent,
-        PaneFooter,
-        MenuItems,
-    }
-    impl sealed::SlotIndex<NavigationViewSlot> for NavigationView {
-        fn slot_index(slot: NavigationViewSlot) -> u8 {
-            slot as u8
-        }
-    }
-    impl SlotsControl for NavigationView {
-        type Slot = NavigationViewSlot;
-    }
     #[derive(Clone, Debug, Default, PartialEq)]
     pub struct NavigationViewItem {
         tag: Property<String>,
@@ -1987,6 +2005,7 @@ pub mod public {
         selects_on_invoked: Property<bool>,
         is_expanded: Property<bool>,
         element_state: Option<std::rc::Rc<ElementState>>,
+        slots: Option<std::rc::Rc<Vec<SlottedView>>>,
     }
     impl NavigationViewItem {
         pub fn new() -> Self {
@@ -2018,6 +2037,35 @@ pub mod public {
             self.is_expanded = Property::from(value);
             self
         }
+        pub fn content(mut self, view: impl Into<View>) -> Self {
+            set_control_slot(
+                &mut self.slots,
+                SlotId::NavigationViewItemContent,
+                SlotContent::Single(view.into()),
+            );
+            self
+        }
+        pub fn icon(mut self, view: impl Into<View>) -> Self {
+            set_control_slot(
+                &mut self.slots,
+                SlotId::NavigationViewItemIcon,
+                SlotContent::Single(view.into()),
+            );
+            self
+        }
+        pub fn menu_items<T>(mut self, children: impl IntoIterator<Item = T>) -> Self
+        where
+            T: Into<KeyedView>,
+        {
+            set_control_slot(
+                &mut self.slots,
+                SlotId::NavigationViewItemMenuItems,
+                SlotContent::Collection(std::rc::Rc::new(
+                    children.into_iter().map(Into::into).collect(),
+                )),
+            );
+            self
+        }
     }
     impl sealed::Sealed for NavigationViewItem {}
     impl sealed::NativeControl for NavigationViewItem {
@@ -2031,22 +2079,6 @@ pub mod public {
         }
     }
     impl LayoutControl for NavigationViewItem {}
-    #[non_exhaustive]
-    #[repr(u8)]
-    #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-    pub enum NavigationViewItemSlot {
-        Content,
-        Icon,
-        MenuItems,
-    }
-    impl sealed::SlotIndex<NavigationViewItemSlot> for NavigationViewItem {
-        fn slot_index(slot: NavigationViewItemSlot) -> u8 {
-            slot as u8
-        }
-    }
-    impl SlotsControl for NavigationViewItem {
-        type Slot = NavigationViewItemSlot;
-    }
     #[derive(Clone, Debug, Default, PartialEq)]
     pub struct SplitView {
         open_pane_length: Property<f64>,
@@ -2055,6 +2087,7 @@ pub mod public {
         is_pane_open: Property<bool>,
         on_pane_closed: Option<Callback<bool>>,
         element_state: Option<std::rc::Rc<ElementState>>,
+        slots: Option<std::rc::Rc<Vec<SlottedView>>>,
     }
     impl SplitView {
         pub fn new() -> Self {
@@ -2084,6 +2117,22 @@ pub mod public {
             self.on_pane_closed = Some(callback.into_payload_callback());
             self
         }
+        pub fn pane(mut self, view: impl Into<View>) -> Self {
+            set_control_slot(
+                &mut self.slots,
+                SlotId::SplitViewPane,
+                SlotContent::Single(view.into()),
+            );
+            self
+        }
+        pub fn content(mut self, view: impl Into<View>) -> Self {
+            set_control_slot(
+                &mut self.slots,
+                SlotId::SplitViewContent,
+                SlotContent::Single(view.into()),
+            );
+            self
+        }
     }
     impl sealed::Sealed for SplitView {}
     impl sealed::NativeControl for SplitView {
@@ -2097,21 +2146,6 @@ pub mod public {
         }
     }
     impl LayoutControl for SplitView {}
-    #[non_exhaustive]
-    #[repr(u8)]
-    #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-    pub enum SplitViewSlot {
-        Pane,
-        Content,
-    }
-    impl sealed::SlotIndex<SplitViewSlot> for SplitView {
-        fn slot_index(slot: SplitViewSlot) -> u8 {
-            slot as u8
-        }
-    }
-    impl SlotsControl for SplitView {
-        type Slot = SplitViewSlot;
-    }
     #[derive(Clone, Debug, Default, PartialEq)]
     pub struct ProgressBar {
         minimum: Property<f64>,
@@ -2182,6 +2216,7 @@ pub mod public {
         on_toggled: Option<Callback<bool>>,
         reference: Option<NativeElementRef>,
         element_state: Option<std::rc::Rc<ElementState>>,
+        slots: Option<std::rc::Rc<Vec<SlottedView>>>,
     }
     impl ToggleSwitch {
         pub fn new() -> Self {
@@ -2205,6 +2240,30 @@ pub mod public {
             self.on_toggled = Some(callback.into_payload_callback());
             self
         }
+        pub fn header(mut self, view: impl Into<View>) -> Self {
+            set_control_slot(
+                &mut self.slots,
+                SlotId::ToggleSwitchHeader,
+                SlotContent::Single(view.into()),
+            );
+            self
+        }
+        pub fn on_content(mut self, view: impl Into<View>) -> Self {
+            set_control_slot(
+                &mut self.slots,
+                SlotId::ToggleSwitchOnContent,
+                SlotContent::Single(view.into()),
+            );
+            self
+        }
+        pub fn off_content(mut self, view: impl Into<View>) -> Self {
+            set_control_slot(
+                &mut self.slots,
+                SlotId::ToggleSwitchOffContent,
+                SlotContent::Single(view.into()),
+            );
+            self
+        }
     }
     impl sealed::Sealed for ToggleSwitch {}
     impl sealed::NativeControl for ToggleSwitch {
@@ -2221,22 +2280,6 @@ pub mod public {
     }
     impl LayoutControl for ToggleSwitch {}
     impl FocusControl for ToggleSwitch {}
-    #[non_exhaustive]
-    #[repr(u8)]
-    #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-    pub enum ToggleSwitchSlot {
-        Header,
-        OnContent,
-        OffContent,
-    }
-    impl sealed::SlotIndex<ToggleSwitchSlot> for ToggleSwitch {
-        fn slot_index(slot: ToggleSwitchSlot) -> u8 {
-            slot as u8
-        }
-    }
-    impl SlotsControl for ToggleSwitch {
-        type Slot = ToggleSwitchSlot;
-    }
     #[derive(Clone, Debug, Default, PartialEq)]
     pub struct CheckBox {
         is_checked: Property<bool>,
@@ -2424,6 +2467,7 @@ pub mod public {
         max_columns: Property<i32>,
         on_selection_changed: Option<Callback<Option<usize>>>,
         element_state: Option<std::rc::Rc<ElementState>>,
+        slots: Option<std::rc::Rc<Vec<SlottedView>>>,
     }
     impl RadioButtons {
         pub fn new() -> Self {
@@ -2466,6 +2510,14 @@ pub mod public {
             self.on_selection_changed = Some(callback.into_payload_callback());
             self
         }
+        pub fn header(mut self, view: impl Into<View>) -> Self {
+            set_control_slot(
+                &mut self.slots,
+                SlotId::RadioButtonsHeader,
+                SlotContent::Single(view.into()),
+            );
+            self
+        }
     }
     impl sealed::Sealed for RadioButtons {}
     impl sealed::NativeControl for RadioButtons {
@@ -2479,20 +2531,6 @@ pub mod public {
         }
     }
     impl LayoutControl for RadioButtons {}
-    #[non_exhaustive]
-    #[repr(u8)]
-    #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-    pub enum RadioButtonsSlot {
-        Header,
-    }
-    impl sealed::SlotIndex<RadioButtonsSlot> for RadioButtons {
-        fn slot_index(slot: RadioButtonsSlot) -> u8 {
-            slot as u8
-        }
-    }
-    impl SlotsControl for RadioButtons {
-        type Slot = RadioButtonsSlot;
-    }
     #[derive(Clone, Debug, Default, PartialEq)]
     pub struct ItemsRepeater {
         element_state: Option<std::rc::Rc<ElementState>>,
@@ -2916,6 +2954,7 @@ pub mod public {
         is_enabled: Property<bool>,
         on_selected_tag_changed: Option<Callback<Option<String>>>,
         element_state: Option<std::rc::Rc<ElementState>>,
+        slots: Option<std::rc::Rc<Vec<SlottedView>>>,
     }
     impl ListBox {
         pub fn new() -> Self {
@@ -2933,6 +2972,19 @@ pub mod public {
             self.on_selected_tag_changed = Some(callback.into_payload_callback());
             self
         }
+        pub fn items<T>(mut self, children: impl IntoIterator<Item = T>) -> Self
+        where
+            T: Into<KeyedView>,
+        {
+            set_control_slot(
+                &mut self.slots,
+                SlotId::ListBoxItems,
+                SlotContent::Collection(std::rc::Rc::new(
+                    children.into_iter().map(Into::into).collect(),
+                )),
+            );
+            self
+        }
     }
     impl sealed::Sealed for ListBox {}
     impl sealed::NativeControl for ListBox {
@@ -2946,20 +2998,6 @@ pub mod public {
         }
     }
     impl LayoutControl for ListBox {}
-    #[non_exhaustive]
-    #[repr(u8)]
-    #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-    pub enum ListBoxSlot {
-        Items,
-    }
-    impl sealed::SlotIndex<ListBoxSlot> for ListBox {
-        fn slot_index(slot: ListBoxSlot) -> u8 {
-            slot as u8
-        }
-    }
-    impl SlotsControl for ListBox {
-        type Slot = ListBoxSlot;
-    }
     #[derive(Clone, Debug, Default, PartialEq)]
     pub struct Rectangle {
         fill: Property<Brush>,
@@ -3491,6 +3529,7 @@ pub mod public {
         is_expanded: Property<bool>,
         on_is_expanded_changed: Option<Callback<bool>>,
         element_state: Option<std::rc::Rc<ElementState>>,
+        slots: Option<std::rc::Rc<Vec<SlottedView>>>,
     }
     impl Expander {
         pub fn new() -> Self {
@@ -3503,6 +3542,22 @@ pub mod public {
         }
         pub fn on_is_expanded_changed(mut self, callback: impl IntoPayloadCallback<bool>) -> Self {
             self.on_is_expanded_changed = Some(callback.into_payload_callback());
+            self
+        }
+        pub fn header(mut self, view: impl Into<View>) -> Self {
+            set_control_slot(
+                &mut self.slots,
+                SlotId::ExpanderHeader,
+                SlotContent::Single(view.into()),
+            );
+            self
+        }
+        pub fn content(mut self, view: impl Into<View>) -> Self {
+            set_control_slot(
+                &mut self.slots,
+                SlotId::ExpanderContent,
+                SlotContent::Single(view.into()),
+            );
             self
         }
     }
@@ -3518,21 +3573,6 @@ pub mod public {
         }
     }
     impl LayoutControl for Expander {}
-    #[non_exhaustive]
-    #[repr(u8)]
-    #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-    pub enum ExpanderSlot {
-        Header,
-        Content,
-    }
-    impl sealed::SlotIndex<ExpanderSlot> for Expander {
-        fn slot_index(slot: ExpanderSlot) -> u8 {
-            slot as u8
-        }
-    }
-    impl SlotsControl for Expander {
-        type Slot = ExpanderSlot;
-    }
     #[derive(Clone, Debug, Default, PartialEq)]
     pub struct ComboBox {
         items_source: Property<std::rc::Rc<Vec<String>>>,
@@ -3543,6 +3583,7 @@ pub mod public {
         on_selection_changed: Option<Callback<Option<usize>>>,
         reference: Option<NativeElementRef>,
         element_state: Option<std::rc::Rc<ElementState>>,
+        slots: Option<std::rc::Rc<Vec<SlottedView>>>,
     }
     impl ComboBox {
         pub fn new() -> Self {
@@ -3605,6 +3646,14 @@ pub mod public {
             self.on_selection_changed = Some(callback.into_payload_callback());
             self
         }
+        pub fn header(mut self, view: impl Into<View>) -> Self {
+            set_control_slot(
+                &mut self.slots,
+                SlotId::ComboBoxHeader,
+                SlotContent::Single(view.into()),
+            );
+            self
+        }
     }
     impl sealed::Sealed for ComboBox {}
     impl sealed::NativeControl for ComboBox {
@@ -3621,26 +3670,13 @@ pub mod public {
     }
     impl LayoutControl for ComboBox {}
     impl FocusControl for ComboBox {}
-    #[non_exhaustive]
-    #[repr(u8)]
-    #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-    pub enum ComboBoxSlot {
-        Header,
-    }
-    impl sealed::SlotIndex<ComboBoxSlot> for ComboBox {
-        fn slot_index(slot: ComboBoxSlot) -> u8 {
-            slot as u8
-        }
-    }
-    impl SlotsControl for ComboBox {
-        type Slot = ComboBoxSlot;
-    }
     #[derive(Clone, Debug, Default, PartialEq)]
     pub struct Pivot {
         selected_index: Property<Option<usize>>,
         title: Property<String>,
         on_selection_changed: Option<Callback<Option<usize>>>,
         element_state: Option<std::rc::Rc<ElementState>>,
+        slots: Option<std::rc::Rc<Vec<SlottedView>>>,
     }
     impl Pivot {
         pub fn new() -> Self {
@@ -3669,6 +3705,19 @@ pub mod public {
             self.on_selection_changed = Some(callback.into_payload_callback());
             self
         }
+        pub fn items<T>(mut self, children: impl IntoIterator<Item = T>) -> Self
+        where
+            T: Into<KeyedView>,
+        {
+            set_control_slot(
+                &mut self.slots,
+                SlotId::PivotItems,
+                SlotContent::Collection(std::rc::Rc::new(
+                    children.into_iter().map(Into::into).collect(),
+                )),
+            );
+            self
+        }
     }
     impl sealed::Sealed for Pivot {}
     impl sealed::NativeControl for Pivot {
@@ -3682,20 +3731,6 @@ pub mod public {
         }
     }
     impl LayoutControl for Pivot {}
-    #[non_exhaustive]
-    #[repr(u8)]
-    #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-    pub enum PivotSlot {
-        Items,
-    }
-    impl sealed::SlotIndex<PivotSlot> for Pivot {
-        fn slot_index(slot: PivotSlot) -> u8 {
-            slot as u8
-        }
-    }
-    impl SlotsControl for Pivot {
-        type Slot = PivotSlot;
-    }
     #[derive(Clone, Debug, Default, PartialEq)]
     pub struct PivotItem {
         header: Property<String>,
@@ -3744,6 +3779,7 @@ pub mod public {
         selected_index: Property<Option<usize>>,
         on_selection_changed: Option<Callback<Option<usize>>>,
         element_state: Option<std::rc::Rc<ElementState>>,
+        slots: Option<std::rc::Rc<Vec<SlottedView>>>,
     }
     impl FlipView {
         pub fn new() -> Self {
@@ -3761,6 +3797,19 @@ pub mod public {
             self.on_selection_changed = Some(callback.into_payload_callback());
             self
         }
+        pub fn items<T>(mut self, children: impl IntoIterator<Item = T>) -> Self
+        where
+            T: Into<KeyedView>,
+        {
+            set_control_slot(
+                &mut self.slots,
+                SlotId::FlipViewItems,
+                SlotContent::Collection(std::rc::Rc::new(
+                    children.into_iter().map(Into::into).collect(),
+                )),
+            );
+            self
+        }
     }
     impl sealed::Sealed for FlipView {}
     impl sealed::NativeControl for FlipView {
@@ -3774,24 +3823,11 @@ pub mod public {
         }
     }
     impl LayoutControl for FlipView {}
-    #[non_exhaustive]
-    #[repr(u8)]
-    #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-    pub enum FlipViewSlot {
-        Items,
-    }
-    impl sealed::SlotIndex<FlipViewSlot> for FlipView {
-        fn slot_index(slot: FlipViewSlot) -> u8 {
-            slot as u8
-        }
-    }
-    impl SlotsControl for FlipView {
-        type Slot = FlipViewSlot;
-    }
     #[derive(Clone, Debug, Default, PartialEq)]
     pub struct SelectorBar {
         on_selected_text_changed: Option<Callback<Option<String>>>,
         element_state: Option<std::rc::Rc<ElementState>>,
+        slots: Option<std::rc::Rc<Vec<SlottedView>>>,
     }
     impl SelectorBar {
         pub fn new() -> Self {
@@ -3802,6 +3838,19 @@ pub mod public {
             callback: impl IntoPayloadCallback<Option<String>>,
         ) -> Self {
             self.on_selected_text_changed = Some(callback.into_payload_callback());
+            self
+        }
+        pub fn items<T>(mut self, children: impl IntoIterator<Item = T>) -> Self
+        where
+            T: Into<KeyedView>,
+        {
+            set_control_slot(
+                &mut self.slots,
+                SlotId::SelectorBarItems,
+                SlotContent::Collection(std::rc::Rc::new(
+                    children.into_iter().map(Into::into).collect(),
+                )),
+            );
             self
         }
     }
@@ -3817,25 +3866,12 @@ pub mod public {
         }
     }
     impl LayoutControl for SelectorBar {}
-    #[non_exhaustive]
-    #[repr(u8)]
-    #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-    pub enum SelectorBarSlot {
-        Items,
-    }
-    impl sealed::SlotIndex<SelectorBarSlot> for SelectorBar {
-        fn slot_index(slot: SelectorBarSlot) -> u8 {
-            slot as u8
-        }
-    }
-    impl SlotsControl for SelectorBar {
-        type Slot = SelectorBarSlot;
-    }
     #[derive(Clone, Debug, Default, PartialEq)]
     pub struct SelectorBarItem {
         text: Property<String>,
         is_selected: Property<bool>,
         element_state: Option<std::rc::Rc<ElementState>>,
+        slots: Option<std::rc::Rc<Vec<SlottedView>>>,
     }
     impl SelectorBarItem {
         pub fn new() -> Self {
@@ -3857,6 +3893,14 @@ pub mod public {
             self.is_selected = Property::from(value);
             self
         }
+        pub fn icon(mut self, view: impl Into<View>) -> Self {
+            set_control_slot(
+                &mut self.slots,
+                SlotId::SelectorBarItemIcon,
+                SlotContent::Single(view.into()),
+            );
+            self
+        }
     }
     impl sealed::Sealed for SelectorBarItem {}
     impl sealed::NativeControl for SelectorBarItem {
@@ -3870,20 +3914,6 @@ pub mod public {
         }
     }
     impl LayoutControl for SelectorBarItem {}
-    #[non_exhaustive]
-    #[repr(u8)]
-    #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-    pub enum SelectorBarItemSlot {
-        Icon,
-    }
-    impl sealed::SlotIndex<SelectorBarItemSlot> for SelectorBarItem {
-        fn slot_index(slot: SelectorBarItemSlot) -> u8 {
-            slot as u8
-        }
-    }
-    impl SlotsControl for SelectorBarItem {
-        type Slot = SelectorBarItemSlot;
-    }
     #[derive(Clone, Debug, Default, PartialEq)]
     pub struct TabView {
         selected_index: Property<Option<usize>>,
@@ -3891,6 +3921,7 @@ pub mod public {
         is_add_tab_button_visible: Property<bool>,
         events: Option<std::rc::Rc<TabViewEvents>>,
         element_state: Option<std::rc::Rc<ElementState>>,
+        slots: Option<std::rc::Rc<Vec<SlottedView>>>,
     }
     impl TabView {
         pub fn new() -> Self {
@@ -3946,6 +3977,19 @@ pub mod public {
             .on_reordered = Some(callback.into_payload_callback());
             self
         }
+        pub fn tab_items<T>(mut self, children: impl IntoIterator<Item = T>) -> Self
+        where
+            T: Into<KeyedView>,
+        {
+            set_control_slot(
+                &mut self.slots,
+                SlotId::TabViewTabItems,
+                SlotContent::Collection(std::rc::Rc::new(
+                    children.into_iter().map(Into::into).collect(),
+                )),
+            );
+            self
+        }
     }
     impl sealed::Sealed for TabView {}
     impl sealed::NativeControl for TabView {
@@ -3959,20 +4003,6 @@ pub mod public {
         }
     }
     impl LayoutControl for TabView {}
-    #[non_exhaustive]
-    #[repr(u8)]
-    #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-    pub enum TabViewSlot {
-        TabItems,
-    }
-    impl sealed::SlotIndex<TabViewSlot> for TabView {
-        fn slot_index(slot: TabViewSlot) -> u8 {
-            slot as u8
-        }
-    }
-    impl SlotsControl for TabView {
-        type Slot = TabViewSlot;
-    }
     #[derive(Clone, Debug, Default, PartialEq)]
     pub struct TabViewItem {
         header: Property<String>,
@@ -4186,10 +4216,37 @@ pub mod public {
     #[derive(Clone, Debug, Default, PartialEq)]
     pub struct CommandBar {
         element_state: Option<std::rc::Rc<ElementState>>,
+        slots: Option<std::rc::Rc<Vec<SlottedView>>>,
     }
     impl CommandBar {
         pub fn new() -> Self {
             Self::default()
+        }
+        pub fn primary_commands<T>(mut self, children: impl IntoIterator<Item = T>) -> Self
+        where
+            T: Into<KeyedView>,
+        {
+            set_control_slot(
+                &mut self.slots,
+                SlotId::CommandBarPrimaryCommands,
+                SlotContent::Collection(std::rc::Rc::new(
+                    children.into_iter().map(Into::into).collect(),
+                )),
+            );
+            self
+        }
+        pub fn secondary_commands<T>(mut self, children: impl IntoIterator<Item = T>) -> Self
+        where
+            T: Into<KeyedView>,
+        {
+            set_control_slot(
+                &mut self.slots,
+                SlotId::CommandBarSecondaryCommands,
+                SlotContent::Collection(std::rc::Rc::new(
+                    children.into_iter().map(Into::into).collect(),
+                )),
+            );
+            self
         }
     }
     impl sealed::Sealed for CommandBar {}
@@ -4204,27 +4261,13 @@ pub mod public {
         }
     }
     impl LayoutControl for CommandBar {}
-    #[non_exhaustive]
-    #[repr(u8)]
-    #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-    pub enum CommandBarSlot {
-        PrimaryCommands,
-        SecondaryCommands,
-    }
-    impl sealed::SlotIndex<CommandBarSlot> for CommandBar {
-        fn slot_index(slot: CommandBarSlot) -> u8 {
-            slot as u8
-        }
-    }
-    impl SlotsControl for CommandBar {
-        type Slot = CommandBarSlot;
-    }
     #[derive(Clone, Debug, Default, PartialEq)]
     pub struct AppBarButton {
         label: Property<String>,
         is_enabled: Property<bool>,
         on_click: Option<Callback<()>>,
         element_state: Option<std::rc::Rc<ElementState>>,
+        slots: Option<std::rc::Rc<Vec<SlottedView>>>,
     }
     impl AppBarButton {
         pub fn new() -> Self {
@@ -4250,6 +4293,14 @@ pub mod public {
             self.on_click = Some(callback.into_unit_callback());
             self
         }
+        pub fn icon(mut self, view: impl Into<View>) -> Self {
+            set_control_slot(
+                &mut self.slots,
+                SlotId::AppBarButtonIcon,
+                SlotContent::Single(view.into()),
+            );
+            self
+        }
     }
     impl sealed::Sealed for AppBarButton {}
     impl sealed::NativeControl for AppBarButton {
@@ -4263,20 +4314,6 @@ pub mod public {
         }
     }
     impl LayoutControl for AppBarButton {}
-    #[non_exhaustive]
-    #[repr(u8)]
-    #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-    pub enum AppBarButtonSlot {
-        Icon,
-    }
-    impl sealed::SlotIndex<AppBarButtonSlot> for AppBarButton {
-        fn slot_index(slot: AppBarButtonSlot) -> u8 {
-            slot as u8
-        }
-    }
-    impl SlotsControl for AppBarButton {
-        type Slot = AppBarButtonSlot;
-    }
     #[derive(Clone, Debug, Default, PartialEq)]
     pub struct AppBarSeparator {
         element_state: Option<std::rc::Rc<ElementState>>,
@@ -4301,10 +4338,24 @@ pub mod public {
     #[derive(Clone, Debug, Default, PartialEq)]
     pub struct MenuBar {
         element_state: Option<std::rc::Rc<ElementState>>,
+        slots: Option<std::rc::Rc<Vec<SlottedView>>>,
     }
     impl MenuBar {
         pub fn new() -> Self {
             Self::default()
+        }
+        pub fn items<T>(mut self, children: impl IntoIterator<Item = T>) -> Self
+        where
+            T: Into<KeyedView>,
+        {
+            set_control_slot(
+                &mut self.slots,
+                SlotId::MenuBarItems,
+                SlotContent::Collection(std::rc::Rc::new(
+                    children.into_iter().map(Into::into).collect(),
+                )),
+            );
+            self
         }
     }
     impl sealed::Sealed for MenuBar {}
@@ -4319,20 +4370,6 @@ pub mod public {
         }
     }
     impl LayoutControl for MenuBar {}
-    #[non_exhaustive]
-    #[repr(u8)]
-    #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-    pub enum MenuBarSlot {
-        Items,
-    }
-    impl sealed::SlotIndex<MenuBarSlot> for MenuBar {
-        fn slot_index(slot: MenuBarSlot) -> u8 {
-            slot as u8
-        }
-    }
-    impl SlotsControl for MenuBar {
-        type Slot = MenuBarSlot;
-    }
     #[derive(Clone, Debug, Default, PartialEq)]
     pub struct MenuBarItem {
         title: Property<String>,
@@ -4481,6 +4518,7 @@ pub mod public {
         is_enabled: Property<bool>,
         on_selected_date_changed: Option<Callback<Option<windows_time::DateTime>>>,
         element_state: Option<std::rc::Rc<ElementState>>,
+        slots: Option<std::rc::Rc<Vec<SlottedView>>>,
     }
     impl DatePicker {
         pub fn new() -> Self {
@@ -4513,6 +4551,14 @@ pub mod public {
             self.on_selected_date_changed = Some(callback.into_payload_callback());
             self
         }
+        pub fn header(mut self, view: impl Into<View>) -> Self {
+            set_control_slot(
+                &mut self.slots,
+                SlotId::DatePickerHeader,
+                SlotContent::Single(view.into()),
+            );
+            self
+        }
     }
     impl sealed::Sealed for DatePicker {}
     impl sealed::NativeControl for DatePicker {
@@ -4526,20 +4572,6 @@ pub mod public {
         }
     }
     impl LayoutControl for DatePicker {}
-    #[non_exhaustive]
-    #[repr(u8)]
-    #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-    pub enum DatePickerSlot {
-        Header,
-    }
-    impl sealed::SlotIndex<DatePickerSlot> for DatePicker {
-        fn slot_index(slot: DatePickerSlot) -> u8 {
-            slot as u8
-        }
-    }
-    impl SlotsControl for DatePicker {
-        type Slot = DatePickerSlot;
-    }
     #[derive(Clone, Debug, Default, PartialEq)]
     pub struct TimePicker {
         clock_identifier: Property<String>,
@@ -4547,6 +4579,7 @@ pub mod public {
         is_enabled: Property<bool>,
         on_selected_time_changed: Option<Callback<Option<windows_time::TimeSpan>>>,
         element_state: Option<std::rc::Rc<ElementState>>,
+        slots: Option<std::rc::Rc<Vec<SlottedView>>>,
     }
     impl TimePicker {
         pub fn new() -> Self {
@@ -4584,6 +4617,14 @@ pub mod public {
             self.on_selected_time_changed = Some(callback.into_payload_callback());
             self
         }
+        pub fn header(mut self, view: impl Into<View>) -> Self {
+            set_control_slot(
+                &mut self.slots,
+                SlotId::TimePickerHeader,
+                SlotContent::Single(view.into()),
+            );
+            self
+        }
     }
     impl sealed::Sealed for TimePicker {}
     impl sealed::NativeControl for TimePicker {
@@ -4597,20 +4638,6 @@ pub mod public {
         }
     }
     impl LayoutControl for TimePicker {}
-    #[non_exhaustive]
-    #[repr(u8)]
-    #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-    pub enum TimePickerSlot {
-        Header,
-    }
-    impl sealed::SlotIndex<TimePickerSlot> for TimePicker {
-        fn slot_index(slot: TimePickerSlot) -> u8 {
-            slot as u8
-        }
-    }
-    impl SlotsControl for TimePicker {
-        type Slot = TimePickerSlot;
-    }
     #[derive(Clone, Debug, Default, PartialEq)]
     pub struct CalendarDatePicker {
         placeholder_text: Property<String>,
@@ -4619,6 +4646,7 @@ pub mod public {
         is_enabled: Property<bool>,
         on_date_changed: Option<Callback<Option<windows_time::DateTime>>>,
         element_state: Option<std::rc::Rc<ElementState>>,
+        slots: Option<std::rc::Rc<Vec<SlottedView>>>,
     }
     impl CalendarDatePicker {
         pub fn new() -> Self {
@@ -4657,6 +4685,14 @@ pub mod public {
             self.on_date_changed = Some(callback.into_payload_callback());
             self
         }
+        pub fn header(mut self, view: impl Into<View>) -> Self {
+            set_control_slot(
+                &mut self.slots,
+                SlotId::CalendarDatePickerHeader,
+                SlotContent::Single(view.into()),
+            );
+            self
+        }
     }
     impl sealed::Sealed for CalendarDatePicker {}
     impl sealed::NativeControl for CalendarDatePicker {
@@ -4670,20 +4706,6 @@ pub mod public {
         }
     }
     impl LayoutControl for CalendarDatePicker {}
-    #[non_exhaustive]
-    #[repr(u8)]
-    #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-    pub enum CalendarDatePickerSlot {
-        Header,
-    }
-    impl sealed::SlotIndex<CalendarDatePickerSlot> for CalendarDatePicker {
-        fn slot_index(slot: CalendarDatePickerSlot) -> u8 {
-            slot as u8
-        }
-    }
-    impl SlotsControl for CalendarDatePicker {
-        type Slot = CalendarDatePickerSlot;
-    }
     #[derive(Clone, Debug, Default, PartialEq)]
     pub(crate) struct ToolTip {
         content: Option<Box<Element>>,
@@ -4863,6 +4885,7 @@ pub mod public {
         allow_drop: Property<bool>,
         events: Option<std::rc::Rc<ListViewEvents>>,
         element_state: Option<std::rc::Rc<ElementState>>,
+        slots: Option<std::rc::Rc<Vec<SlottedView>>>,
     }
     impl ListView {
         pub fn new() -> Self {
@@ -4912,6 +4935,19 @@ pub mod public {
             .on_reordered = Some(callback.into_payload_callback());
             self
         }
+        pub fn items<T>(mut self, children: impl IntoIterator<Item = T>) -> Self
+        where
+            T: Into<KeyedView>,
+        {
+            set_control_slot(
+                &mut self.slots,
+                SlotId::ListViewItems,
+                SlotContent::Collection(std::rc::Rc::new(
+                    children.into_iter().map(Into::into).collect(),
+                )),
+            );
+            self
+        }
     }
     impl sealed::Sealed for ListView {}
     impl sealed::NativeControl for ListView {
@@ -4925,20 +4961,6 @@ pub mod public {
         }
     }
     impl LayoutControl for ListView {}
-    #[non_exhaustive]
-    #[repr(u8)]
-    #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-    pub enum ListViewSlot {
-        Items,
-    }
-    impl sealed::SlotIndex<ListViewSlot> for ListView {
-        fn slot_index(slot: ListViewSlot) -> u8 {
-            slot as u8
-        }
-    }
-    impl SlotsControl for ListView {
-        type Slot = ListViewSlot;
-    }
     #[derive(Clone, Debug, Default, PartialEq)]
     pub struct ListViewItem {
         tag: Property<String>,
@@ -5022,6 +5044,7 @@ pub mod public {
         allow_drop: Property<bool>,
         events: Option<std::rc::Rc<GridViewEvents>>,
         element_state: Option<std::rc::Rc<ElementState>>,
+        slots: Option<std::rc::Rc<Vec<SlottedView>>>,
     }
     impl GridView {
         pub fn new() -> Self {
@@ -5066,6 +5089,19 @@ pub mod public {
             .on_selection_changed = Some(callback.into_payload_callback());
             self
         }
+        pub fn items<T>(mut self, children: impl IntoIterator<Item = T>) -> Self
+        where
+            T: Into<KeyedView>,
+        {
+            set_control_slot(
+                &mut self.slots,
+                SlotId::GridViewItems,
+                SlotContent::Collection(std::rc::Rc::new(
+                    children.into_iter().map(Into::into).collect(),
+                )),
+            );
+            self
+        }
     }
     impl sealed::Sealed for GridView {}
     impl sealed::NativeControl for GridView {
@@ -5079,20 +5115,6 @@ pub mod public {
         }
     }
     impl LayoutControl for GridView {}
-    #[non_exhaustive]
-    #[repr(u8)]
-    #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-    pub enum GridViewSlot {
-        Items,
-    }
-    impl sealed::SlotIndex<GridViewSlot> for GridView {
-        fn slot_index(slot: GridViewSlot) -> u8 {
-            slot as u8
-        }
-    }
-    impl SlotsControl for GridView {
-        type Slot = GridViewSlot;
-    }
     #[derive(Clone, Debug, Default, PartialEq)]
     pub struct GridViewItem {
         tag: Property<String>,
@@ -5213,6 +5235,7 @@ pub mod public {
         on_text_changed: Option<Callback<String>>,
         reference: Option<NativeElementRef>,
         element_state: Option<std::rc::Rc<ElementState>>,
+        slots: Option<std::rc::Rc<Vec<SlottedView>>>,
     }
     impl RichEditBox {
         pub fn new() -> Self {
@@ -5258,6 +5281,14 @@ pub mod public {
             self.on_text_changed = Some(callback.into_payload_callback());
             self
         }
+        pub fn header(mut self, view: impl Into<View>) -> Self {
+            set_control_slot(
+                &mut self.slots,
+                SlotId::RichEditBoxHeader,
+                SlotContent::Single(view.into()),
+            );
+            self
+        }
     }
     impl sealed::Sealed for RichEditBox {}
     impl sealed::NativeControl for RichEditBox {
@@ -5274,20 +5305,6 @@ pub mod public {
     }
     impl LayoutControl for RichEditBox {}
     impl FocusControl for RichEditBox {}
-    #[non_exhaustive]
-    #[repr(u8)]
-    #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-    pub enum RichEditBoxSlot {
-        Header,
-    }
-    impl sealed::SlotIndex<RichEditBoxSlot> for RichEditBox {
-        fn slot_index(slot: RichEditBoxSlot) -> u8 {
-            slot as u8
-        }
-    }
-    impl SlotsControl for RichEditBox {
-        type Slot = RichEditBoxSlot;
-    }
     #[derive(Clone, Debug, Default, PartialEq)]
     pub struct RichTextBlock {
         paragraphs: Property<RichText>,
@@ -5343,6 +5360,7 @@ pub mod public {
     pub struct Viewbox {
         stretch: Property<Stretch>,
         element_state: Option<std::rc::Rc<ElementState>>,
+        slots: Option<std::rc::Rc<Vec<SlottedView>>>,
     }
     impl Viewbox {
         pub fn new() -> Self {
@@ -5351,6 +5369,14 @@ pub mod public {
         pub fn stretch(mut self, value: impl Into<Option<Stretch>>) -> Self {
             let value = value.into();
             self.stretch = Property::from(value);
+            self
+        }
+        pub fn child(mut self, view: impl Into<View>) -> Self {
+            set_control_slot(
+                &mut self.slots,
+                SlotId::ViewboxChild,
+                SlotContent::Single(view.into()),
+            );
             self
         }
     }
@@ -5366,20 +5392,6 @@ pub mod public {
         }
     }
     impl LayoutControl for Viewbox {}
-    #[non_exhaustive]
-    #[repr(u8)]
-    #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-    pub enum ViewboxSlot {
-        Child,
-    }
-    impl sealed::SlotIndex<ViewboxSlot> for Viewbox {
-        fn slot_index(slot: ViewboxSlot) -> u8 {
-            slot as u8
-        }
-    }
-    impl SlotsControl for Viewbox {
-        type Slot = ViewboxSlot;
-    }
     #[derive(Clone, Debug, Default, PartialEq)]
     pub struct WebView2 {
         reference: Option<NativeElementRef>,
@@ -5615,7 +5627,11 @@ pub mod public {
     }
     impl From<TextBox> for View {
         fn from(value: TextBox) -> Self {
-            Self::native(value)
+            let mut value = value;
+            match value.slots.take() {
+                Some(slots) => Self::slotted(value.into(), slots),
+                None => Self::native(value),
+            }
         }
     }
     impl From<AutoSuggestBox> for Element {
@@ -5625,7 +5641,11 @@ pub mod public {
     }
     impl From<AutoSuggestBox> for View {
         fn from(value: AutoSuggestBox) -> Self {
-            Self::native(value)
+            let mut value = value;
+            match value.slots.take() {
+                Some(slots) => Self::slotted(value.into(), slots),
+                None => Self::native(value),
+            }
         }
     }
     impl From<PasswordBox> for Element {
@@ -5635,7 +5655,11 @@ pub mod public {
     }
     impl From<PasswordBox> for View {
         fn from(value: PasswordBox) -> Self {
-            Self::native(value)
+            let mut value = value;
+            match value.slots.take() {
+                Some(slots) => Self::slotted(value.into(), slots),
+                None => Self::native(value),
+            }
         }
     }
     impl From<NumberBox> for Element {
@@ -5645,7 +5669,11 @@ pub mod public {
     }
     impl From<NumberBox> for View {
         fn from(value: NumberBox) -> Self {
-            Self::native(value)
+            let mut value = value;
+            match value.slots.take() {
+                Some(slots) => Self::slotted(value.into(), slots),
+                None => Self::native(value),
+            }
         }
     }
     impl From<Slider> for Element {
@@ -5655,7 +5683,11 @@ pub mod public {
     }
     impl From<Slider> for View {
         fn from(value: Slider) -> Self {
-            Self::native(value)
+            let mut value = value;
+            match value.slots.take() {
+                Some(slots) => Self::slotted(value.into(), slots),
+                None => Self::native(value),
+            }
         }
     }
     impl From<TitleBar> for Element {
@@ -5665,7 +5697,12 @@ pub mod public {
     }
     impl From<TitleBar> for View {
         fn from(value: TitleBar) -> Self {
-            Self::native(value)
+            let mut value = value;
+            let slots = value
+                .slots
+                .take()
+                .unwrap_or_else(|| std::rc::Rc::new(Vec::new()));
+            Self::slotted(value.into(), slots)
         }
     }
     impl From<NavigationView> for Element {
@@ -5675,7 +5712,11 @@ pub mod public {
     }
     impl From<NavigationView> for View {
         fn from(value: NavigationView) -> Self {
-            Self::native(value)
+            let mut value = value;
+            match value.slots.take() {
+                Some(slots) => Self::slotted(value.into(), slots),
+                None => Self::native(value),
+            }
         }
     }
     impl From<NavigationViewItem> for Element {
@@ -5685,7 +5726,11 @@ pub mod public {
     }
     impl From<NavigationViewItem> for View {
         fn from(value: NavigationViewItem) -> Self {
-            Self::native(value)
+            let mut value = value;
+            match value.slots.take() {
+                Some(slots) => Self::slotted(value.into(), slots),
+                None => Self::native(value),
+            }
         }
     }
     impl From<SplitView> for Element {
@@ -5695,7 +5740,11 @@ pub mod public {
     }
     impl From<SplitView> for View {
         fn from(value: SplitView) -> Self {
-            Self::native(value)
+            let mut value = value;
+            match value.slots.take() {
+                Some(slots) => Self::slotted(value.into(), slots),
+                None => Self::native(value),
+            }
         }
     }
     impl From<ProgressBar> for Element {
@@ -5715,7 +5764,11 @@ pub mod public {
     }
     impl From<ToggleSwitch> for View {
         fn from(value: ToggleSwitch) -> Self {
-            Self::native(value)
+            let mut value = value;
+            match value.slots.take() {
+                Some(slots) => Self::slotted(value.into(), slots),
+                None => Self::native(value),
+            }
         }
     }
     impl From<CheckBox> for Element {
@@ -5755,7 +5808,11 @@ pub mod public {
     }
     impl From<RadioButtons> for View {
         fn from(value: RadioButtons) -> Self {
-            Self::native(value)
+            let mut value = value;
+            match value.slots.take() {
+                Some(slots) => Self::slotted(value.into(), slots),
+                None => Self::native(value),
+            }
         }
     }
     impl From<ItemsRepeater> for Element {
@@ -5845,7 +5902,11 @@ pub mod public {
     }
     impl From<ListBox> for View {
         fn from(value: ListBox) -> Self {
-            Self::native(value)
+            let mut value = value;
+            match value.slots.take() {
+                Some(slots) => Self::slotted(value.into(), slots),
+                None => Self::native(value),
+            }
         }
     }
     impl From<Rectangle> for Element {
@@ -5955,7 +6016,11 @@ pub mod public {
     }
     impl From<Expander> for View {
         fn from(value: Expander) -> Self {
-            Self::native(value)
+            let mut value = value;
+            match value.slots.take() {
+                Some(slots) => Self::slotted(value.into(), slots),
+                None => Self::native(value),
+            }
         }
     }
     impl From<ComboBox> for Element {
@@ -5965,7 +6030,11 @@ pub mod public {
     }
     impl From<ComboBox> for View {
         fn from(value: ComboBox) -> Self {
-            Self::native(value)
+            let mut value = value;
+            match value.slots.take() {
+                Some(slots) => Self::slotted(value.into(), slots),
+                None => Self::native(value),
+            }
         }
     }
     impl From<Pivot> for Element {
@@ -5975,7 +6044,11 @@ pub mod public {
     }
     impl From<Pivot> for View {
         fn from(value: Pivot) -> Self {
-            Self::native(value)
+            let mut value = value;
+            match value.slots.take() {
+                Some(slots) => Self::slotted(value.into(), slots),
+                None => Self::native(value),
+            }
         }
     }
     impl From<PivotItem> for Element {
@@ -5995,7 +6068,11 @@ pub mod public {
     }
     impl From<FlipView> for View {
         fn from(value: FlipView) -> Self {
-            Self::native(value)
+            let mut value = value;
+            match value.slots.take() {
+                Some(slots) => Self::slotted(value.into(), slots),
+                None => Self::native(value),
+            }
         }
     }
     impl From<SelectorBar> for Element {
@@ -6005,7 +6082,11 @@ pub mod public {
     }
     impl From<SelectorBar> for View {
         fn from(value: SelectorBar) -> Self {
-            Self::native(value)
+            let mut value = value;
+            match value.slots.take() {
+                Some(slots) => Self::slotted(value.into(), slots),
+                None => Self::native(value),
+            }
         }
     }
     impl From<SelectorBarItem> for Element {
@@ -6015,7 +6096,11 @@ pub mod public {
     }
     impl From<SelectorBarItem> for View {
         fn from(value: SelectorBarItem) -> Self {
-            Self::native(value)
+            let mut value = value;
+            match value.slots.take() {
+                Some(slots) => Self::slotted(value.into(), slots),
+                None => Self::native(value),
+            }
         }
     }
     impl From<TabView> for Element {
@@ -6025,7 +6110,11 @@ pub mod public {
     }
     impl From<TabView> for View {
         fn from(value: TabView) -> Self {
-            Self::native(value)
+            let mut value = value;
+            match value.slots.take() {
+                Some(slots) => Self::slotted(value.into(), slots),
+                None => Self::native(value),
+            }
         }
     }
     impl From<TabViewItem> for Element {
@@ -6065,7 +6154,11 @@ pub mod public {
     }
     impl From<CommandBar> for View {
         fn from(value: CommandBar) -> Self {
-            Self::native(value)
+            let mut value = value;
+            match value.slots.take() {
+                Some(slots) => Self::slotted(value.into(), slots),
+                None => Self::native(value),
+            }
         }
     }
     impl From<AppBarButton> for Element {
@@ -6075,7 +6168,11 @@ pub mod public {
     }
     impl From<AppBarButton> for View {
         fn from(value: AppBarButton) -> Self {
-            Self::native(value)
+            let mut value = value;
+            match value.slots.take() {
+                Some(slots) => Self::slotted(value.into(), slots),
+                None => Self::native(value),
+            }
         }
     }
     impl From<AppBarSeparator> for Element {
@@ -6095,7 +6192,11 @@ pub mod public {
     }
     impl From<MenuBar> for View {
         fn from(value: MenuBar) -> Self {
-            Self::native(value)
+            let mut value = value;
+            match value.slots.take() {
+                Some(slots) => Self::slotted(value.into(), slots),
+                None => Self::native(value),
+            }
         }
     }
     impl From<MenuBarItem> for Element {
@@ -6135,7 +6236,11 @@ pub mod public {
     }
     impl From<DatePicker> for View {
         fn from(value: DatePicker) -> Self {
-            Self::native(value)
+            let mut value = value;
+            match value.slots.take() {
+                Some(slots) => Self::slotted(value.into(), slots),
+                None => Self::native(value),
+            }
         }
     }
     impl From<TimePicker> for Element {
@@ -6145,7 +6250,11 @@ pub mod public {
     }
     impl From<TimePicker> for View {
         fn from(value: TimePicker) -> Self {
-            Self::native(value)
+            let mut value = value;
+            match value.slots.take() {
+                Some(slots) => Self::slotted(value.into(), slots),
+                None => Self::native(value),
+            }
         }
     }
     impl From<CalendarDatePicker> for Element {
@@ -6155,7 +6264,11 @@ pub mod public {
     }
     impl From<CalendarDatePicker> for View {
         fn from(value: CalendarDatePicker) -> Self {
-            Self::native(value)
+            let mut value = value;
+            match value.slots.take() {
+                Some(slots) => Self::slotted(value.into(), slots),
+                None => Self::native(value),
+            }
         }
     }
     impl From<ToolTip> for Element {
@@ -6196,7 +6309,11 @@ pub mod public {
     }
     impl From<ListView> for View {
         fn from(value: ListView) -> Self {
-            Self::native(value)
+            let mut value = value;
+            match value.slots.take() {
+                Some(slots) => Self::slotted(value.into(), slots),
+                None => Self::native(value),
+            }
         }
     }
     impl From<ListViewItem> for Element {
@@ -6226,7 +6343,11 @@ pub mod public {
     }
     impl From<GridView> for View {
         fn from(value: GridView) -> Self {
-            Self::native(value)
+            let mut value = value;
+            match value.slots.take() {
+                Some(slots) => Self::slotted(value.into(), slots),
+                None => Self::native(value),
+            }
         }
     }
     impl From<GridViewItem> for Element {
@@ -6266,7 +6387,11 @@ pub mod public {
     }
     impl From<RichEditBox> for View {
         fn from(value: RichEditBox) -> Self {
-            Self::native(value)
+            let mut value = value;
+            match value.slots.take() {
+                Some(slots) => Self::slotted(value.into(), slots),
+                None => Self::native(value),
+            }
         }
     }
     impl From<RichTextBlock> for Element {
@@ -6286,7 +6411,11 @@ pub mod public {
     }
     impl From<Viewbox> for View {
         fn from(value: Viewbox) -> Self {
-            Self::native(value)
+            let mut value = value;
+            match value.slots.take() {
+                Some(slots) => Self::slotted(value.into(), slots),
+                None => Self::native(value),
+            }
         }
     }
     impl From<WebView2> for Element {
@@ -6654,6 +6783,7 @@ pub mod public {
                         on_text_changed,
                         reference,
                         element_state,
+                        slots: _,
                     } = value;
                     ElementParts {
                         kind: MountedKind::TextBox,
@@ -6684,6 +6814,7 @@ pub mod public {
                         events,
                         reference,
                         element_state,
+                        slots: _,
                     } = value;
                     ElementParts {
                         kind: MountedKind::AutoSuggestBox,
@@ -6712,6 +6843,7 @@ pub mod public {
                         on_password_changed,
                         reference,
                         element_state,
+                        slots: _,
                     } = value;
                     ElementParts {
                         kind: MountedKind::PasswordBox,
@@ -6740,6 +6872,7 @@ pub mod public {
                         on_value_changed,
                         reference,
                         element_state,
+                        slots: _,
                     } = value;
                     ElementParts {
                         kind: MountedKind::NumberBox,
@@ -6768,6 +6901,7 @@ pub mod public {
                         on_value_changed,
                         reference,
                         element_state,
+                        slots: _,
                     } = value;
                     ElementParts {
                         kind: MountedKind::Slider,
@@ -6797,6 +6931,7 @@ pub mod public {
                         events,
                         element_state,
                         preferred_height,
+                        slots: _,
                     } = value;
                     ElementParts {
                         kind: MountedKind::TitleBar,
@@ -6828,6 +6963,7 @@ pub mod public {
                         is_pane_open,
                         events,
                         element_state,
+                        slots: _,
                     } = value;
                     ElementParts {
                         kind: MountedKind::NavigationView,
@@ -6859,6 +6995,7 @@ pub mod public {
                         selects_on_invoked,
                         is_expanded,
                         element_state,
+                        slots: _,
                     } = value;
                     ElementParts {
                         kind: MountedKind::NavigationViewItem,
@@ -6885,6 +7022,7 @@ pub mod public {
                         is_pane_open,
                         on_pane_closed,
                         element_state,
+                        slots: _,
                     } = value;
                     ElementParts {
                         kind: MountedKind::SplitView,
@@ -6940,6 +7078,7 @@ pub mod public {
                         on_toggled,
                         reference,
                         element_state,
+                        slots: _,
                     } = value;
                     ElementParts {
                         kind: MountedKind::ToggleSwitch,
@@ -7039,6 +7178,7 @@ pub mod public {
                         max_columns,
                         on_selection_changed,
                         element_state,
+                        slots: _,
                     } = value;
                     ElementParts {
                         kind: MountedKind::RadioButtons,
@@ -7237,6 +7377,7 @@ pub mod public {
                         is_enabled,
                         on_selected_tag_changed,
                         element_state,
+                        slots: _,
                     } = value;
                     ElementParts {
                         kind: MountedKind::ListBox,
@@ -7463,6 +7604,7 @@ pub mod public {
                         is_expanded,
                         on_is_expanded_changed,
                         element_state,
+                        slots: _,
                     } = value;
                     ElementParts {
                         kind: MountedKind::Expander,
@@ -7487,6 +7629,7 @@ pub mod public {
                         on_selection_changed,
                         reference,
                         element_state,
+                        slots: _,
                     } = value;
                     ElementParts {
                         kind: MountedKind::ComboBox,
@@ -7511,6 +7654,7 @@ pub mod public {
                         title,
                         on_selection_changed,
                         element_state,
+                        slots: _,
                     } = value;
                     ElementParts {
                         kind: MountedKind::Pivot,
@@ -7549,6 +7693,7 @@ pub mod public {
                         selected_index,
                         on_selection_changed,
                         element_state,
+                        slots: _,
                     } = value;
                     ElementParts {
                         kind: MountedKind::FlipView,
@@ -7567,6 +7712,7 @@ pub mod public {
                     let SelectorBar {
                         on_selected_text_changed,
                         element_state,
+                        slots: _,
                     } = value;
                     ElementParts {
                         kind: MountedKind::SelectorBar,
@@ -7587,6 +7733,7 @@ pub mod public {
                         text,
                         is_selected,
                         element_state,
+                        slots: _,
                     } = value;
                     ElementParts {
                         kind: MountedKind::SelectorBarItem,
@@ -7607,6 +7754,7 @@ pub mod public {
                         is_add_tab_button_visible,
                         events,
                         element_state,
+                        slots: _,
                     } = value;
                     ElementParts {
                         kind: MountedKind::TabView,
@@ -7703,7 +7851,10 @@ pub mod public {
                 }
                 Self::CommandBar(value) => {
                     let value = std::rc::Rc::unwrap_or_clone(value);
-                    let CommandBar { element_state } = value;
+                    let CommandBar {
+                        element_state,
+                        slots: _,
+                    } = value;
                     ElementParts {
                         kind: MountedKind::CommandBar,
                         props: MountedProps::CommandBar(std::rc::Rc::new(
@@ -7722,6 +7873,7 @@ pub mod public {
                         is_enabled,
                         on_click,
                         element_state,
+                        slots: _,
                     } = value;
                     ElementParts {
                         kind: MountedKind::AppBarButton,
@@ -7754,7 +7906,10 @@ pub mod public {
                 }
                 Self::MenuBar(value) => {
                     let value = std::rc::Rc::unwrap_or_clone(value);
-                    let MenuBar { element_state } = value;
+                    let MenuBar {
+                        element_state,
+                        slots: _,
+                    } = value;
                     ElementParts {
                         kind: MountedKind::MenuBar,
                         props: MountedProps::MenuBar(std::rc::Rc::new(MenuBarMountedProps {})),
@@ -7843,6 +7998,7 @@ pub mod public {
                         is_enabled,
                         on_selected_date_changed,
                         element_state,
+                        slots: _,
                     } = value;
                     ElementParts {
                         kind: MountedKind::DatePicker,
@@ -7867,6 +8023,7 @@ pub mod public {
                         is_enabled,
                         on_selected_time_changed,
                         element_state,
+                        slots: _,
                     } = value;
                     ElementParts {
                         kind: MountedKind::TimePicker,
@@ -7891,6 +8048,7 @@ pub mod public {
                         is_enabled,
                         on_date_changed,
                         element_state,
+                        slots: _,
                     } = value;
                     ElementParts {
                         kind: MountedKind::CalendarDatePicker,
@@ -7988,6 +8146,7 @@ pub mod public {
                         allow_drop,
                         events,
                         element_state,
+                        slots: _,
                     } = value;
                     ElementParts {
                         kind: MountedKind::ListView,
@@ -8051,6 +8210,7 @@ pub mod public {
                         allow_drop,
                         events,
                         element_state,
+                        slots: _,
                     } = value;
                     ElementParts {
                         kind: MountedKind::GridView,
@@ -8127,6 +8287,7 @@ pub mod public {
                         on_text_changed,
                         reference,
                         element_state,
+                        slots: _,
                     } = value;
                     ElementParts {
                         kind: MountedKind::RichEditBox,
@@ -8175,6 +8336,7 @@ pub mod public {
                     let Viewbox {
                         stretch,
                         element_state,
+                        slots: _,
                     } = value;
                     ElementParts {
                         kind: MountedKind::Viewbox,
@@ -12323,6 +12485,7 @@ pub enum SlotId {
     NavigationViewPaneCustomContent,
     NavigationViewPaneFooter,
     NavigationViewMenuItems,
+    NavigationViewFooterMenuItems,
     NavigationViewItemContent,
     NavigationViewItemIcon,
     NavigationViewItemMenuItems,
@@ -12353,139 +12516,6 @@ pub enum SlotId {
     RichEditBoxHeader,
     ViewboxChild,
 }
-pub fn slot_id(kind: MountedKind, index: u8) -> Option<SlotId> {
-    match kind {
-        MountedKind::TextBox => match index {
-            0u8 => Some(SlotId::TextBoxHeader),
-            _ => None,
-        },
-        MountedKind::AutoSuggestBox => match index {
-            0u8 => Some(SlotId::AutoSuggestBoxHeader),
-            _ => None,
-        },
-        MountedKind::PasswordBox => match index {
-            0u8 => Some(SlotId::PasswordBoxHeader),
-            _ => None,
-        },
-        MountedKind::NumberBox => match index {
-            0u8 => Some(SlotId::NumberBoxHeader),
-            _ => None,
-        },
-        MountedKind::Slider => match index {
-            0u8 => Some(SlotId::SliderHeader),
-            _ => None,
-        },
-        MountedKind::TitleBar => match index {
-            0u8 => Some(SlotId::TitleBarContent),
-            1u8 => Some(SlotId::TitleBarRightHeader),
-            _ => None,
-        },
-        MountedKind::NavigationView => match index {
-            0u8 => Some(SlotId::NavigationViewContent),
-            1u8 => Some(SlotId::NavigationViewHeader),
-            2u8 => Some(SlotId::NavigationViewPaneCustomContent),
-            3u8 => Some(SlotId::NavigationViewPaneFooter),
-            4u8 => Some(SlotId::NavigationViewMenuItems),
-            _ => None,
-        },
-        MountedKind::NavigationViewItem => match index {
-            0u8 => Some(SlotId::NavigationViewItemContent),
-            1u8 => Some(SlotId::NavigationViewItemIcon),
-            2u8 => Some(SlotId::NavigationViewItemMenuItems),
-            _ => None,
-        },
-        MountedKind::SplitView => match index {
-            0u8 => Some(SlotId::SplitViewPane),
-            1u8 => Some(SlotId::SplitViewContent),
-            _ => None,
-        },
-        MountedKind::ToggleSwitch => match index {
-            0u8 => Some(SlotId::ToggleSwitchHeader),
-            1u8 => Some(SlotId::ToggleSwitchOnContent),
-            2u8 => Some(SlotId::ToggleSwitchOffContent),
-            _ => None,
-        },
-        MountedKind::RadioButtons => match index {
-            0u8 => Some(SlotId::RadioButtonsHeader),
-            _ => None,
-        },
-        MountedKind::ListBox => match index {
-            0u8 => Some(SlotId::ListBoxItems),
-            _ => None,
-        },
-        MountedKind::Expander => match index {
-            0u8 => Some(SlotId::ExpanderHeader),
-            1u8 => Some(SlotId::ExpanderContent),
-            _ => None,
-        },
-        MountedKind::ComboBox => match index {
-            0u8 => Some(SlotId::ComboBoxHeader),
-            _ => None,
-        },
-        MountedKind::Pivot => match index {
-            0u8 => Some(SlotId::PivotItems),
-            _ => None,
-        },
-        MountedKind::FlipView => match index {
-            0u8 => Some(SlotId::FlipViewItems),
-            _ => None,
-        },
-        MountedKind::SelectorBar => match index {
-            0u8 => Some(SlotId::SelectorBarItems),
-            _ => None,
-        },
-        MountedKind::SelectorBarItem => match index {
-            0u8 => Some(SlotId::SelectorBarItemIcon),
-            _ => None,
-        },
-        MountedKind::TabView => match index {
-            0u8 => Some(SlotId::TabViewTabItems),
-            _ => None,
-        },
-        MountedKind::CommandBar => match index {
-            0u8 => Some(SlotId::CommandBarPrimaryCommands),
-            1u8 => Some(SlotId::CommandBarSecondaryCommands),
-            _ => None,
-        },
-        MountedKind::AppBarButton => match index {
-            0u8 => Some(SlotId::AppBarButtonIcon),
-            _ => None,
-        },
-        MountedKind::MenuBar => match index {
-            0u8 => Some(SlotId::MenuBarItems),
-            _ => None,
-        },
-        MountedKind::DatePicker => match index {
-            0u8 => Some(SlotId::DatePickerHeader),
-            _ => None,
-        },
-        MountedKind::TimePicker => match index {
-            0u8 => Some(SlotId::TimePickerHeader),
-            _ => None,
-        },
-        MountedKind::CalendarDatePicker => match index {
-            0u8 => Some(SlotId::CalendarDatePickerHeader),
-            _ => None,
-        },
-        MountedKind::ListView => match index {
-            0u8 => Some(SlotId::ListViewItems),
-            _ => None,
-        },
-        MountedKind::GridView => match index {
-            0u8 => Some(SlotId::GridViewItems),
-            _ => None,
-        },
-        MountedKind::RichEditBox => match index {
-            0u8 => Some(SlotId::RichEditBoxHeader),
-            _ => None,
-        },
-        MountedKind::Viewbox => match index {
-            0u8 => Some(SlotId::ViewboxChild),
-            _ => None,
-        },
-        _ => None,
-    }
-}
 pub fn slots(kind: MountedKind) -> &'static [SlotId] {
     match kind {
         MountedKind::TextBlock => &[],
@@ -12509,6 +12539,7 @@ pub fn slots(kind: MountedKind) -> &'static [SlotId] {
             SlotId::NavigationViewPaneCustomContent,
             SlotId::NavigationViewPaneFooter,
             SlotId::NavigationViewMenuItems,
+            SlotId::NavigationViewFooterMenuItems,
         ],
         MountedKind::NavigationViewItem => &[
             SlotId::NavigationViewItemContent,
@@ -12590,6 +12621,7 @@ pub fn slot_is_collection(slot: SlotId) -> bool {
     matches!(
         slot,
         SlotId::NavigationViewMenuItems
+            | SlotId::NavigationViewFooterMenuItems
             | SlotId::NavigationViewItemMenuItems
             | SlotId::ListBoxItems
             | SlotId::PivotItems
@@ -14690,7 +14722,7 @@ pub struct SlotDescriptor {
 }
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct SelectionDescriptor {
-    pub slot: SlotId,
+    pub slots: &'static [SlotId],
     pub item: MountedKind,
     pub selected_property: PropertyId,
     pub event: EventId,
@@ -15900,6 +15932,13 @@ const NAVIGATION_VIEW_SLOTS: &[SlotDescriptor] = &[
     SlotDescriptor {
         id: SlotId::NavigationViewMenuItems,
         name: "MenuItems",
+        interface: "Microsoft.UI.Xaml.Controls.INavigationView",
+        target: "inspectable",
+        collection: true,
+    },
+    SlotDescriptor {
+        id: SlotId::NavigationViewFooterMenuItems,
+        name: "FooterMenuItems",
         interface: "Microsoft.UI.Xaml.Controls.INavigationView",
         target: "inspectable",
         collection: true,
@@ -18418,7 +18457,10 @@ pub const CONTROLS: &[ControlDescriptor] = &[
         events: NAVIGATION_VIEW_EVENTS,
         slots: NAVIGATION_VIEW_SLOTS,
         selection: Some(SelectionDescriptor {
-            slot: SlotId::NavigationViewMenuItems,
+            slots: &[
+                SlotId::NavigationViewMenuItems,
+                SlotId::NavigationViewFooterMenuItems,
+            ],
             item: MountedKind::NavigationViewItem,
             selected_property: PropertyId::NavigationViewItemIsSelected,
             event: EventId::NavigationViewSelectionChanged,
@@ -18643,7 +18685,7 @@ pub const CONTROLS: &[ControlDescriptor] = &[
         events: LIST_BOX_EVENTS,
         slots: LIST_BOX_SLOTS,
         selection: Some(SelectionDescriptor {
-            slot: SlotId::ListBoxItems,
+            slots: &[SlotId::ListBoxItems],
             item: MountedKind::ListBoxItem,
             selected_property: PropertyId::ListBoxItemIsSelected,
             event: EventId::ListBoxSelectionChanged,
@@ -18849,7 +18891,7 @@ pub const CONTROLS: &[ControlDescriptor] = &[
         events: SELECTOR_BAR_EVENTS,
         slots: SELECTOR_BAR_SLOTS,
         selection: Some(SelectionDescriptor {
-            slot: SlotId::SelectorBarItems,
+            slots: &[SlotId::SelectorBarItems],
             item: MountedKind::SelectorBarItem,
             selected_property: PropertyId::SelectorBarItemIsSelected,
             event: EventId::SelectorBarSelectionChanged,
@@ -19243,18 +19285,20 @@ pub fn selection_for_event(event: EventId) -> Option<SelectionDescriptor> {
     })
 }
 pub fn selection_for_slot(slot: SlotId) -> Option<SelectionDescriptor> {
-    CONTROLS
-        .iter()
-        .find_map(|control| control.selection.filter(|selection| selection.slot == slot))
+    CONTROLS.iter().find_map(|control| {
+        control
+            .selection
+            .filter(|selection| selection.slots.contains(&slot))
+    })
 }
 pub fn selection_for_item_property(
     property: PropertyId,
     slot: SlotId,
 ) -> Option<SelectionDescriptor> {
     CONTROLS.iter().find_map(|control| {
-        control
-            .selection
-            .filter(|selection| selection.selected_property == property && selection.slot == slot)
+        control.selection.filter(|selection| {
+            selection.selected_property == property && selection.slots.contains(&slot)
+        })
     })
 }
 pub fn controlled_collection_for_slot(slot: SlotId) -> Option<ControlledCollectionDescriptor> {

--- a/crates/libs/reactor/src/native/winui/bindings.rs
+++ b/crates/libs/reactor/src/native/winui/bindings.rs
@@ -11663,6 +11663,18 @@ impl INavigationView {
             .ok()
         }
     }
+    pub(crate) fn FooterMenuItems(
+        &self,
+    ) -> windows_core::Result<windows_collections::IVector<windows_core::IInspectable>> {
+        unsafe {
+            let mut result__ = core::mem::zeroed();
+            (windows_core::Interface::vtable(self).FooterMenuItems)(
+                windows_core::Interface::as_raw(self),
+                &mut result__,
+            )
+            .and_then(|| windows_core::imp::Type::from_abi(result__))
+        }
+    }
     pub(crate) fn SetPaneFooter<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<UIElement>,
@@ -11849,7 +11861,10 @@ pub struct INavigationView_Vtbl {
     SetCompactModeThresholdWidth: usize,
     ExpandedModeThresholdWidth: usize,
     SetExpandedModeThresholdWidth: usize,
-    FooterMenuItems: usize,
+    pub FooterMenuItems: unsafe extern "system" fn(
+        *mut core::ffi::c_void,
+        *mut *mut core::ffi::c_void,
+    ) -> windows_core::HRESULT,
     FooterMenuItemsSource: usize,
     SetFooterMenuItemsSource: usize,
     PaneFooter: usize,

--- a/crates/libs/reactor/src/native/winui/generated.rs
+++ b/crates/libs/reactor/src/native/winui/generated.rs
@@ -3983,6 +3983,9 @@ pub fn slot_collection(handle: &Handle, slot: SlotId) -> Result<SlotCollection, 
         (Handle::NavigationView(control), SlotId::NavigationViewMenuItems) => Ok(
             SlotCollection::Inspectable(control.MenuItems().map_err(native_error)?),
         ),
+        (Handle::NavigationView(control), SlotId::NavigationViewFooterMenuItems) => Ok(
+            SlotCollection::Inspectable(control.FooterMenuItems().map_err(native_error)?),
+        ),
         (Handle::NavigationViewItem(control), SlotId::NavigationViewItemMenuItems) => {
             Ok(SlotCollection::Inspectable(
                 control
@@ -4071,15 +4074,15 @@ pub fn selected_item(
     handle: &Handle,
     selection: SelectionDescriptor,
 ) -> Result<Option<windows_core::IInspectable>, RuntimeError> {
-    match (handle, selection.slot) {
-        (Handle::NavigationView(value), SlotId::NavigationViewMenuItems) => {
+    match (handle, selection.event) {
+        (Handle::NavigationView(value), EventId::NavigationViewSelectionChanged) => {
             match value.SelectedItem() {
                 Ok(selected) => Ok(Some(selected)),
                 Err(error) if error.code().is_ok() => Ok(None),
                 Err(error) => Err(native_error(error)),
             }
         }
-        (Handle::ListBox(value), SlotId::ListBoxItems) => {
+        (Handle::ListBox(value), EventId::ListBoxSelectionChanged) => {
             match value
                 .cast::<ISelector>()
                 .and_then(|value| value.SelectedItem())
@@ -4089,11 +4092,13 @@ pub fn selected_item(
                 Err(error) => Err(native_error(error)),
             }
         }
-        (Handle::SelectorBar(value), SlotId::SelectorBarItems) => match value.SelectedItem() {
-            Ok(selected) => Ok(Some(selected.into())),
-            Err(error) if error.code().is_ok() => Ok(None),
-            Err(error) => Err(native_error(error)),
-        },
+        (Handle::SelectorBar(value), EventId::SelectorBarSelectionChanged) => {
+            match value.SelectedItem() {
+                Ok(selected) => Ok(Some(selected.into())),
+                Err(error) if error.code().is_ok() => Ok(None),
+                Err(error) => Err(native_error(error)),
+            }
+        }
         _ => Ok(None),
     }
 }
@@ -4102,15 +4107,15 @@ pub fn set_selected_item(
     selection: SelectionDescriptor,
     selected: &windows_core::IInspectable,
 ) -> Result<(), RuntimeError> {
-    match (handle, selection.slot) {
-        (Handle::NavigationView(value), SlotId::NavigationViewMenuItems) => {
+    match (handle, selection.event) {
+        (Handle::NavigationView(value), EventId::NavigationViewSelectionChanged) => {
             value.SetSelectedItem(selected).map_err(native_error)
         }
-        (Handle::ListBox(value), SlotId::ListBoxItems) => value
+        (Handle::ListBox(value), EventId::ListBoxSelectionChanged) => value
             .cast::<ISelector>()
             .and_then(|value| value.SetSelectedItem(selected))
             .map_err(native_error),
-        (Handle::SelectorBar(value), SlotId::SelectorBarItems) => selected
+        (Handle::SelectorBar(value), EventId::SelectorBarSelectionChanged) => selected
             .cast::<bindings::SelectorBarItem>()
             .and_then(|selected| value.SetSelectedItem(&selected))
             .map_err(native_error),

--- a/crates/libs/reactor/src/native/winui/mod.rs
+++ b/crates/libs/reactor/src/native/winui/mod.rs
@@ -2562,6 +2562,10 @@ impl WinUiRuntime {
         let collection = slot_collection(parent, slot)?;
         let child: windows_core::IInspectable = self.ui_element(child)?.into();
         let selection = selection_for_slot(slot);
+        let selected = selection
+            .map(|selection| selected_item(parent, selection))
+            .transpose()?
+            .flatten();
         let retained = self.retained_identities(parent_id, Some(slot))?;
         let current = (0..collection.Size()?)
             .map(|index| {
@@ -2573,10 +2577,12 @@ impl WinUiRuntime {
         let result = self.with_controlled_collection_preserved(parent_id, parent, slot, || {
             self.with_selection_suppressed(selection.map(|_| (parent_id, slot)), || {
                 collection.InsertAt(index32(index)?, &child)?;
-                if let Some(selection) = selection
-                    && selection_item_is_selected(selection, &child)?
-                {
-                    set_selected_item(parent, selection, &child)?;
+                if let Some(selection) = selection {
+                    if selection_item_is_selected(selection, &child)? {
+                        set_selected_item(parent, selection, &child)?;
+                    } else if let Some(selected) = selected.as_ref() {
+                        set_selected_item(parent, selection, selected)?;
+                    }
                 }
                 Ok(())
             })
@@ -2603,10 +2609,21 @@ impl WinUiRuntime {
         let collection = slot_collection(parent, slot)?;
         let child: windows_core::IInspectable = self.ui_element(child)?.into();
         let selection = selection_for_slot(slot);
+        let selected = selection
+            .map(|selection| selected_item(parent, selection))
+            .transpose()?
+            .flatten();
         let result = self.with_controlled_collection_preserved(parent_id, parent, slot, || {
             self.with_selection_suppressed(selection.map(|_| (parent_id, slot)), || {
                 let index = inspectable_child_index(&collection, child_id, &child)?;
-                collection.RemoveAt(index)
+                collection.RemoveAt(index)?;
+                if let Some(selection) = selection
+                    && let Some(selected) = selected.as_ref()
+                    && selected != &child
+                {
+                    set_selected_item(parent, selection, selected)?;
+                }
+                Ok(())
             })
         });
         if result.is_ok() {
@@ -2638,12 +2655,10 @@ impl WinUiRuntime {
             .flatten();
         let collection = slot_collection(parent, slot)?;
         let child: windows_core::IInspectable = self.ui_element(child)?.into();
-        let restore_selection = match selection {
-            Some(selection) => {
-                selected.as_ref() == Some(&child) || selection_item_is_selected(selection, &child)?
-            }
-            None => false,
-        };
+        let child_selected = selection
+            .map(|selection| selection_item_is_selected(selection, &child))
+            .transpose()?
+            .unwrap_or(false);
         let child_identity = com_identity(&child)?;
         let retained = self.retained_identities(parent_id, Some(slot))?;
         let current = (0..collection.Size()?)
@@ -2661,8 +2676,12 @@ impl WinUiRuntime {
                 let from = inspectable_child_index(&collection, child_id, &child)?;
                 collection.RemoveAt(from)?;
                 collection.InsertAt(index32(index)?, &child)?;
-                if restore_selection {
-                    set_selected_item(parent, selection.unwrap(), &child)?;
+                if let Some(selection) = selection {
+                    if child_selected {
+                        set_selected_item(parent, selection, &child)?;
+                    } else if let Some(selected) = selected.as_ref() {
+                        set_selected_item(parent, selection, selected)?;
+                    }
                 }
                 Ok(())
             })
@@ -2727,10 +2746,12 @@ impl WinUiRuntime {
             .collect::<Vec<_>>();
         let retained = retained_subsequence(&current_ids, &target_ids);
         let restore_selection = selected.as_ref().is_some_and(|selected| {
-            current
-                .iter()
-                .any(|(identity, item)| !retained.contains(identity) && item == selected)
-                && desired.iter().any(|(_, _, item)| item == selected)
+            let selected_in_current = current.iter().any(|(_, item)| item == selected);
+            !selected_in_current
+                || current
+                    .iter()
+                    .any(|(identity, item)| !retained.contains(identity) && item == selected)
+                    && desired.iter().any(|(_, _, item)| item == selected)
         });
 
         let result = self.with_controlled_collection_preserved(parent_id, parent, slot, || {

--- a/crates/samples/reactor/function-component/src/main.rs
+++ b/crates/samples/reactor/function-component/src/main.rs
@@ -83,7 +83,7 @@ impl Component for FunctionComponentSample {
                 .text(self.name.clone())
                 .placeholder_text("Type a name...")
                 .on_text_changed(context.forward())
-                .slot(TextBoxSlot::Header, "Your name"),
+                .header("Your name"),
             View::component::<Counter>(()),
         ))
     }

--- a/crates/samples/reactor/gallery/src/pages/basic_input/combo_box.rs
+++ b/crates/samples/reactor/gallery/src/pages/basic_input/combo_box.rs
@@ -37,7 +37,7 @@ impl Component for ComboBoxPage {
                                 .selected_index(self.selected)
                                 .placeholder_text("Pick a color")
                                 .on_selection_changed(context.forward())
-                                .slot(ComboBoxSlot::Header, "Color"),
+                                .header("Color"),
                             TextBlock::new()
                                 .text(format!("Selected: {label}"))
                                 .opacity(0.6),
@@ -53,7 +53,7 @@ impl Component for ComboBoxPage {
                             .items_source(["Cat", "Dog", "Fox"])
                             .placeholder_text("Type or pick")
                             .is_editable(true)
-                            .slot(ComboBoxSlot::Header, "Animal"),
+                            .header("Animal"),
                         "ComboBox::new().items_source(items).is_editable(true)",
                     ),
                 ),

--- a/crates/samples/reactor/gallery/src/pages/basic_input/number_box.rs
+++ b/crates/samples/reactor/gallery/src/pages/basic_input/number_box.rs
@@ -43,7 +43,7 @@ impl Component for NumberBoxPage {
                             NumberBox::new()
                                 .value(self.value)
                                 .on_value_changed(context.callback(Message::Value))
-                                .slot(NumberBoxSlot::Header, "Quantity"),
+                                .header("Quantity"),
                             format!("Value: {:?}", self.value),
                         )),
                         "NumberBox::new().value(value).on_value_changed(handler)",

--- a/crates/samples/reactor/gallery/src/pages/basic_input/password_box.rs
+++ b/crates/samples/reactor/gallery/src/pages/basic_input/password_box.rs
@@ -33,7 +33,7 @@ impl Component for PasswordBoxPage {
                                 .password(&self.password)
                                 .placeholder_text("Enter password")
                                 .on_password_changed(context.forward())
-                                .slot(PasswordBoxSlot::Header, "Password"),
+                                .header("Password"),
                             TextBlock::new()
                                 .text(format!("Length: {} chars", self.password.len()))
                                 .opacity(0.6),

--- a/crates/samples/reactor/gallery/src/pages/basic_input/radio_button.rs
+++ b/crates/samples/reactor/gallery/src/pages/basic_input/radio_button.rs
@@ -36,7 +36,7 @@ impl Component for RadioButtonPage {
                                 .items_source(options)
                                 .selected_index(self.selected)
                                 .on_selection_changed(context.forward())
-                                .slot(RadioButtonsSlot::Header, "Pick one"),
+                                .header("Pick one"),
                             TextBlock::new()
                                 .text(format!("Selected: {label}"))
                                 .opacity(0.6),
@@ -51,7 +51,7 @@ impl Component for RadioButtonPage {
                         RadioButtons::new()
                             .items_source(["Small", "Medium", "Large", "Extra Large"])
                             .selected_index(1)
-                            .slot(RadioButtonsSlot::Header, "T-shirt size"),
+                            .header("T-shirt size"),
                         "RadioButtons::new().items_source(sizes).selected_index(1)",
                     ),
                 ),

--- a/crates/samples/reactor/gallery/src/pages/basic_input/text_box.rs
+++ b/crates/samples/reactor/gallery/src/pages/basic_input/text_box.rs
@@ -44,7 +44,7 @@ impl Component for TextBoxPage {
                                 .text(&self.text)
                                 .placeholder_text("Type here...")
                                 .on_text_changed(context.callback(Message::Text))
-                                .slot(TextBoxSlot::Header, "Name"),
+                                .header("Name"),
                             TextBlock::new()
                                 .text(format!("Characters: {}", self.text.len()))
                                 .opacity(0.6),

--- a/crates/samples/reactor/gallery/src/pages/basic_input/toggle_switch.rs
+++ b/crates/samples/reactor/gallery/src/pages/basic_input/toggle_switch.rs
@@ -43,11 +43,9 @@ impl Component for ToggleSwitchPage {
             ToggleSwitch::new()
                 .is_on(is_on)
                 .on_toggled(context.callback(message))
-                .slots([
-                    SlotView::new(ToggleSwitchSlot::Header, header),
-                    SlotView::new(ToggleSwitchSlot::OnContent, "On"),
-                    SlotView::new(ToggleSwitchSlot::OffContent, "Off"),
-                ])
+                .header(header)
+                .on_content("On")
+                .off_content("Off")
         };
         page_content(
             "ToggleSwitch",
@@ -84,7 +82,7 @@ impl Component for ToggleSwitchPage {
                                 })
                                 .opacity(0.6),
                         )),
-                        "ToggleSwitch::new().slots([header, on_content, off_content])",
+                        "ToggleSwitch::new().header(header).on_content(on).off_content(off)",
                     ),
                 ),
                 KeyedView::new(
@@ -101,7 +99,7 @@ impl Component for ToggleSwitchPage {
                                 .is_on(self.overnight)
                                 .is_enabled(self.automation)
                                 .on_toggled(context.callback(Message::Overnight))
-                                .slot(ToggleSwitchSlot::Header, "Install updates overnight"),
+                                .header("Install updates overnight"),
                         )),
                         "ToggleSwitch::new().is_enabled(parent_enabled)",
                     ),

--- a/crates/samples/reactor/gallery/src/pages/collections/flip_view.rs
+++ b/crates/samples/reactor/gallery/src/pages/collections/flip_view.rs
@@ -57,15 +57,12 @@ impl Component for FlipViewPage {
                             .selected_index(self.selected)
                             .on_selection_changed(context.callback(Message::Selected))
                             .height(200.0)
-                            .collection_slot(
-                                FlipViewSlot::Items,
-                                [
-                                    slide("welcome", "Welcome", 0),
-                                    slide("features", "Features", 1),
-                                    slide("getting-started", "Getting Started", 2),
-                                    slide("resources", "Resources", 3),
-                                ],
-                            ),
+                            .items([
+                                slide("welcome", "Welcome", 0),
+                                slide("features", "Features", 1),
+                                slide("getting-started", "Getting Started", 2),
+                                slide("resources", "Resources", 3),
+                            ]),
                         TextBlock::new()
                             .text(format!(
                                 "Current slide: {}",
@@ -74,7 +71,7 @@ impl Component for FlipViewPage {
                             .opacity(0.6),
                     )),
                     r#"FlipView::new().selected_index(selected).on_selection_changed(...)
-    .collection_slot(FlipViewSlot::Items, [...])"#,
+    .items([...])"#,
                 ),
             )],
         )

--- a/crates/samples/reactor/gallery/src/pages/collections/grid_view.rs
+++ b/crates/samples/reactor/gallery/src/pages/collections/grid_view.rs
@@ -43,27 +43,24 @@ impl Component for GridViewPage {
                             .height(300.0)
                             .selected_index(self.selected)
                             .on_selection_changed(context.callback(Message::Selected))
-                            .collection_slot(
-                                GridViewSlot::Items,
-                                items.iter().map(|item| {
-                                    KeyedView::new(
-                                        item.clone(),
-                                        GridViewItem::new().tag(item).content(
-                                            Border::new().padding(16.0).corner_radius(4.0).content(
-                                                TextBlock::new()
-                                                    .text(item)
-                                                    .font_weight(FontWeight::BOLD),
-                                            ),
+                            .items(items.iter().map(|item| {
+                                KeyedView::new(
+                                    item.clone(),
+                                    GridViewItem::new().tag(item).content(
+                                        Border::new().padding(16.0).corner_radius(4.0).content(
+                                            TextBlock::new()
+                                                .text(item)
+                                                .font_weight(FontWeight::BOLD),
                                         ),
-                                    )
-                                }),
-                            ),
+                                    ),
+                                )
+                            })),
                         TextBlock::new().text(label).opacity(0.6),
                     )),
                     r#"GridView::new()
     .selected_index(selected)
     .on_selection_changed(handler)
-    .collection_slot(GridViewSlot::Items, selectable_items)"#,
+    .items(selectable_items)"#,
                 ),
             )],
         )

--- a/crates/samples/reactor/gallery/src/pages/collections/list_box.rs
+++ b/crates/samples/reactor/gallery/src/pages/collections/list_box.rs
@@ -70,24 +70,22 @@ impl Component for ListBoxPage {
                         StackPanel::new().spacing(8.0).children((
                             ListBox::new()
                                 .on_selected_tag_changed(context.callback(Message::Selected))
-                                .collection_slot(ListBoxSlot::Items, items),
+                                .items(items),
                             TextBlock::new()
                                 .text(format!("Selected: {label}"))
                                 .opacity(0.6),
                         )),
                         r#"ListBox::new().on_selected_tag_changed(...)
-    .collection_slot(ListBoxSlot::Items, items)"#,
+    .items(items)"#,
                     ),
                 ),
                 KeyedView::new(
                     "disabled-list-box",
                     sample_card(
                         "Disabled ListBox",
-                        ListBox::new()
-                            .is_enabled(false)
-                            .collection_slot(ListBoxSlot::Items, disabled_items),
+                        ListBox::new().is_enabled(false).items(disabled_items),
                         r#"ListBox::new().is_enabled(false)
-    .collection_slot(ListBoxSlot::Items, items)"#,
+    .items(items)"#,
                     ),
                 ),
             ],

--- a/crates/samples/reactor/gallery/src/pages/collections/list_view.rs
+++ b/crates/samples/reactor/gallery/src/pages/collections/list_view.rs
@@ -61,8 +61,7 @@ impl Component for ListViewPage {
                     "basic-list-view",
                     sample_card(
                         "Basic ListView",
-                        ListView::new().height(220.0).collection_slot(
-                            ListViewSlot::Items,
+                        ListView::new().height(220.0).items(
                             INBOX_ITEMS.into_iter().enumerate().map(|(index, subject)| {
                                 KeyedView::new(
                                     subject,
@@ -82,7 +81,7 @@ impl Component for ListViewPage {
                                 )
                             }),
                         ),
-                        r#"ListView::new().collection_slot(ListViewSlot::Items, items)"#,
+                        r#"ListView::new().items(items)"#,
                     ),
                 ),
                 KeyedView::new(
@@ -94,22 +93,19 @@ impl Component for ListViewPage {
                                 .height(180.0)
                                 .selected_index(self.selected_contact)
                                 .on_selection_changed(context.callback(Message::SelectContact))
-                                .collection_slot(
-                                    ListViewSlot::Items,
-                                    CONTACTS.into_iter().map(|name| {
-                                        KeyedView::new(
-                                            name,
-                                            ListViewItem::new().tag(name).content(name),
-                                        )
-                                    }),
-                                ),
+                                .items(CONTACTS.into_iter().map(|name| {
+                                    KeyedView::new(
+                                        name,
+                                        ListViewItem::new().tag(name).content(name),
+                                    )
+                                })),
                             TextBlock::new()
                                 .text(format!("Selected contact: {contact_label}"))
                                 .opacity(0.6),
                         )),
                         r#"ListView::new().selected_index(selected_contact)
     .on_selection_changed(...)
-    .collection_slot(ListViewSlot::Items, contacts)"#,
+    .items(contacts)"#,
                     ),
                 ),
                 KeyedView::new(
@@ -121,34 +117,31 @@ impl Component for ListViewPage {
                                 .height(200.0)
                                 .selected_index(self.selected_playlist)
                                 .on_selection_changed(context.callback(Message::SelectPlaylist))
-                                .collection_slot(
-                                    ListViewSlot::Items,
-                                    PLAYLISTS.into_iter().enumerate().map(|(index, name)| {
-                                        KeyedView::new(
-                                            name,
-                                            ListViewItem::new().tag(name).content(
-                                                StackPanel::new().spacing(2.0).children((
-                                                    TextBlock::new()
-                                                        .text(name)
-                                                        .font_weight(FontWeight::BOLD),
-                                                    TextBlock::new()
-                                                        .text(format!(
-                                                            "{} tracks ready to play",
-                                                            12 + index * 5
-                                                        ))
-                                                        .opacity(0.6),
-                                                )),
-                                            ),
-                                        )
-                                    }),
-                                ),
+                                .items(PLAYLISTS.into_iter().enumerate().map(|(index, name)| {
+                                    KeyedView::new(
+                                        name,
+                                        ListViewItem::new().tag(name).content(
+                                            StackPanel::new().spacing(2.0).children((
+                                                TextBlock::new()
+                                                    .text(name)
+                                                    .font_weight(FontWeight::BOLD),
+                                                TextBlock::new()
+                                                    .text(format!(
+                                                        "{} tracks ready to play",
+                                                        12 + index * 5
+                                                    ))
+                                                    .opacity(0.6),
+                                            )),
+                                        ),
+                                    )
+                                })),
                             TextBlock::new()
                                 .text(format!("Now browsing: {playlist_label}"))
                                 .opacity(0.6),
                         )),
                         r#"ListView::new().selected_index(selected_playlist)
     .on_selection_changed(...)
-    .collection_slot(ListViewSlot::Items, playlists)"#,
+    .items(playlists)"#,
                     ),
                 ),
             ],

--- a/crates/samples/reactor/gallery/src/pages/date_time/calendar_date_picker.rs
+++ b/crates/samples/reactor/gallery/src/pages/date_time/calendar_date_picker.rs
@@ -35,7 +35,7 @@ impl Component for CalendarDatePickerPage {
                             CalendarDatePicker::new()
                                 .placeholder_text("Select a date")
                                 .on_date_changed(context.forward())
-                                .slot(CalendarDatePickerSlot::Header, "Appointment Date"),
+                                .header("Appointment Date"),
                             TextBlock::new().text(&self.label).opacity(0.6),
                         )),
                         "CalendarDatePicker::new()\n    .placeholder_text(\"Select a date\")\n    .on_date_changed(|date| ...)",
@@ -48,7 +48,7 @@ impl Component for CalendarDatePickerPage {
                         CalendarDatePicker::new()
                             .placeholder_text("Cannot change")
                             .is_enabled(false)
-                            .slot(CalendarDatePickerSlot::Header, "Locked Date"),
+                            .header("Locked Date"),
                         "CalendarDatePicker::new().is_enabled(false)",
                     ),
                 ),

--- a/crates/samples/reactor/gallery/src/pages/date_time/calendar_view.rs
+++ b/crates/samples/reactor/gallery/src/pages/date_time/calendar_view.rs
@@ -43,7 +43,7 @@ impl Component for CalendarViewPage {
                             ToggleSwitch::new()
                                 .is_on(self.today_highlighted)
                                 .on_toggled(context.callback(Message::HighlightTodayToggled))
-                                .slot(ToggleSwitchSlot::Header, "Highlight today"),
+                                .header("Highlight today"),
                             CalendarView::new()
                                 .is_today_highlighted(self.today_highlighted)
                                 .on_selected_dates_changed(

--- a/crates/samples/reactor/gallery/src/pages/date_time/date_picker.rs
+++ b/crates/samples/reactor/gallery/src/pages/date_time/date_picker.rs
@@ -34,7 +34,7 @@ impl Component for DatePickerPage {
                         StackPanel::new().spacing(8.0).children((
                             DatePicker::new()
                                 .on_selected_date_changed(context.forward())
-                                .slot(DatePickerSlot::Header, "Select date"),
+                                .header("Select date"),
                             TextBlock::new().text(&self.label).opacity(0.6),
                         )),
                         "DatePicker::new()\n    .on_selected_date_changed(|date| ...)",
@@ -44,9 +44,7 @@ impl Component for DatePickerPage {
                     "month-year-date-picker",
                     sample_card(
                         "Month and Year Only",
-                        DatePicker::new()
-                            .day_visible(false)
-                            .slot(DatePickerSlot::Header, "Month/Year"),
+                        DatePicker::new().day_visible(false).header("Month/Year"),
                         "DatePicker::new().day_visible(false)",
                     ),
                 ),

--- a/crates/samples/reactor/gallery/src/pages/date_time/time_picker.rs
+++ b/crates/samples/reactor/gallery/src/pages/date_time/time_picker.rs
@@ -38,7 +38,7 @@ impl Component for TimePickerPage {
                         StackPanel::new().spacing(8.0).children((
                             TimePicker::new()
                                 .on_selected_time_changed(context.forward())
-                                .slot(TimePickerSlot::Header, "Select time"),
+                                .header("Select time"),
                             TextBlock::new().text(&self.label).opacity(0.6),
                         )),
                         "TimePicker::new()\n    .on_selected_time_changed(|time| ...)",
@@ -50,7 +50,7 @@ impl Component for TimePickerPage {
                         "15-Minute Increments",
                         TimePicker::new()
                             .minute_increment(15)
-                            .slot(TimePickerSlot::Header, "Meeting time"),
+                            .header("Meeting time"),
                         "TimePicker::new().minute_increment(15)",
                     ),
                 ),

--- a/crates/samples/reactor/gallery/src/pages/layout/border.rs
+++ b/crates/samples/reactor/gallery/src/pages/layout/border.rs
@@ -54,7 +54,7 @@ impl Component for BorderPage {
                             ToggleSwitch::new()
                                 .is_on(self.thick)
                                 .on_toggled(context.callback(Message::Thick))
-                                .slot(ToggleSwitchSlot::Header, "Thick border"),
+                                .header("Thick border"),
                         )),
                         "Border::new().corner_radius(radius).border_thickness(thickness)",
                     ),

--- a/crates/samples/reactor/gallery/src/pages/layout/expander.rs
+++ b/crates/samples/reactor/gallery/src/pages/layout/expander.rs
@@ -30,16 +30,8 @@ impl Component for ExpanderPage {
                             Expander::new()
                                 .is_expanded(self.expanded)
                                 .on_is_expanded_changed(context.forward())
-                                .slots([
-                                    SlotView::new(
-                                        ExpanderSlot::Header,
-                                        "Click to expand or collapse",
-                                    ),
-                                    SlotView::new(
-                                        ExpanderSlot::Content,
-                                        "This content can be shown or hidden.",
-                                    ),
-                                ]),
+                                .header("Click to expand or collapse")
+                                .content("This content can be shown or hidden."),
                             TextBlock::new()
                                 .text(if self.expanded {
                                     "Expanded"
@@ -55,10 +47,10 @@ impl Component for ExpanderPage {
                     "collapsed",
                     sample_card(
                         "Collapsed by Default",
-                        Expander::new().is_expanded(false).slots([
-                            SlotView::new(ExpanderSlot::Header, "More info"),
-                            SlotView::new(ExpanderSlot::Content, "Hidden by default."),
-                        ]),
+                        Expander::new()
+                            .is_expanded(false)
+                            .header("More info")
+                            .content("Hidden by default."),
                         "Expander::new().is_expanded(false)",
                     ),
                 ),

--- a/crates/samples/reactor/gallery/src/pages/layout/grid.rs
+++ b/crates/samples/reactor/gallery/src/pages/layout/grid.rs
@@ -97,7 +97,7 @@ impl Component for GridPage {
                             ToggleSwitch::new()
                                 .is_on(self.wide)
                                 .on_toggled(context.forward())
-                                .slot(ToggleSwitchSlot::Header, "Wide layout"),
+                                .header("Wide layout"),
                             dynamic,
                         )),
                         "if wide { three columns } else { two by two }",

--- a/crates/samples/reactor/gallery/src/pages/layout/relative_panel.rs
+++ b/crates/samples/reactor/gallery/src/pages/layout/relative_panel.rs
@@ -51,7 +51,7 @@ impl Component for RelativePanelPage {
                         ToggleSwitch::new()
                             .is_on(self.bottom)
                             .on_toggled(context.forward())
-                            .slot(ToggleSwitchSlot::Header, "Show bottom corners"),
+                            .header("Show bottom corners"),
                         RelativePanel::new().height(200.0).children((
                             left,
                             right,

--- a/crates/samples/reactor/gallery/src/pages/layout/split_view.rs
+++ b/crates/samples/reactor/gallery/src/pages/layout/split_view.rs
@@ -29,22 +29,14 @@ impl Component for SplitViewPage {
                         ToggleSwitch::new()
                             .is_on(self.open)
                             .on_toggled(context.forward())
-                            .slot(ToggleSwitchSlot::Header, "Pane open"),
+                            .header("Pane open"),
                         SplitView::new()
                             .is_pane_open(self.open)
                             .open_pane_length(180.0)
-                            .slots([
-                                SlotView::new(
-                                    SplitViewSlot::Pane,
-                                    Border::new().padding(16.0).content("Pane content"),
-                                ),
-                                SlotView::new(
-                                    SplitViewSlot::Content,
-                                    Border::new().padding(16.0).content("Main content area"),
-                                ),
-                            ]),
+                            .pane(Border::new().padding(16.0).content("Pane content"))
+                            .content(Border::new().padding(16.0).content("Main content area")),
                     )),
-                    "SplitView::new().is_pane_open(open).slots([pane, content])",
+                    "SplitView::new().is_pane_open(open).pane(pane).content(content)",
                 ),
             )],
         )

--- a/crates/samples/reactor/gallery/src/pages/layout/viewbox.rs
+++ b/crates/samples/reactor/gallery/src/pages/layout/viewbox.rs
@@ -30,8 +30,7 @@ impl Component for ViewboxPage {
                             .width(self.size)
                             .height(100.0)
                             .stretch(Stretch::Uniform)
-                            .slot(
-                                ViewboxSlot::Child,
+                            .child(
                                 Border::new()
                                     .width(200.0)
                                     .height(100.0)
@@ -49,7 +48,7 @@ impl Component for ViewboxPage {
     .width(viewport_width)
     .height(100.0)
     .stretch(Stretch::Uniform)
-    .slot(ViewboxSlot::Child, content)"#,
+    .child(content)"#,
                 ),
             )],
         )

--- a/crates/samples/reactor/gallery/src/pages/media/person_picture.rs
+++ b/crates/samples/reactor/gallery/src/pages/media/person_picture.rs
@@ -57,7 +57,7 @@ impl Component for PersonPicturePage {
                         ToggleSwitch::new()
                             .is_on(self.show_display_names)
                             .on_toggled(context.callback(Message::SetShowDisplayNames))
-                            .slot(ToggleSwitchSlot::Header, "Use display names"),
+                            .header("Use display names"),
                         pictures,
                         TextBlock::new()
                             .text(if self.show_display_names {
@@ -67,8 +67,8 @@ impl Component for PersonPicturePage {
                             })
                             .opacity(0.6),
                     )),
-                    r#"ToggleSwitch::new().is_on(value).on_toggled(...).slot(
-    ToggleSwitchSlot::Header, "Use display names")
+                    r#"ToggleSwitch::new().is_on(value).on_toggled(...).header(
+    "Use display names")
 PersonPicture::new().display_name("Alice Smith")
 PersonPicture::new().initials("AS")"#,
                 ),

--- a/crates/samples/reactor/gallery/src/pages/menus/menu_bar.rs
+++ b/crates/samples/reactor/gallery/src/pages/menus/menu_bar.rs
@@ -36,39 +36,36 @@ impl Component for MenuBarPage {
                 sample_card(
                     "Basic MenuBar",
                     StackPanel::new().spacing(8.0).children((
-                        MenuBar::new().collection_slot(
-                            MenuBarSlot::Items,
-                            [
-                                KeyedView::new(
-                                    "file",
-                                    MenuBarItem::new().title("File").menu(Menu::new(
-                                        [
-                                            MenuItem::item("new", "New"),
-                                            MenuItem::item("open", "Open"),
-                                            MenuItem::item("save", "Save"),
-                                        ],
-                                        callback.clone(),
-                                    )),
-                                ),
-                                KeyedView::new(
-                                    "edit",
-                                    MenuBarItem::new().title("Edit").menu(Menu::new(
-                                        [
-                                            MenuItem::item("undo", "Undo"),
-                                            MenuItem::item("cut", "Cut"),
-                                            MenuItem::item("copy", "Copy"),
-                                            MenuItem::item("paste", "Paste"),
-                                        ],
-                                        callback,
-                                    )),
-                                ),
-                            ],
-                        ),
+                        MenuBar::new().items([
+                            KeyedView::new(
+                                "file",
+                                MenuBarItem::new().title("File").menu(Menu::new(
+                                    [
+                                        MenuItem::item("new", "New"),
+                                        MenuItem::item("open", "Open"),
+                                        MenuItem::item("save", "Save"),
+                                    ],
+                                    callback.clone(),
+                                )),
+                            ),
+                            KeyedView::new(
+                                "edit",
+                                MenuBarItem::new().title("Edit").menu(Menu::new(
+                                    [
+                                        MenuItem::item("undo", "Undo"),
+                                        MenuItem::item("cut", "Cut"),
+                                        MenuItem::item("copy", "Copy"),
+                                        MenuItem::item("paste", "Paste"),
+                                    ],
+                                    callback,
+                                )),
+                            ),
+                        ]),
                         TextBlock::new()
                             .text(format!("Last clicked: {}", self.last_click))
                             .opacity(0.6),
                     )),
-                    r#"MenuBar::new().collection_slot(MenuBarSlot::Items, [...])"#,
+                    r#"MenuBar::new().items([...])"#,
                 ),
             )],
         )

--- a/crates/samples/reactor/gallery/src/pages/menus/selector_bar.rs
+++ b/crates/samples/reactor/gallery/src/pages/menus/selector_bar.rs
@@ -47,17 +47,14 @@ impl Component for SelectorBarPage {
                     StackPanel::new().spacing(8.0).children((
                         SelectorBar::new()
                             .on_selected_text_changed(context.callback(Message::SelectionChanged))
-                            .collection_slot(
-                                SelectorBarSlot::Items,
-                                [item("Recent"), item("Shared"), item("Favorites")],
-                            ),
+                            .items([item("Recent"), item("Shared"), item("Favorites")]),
                         TextBlock::new()
                             .text(format!("Selected: {}", self.selected))
                             .opacity(0.6),
                     )),
                     r#"SelectorBar::new()
     .on_selected_text_changed(h)
-    .collection_slot(SelectorBarSlot::Items, [...])"#,
+    .items([...])"#,
                 ),
             )],
         )

--- a/crates/samples/reactor/gallery/src/pages/navigation/navigation_view.rs
+++ b/crates/samples/reactor/gallery/src/pages/navigation/navigation_view.rs
@@ -19,10 +19,8 @@ fn item(tag: &str, label: &str, icon: Symbol, selected: bool) -> KeyedView {
             .tag(tag)
             .is_selected(selected)
             .selects_on_invoked(true)
-            .slots([
-                SlotView::new(NavigationViewItemSlot::Content, label),
-                SlotView::new(NavigationViewItemSlot::Icon, SymbolIcon::new().symbol(icon)),
-            ]),
+            .content(label)
+            .icon(SymbolIcon::new().symbol(icon)),
     )
 }
 
@@ -69,31 +67,18 @@ impl Component for NavigationViewPage {
                             .is_settings_visible(false)
                             .height(300.0)
                             .on_selected_tag_changed(context.callback(Message::Left))
-                            .slots([
-                                SlotView::collection(
-                                    NavigationViewSlot::MenuItems,
-                                    [
-                                        item("home", "Home", Symbol::Home, self.selected == "home"),
-                                        item(
-                                            "browse",
-                                            "Browse",
-                                            Symbol::Find,
-                                            self.selected == "browse",
-                                        ),
-                                        item(
-                                            "settings",
-                                            "Settings",
-                                            Symbol::Setting,
-                                            self.selected == "settings",
-                                        ),
-                                    ],
+                            .menu_items([
+                                item("home", "Home", Symbol::Home, self.selected == "home"),
+                                item("browse", "Browse", Symbol::Find, self.selected == "browse"),
+                                item(
+                                    "settings",
+                                    "Settings",
+                                    Symbol::Setting,
+                                    self.selected == "settings",
                                 ),
-                                SlotView::new(
-                                    NavigationViewSlot::Content,
-                                    Border::new().padding(20.0).content(left_body),
-                                ),
-                            ]),
-                        "NavigationView::new().slots([menu_items, content])",
+                            ])
+                            .content(Border::new().padding(20.0).content(left_body)),
+                        "NavigationView::new().menu_items(menu_items).content(content)",
                     ),
                 ),
                 KeyedView::new(
@@ -105,35 +90,27 @@ impl Component for NavigationViewPage {
                             .is_settings_visible(false)
                             .height(200.0)
                             .on_selected_tag_changed(context.callback(Message::Top))
-                            .slots([
-                                SlotView::collection(
-                                    NavigationViewSlot::MenuItems,
-                                    [
-                                        item(
-                                            "overview",
-                                            "Overview",
-                                            Symbol::Home,
-                                            self.top_selected == "overview",
-                                        ),
-                                        item(
-                                            "documents",
-                                            "Documents",
-                                            Symbol::Edit,
-                                            self.top_selected == "documents",
-                                        ),
-                                        item(
-                                            "downloads",
-                                            "Downloads",
-                                            Symbol::Download,
-                                            self.top_selected == "downloads",
-                                        ),
-                                    ],
+                            .menu_items([
+                                item(
+                                    "overview",
+                                    "Overview",
+                                    Symbol::Home,
+                                    self.top_selected == "overview",
                                 ),
-                                SlotView::new(
-                                    NavigationViewSlot::Content,
-                                    Border::new().padding(20.0).content(top_body),
+                                item(
+                                    "documents",
+                                    "Documents",
+                                    Symbol::Edit,
+                                    self.top_selected == "documents",
                                 ),
-                            ]),
+                                item(
+                                    "downloads",
+                                    "Downloads",
+                                    Symbol::Download,
+                                    self.top_selected == "downloads",
+                                ),
+                            ])
+                            .content(Border::new().padding(20.0).content(top_body)),
                         "NavigationView::new().pane_display_mode(NavigationViewPaneDisplayMode::Top)",
                     ),
                 ),

--- a/crates/samples/reactor/gallery/src/pages/navigation/pivot.rs
+++ b/crates/samples/reactor/gallery/src/pages/navigation/pivot.rs
@@ -41,9 +41,9 @@ impl Component for PivotPage {
                         Pivot::new()
                             .selected_index(self.selected)
                             .on_selection_changed(context.forward())
-                            .collection_slot(PivotSlot::Items, items("basic")),
+                            .items(items("basic")),
                         "Pivot::new().selected_index(index)\n    \
-                         .collection_slot(PivotSlot::Items, items)",
+                         .items(items)",
                     ),
                 ),
                 KeyedView::new(
@@ -54,7 +54,7 @@ impl Component for PivotPage {
                             Pivot::new()
                                 .selected_index(self.selected)
                                 .on_selection_changed(context.forward())
-                                .collection_slot(PivotSlot::Items, items("tracking")),
+                                .items(items("tracking")),
                             TextBlock::new()
                                 .text(format!("Active tab index: {:?}", self.selected))
                                 .opacity(0.6),

--- a/crates/samples/reactor/gallery/src/pages/navigation/tab_view.rs
+++ b/crates/samples/reactor/gallery/src/pages/navigation/tab_view.rs
@@ -103,9 +103,9 @@ impl Component for TabViewPage {
                             .height(200.0)
                             .on_selection_changed(context.callback(Message::BasicSelected))
                             .on_close_requested(context.callback(Message::CloseBasic))
-                            .collection_slot(TabViewSlot::TabItems, tabs(&self.basic_tabs, true)),
+                            .tab_items(tabs(&self.basic_tabs, true)),
                         "TabView::new().selected_index(index)\n    \
-                         .collection_slot(TabViewSlot::TabItems, tab_items)",
+                         .tab_items(tab_items)",
                     ),
                 ),
                 KeyedView::new(
@@ -118,10 +118,7 @@ impl Component for TabViewPage {
                                 .height(180.0)
                                 .on_selection_changed(context.callback(Message::DynamicSelected))
                                 .on_close_requested(context.callback(Message::CloseDynamic))
-                                .collection_slot(
-                                    TabViewSlot::TabItems,
-                                    tabs(&self.dynamic_tabs, true),
-                                ),
+                                .tab_items(tabs(&self.dynamic_tabs, true)),
                             StackPanel::new()
                                 .orientation(Orientation::Horizontal)
                                 .spacing(8.0)
@@ -142,9 +139,7 @@ impl Component for TabViewPage {
                     "fixed",
                     sample_card(
                         "Non-closable Tabs",
-                        TabView::new()
-                            .height(150.0)
-                            .collection_slot(TabViewSlot::TabItems, tabs(&[1, 2], false)),
+                        TabView::new().height(150.0).tab_items(tabs(&[1, 2], false)),
                         "TabViewItem::new().is_closable(false)",
                     ),
                 ),

--- a/crates/samples/reactor/gallery/src/pages/navigation/title_bar.rs
+++ b/crates/samples/reactor/gallery/src/pages/navigation/title_bar.rs
@@ -24,7 +24,7 @@ impl Component for TitleBarPage {
                         "Live TitleBar",
                         "The gallery title bar above is the live control. Its buttons, search box, \
                          title, and subtitle are all declarative.",
-                        "TitleBar::new().title(title).subtitle(subtitle).slots(content)",
+                        "TitleBar::new().title(title).subtitle(subtitle).content(content)",
                     ),
                 ),
                 KeyedView::new(

--- a/crates/samples/reactor/gallery/src/pages/status/info_bar.rs
+++ b/crates/samples/reactor/gallery/src/pages/status/info_bar.rs
@@ -37,7 +37,7 @@ impl Component for InfoBarPage {
                             ToggleSwitch::new()
                                 .is_on(self.visible)
                                 .on_toggled(context.forward())
-                                .slot(ToggleSwitchSlot::Header, "Show InfoBar"),
+                                .header("Show InfoBar"),
                             InfoBar::new()
                                 .title("Update available")
                                 .message("A new version is ready to install.")

--- a/crates/samples/reactor/gallery/src/pages/status/progress_bar.rs
+++ b/crates/samples/reactor/gallery/src/pages/status/progress_bar.rs
@@ -70,10 +70,8 @@ impl Component for ProgressBarPage {
                             ToggleSwitch::new()
                                 .is_on(self.loading)
                                 .on_toggled(context.callback(Message::Loading))
-                                .slots([
-                                    SlotView::new(ToggleSwitchSlot::OnContent, "Loading"),
-                                    SlotView::new(ToggleSwitchSlot::OffContent, "Complete"),
-                                ]),
+                                .on_content("Loading")
+                                .off_content("Complete"),
                         )),
                         "ProgressBar::new().is_indeterminate(loading)",
                     ),

--- a/crates/samples/reactor/gallery/src/pages/text/rich_edit_box.rs
+++ b/crates/samples/reactor/gallery/src/pages/text/rich_edit_box.rs
@@ -34,7 +34,7 @@ impl Component for RichEditBoxPage {
                                 .placeholder_text("Start typing...")
                                 .height(200.0)
                                 .on_text_changed(context.forward())
-                                .slot(RichEditBoxSlot::Header, "Document"),
+                                .header("Document"),
                             TextBlock::new()
                                 .text(if self.text.is_empty() {
                                     "No changes yet".to_string()

--- a/crates/samples/reactor/gallery/src/shell.rs
+++ b/crates/samples/reactor/gallery/src/shell.rs
@@ -66,27 +66,18 @@ fn nav_item(
     children: Vec<KeyedView>,
 ) -> KeyedView {
     let has_children = !children.is_empty();
-    let mut slots = vec![SlotView::new(NavigationViewItemSlot::Content, label)];
-    if let Some(symbol) = icon {
-        slots.push(SlotView::new(
-            NavigationViewItemSlot::Icon,
-            SymbolIcon::new().symbol(symbol),
-        ));
-    }
-    if has_children {
-        slots.push(SlotView::collection(
-            NavigationViewItemSlot::MenuItems,
-            children,
-        ));
-    }
     let mut item = NavigationViewItem::new()
         .tag(tag)
         .is_selected(selected)
-        .selects_on_invoked(true);
-    if has_children {
-        item = item.is_expanded(expanded);
+        .selects_on_invoked(true)
+        .content(label);
+    if let Some(symbol) = icon {
+        item = item.icon(SymbolIcon::new().symbol(symbol));
     }
-    KeyedView::new(tag.to_string(), item.slots(slots))
+    if has_children {
+        item = item.menu_items(children).is_expanded(expanded);
+    }
+    KeyedView::new(tag.to_string(), item)
 }
 
 /// Renders a category's control list as a card grid, matching the incumbent gallery's category
@@ -293,10 +284,8 @@ impl Component for Gallery {
             .on_is_pane_open_changed(context.callback(Message::PaneOpenChanged))
             .on_selected_tag_changed(context.callback(Message::SelectedTagChanged))
             .grid_row(1)
-            .slots([
-                SlotView::collection(NavigationViewSlot::MenuItems, menu_items),
-                SlotView::new(NavigationViewSlot::Content, content),
-            ]);
+            .menu_items(menu_items)
+            .content(content);
 
         let title_bar = TitleBar::new()
             .preferred_height(WindowTitleBarHeight::Tall)
@@ -308,21 +297,17 @@ impl Component for Gallery {
             .on_back_requested(context.message(Message::Back))
             .on_pane_toggle_requested(context.message(Message::TogglePane))
             .grid_row(0)
-            .slots([
-                SlotView::new(
-                    TitleBarSlot::Content,
-                    TextBox::new()
-                        .text(self.search.clone())
-                        .placeholder_text("Search controls and samples...")
-                        .on_text_changed(context.callback(Message::SearchChanged)),
-                ),
-                SlotView::new(
-                    TitleBarSlot::RightHeader,
-                    Button::new()
-                        .on_click(context.message(Message::CycleTheme))
-                        .content(format!("Theme: {}", theme_name(self.theme))),
-                ),
-            ]);
+            .content(
+                TextBox::new()
+                    .text(self.search.clone())
+                    .placeholder_text("Search controls and samples...")
+                    .on_text_changed(context.callback(Message::SearchChanged)),
+            )
+            .right_header(
+                Button::new()
+                    .on_click(context.message(Message::CycleTheme))
+                    .content(format!("Theme: {}", theme_name(self.theme))),
+            );
 
         Grid::new()
             .rows([GridLength::Auto, GridLength::Star(1.0)])

--- a/crates/samples/reactor/icon-elements/src/main.rs
+++ b/crates/samples/reactor/icon-elements/src/main.rs
@@ -35,10 +35,8 @@ impl Component for IconElementsSample {
                 NavigationViewItem::new()
                     .tag(tag)
                     .is_selected(self.page == tag)
-                    .slots([
-                        SlotView::new(NavigationViewItemSlot::Content, label),
-                        SlotView::new(NavigationViewItemSlot::Icon, icon),
-                    ]),
+                    .content(label)
+                    .icon(icon),
             )
         };
         let content = match self.page.as_str() {
@@ -54,45 +52,41 @@ impl Component for IconElementsSample {
         NavigationView::new()
             .is_settings_visible(false)
             .on_selected_tag_changed(context.forward())
-            .slots([
-                SlotView::collection(
-                    NavigationViewSlot::MenuItems,
-                    [
-                        item(
-                            "home",
-                            "Home",
-                            SymbolIcon::new().symbol(Symbol::Home).into(),
-                        ),
-                        item(
-                            "starred",
-                            "Starred",
-                            FontIcon::new().glyph("\u{E734}").into(),
-                        ),
-                        item(
-                            "repo",
-                            "Repository",
-                            ImageIcon::new().source(image).unwrap().into(),
-                        ),
-                        item(
-                            "bitmap",
-                            "Bitmap mask",
-                            BitmapIcon::new()
-                                .uri_source(bitmap)
-                                .unwrap()
-                                .show_as_monochrome(true)
-                                .into(),
-                        ),
-                        item(
-                            "path",
-                            "Path",
-                            PathIcon::new()
-                                .data("F1 M 0,8 L 6,14 L 16,2 L 14,0 L 6,10 L 2,6 Z")
-                                .into(),
-                        ),
-                    ],
+            .menu_items([
+                item(
+                    "home",
+                    "Home",
+                    SymbolIcon::new().symbol(Symbol::Home).into(),
                 ),
-                SlotView::new(NavigationViewSlot::Content, content),
+                item(
+                    "starred",
+                    "Starred",
+                    FontIcon::new().glyph("\u{E734}").into(),
+                ),
+                item(
+                    "repo",
+                    "Repository",
+                    ImageIcon::new().source(image).unwrap().into(),
+                ),
+                item(
+                    "bitmap",
+                    "Bitmap mask",
+                    BitmapIcon::new()
+                        .uri_source(bitmap)
+                        .unwrap()
+                        .show_as_monochrome(true)
+                        .into(),
+                ),
+                item(
+                    "path",
+                    "Path",
+                    PathIcon::new()
+                        .data("F1 M 0,8 L 6,14 L 16,2 L 14,0 L 6,10 L 2,6 Z")
+                        .into(),
+                ),
             ])
+            .content(content)
+            .into()
     }
 }
 

--- a/crates/samples/reactor/navigation-view-icons/src/main.rs
+++ b/crates/samples/reactor/navigation-view-icons/src/main.rs
@@ -27,13 +27,8 @@ impl Component for NavigationIconsSample {
                 NavigationViewItem::new()
                     .tag(tag)
                     .is_selected(self.page == tag)
-                    .slots([
-                        SlotView::new(NavigationViewItemSlot::Content, label),
-                        SlotView::new(
-                            NavigationViewItemSlot::Icon,
-                            SymbolIcon::new().symbol(symbol),
-                        ),
-                    ]),
+                    .content(label)
+                    .icon(SymbolIcon::new().symbol(symbol)),
             )
         };
         let content = match self.page.as_str() {
@@ -48,18 +43,14 @@ impl Component for NavigationIconsSample {
         NavigationView::new()
             .is_settings_visible(false)
             .on_selected_tag_changed(context.forward())
-            .slots([
-                SlotView::collection(
-                    NavigationViewSlot::MenuItems,
-                    [
-                        item("home", "Home", Symbol::Home),
-                        item("mail", "Mail", Symbol::Mail),
-                        item("people", "People", Symbol::People),
-                        item("settings", "Settings", Symbol::Setting),
-                    ],
-                ),
-                SlotView::new(NavigationViewSlot::Content, content),
+            .menu_items([
+                item("home", "Home", Symbol::Home),
+                item("mail", "Mail", Symbol::Mail),
+                item("people", "People", Symbol::People),
+                item("settings", "Settings", Symbol::Setting),
             ])
+            .content(content)
+            .into()
     }
 }
 

--- a/crates/samples/reactor/navigation-view-pane/src/main.rs
+++ b/crates/samples/reactor/navigation-view-pane/src/main.rs
@@ -27,19 +27,14 @@ impl Component for NavigationPaneSample {
                 NavigationViewItem::new()
                     .tag(tag)
                     .is_selected(self.page == tag)
-                    .slots([
-                        SlotView::new(NavigationViewItemSlot::Content, label),
-                        SlotView::new(
-                            NavigationViewItemSlot::Icon,
-                            SymbolIcon::new().symbol(symbol),
-                        ),
-                    ]),
+                    .content(label)
+                    .icon(SymbolIcon::new().symbol(symbol)),
             )
         };
-        let body = if self.page == "docs" {
-            "Documents page"
-        } else {
-            "Home page"
+        let body = match self.page.as_str() {
+            "docs" => "Documents page",
+            "settings" => "Settings page",
+            _ => "Home page",
         };
 
         context.window_title("NavigationView pane");
@@ -49,22 +44,18 @@ impl Component for NavigationPaneSample {
             .open_pane_length(400.0)
             .is_settings_visible(false)
             .on_selected_tag_changed(context.forward())
-            .slots([
-                SlotView::collection(
-                    NavigationViewSlot::MenuItems,
-                    [
-                        item("home", "Home", Symbol::Home),
-                        item("docs", "Documents", Symbol::Document),
-                    ],
-                ),
-                SlotView::new(NavigationViewSlot::Content, body),
-                SlotView::new(
-                    NavigationViewSlot::PaneFooter,
-                    Button::new()
-                        .on_click(|| println!("signed out"))
-                        .content("Sign out"),
-                ),
+            .menu_items([
+                item("home", "Home", Symbol::Home),
+                item("docs", "Documents", Symbol::Document),
             ])
+            .footer_menu_items([item("settings", "Settings", Symbol::Setting)])
+            .content(body)
+            .pane_footer(
+                Button::new()
+                    .on_click(|| println!("signed out"))
+                    .content("Sign out"),
+            )
+            .into()
     }
 }
 

--- a/crates/samples/reactor/navigation/src/main.rs
+++ b/crates/samples/reactor/navigation/src/main.rs
@@ -314,10 +314,8 @@ impl Component for Workspace {
                 .compact_pane_length(48.0)
                 .display_mode(SplitViewDisplayMode::CompactInline)
                 .is_pane_open(true)
-                .slots([
-                    SlotView::new(SplitViewSlot::Pane, header),
-                    SlotView::new(SplitViewSlot::Content, page),
-                ]),
+                .pane(header)
+                .content(page),
         )
     }
 }

--- a/crates/samples/reactor/radio-buttons/src/main.rs
+++ b/crates/samples/reactor/radio-buttons/src/main.rs
@@ -33,7 +33,7 @@ impl Component for RadioButtonsSample {
                 .selected_index(self.selected)
                 .max_columns(3)
                 .on_selection_changed(context.callback(|index| index))
-                .slot(RadioButtonsSlot::Header, "Notifications"),
+                .header("Notifications"),
             format!("selected_index = {:?} ({label})", self.selected),
         ))
     }

--- a/crates/samples/reactor/responsive-navigation/src/main.rs
+++ b/crates/samples/reactor/responsive-navigation/src/main.rs
@@ -55,13 +55,10 @@ impl Component for ResponsiveNavigation {
         .map(|(tag, label, symbol)| {
             KeyedView::new(
                 tag,
-                NavigationViewItem::new().tag(tag).slots([
-                    SlotView::new(NavigationViewItemSlot::Content, label),
-                    SlotView::new(
-                        NavigationViewItemSlot::Icon,
-                        SymbolIcon::new().symbol(symbol),
-                    ),
-                ]),
+                NavigationViewItem::new()
+                    .tag(tag)
+                    .content(label)
+                    .icon(SymbolIcon::new().symbol(symbol)),
             )
         });
         NavigationView::new()
@@ -71,28 +68,26 @@ impl Component for ResponsiveNavigation {
             .on_display_mode_changed(context.callback(NavigationMessage::DisplayMode))
             .pane_title("Responsive navigation")
             .is_settings_visible(false)
-            .slots([
-                SlotView::collection(NavigationViewSlot::MenuItems, items),
-                SlotView::new(
-                    NavigationViewSlot::Content,
-                    StackPanel::new().spacing(12.0).children((
-                        format!(
-                            "Actual display mode: {}",
-                            display_mode_name(self.display_mode)
-                        ),
-                        if self.pane_open {
-                            "Pane is open"
-                        } else {
-                            "Pane is closed"
-                        },
-                        Button::new()
-                            .on_click(context.callback(|_| NavigationMessage::TogglePane))
-                            .content("Toggle pane"),
-                        "Resize the window to cross compact and minimal thresholds.",
-                    )),
-                ),
-                SlotView::new(NavigationViewSlot::PaneFooter, footer),
-            ])
+            .menu_items(items)
+            .content(
+                StackPanel::new().spacing(12.0).children((
+                    format!(
+                        "Actual display mode: {}",
+                        display_mode_name(self.display_mode)
+                    ),
+                    if self.pane_open {
+                        "Pane is open"
+                    } else {
+                        "Pane is closed"
+                    },
+                    Button::new()
+                        .on_click(context.callback(|_| NavigationMessage::TogglePane))
+                        .content("Toggle pane"),
+                    "Resize the window to cross compact and minimal thresholds.",
+                )),
+            )
+            .pane_footer(footer)
+            .into()
     }
 }
 

--- a/crates/samples/reactor/solitaire/src/main.rs
+++ b/crates/samples/reactor/solitaire/src/main.rs
@@ -495,10 +495,7 @@ impl Component for Solitaire {
                 .children((
                     title_bar,
                     header,
-                    Viewbox::new().slot(
-                        ViewboxSlot::Child,
-                        build_board(&self.game, context.callback(Message::Click)),
-                    ),
+                    Viewbox::new().child(build_board(&self.game, context.callback(Message::Click))),
                 )),
         )
     }

--- a/crates/samples/reactor/tab-view-add-button/src/main.rs
+++ b/crates/samples/reactor/tab-view-add-button/src/main.rs
@@ -104,7 +104,7 @@ impl Component for TabViewAddButtonSample {
                 .on_add_tab_button_click(context.message(Message::Add))
                 .on_close_requested(context.callback(Message::Close))
                 .on_reordered(context.callback(Message::Reordered))
-                .collection_slot(TabViewSlot::TabItems, items),
+                .tab_items(items),
             format!(
                 "selected = {:?}, total tabs = {}",
                 self.selected,

--- a/crates/tests/libs/reactor/tests/public_surface.rs
+++ b/crates/tests/libs/reactor/tests/public_surface.rs
@@ -52,36 +52,19 @@ fn generated_structural_capabilities_compose_views() {
         .item("first", TextBlock::new().text("one"))
         .items([(2_u64, View::component::<TestComponent>("two".to_string()))]);
     let _: View = ScrollViewer::new().content(repeater);
-    let _: View = NavigationView::new().slots([
-        SlotView::new(NavigationViewSlot::Content, TextBlock::new()),
-        SlotView::new(NavigationViewSlot::Header, Button::new()),
-    ]);
-    let _: View = NavigationView::new().collection_slot(
-        NavigationViewSlot::MenuItems,
-        [
-            (
-                "first",
-                NavigationViewItem::new().slot(NavigationViewItemSlot::Content, "one"),
-            ),
-            (
-                "second",
-                NavigationViewItem::new().slot(NavigationViewItemSlot::Content, "two"),
-            ),
-        ],
-    );
-    let _: SlotView<NavigationViewSlot> = SlotView::collection(
-        NavigationViewSlot::MenuItems,
-        [
-            (
-                "first",
-                NavigationViewItem::new().slot(NavigationViewItemSlot::Content, "one"),
-            ),
-            (
-                "second",
-                NavigationViewItem::new().slot(NavigationViewItemSlot::Content, "two"),
-            ),
-        ],
-    );
+    let _: View = NavigationView::new()
+        .content(TextBlock::new())
+        .header(Button::new())
+        .into();
+    let _: View = NavigationView::new()
+        .menu_items([
+            ("first", NavigationViewItem::new().content("one")),
+            ("second", NavigationViewItem::new().content("two")),
+        ])
+        .into();
+    let _: View = NavigationView::new()
+        .footer_menu_items([("settings", NavigationViewItem::new().content("Settings"))])
+        .into();
     let _: View = View::keyed_fragment([
         ("first", TextBlock::new().text("one")),
         ("second", TextBlock::new().text("two")),
@@ -89,8 +72,8 @@ fn generated_structural_capabilities_compose_views() {
     let _: KeyedView = ("key", TextBlock::new().text("value")).into();
     let _: View = TitleBar::new()
         .preferred_height(WindowTitleBarHeight::Tall)
-        .slots(std::iter::empty::<SlotView<TitleBarSlot>>());
-    let _: View = TitleBar::new().slots(std::iter::empty::<SlotView<TitleBarSlot>>());
+        .into();
+    let _: View = TitleBar::new().into();
 }
 
 struct TestComponent;

--- a/crates/tests/libs/reactor_surface/src/generated_surface.rs
+++ b/crates/tests/libs/reactor_surface/src/generated_surface.rs
@@ -49,7 +49,7 @@ pub(crate) const PROJECTED_CONTROL_COUNT: usize = 79usize;
 pub(crate) const PROJECTED_PROPERTY_COUNT: usize = 230usize;
 pub(crate) const PROJECTED_EVENT_COUNT: usize = 63usize;
 pub(crate) const CAPABILITY_PROPERTY_COUNT: usize = 27usize;
-pub(crate) const STRUCTURAL_COUNT: usize = 64usize;
+pub(crate) const STRUCTURAL_COUNT: usize = 65usize;
 pub(crate) const EXTENSION_COUNT: usize = 5;
 fn construct_text_block(_stage: usize) -> View {
     Grid::new().children((TextBlock::new(),))
@@ -94,7 +94,7 @@ fn construct_slider(_stage: usize) -> View {
     Grid::new().children((Slider::new(),))
 }
 fn construct_title_bar(_stage: usize) -> View {
-    Grid::new().children((TitleBar::new().slots(std::iter::empty::<SlotView<TitleBarSlot>>()),))
+    Grid::new().children((TitleBar::new(),))
 }
 fn construct_navigation_view(_stage: usize) -> View {
     Grid::new().children((NavigationView::new(),))
@@ -2183,56 +2183,41 @@ fn property_viewbox_stretch(stage: usize) -> View {
 }
 fn property_title_bar_title(stage: usize) -> View {
     match stage {
-        0 | 3 => Grid::new()
-            .children(((TitleBar::new()).slots(std::iter::empty::<SlotView<TitleBarSlot>>()),)),
-        1 => Grid::new().children(((TitleBar::new().title("surface a"))
-            .slots(std::iter::empty::<SlotView<TitleBarSlot>>()),)),
-        2 => Grid::new().children(((TitleBar::new().title("surface b"))
-            .slots(std::iter::empty::<SlotView<TitleBarSlot>>()),)),
+        0 | 3 => Grid::new().children((TitleBar::new(),)),
+        1 => Grid::new().children((TitleBar::new().title("surface a"),)),
+        2 => Grid::new().children((TitleBar::new().title("surface b"),)),
         _ => unreachable!(),
     }
 }
 fn property_title_bar_subtitle(stage: usize) -> View {
     match stage {
-        0 | 3 => Grid::new()
-            .children(((TitleBar::new()).slots(std::iter::empty::<SlotView<TitleBarSlot>>()),)),
-        1 => Grid::new().children(((TitleBar::new().subtitle("surface a"))
-            .slots(std::iter::empty::<SlotView<TitleBarSlot>>()),)),
-        2 => Grid::new().children(((TitleBar::new().subtitle("surface b"))
-            .slots(std::iter::empty::<SlotView<TitleBarSlot>>()),)),
+        0 | 3 => Grid::new().children((TitleBar::new(),)),
+        1 => Grid::new().children((TitleBar::new().subtitle("surface a"),)),
+        2 => Grid::new().children((TitleBar::new().subtitle("surface b"),)),
         _ => unreachable!(),
     }
 }
 fn property_title_bar_is_back_button_visible(stage: usize) -> View {
     match stage {
-        0 | 3 => Grid::new()
-            .children(((TitleBar::new()).slots(std::iter::empty::<SlotView<TitleBarSlot>>()),)),
-        1 => Grid::new().children(((TitleBar::new().is_back_button_visible(true))
-            .slots(std::iter::empty::<SlotView<TitleBarSlot>>()),)),
-        2 => Grid::new().children(((TitleBar::new().is_back_button_visible(false))
-            .slots(std::iter::empty::<SlotView<TitleBarSlot>>()),)),
+        0 | 3 => Grid::new().children((TitleBar::new(),)),
+        1 => Grid::new().children((TitleBar::new().is_back_button_visible(true),)),
+        2 => Grid::new().children((TitleBar::new().is_back_button_visible(false),)),
         _ => unreachable!(),
     }
 }
 fn property_title_bar_is_back_button_enabled(stage: usize) -> View {
     match stage {
-        0 | 3 => Grid::new()
-            .children(((TitleBar::new()).slots(std::iter::empty::<SlotView<TitleBarSlot>>()),)),
-        1 => Grid::new().children(((TitleBar::new().is_back_button_enabled(true))
-            .slots(std::iter::empty::<SlotView<TitleBarSlot>>()),)),
-        2 => Grid::new().children(((TitleBar::new().is_back_button_enabled(false))
-            .slots(std::iter::empty::<SlotView<TitleBarSlot>>()),)),
+        0 | 3 => Grid::new().children((TitleBar::new(),)),
+        1 => Grid::new().children((TitleBar::new().is_back_button_enabled(true),)),
+        2 => Grid::new().children((TitleBar::new().is_back_button_enabled(false),)),
         _ => unreachable!(),
     }
 }
 fn property_title_bar_is_pane_toggle_button_visible(stage: usize) -> View {
     match stage {
-        0 | 3 => Grid::new()
-            .children(((TitleBar::new()).slots(std::iter::empty::<SlotView<TitleBarSlot>>()),)),
-        1 => Grid::new().children(((TitleBar::new().is_pane_toggle_button_visible(true))
-            .slots(std::iter::empty::<SlotView<TitleBarSlot>>()),)),
-        2 => Grid::new().children(((TitleBar::new().is_pane_toggle_button_visible(false))
-            .slots(std::iter::empty::<SlotView<TitleBarSlot>>()),)),
+        0 | 3 => Grid::new().children((TitleBar::new(),)),
+        1 => Grid::new().children((TitleBar::new().is_pane_toggle_button_visible(true),)),
+        2 => Grid::new().children((TitleBar::new().is_pane_toggle_button_visible(false),)),
         _ => unreachable!(),
     }
 }
@@ -2970,31 +2955,25 @@ fn event_rich_edit_box_on_text_changed(stage: usize) -> View {
 }
 fn event_title_bar_on_back_requested(stage: usize) -> View {
     match stage {
-        0 | 3 => Grid::new()
-            .children(((TitleBar::new()).slots(std::iter::empty::<SlotView<TitleBarSlot>>()),)),
-        1 => Grid::new().children(((TitleBar::new().on_back_requested(move || {
+        0 | 3 => Grid::new().children((TitleBar::new(),)),
+        1 => Grid::new().children((TitleBar::new().on_back_requested(move || {
             let _ = 0u8;
-        }))
-        .slots(std::iter::empty::<SlotView<TitleBarSlot>>()),)),
-        2 => Grid::new().children(((TitleBar::new().on_back_requested(move || {
+        }),)),
+        2 => Grid::new().children((TitleBar::new().on_back_requested(move || {
             let _ = 1u8;
-        }))
-        .slots(std::iter::empty::<SlotView<TitleBarSlot>>()),)),
+        }),)),
         _ => unreachable!(),
     }
 }
 fn event_title_bar_on_pane_toggle_requested(stage: usize) -> View {
     match stage {
-        0 | 3 => Grid::new()
-            .children(((TitleBar::new()).slots(std::iter::empty::<SlotView<TitleBarSlot>>()),)),
-        1 => Grid::new().children(((TitleBar::new().on_pane_toggle_requested(move || {
+        0 | 3 => Grid::new().children((TitleBar::new(),)),
+        1 => Grid::new().children((TitleBar::new().on_pane_toggle_requested(move || {
             let _ = 0u8;
-        }))
-        .slots(std::iter::empty::<SlotView<TitleBarSlot>>()),)),
-        2 => Grid::new().children(((TitleBar::new().on_pane_toggle_requested(move || {
+        }),)),
+        2 => Grid::new().children((TitleBar::new().on_pane_toggle_requested(move || {
             let _ = 1u8;
-        }))
-        .slots(std::iter::empty::<SlotView<TitleBarSlot>>()),)),
+        }),)),
         _ => unreachable!(),
     }
 }
@@ -3298,283 +3277,177 @@ fn structural_grid_children(stage: usize) -> View {
 }
 fn structural_text_box_slot_header(stage: usize) -> View {
     match stage {
-        0 | 3 => (TextBox::new().slots(std::iter::empty::<SlotView<TextBoxSlot>>())).into(),
-        1 => (TextBox::new().slot(TextBoxSlot::Header, TextBlock::new().text("surface a"))).into(),
-        2 => (TextBox::new().slot(TextBoxSlot::Header, TextBlock::new().text("surface b"))).into(),
+        0 | 3 => (TextBox::new()).into(),
+        1 => (TextBox::new().header(TextBlock::new().text("surface a"))).into(),
+        2 => (TextBox::new().header(TextBlock::new().text("surface b"))).into(),
         _ => unreachable!(),
     }
 }
 fn structural_auto_suggest_box_slot_header(stage: usize) -> View {
     match stage {
-        0 | 3 => {
-            (AutoSuggestBox::new().slots(std::iter::empty::<SlotView<AutoSuggestBoxSlot>>())).into()
-        }
-        1 => (AutoSuggestBox::new().slot(
-            AutoSuggestBoxSlot::Header,
-            TextBlock::new().text("surface a"),
-        ))
-        .into(),
-        2 => (AutoSuggestBox::new().slot(
-            AutoSuggestBoxSlot::Header,
-            TextBlock::new().text("surface b"),
-        ))
-        .into(),
+        0 | 3 => (AutoSuggestBox::new()).into(),
+        1 => (AutoSuggestBox::new().header(TextBlock::new().text("surface a"))).into(),
+        2 => (AutoSuggestBox::new().header(TextBlock::new().text("surface b"))).into(),
         _ => unreachable!(),
     }
 }
 fn structural_password_box_slot_header(stage: usize) -> View {
     match stage {
-        0 | 3 => (PasswordBox::new().slots(std::iter::empty::<SlotView<PasswordBoxSlot>>())).into(),
-        1 => (PasswordBox::new().slot(PasswordBoxSlot::Header, TextBlock::new().text("surface a")))
-            .into(),
-        2 => (PasswordBox::new().slot(PasswordBoxSlot::Header, TextBlock::new().text("surface b")))
-            .into(),
+        0 | 3 => (PasswordBox::new()).into(),
+        1 => (PasswordBox::new().header(TextBlock::new().text("surface a"))).into(),
+        2 => (PasswordBox::new().header(TextBlock::new().text("surface b"))).into(),
         _ => unreachable!(),
     }
 }
 fn structural_number_box_slot_header(stage: usize) -> View {
     match stage {
-        0 | 3 => (NumberBox::new().slots(std::iter::empty::<SlotView<NumberBoxSlot>>())).into(),
-        1 => (NumberBox::new().slot(NumberBoxSlot::Header, TextBlock::new().text("surface a")))
-            .into(),
-        2 => (NumberBox::new().slot(NumberBoxSlot::Header, TextBlock::new().text("surface b")))
-            .into(),
+        0 | 3 => (NumberBox::new()).into(),
+        1 => (NumberBox::new().header(TextBlock::new().text("surface a"))).into(),
+        2 => (NumberBox::new().header(TextBlock::new().text("surface b"))).into(),
         _ => unreachable!(),
     }
 }
 fn structural_slider_slot_header(stage: usize) -> View {
     match stage {
-        0 | 3 => (Slider::new().slots(std::iter::empty::<SlotView<SliderSlot>>())).into(),
-        1 => (Slider::new().slot(SliderSlot::Header, TextBlock::new().text("surface a"))).into(),
-        2 => (Slider::new().slot(SliderSlot::Header, TextBlock::new().text("surface b"))).into(),
+        0 | 3 => (Slider::new()).into(),
+        1 => (Slider::new().header(TextBlock::new().text("surface a"))).into(),
+        2 => (Slider::new().header(TextBlock::new().text("surface b"))).into(),
         _ => unreachable!(),
     }
 }
 fn structural_navigation_view_slot_content(stage: usize) -> View {
     match stage {
-        0 | 3 => {
-            (NavigationView::new().slots(std::iter::empty::<SlotView<NavigationViewSlot>>())).into()
-        }
-        1 => (NavigationView::new().slot(
-            NavigationViewSlot::Content,
-            TextBlock::new().text("surface a"),
-        ))
-        .into(),
-        2 => (NavigationView::new().slot(
-            NavigationViewSlot::Content,
-            TextBlock::new().text("surface b"),
-        ))
-        .into(),
+        0 | 3 => (NavigationView::new()).into(),
+        1 => (NavigationView::new().content(TextBlock::new().text("surface a"))).into(),
+        2 => (NavigationView::new().content(TextBlock::new().text("surface b"))).into(),
         _ => unreachable!(),
     }
 }
 fn structural_navigation_view_slot_header(stage: usize) -> View {
     match stage {
-        0 | 3 => {
-            (NavigationView::new().slots(std::iter::empty::<SlotView<NavigationViewSlot>>())).into()
-        }
-        1 => (NavigationView::new().slot(
-            NavigationViewSlot::Header,
-            TextBlock::new().text("surface a"),
-        ))
-        .into(),
-        2 => (NavigationView::new().slot(
-            NavigationViewSlot::Header,
-            TextBlock::new().text("surface b"),
-        ))
-        .into(),
+        0 | 3 => (NavigationView::new()).into(),
+        1 => (NavigationView::new().header(TextBlock::new().text("surface a"))).into(),
+        2 => (NavigationView::new().header(TextBlock::new().text("surface b"))).into(),
         _ => unreachable!(),
     }
 }
 fn structural_navigation_view_slot_pane_custom_content(stage: usize) -> View {
     match stage {
-        0 | 3 => {
-            (NavigationView::new().slots(std::iter::empty::<SlotView<NavigationViewSlot>>())).into()
-        }
-        1 => (NavigationView::new().slot(
-            NavigationViewSlot::PaneCustomContent,
-            TextBlock::new().text("surface a"),
-        ))
-        .into(),
-        2 => (NavigationView::new().slot(
-            NavigationViewSlot::PaneCustomContent,
-            TextBlock::new().text("surface b"),
-        ))
-        .into(),
+        0 | 3 => (NavigationView::new()).into(),
+        1 => (NavigationView::new().pane_custom_content(TextBlock::new().text("surface a"))).into(),
+        2 => (NavigationView::new().pane_custom_content(TextBlock::new().text("surface b"))).into(),
         _ => unreachable!(),
     }
 }
 fn structural_navigation_view_slot_pane_footer(stage: usize) -> View {
     match stage {
-        0 | 3 => {
-            (NavigationView::new().slots(std::iter::empty::<SlotView<NavigationViewSlot>>())).into()
-        }
-        1 => (NavigationView::new().slot(
-            NavigationViewSlot::PaneFooter,
-            TextBlock::new().text("surface a"),
-        ))
-        .into(),
-        2 => (NavigationView::new().slot(
-            NavigationViewSlot::PaneFooter,
-            TextBlock::new().text("surface b"),
-        ))
-        .into(),
+        0 | 3 => (NavigationView::new()).into(),
+        1 => (NavigationView::new().pane_footer(TextBlock::new().text("surface a"))).into(),
+        2 => (NavigationView::new().pane_footer(TextBlock::new().text("surface b"))).into(),
         _ => unreachable!(),
     }
 }
 fn structural_navigation_view_slot_menu_items(stage: usize) -> View {
     match stage {
-        0 | 3 => {
-            (NavigationView::new().slots(std::iter::empty::<SlotView<NavigationViewSlot>>())).into()
-        }
-        1 => (NavigationView::new().collection_slot(
-            NavigationViewSlot::MenuItems,
-            [KeyedView::new(
-                "surface",
-                NavigationViewItem::new().width(40.0),
-            )],
-        ))
+        0 | 3 => (NavigationView::new()).into(),
+        1 => (NavigationView::new().menu_items([KeyedView::new(
+            "surface",
+            NavigationViewItem::new().width(40.0),
+        )]))
         .into(),
-        2 => (NavigationView::new().collection_slot(
-            NavigationViewSlot::MenuItems,
-            [KeyedView::new(
-                "surface",
-                NavigationViewItem::new().width(80.0),
-            )],
-        ))
+        2 => (NavigationView::new().menu_items([KeyedView::new(
+            "surface",
+            NavigationViewItem::new().width(80.0),
+        )]))
+        .into(),
+        _ => unreachable!(),
+    }
+}
+fn structural_navigation_view_slot_footer_menu_items(stage: usize) -> View {
+    match stage {
+        0 | 3 => (NavigationView::new()).into(),
+        1 => (NavigationView::new().footer_menu_items([KeyedView::new(
+            "surface",
+            NavigationViewItem::new().width(40.0),
+        )]))
+        .into(),
+        2 => (NavigationView::new().footer_menu_items([KeyedView::new(
+            "surface",
+            NavigationViewItem::new().width(80.0),
+        )]))
         .into(),
         _ => unreachable!(),
     }
 }
 fn structural_navigation_view_item_slot_content(stage: usize) -> View {
     match stage {
-        0 | 3 => (NavigationViewItem::new()
-            .slots(std::iter::empty::<SlotView<NavigationViewItemSlot>>()))
-        .into(),
-        1 => (NavigationViewItem::new().slot(
-            NavigationViewItemSlot::Content,
-            TextBlock::new().text("surface a"),
-        ))
-        .into(),
-        2 => (NavigationViewItem::new().slot(
-            NavigationViewItemSlot::Content,
-            TextBlock::new().text("surface b"),
-        ))
-        .into(),
+        0 | 3 => (NavigationViewItem::new()).into(),
+        1 => (NavigationViewItem::new().content(TextBlock::new().text("surface a"))).into(),
+        2 => (NavigationViewItem::new().content(TextBlock::new().text("surface b"))).into(),
         _ => unreachable!(),
     }
 }
 fn structural_navigation_view_item_slot_icon(stage: usize) -> View {
     match stage {
-        0 | 3 => (NavigationViewItem::new()
-            .slots(std::iter::empty::<SlotView<NavigationViewItemSlot>>()))
-        .into(),
-        1 => (NavigationViewItem::new().slot(
-            NavigationViewItemSlot::Icon,
-            SymbolIcon::new().symbol(Symbol::Add),
-        ))
-        .into(),
-        2 => (NavigationViewItem::new().slot(
-            NavigationViewItemSlot::Icon,
-            SymbolIcon::new().symbol(Symbol::Accept),
-        ))
-        .into(),
+        0 | 3 => (NavigationViewItem::new()).into(),
+        1 => (NavigationViewItem::new().icon(SymbolIcon::new().symbol(Symbol::Add))).into(),
+        2 => (NavigationViewItem::new().icon(SymbolIcon::new().symbol(Symbol::Accept))).into(),
         _ => unreachable!(),
     }
 }
 fn structural_navigation_view_item_slot_menu_items(stage: usize) -> View {
     match stage {
-        0 | 3 => (NavigationViewItem::new()
-            .slots(std::iter::empty::<SlotView<NavigationViewItemSlot>>()))
+        0 | 3 => (NavigationViewItem::new()).into(),
+        1 => (NavigationViewItem::new().menu_items([KeyedView::new(
+            "surface",
+            TextBlock::new().text("surface a"),
+        )]))
         .into(),
-        1 => (NavigationViewItem::new().collection_slot(
-            NavigationViewItemSlot::MenuItems,
-            [KeyedView::new(
-                "surface",
-                TextBlock::new().text("surface a"),
-            )],
-        ))
-        .into(),
-        2 => (NavigationViewItem::new().collection_slot(
-            NavigationViewItemSlot::MenuItems,
-            [KeyedView::new(
-                "surface",
-                TextBlock::new().text("surface b"),
-            )],
-        ))
+        2 => (NavigationViewItem::new().menu_items([KeyedView::new(
+            "surface",
+            TextBlock::new().text("surface b"),
+        )]))
         .into(),
         _ => unreachable!(),
     }
 }
 fn structural_split_view_slot_pane(stage: usize) -> View {
     match stage {
-        0 | 3 => (SplitView::new().slots(std::iter::empty::<SlotView<SplitViewSlot>>())).into(),
-        1 => {
-            (SplitView::new().slot(SplitViewSlot::Pane, TextBlock::new().text("surface a"))).into()
-        }
-        2 => {
-            (SplitView::new().slot(SplitViewSlot::Pane, TextBlock::new().text("surface b"))).into()
-        }
+        0 | 3 => (SplitView::new()).into(),
+        1 => (SplitView::new().pane(TextBlock::new().text("surface a"))).into(),
+        2 => (SplitView::new().pane(TextBlock::new().text("surface b"))).into(),
         _ => unreachable!(),
     }
 }
 fn structural_split_view_slot_content(stage: usize) -> View {
     match stage {
-        0 | 3 => (SplitView::new().slots(std::iter::empty::<SlotView<SplitViewSlot>>())).into(),
-        1 => (SplitView::new().slot(SplitViewSlot::Content, TextBlock::new().text("surface a")))
-            .into(),
-        2 => (SplitView::new().slot(SplitViewSlot::Content, TextBlock::new().text("surface b")))
-            .into(),
+        0 | 3 => (SplitView::new()).into(),
+        1 => (SplitView::new().content(TextBlock::new().text("surface a"))).into(),
+        2 => (SplitView::new().content(TextBlock::new().text("surface b"))).into(),
         _ => unreachable!(),
     }
 }
 fn structural_toggle_switch_slot_header(stage: usize) -> View {
     match stage {
-        0 | 3 => {
-            (ToggleSwitch::new().slots(std::iter::empty::<SlotView<ToggleSwitchSlot>>())).into()
-        }
-        1 => (ToggleSwitch::new()
-            .slot(ToggleSwitchSlot::Header, TextBlock::new().text("surface a")))
-        .into(),
-        2 => (ToggleSwitch::new()
-            .slot(ToggleSwitchSlot::Header, TextBlock::new().text("surface b")))
-        .into(),
+        0 | 3 => (ToggleSwitch::new()).into(),
+        1 => (ToggleSwitch::new().header(TextBlock::new().text("surface a"))).into(),
+        2 => (ToggleSwitch::new().header(TextBlock::new().text("surface b"))).into(),
         _ => unreachable!(),
     }
 }
 fn structural_toggle_switch_slot_on_content(stage: usize) -> View {
     match stage {
-        0 | 3 => {
-            (ToggleSwitch::new().slots(std::iter::empty::<SlotView<ToggleSwitchSlot>>())).into()
-        }
-        1 => (ToggleSwitch::new().slot(
-            ToggleSwitchSlot::OnContent,
-            TextBlock::new().text("surface a"),
-        ))
-        .into(),
-        2 => (ToggleSwitch::new().slot(
-            ToggleSwitchSlot::OnContent,
-            TextBlock::new().text("surface b"),
-        ))
-        .into(),
+        0 | 3 => (ToggleSwitch::new()).into(),
+        1 => (ToggleSwitch::new().on_content(TextBlock::new().text("surface a"))).into(),
+        2 => (ToggleSwitch::new().on_content(TextBlock::new().text("surface b"))).into(),
         _ => unreachable!(),
     }
 }
 fn structural_toggle_switch_slot_off_content(stage: usize) -> View {
     match stage {
-        0 | 3 => {
-            (ToggleSwitch::new().slots(std::iter::empty::<SlotView<ToggleSwitchSlot>>())).into()
-        }
-        1 => (ToggleSwitch::new().slot(
-            ToggleSwitchSlot::OffContent,
-            TextBlock::new().text("surface a"),
-        ))
-        .into(),
-        2 => (ToggleSwitch::new().slot(
-            ToggleSwitchSlot::OffContent,
-            TextBlock::new().text("surface b"),
-        ))
-        .into(),
+        0 | 3 => (ToggleSwitch::new()).into(),
+        1 => (ToggleSwitch::new().off_content(TextBlock::new().text("surface a"))).into(),
+        2 => (ToggleSwitch::new().off_content(TextBlock::new().text("surface b"))).into(),
         _ => unreachable!(),
     }
 }
@@ -3604,15 +3477,9 @@ fn structural_radio_button_content(stage: usize) -> View {
 }
 fn structural_radio_buttons_slot_header(stage: usize) -> View {
     match stage {
-        0 | 3 => {
-            (RadioButtons::new().slots(std::iter::empty::<SlotView<RadioButtonsSlot>>())).into()
-        }
-        1 => (RadioButtons::new()
-            .slot(RadioButtonsSlot::Header, TextBlock::new().text("surface a")))
-        .into(),
-        2 => (RadioButtons::new()
-            .slot(RadioButtonsSlot::Header, TextBlock::new().text("surface b")))
-        .into(),
+        0 | 3 => (RadioButtons::new()).into(),
+        1 => (RadioButtons::new().header(TextBlock::new().text("surface a"))).into(),
+        2 => (RadioButtons::new().header(TextBlock::new().text("surface b"))).into(),
         _ => unreachable!(),
     }
 }
@@ -3645,17 +3512,11 @@ fn structural_scroll_view_content(stage: usize) -> View {
 }
 fn structural_list_box_slot_items(stage: usize) -> View {
     match stage {
-        0 | 3 => (ListBox::new().slots(std::iter::empty::<SlotView<ListBoxSlot>>())).into(),
-        1 => (ListBox::new().collection_slot(
-            ListBoxSlot::Items,
-            [KeyedView::new("surface", ListBoxItem::new().width(40.0))],
-        ))
-        .into(),
-        2 => (ListBox::new().collection_slot(
-            ListBoxSlot::Items,
-            [KeyedView::new("surface", ListBoxItem::new().width(80.0))],
-        ))
-        .into(),
+        0 | 3 => (ListBox::new()).into(),
+        1 => (ListBox::new().items([KeyedView::new("surface", ListBoxItem::new().width(40.0))]))
+            .into(),
+        2 => (ListBox::new().items([KeyedView::new("surface", ListBoxItem::new().width(80.0))]))
+            .into(),
         _ => unreachable!(),
     }
 }
@@ -3669,53 +3530,33 @@ fn structural_list_box_item_content(stage: usize) -> View {
 }
 fn structural_expander_slot_header(stage: usize) -> View {
     match stage {
-        0 | 3 => (Expander::new().slots(std::iter::empty::<SlotView<ExpanderSlot>>())).into(),
-        1 => {
-            (Expander::new().slot(ExpanderSlot::Header, TextBlock::new().text("surface a"))).into()
-        }
-        2 => {
-            (Expander::new().slot(ExpanderSlot::Header, TextBlock::new().text("surface b"))).into()
-        }
+        0 | 3 => (Expander::new()).into(),
+        1 => (Expander::new().header(TextBlock::new().text("surface a"))).into(),
+        2 => (Expander::new().header(TextBlock::new().text("surface b"))).into(),
         _ => unreachable!(),
     }
 }
 fn structural_expander_slot_content(stage: usize) -> View {
     match stage {
-        0 | 3 => (Expander::new().slots(std::iter::empty::<SlotView<ExpanderSlot>>())).into(),
-        1 => {
-            (Expander::new().slot(ExpanderSlot::Content, TextBlock::new().text("surface a"))).into()
-        }
-        2 => {
-            (Expander::new().slot(ExpanderSlot::Content, TextBlock::new().text("surface b"))).into()
-        }
+        0 | 3 => (Expander::new()).into(),
+        1 => (Expander::new().content(TextBlock::new().text("surface a"))).into(),
+        2 => (Expander::new().content(TextBlock::new().text("surface b"))).into(),
         _ => unreachable!(),
     }
 }
 fn structural_combo_box_slot_header(stage: usize) -> View {
     match stage {
-        0 | 3 => (ComboBox::new().slots(std::iter::empty::<SlotView<ComboBoxSlot>>())).into(),
-        1 => {
-            (ComboBox::new().slot(ComboBoxSlot::Header, TextBlock::new().text("surface a"))).into()
-        }
-        2 => {
-            (ComboBox::new().slot(ComboBoxSlot::Header, TextBlock::new().text("surface b"))).into()
-        }
+        0 | 3 => (ComboBox::new()).into(),
+        1 => (ComboBox::new().header(TextBlock::new().text("surface a"))).into(),
+        2 => (ComboBox::new().header(TextBlock::new().text("surface b"))).into(),
         _ => unreachable!(),
     }
 }
 fn structural_pivot_slot_items(stage: usize) -> View {
     match stage {
-        0 | 3 => (Pivot::new().slots(std::iter::empty::<SlotView<PivotSlot>>())).into(),
-        1 => (Pivot::new().collection_slot(
-            PivotSlot::Items,
-            [KeyedView::new("surface", PivotItem::new().width(40.0))],
-        ))
-        .into(),
-        2 => (Pivot::new().collection_slot(
-            PivotSlot::Items,
-            [KeyedView::new("surface", PivotItem::new().width(80.0))],
-        ))
-        .into(),
+        0 | 3 => (Pivot::new()).into(),
+        1 => (Pivot::new().items([KeyedView::new("surface", PivotItem::new().width(40.0))])).into(),
+        2 => (Pivot::new().items([KeyedView::new("surface", PivotItem::new().width(80.0))])).into(),
         _ => unreachable!(),
     }
 }
@@ -3729,84 +3570,56 @@ fn structural_pivot_item_content(stage: usize) -> View {
 }
 fn structural_flip_view_slot_items(stage: usize) -> View {
     match stage {
-        0 | 3 => (FlipView::new().slots(std::iter::empty::<SlotView<FlipViewSlot>>())).into(),
-        1 => (FlipView::new().collection_slot(
-            FlipViewSlot::Items,
-            [KeyedView::new(
-                "surface",
-                TextBlock::new().text("surface a"),
-            )],
-        ))
+        0 | 3 => (FlipView::new()).into(),
+        1 => (FlipView::new().items([KeyedView::new(
+            "surface",
+            TextBlock::new().text("surface a"),
+        )]))
         .into(),
-        2 => (FlipView::new().collection_slot(
-            FlipViewSlot::Items,
-            [KeyedView::new(
-                "surface",
-                TextBlock::new().text("surface b"),
-            )],
-        ))
+        2 => (FlipView::new().items([KeyedView::new(
+            "surface",
+            TextBlock::new().text("surface b"),
+        )]))
         .into(),
         _ => unreachable!(),
     }
 }
 fn structural_selector_bar_slot_items(stage: usize) -> View {
     match stage {
-        0 | 3 => (SelectorBar::new().slots(std::iter::empty::<SlotView<SelectorBarSlot>>())).into(),
-        1 => (SelectorBar::new().collection_slot(
-            SelectorBarSlot::Items,
-            [KeyedView::new(
-                "surface",
-                SelectorBarItem::new().width(40.0),
-            )],
-        ))
+        0 | 3 => (SelectorBar::new()).into(),
+        1 => (SelectorBar::new().items([KeyedView::new(
+            "surface",
+            SelectorBarItem::new().width(40.0),
+        )]))
         .into(),
-        2 => (SelectorBar::new().collection_slot(
-            SelectorBarSlot::Items,
-            [KeyedView::new(
-                "surface",
-                SelectorBarItem::new().width(80.0),
-            )],
-        ))
+        2 => (SelectorBar::new().items([KeyedView::new(
+            "surface",
+            SelectorBarItem::new().width(80.0),
+        )]))
         .into(),
         _ => unreachable!(),
     }
 }
 fn structural_selector_bar_item_slot_icon(stage: usize) -> View {
     match stage {
-        0 | 3 => (SelectorBarItem::new()
-            .slots(std::iter::empty::<SlotView<SelectorBarItemSlot>>()))
-        .into(),
-        1 => (SelectorBarItem::new().slot(
-            SelectorBarItemSlot::Icon,
-            SymbolIcon::new().symbol(Symbol::Add),
-        ))
-        .into(),
-        2 => (SelectorBarItem::new().slot(
-            SelectorBarItemSlot::Icon,
-            SymbolIcon::new().symbol(Symbol::Accept),
-        ))
-        .into(),
+        0 | 3 => (SelectorBarItem::new()).into(),
+        1 => (SelectorBarItem::new().icon(SymbolIcon::new().symbol(Symbol::Add))).into(),
+        2 => (SelectorBarItem::new().icon(SymbolIcon::new().symbol(Symbol::Accept))).into(),
         _ => unreachable!(),
     }
 }
 fn structural_tab_view_slot_tab_items(stage: usize) -> View {
     match stage {
-        0 | 3 => (TabView::new().slots(std::iter::empty::<SlotView<TabViewSlot>>())).into(),
-        1 => (TabView::new().collection_slot(
-            TabViewSlot::TabItems,
-            [KeyedView::new(
-                "surface",
-                TextBlock::new().text("surface a"),
-            )],
-        ))
+        0 | 3 => (TabView::new()).into(),
+        1 => (TabView::new().tab_items([KeyedView::new(
+            "surface",
+            TextBlock::new().text("surface a"),
+        )]))
         .into(),
-        2 => (TabView::new().collection_slot(
-            TabViewSlot::TabItems,
-            [KeyedView::new(
-                "surface",
-                TextBlock::new().text("surface b"),
-            )],
-        ))
+        2 => (TabView::new().tab_items([KeyedView::new(
+            "surface",
+            TextBlock::new().text("surface b"),
+        )]))
         .into(),
         _ => unreachable!(),
     }
@@ -3829,67 +3642,43 @@ fn structural_drop_down_button_content(stage: usize) -> View {
 }
 fn structural_command_bar_slot_primary_commands(stage: usize) -> View {
     match stage {
-        0 | 3 => (CommandBar::new().slots(std::iter::empty::<SlotView<CommandBarSlot>>())).into(),
-        1 => (CommandBar::new().collection_slot(
-            CommandBarSlot::PrimaryCommands,
-            [KeyedView::new("surface", AppBarButton::new().width(40.0))],
-        ))
+        0 | 3 => (CommandBar::new()).into(),
+        1 => (CommandBar::new()
+            .primary_commands([KeyedView::new("surface", AppBarButton::new().width(40.0))]))
         .into(),
-        2 => (CommandBar::new().collection_slot(
-            CommandBarSlot::PrimaryCommands,
-            [KeyedView::new("surface", AppBarButton::new().width(80.0))],
-        ))
+        2 => (CommandBar::new()
+            .primary_commands([KeyedView::new("surface", AppBarButton::new().width(80.0))]))
         .into(),
         _ => unreachable!(),
     }
 }
 fn structural_command_bar_slot_secondary_commands(stage: usize) -> View {
     match stage {
-        0 | 3 => (CommandBar::new().slots(std::iter::empty::<SlotView<CommandBarSlot>>())).into(),
-        1 => (CommandBar::new().collection_slot(
-            CommandBarSlot::SecondaryCommands,
-            [KeyedView::new("surface", AppBarButton::new().width(40.0))],
-        ))
+        0 | 3 => (CommandBar::new()).into(),
+        1 => (CommandBar::new()
+            .secondary_commands([KeyedView::new("surface", AppBarButton::new().width(40.0))]))
         .into(),
-        2 => (CommandBar::new().collection_slot(
-            CommandBarSlot::SecondaryCommands,
-            [KeyedView::new("surface", AppBarButton::new().width(80.0))],
-        ))
+        2 => (CommandBar::new()
+            .secondary_commands([KeyedView::new("surface", AppBarButton::new().width(80.0))]))
         .into(),
         _ => unreachable!(),
     }
 }
 fn structural_app_bar_button_slot_icon(stage: usize) -> View {
     match stage {
-        0 | 3 => {
-            (AppBarButton::new().slots(std::iter::empty::<SlotView<AppBarButtonSlot>>())).into()
-        }
-        1 => (AppBarButton::new().slot(
-            AppBarButtonSlot::Icon,
-            SymbolIcon::new().symbol(Symbol::Add),
-        ))
-        .into(),
-        2 => (AppBarButton::new().slot(
-            AppBarButtonSlot::Icon,
-            SymbolIcon::new().symbol(Symbol::Accept),
-        ))
-        .into(),
+        0 | 3 => (AppBarButton::new()).into(),
+        1 => (AppBarButton::new().icon(SymbolIcon::new().symbol(Symbol::Add))).into(),
+        2 => (AppBarButton::new().icon(SymbolIcon::new().symbol(Symbol::Accept))).into(),
         _ => unreachable!(),
     }
 }
 fn structural_menu_bar_slot_items(stage: usize) -> View {
     match stage {
-        0 | 3 => (MenuBar::new().slots(std::iter::empty::<SlotView<MenuBarSlot>>())).into(),
-        1 => (MenuBar::new().collection_slot(
-            MenuBarSlot::Items,
-            [KeyedView::new("surface", MenuBarItem::new().width(40.0))],
-        ))
-        .into(),
-        2 => (MenuBar::new().collection_slot(
-            MenuBarSlot::Items,
-            [KeyedView::new("surface", MenuBarItem::new().width(80.0))],
-        ))
-        .into(),
+        0 | 3 => (MenuBar::new()).into(),
+        1 => (MenuBar::new().items([KeyedView::new("surface", MenuBarItem::new().width(40.0))]))
+            .into(),
+        2 => (MenuBar::new().items([KeyedView::new("surface", MenuBarItem::new().width(80.0))]))
+            .into(),
         _ => unreachable!(),
     }
 }
@@ -3903,39 +3692,25 @@ fn structural_split_button_content(stage: usize) -> View {
 }
 fn structural_date_picker_slot_header(stage: usize) -> View {
     match stage {
-        0 | 3 => (DatePicker::new().slots(std::iter::empty::<SlotView<DatePickerSlot>>())).into(),
-        1 => (DatePicker::new().slot(DatePickerSlot::Header, TextBlock::new().text("surface a")))
-            .into(),
-        2 => (DatePicker::new().slot(DatePickerSlot::Header, TextBlock::new().text("surface b")))
-            .into(),
+        0 | 3 => (DatePicker::new()).into(),
+        1 => (DatePicker::new().header(TextBlock::new().text("surface a"))).into(),
+        2 => (DatePicker::new().header(TextBlock::new().text("surface b"))).into(),
         _ => unreachable!(),
     }
 }
 fn structural_time_picker_slot_header(stage: usize) -> View {
     match stage {
-        0 | 3 => (TimePicker::new().slots(std::iter::empty::<SlotView<TimePickerSlot>>())).into(),
-        1 => (TimePicker::new().slot(TimePickerSlot::Header, TextBlock::new().text("surface a")))
-            .into(),
-        2 => (TimePicker::new().slot(TimePickerSlot::Header, TextBlock::new().text("surface b")))
-            .into(),
+        0 | 3 => (TimePicker::new()).into(),
+        1 => (TimePicker::new().header(TextBlock::new().text("surface a"))).into(),
+        2 => (TimePicker::new().header(TextBlock::new().text("surface b"))).into(),
         _ => unreachable!(),
     }
 }
 fn structural_calendar_date_picker_slot_header(stage: usize) -> View {
     match stage {
-        0 | 3 => (CalendarDatePicker::new()
-            .slots(std::iter::empty::<SlotView<CalendarDatePickerSlot>>()))
-        .into(),
-        1 => (CalendarDatePicker::new().slot(
-            CalendarDatePickerSlot::Header,
-            TextBlock::new().text("surface a"),
-        ))
-        .into(),
-        2 => (CalendarDatePicker::new().slot(
-            CalendarDatePickerSlot::Header,
-            TextBlock::new().text("surface b"),
-        ))
-        .into(),
+        0 | 3 => (CalendarDatePicker::new()).into(),
+        1 => (CalendarDatePicker::new().header(TextBlock::new().text("surface a"))).into(),
+        2 => (CalendarDatePicker::new().header(TextBlock::new().text("surface b"))).into(),
         _ => unreachable!(),
     }
 }
@@ -3951,22 +3726,16 @@ fn structural_content_dialog_content(stage: usize) -> View {
 }
 fn structural_list_view_slot_items(stage: usize) -> View {
     match stage {
-        0 | 3 => (ListView::new().slots(std::iter::empty::<SlotView<ListViewSlot>>())).into(),
-        1 => (ListView::new().collection_slot(
-            ListViewSlot::Items,
-            [KeyedView::new(
-                "surface",
-                TextBlock::new().text("surface a"),
-            )],
-        ))
+        0 | 3 => (ListView::new()).into(),
+        1 => (ListView::new().items([KeyedView::new(
+            "surface",
+            TextBlock::new().text("surface a"),
+        )]))
         .into(),
-        2 => (ListView::new().collection_slot(
-            ListViewSlot::Items,
-            [KeyedView::new(
-                "surface",
-                TextBlock::new().text("surface b"),
-            )],
-        ))
+        2 => (ListView::new().items([KeyedView::new(
+            "surface",
+            TextBlock::new().text("surface b"),
+        )]))
         .into(),
         _ => unreachable!(),
     }
@@ -3981,22 +3750,16 @@ fn structural_list_view_item_content(stage: usize) -> View {
 }
 fn structural_grid_view_slot_items(stage: usize) -> View {
     match stage {
-        0 | 3 => (GridView::new().slots(std::iter::empty::<SlotView<GridViewSlot>>())).into(),
-        1 => (GridView::new().collection_slot(
-            GridViewSlot::Items,
-            [KeyedView::new(
-                "surface",
-                TextBlock::new().text("surface a"),
-            )],
-        ))
+        0 | 3 => (GridView::new()).into(),
+        1 => (GridView::new().items([KeyedView::new(
+            "surface",
+            TextBlock::new().text("surface a"),
+        )]))
         .into(),
-        2 => (GridView::new().collection_slot(
-            GridViewSlot::Items,
-            [KeyedView::new(
-                "surface",
-                TextBlock::new().text("surface b"),
-            )],
-        ))
+        2 => (GridView::new().items([KeyedView::new(
+            "surface",
+            TextBlock::new().text("surface b"),
+        )]))
         .into(),
         _ => unreachable!(),
     }
@@ -4035,47 +3798,35 @@ fn structural_canvas_children(stage: usize) -> View {
 }
 fn structural_rich_edit_box_slot_header(stage: usize) -> View {
     match stage {
-        0 | 3 => (RichEditBox::new().slots(std::iter::empty::<SlotView<RichEditBoxSlot>>())).into(),
-        1 => (RichEditBox::new().slot(RichEditBoxSlot::Header, TextBlock::new().text("surface a")))
-            .into(),
-        2 => (RichEditBox::new().slot(RichEditBoxSlot::Header, TextBlock::new().text("surface b")))
-            .into(),
+        0 | 3 => (RichEditBox::new()).into(),
+        1 => (RichEditBox::new().header(TextBlock::new().text("surface a"))).into(),
+        2 => (RichEditBox::new().header(TextBlock::new().text("surface b"))).into(),
         _ => unreachable!(),
     }
 }
 fn structural_viewbox_slot_child(stage: usize) -> View {
     match stage {
-        0 | 3 => (Viewbox::new().slots(std::iter::empty::<SlotView<ViewboxSlot>>())).into(),
-        1 => (Viewbox::new().slot(ViewboxSlot::Child, TextBlock::new().text("surface a"))).into(),
-        2 => (Viewbox::new().slot(ViewboxSlot::Child, TextBlock::new().text("surface b"))).into(),
+        0 | 3 => (Viewbox::new()).into(),
+        1 => (Viewbox::new().child(TextBlock::new().text("surface a"))).into(),
+        2 => (Viewbox::new().child(TextBlock::new().text("surface b"))).into(),
         _ => unreachable!(),
     }
 }
 fn structural_title_bar_slot_content(stage: usize) -> View {
     match stage {
-        0 | 3 => Grid::new()
-            .children((TitleBar::new().slots(std::iter::empty::<SlotView<TitleBarSlot>>()),)),
-        1 => Grid::new().children((
-            TitleBar::new().slot(TitleBarSlot::Content, TextBlock::new().text("surface a")),
-        )),
-        2 => Grid::new().children((
-            TitleBar::new().slot(TitleBarSlot::Content, TextBlock::new().text("surface b")),
-        )),
+        0 | 3 => Grid::new().children((TitleBar::new(),)),
+        1 => Grid::new().children((TitleBar::new().content(TextBlock::new().text("surface a")),)),
+        2 => Grid::new().children((TitleBar::new().content(TextBlock::new().text("surface b")),)),
         _ => unreachable!(),
     }
 }
 fn structural_title_bar_slot_right_header(stage: usize) -> View {
     match stage {
-        0 | 3 => Grid::new()
-            .children((TitleBar::new().slots(std::iter::empty::<SlotView<TitleBarSlot>>()),)),
-        1 => Grid::new().children((TitleBar::new().slot(
-            TitleBarSlot::RightHeader,
-            TextBlock::new().text("surface a"),
-        ),)),
-        2 => Grid::new().children((TitleBar::new().slot(
-            TitleBarSlot::RightHeader,
-            TextBlock::new().text("surface b"),
-        ),)),
+        0 | 3 => Grid::new().children((TitleBar::new(),)),
+        1 => Grid::new()
+            .children((TitleBar::new().right_header(TextBlock::new().text("surface a")),)),
+        2 => Grid::new()
+            .children((TitleBar::new().right_header(TextBlock::new().text("surface b")),)),
         _ => unreachable!(),
     }
 }
@@ -5281,6 +5032,13 @@ pub(crate) static SURFACE_CASES: &[SurfaceCase] = &[
         stages: 4,
         subscription_delta: None,
         build: structural_navigation_view_slot_menu_items,
+    },
+    SurfaceCase {
+        name: "structural.NavigationView.Slot.FooterMenuItems",
+        kind: SurfaceKind::Structural,
+        stages: 4,
+        subscription_delta: None,
+        build: structural_navigation_view_slot_footer_menu_items,
     },
     SurfaceCase {
         name: "event.NavigationView.IsPaneOpenChanged",
@@ -10265,6 +10023,10 @@ pub static STRUCTURAL_SURFACES: &[StructuralSurface] = &[
     StructuralSurface {
         control: "NavigationView",
         member: "Slot.MenuItems",
+    },
+    StructuralSurface {
+        control: "NavigationView",
+        member: "Slot.FooterMenuItems",
     },
     StructuralSurface {
         control: "NavigationViewItem",

--- a/crates/tools/reactor/src/control_bindings.txt
+++ b/crates/tools/reactor/src/control_bindings.txt
@@ -160,6 +160,7 @@ Microsoft::UI::Xaml::Controls::INavigationView2::put_IsBackButtonVisible
 Microsoft::UI::Xaml::Controls::INavigationView2::put_PaneCustomContent
 Microsoft::UI::Xaml::Controls::INavigationView2::put_PaneDisplayMode
 Microsoft::UI::Xaml::Controls::INavigationView2::put_PaneTitle
+Microsoft::UI::Xaml::Controls::INavigationView::get_FooterMenuItems
 Microsoft::UI::Xaml::Controls::INavigationView::get_IsPaneOpen
 Microsoft::UI::Xaml::Controls::INavigationView::get_MenuItems
 Microsoft::UI::Xaml::Controls::INavigationView::put_AlwaysShowHeader

--- a/crates/tools/reactor/src/generate.rs
+++ b/crates/tools/reactor/src/generate.rs
@@ -26,6 +26,25 @@ pub(crate) fn generate(schema: &ResolvedSchema) -> String {
                 let open = value.is_open;
                 Self::content_dialog(value.into(), None, open)
             }
+        } else if matches!(control.role, Role::Slots)
+            && control.placement == ResolvedPlacement::WindowLifetime
+        {
+            quote! {
+                let mut value = value;
+                let slots = value
+                    .slots
+                    .take()
+                    .unwrap_or_else(|| std::rc::Rc::new(Vec::new()));
+                Self::slotted(value.into(), slots)
+            }
+        } else if matches!(control.role, Role::Slots) {
+            quote! {
+                let mut value = value;
+                match value.slots.take() {
+                    Some(slots) => Self::slotted(value.into(), slots),
+                    None => Self::native(value),
+                }
+            }
         } else {
             quote! { Self::native(value) }
         };
@@ -105,24 +124,6 @@ pub(crate) fn generate(schema: &ResolvedSchema) -> String {
             .iter()
             .map(|slot| ident(&format!("{}{}", control.name, slot.name)))
     });
-    let slot_id_lookups = schema
-        .controls
-        .iter()
-        .filter(|control| !control.slots.is_empty())
-        .map(|control| {
-            let kind = ident(&control.name);
-            let indexes = control.slots.iter().enumerate().map(|(index, slot)| {
-                let index = u8::try_from(index).unwrap();
-                let slot = ident(&format!("{}{}", control.name, slot.name));
-                quote! { #index => Some(SlotId::#slot) }
-            });
-            quote! {
-                MountedKind::#kind => match index {
-                    #(#indexes,)*
-                    _ => None,
-                }
-            }
-        });
     let slot_lists = schema.controls.iter().map(|control| {
         let kind = ident(&control.name);
         let slots = control.slots.iter().map(|slot| {
@@ -303,13 +304,6 @@ pub(crate) fn generate(schema: &ResolvedSchema) -> String {
             #(#slot_ids),*
         }
 
-        pub fn slot_id(kind: MountedKind, index: u8) -> Option<SlotId> {
-            match kind {
-                #(#slot_id_lookups,)*
-                _ => None,
-            }
-        }
-
         pub fn slots(kind: MountedKind) -> &'static [SlotId] {
             match kind {
                 #(#slot_lists),*
@@ -452,7 +446,7 @@ pub(crate) fn generate(schema: &ResolvedSchema) -> String {
 
         #[derive(Clone, Copy, Debug, Eq, PartialEq)]
         pub struct SelectionDescriptor {
-            pub slot: SlotId,
+            pub slots: &'static [SlotId],
             pub item: MountedKind,
             pub selected_property: PropertyId,
             pub event: EventId,
@@ -495,7 +489,11 @@ pub(crate) fn generate(schema: &ResolvedSchema) -> String {
         pub fn selection_for_slot(slot: SlotId) -> Option<SelectionDescriptor> {
             CONTROLS
                 .iter()
-                .find_map(|control| control.selection.filter(|selection| selection.slot == slot))
+                .find_map(|control| {
+                    control
+                        .selection
+                        .filter(|selection| selection.slots.contains(&slot))
+                })
         }
 
         pub fn selection_for_item_property(
@@ -504,7 +502,7 @@ pub(crate) fn generate(schema: &ResolvedSchema) -> String {
         ) -> Option<SelectionDescriptor> {
             CONTROLS.iter().find_map(|control| {
                 control.selection.filter(|selection| {
-                    selection.selected_property == property && selection.slot == slot
+                    selection.selected_property == property && selection.slots.contains(&slot)
                 })
             })
         }
@@ -757,6 +755,7 @@ fn generate_element_parts(control: &ResolvedControl) -> TokenStream {
         ),
         Role::Leaf | Role::Slots => (TokenStream::new(), quote! { ElementStructure::None }),
     };
+    let slot_pattern = matches!(control.role, Role::Slots).then(|| quote! { slots: _, });
     let lifecycle_pattern =
         (control.lifecycle == Some(Lifecycle::ContentDialog)).then(|| quote! { , is_open: _ });
 
@@ -768,6 +767,7 @@ fn generate_element_parts(control: &ResolvedControl) -> TokenStream {
                 #reference_pattern
                 #element_state_pattern
                 #window_title_bar_pattern
+                #slot_pattern
                 #structural_pattern
                 #lifecycle_pattern
             } = value;
@@ -1545,6 +1545,42 @@ fn generate_element(control: &ResolvedControl) -> TokenStream {
             }
         }
     });
+    let slot_field = (!control.slots.is_empty())
+        .then(|| quote! { slots: Option<std::rc::Rc<Vec<SlottedView>>>, });
+    let slot_methods = control.slots.iter().map(|slot| {
+        let method = ident(&crate::helpers::to_snake_case(&slot.name));
+        let slot_id = ident(&format!("{}{}", control.name, slot.name));
+        match &slot.shape {
+            crate::schema::SlotShape::Single(_) => quote! {
+                #visibility fn #method(mut self, view: impl Into<View>) -> Self {
+                    set_control_slot(
+                        &mut self.slots,
+                        SlotId::#slot_id,
+                        SlotContent::Single(view.into()),
+                    );
+                    self
+                }
+            },
+            crate::schema::SlotShape::Collection(_) => quote! {
+                #visibility fn #method<T>(
+                    mut self,
+                    children: impl IntoIterator<Item = T>,
+                ) -> Self
+                where
+                    T: Into<KeyedView>,
+                {
+                    set_control_slot(
+                        &mut self.slots,
+                        SlotId::#slot_id,
+                        SlotContent::Collection(std::rc::Rc::new(
+                            children.into_iter().map(Into::into).collect(),
+                        )),
+                    );
+                    self
+                }
+            },
+        }
+    });
     let property_methods = control.properties.iter().map(|property| {
         let field = ident(&property.field);
         let value = value_type(&property.value);
@@ -1956,30 +1992,6 @@ fn generate_element(control: &ResolvedControl) -> TokenStream {
             Some(quote! { impl #capability for #name {} })
         }
     });
-    let slots = if control.slots.is_empty() {
-        TokenStream::new()
-    } else {
-        let slot_name = ident(&format!("{}Slot", control.name));
-        let variants = control.slots.iter().map(|slot| ident(&slot.name));
-        quote! {
-            #[non_exhaustive]
-            #[repr(u8)]
-            #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-            pub enum #slot_name {
-                #(#variants),*
-            }
-
-            impl sealed::SlotIndex<#slot_name> for #name {
-                fn slot_index(slot: #slot_name) -> u8 {
-                    slot as u8
-                }
-            }
-
-            impl SlotsControl for #name {
-                type Slot = #slot_name;
-            }
-        }
-    };
     quote! {
         #[derive(Clone, Debug, Default, PartialEq)]
         #visibility struct #name {
@@ -1989,6 +2001,7 @@ fn generate_element(control: &ResolvedControl) -> TokenStream {
             #element_state_field
             #window_title_bar_field
             #grid_definition_fields
+            #slot_field
             #structural_field
             #lifecycle_field
         }
@@ -2004,6 +2017,7 @@ fn generate_element(control: &ResolvedControl) -> TokenStream {
 
             #(#property_methods)*
             #(#event_methods)*
+            #(#slot_methods)*
             #grid_definition_methods
             #structural_methods
         }
@@ -2016,7 +2030,6 @@ fn generate_element(control: &ResolvedControl) -> TokenStream {
         }
         #reference_impls
         #(#capability_impls)*
-        #slots
         #structural_test_impl
     }
 }
@@ -2280,7 +2293,10 @@ fn generate_control(control: &ResolvedControl) -> TokenStream {
     let selection = control.selection.as_ref().map_or_else(
         || quote! { None },
         |selection| {
-            let slot = ident(&format!("{}{}", control.name, selection.slot));
+            let slots = selection
+                .slots
+                .iter()
+                .map(|slot| ident(&format!("{}{}", control.name, slot)));
             let item = ident(&selection.item);
             let selected_property = ident(&format!(
                 "{}{}",
@@ -2291,7 +2307,7 @@ fn generate_control(control: &ResolvedControl) -> TokenStream {
                 ident(&format!("{}{}", selection.item, selection.payload_property));
             quote! {
                 Some(SelectionDescriptor {
-                    slot: SlotId::#slot,
+                    slots: &[#(SlotId::#slots),*],
                     item: MountedKind::#item,
                     selected_property: PropertyId::#selected_property,
                     event: EventId::#event,
@@ -2513,7 +2529,7 @@ property = "NewValue"
         let resolved = Schema::parse(&source).unwrap().resolve(&metadata).unwrap();
         let output = generate(&resolved);
 
-        for name in ["Orientation", "ContentDialogResult", "NavigationViewSlot"] {
+        for name in ["Orientation", "ContentDialogResult"] {
             let enum_start = output.find(&format!("pub enum {name}")).unwrap();
             let attributes = &output[enum_start.saturating_sub(160)..enum_start];
             assert!(
@@ -2521,5 +2537,6 @@ property = "NewValue"
                 "{name} must be non-exhaustive"
             );
         }
+        assert!(!output.contains("enum NavigationViewSlot"));
     }
 }

--- a/crates/tools/reactor/src/generate_surface.rs
+++ b/crates/tools/reactor/src/generate_surface.rs
@@ -65,16 +65,6 @@ pub(crate) fn generate(schema: &ResolvedSchema) -> String {
                     Grid::new().children((#name::new(),))
                 }
             },
-            ResolvedPlacement::WindowLifetime if !control.slots.is_empty() => {
-                let slot_type = ident(&format!("{}Slot", control.name));
-                quote! {
-                    fn #function(_stage: usize) -> View {
-                        Grid::new().children((
-                            #name::new().slots(std::iter::empty::<SlotView<#slot_type>>()),
-                        ))
-                    }
-                }
-            }
             ResolvedPlacement::WindowLifetime => quote! {
                 fn #function(_stage: usize) -> View {
                     Grid::new().children((#name::new(),))
@@ -221,12 +211,11 @@ pub(crate) fn generate(schema: &ResolvedSchema) -> String {
                 );
             }
             for slot in &control.slots {
-                let slot_type = ident(&format!("{}Slot", control.name));
-                let slot_name = ident(&slot.name);
+                let slot_method = ident(&to_snake_case(&slot.name));
                 let item_control = control
                     .selection
                     .as_ref()
-                    .filter(|selection| selection.slot == slot.name)
+                    .filter(|selection| selection.slots.contains(&slot.name))
                     .map(|selection| selection.item.as_str())
                     .or_else(|| slot.item_controls.first().map(String::as_str))
                     .or_else(|| {
@@ -256,22 +245,20 @@ pub(crate) fn generate(schema: &ResolvedSchema) -> String {
                 };
                 let initial = match &slot.shape {
                     SlotShape::Single(_) => quote! {
-                        #control_name::new().slot(#slot_type::#slot_name, #initial_child)
+                        #control_name::new().#slot_method(#initial_child)
                     },
                     SlotShape::Collection(_) => quote! {
-                        #control_name::new().collection_slot(
-                            #slot_type::#slot_name,
+                        #control_name::new().#slot_method(
                             [KeyedView::new("surface", #initial_child)],
                         )
                     },
                 };
                 let alternate = match &slot.shape {
                     SlotShape::Single(_) => quote! {
-                        #control_name::new().slot(#slot_type::#slot_name, #alternate_child)
+                        #control_name::new().#slot_method(#alternate_child)
                     },
                     SlotShape::Collection(_) => quote! {
-                        #control_name::new().collection_slot(
-                            #slot_type::#slot_name,
+                        #control_name::new().#slot_method(
                             [KeyedView::new("surface", #alternate_child)],
                         )
                     },
@@ -279,13 +266,7 @@ pub(crate) fn generate(schema: &ResolvedSchema) -> String {
                 add_structural_case(
                     control,
                     &format!("Slot.{}", slot.name),
-                    wrap_structural(
-                        control,
-                        quote! {
-                            #control_name::new()
-                                .slots(std::iter::empty::<SlotView<#slot_type>>())
-                        },
-                    ),
+                    wrap_structural(control, quote! { #control_name::new() }),
                     wrap_structural(control, initial),
                     wrap_structural(control, alternate),
                     &mut structural_builders,
@@ -970,14 +951,6 @@ fn wrap_control(
     match control.placement {
         ResolvedPlacement::Visual | ResolvedPlacement::Declaration => {
             quote! { Grid::new().children((#value,)) }
-        }
-        ResolvedPlacement::WindowLifetime if !control.slots.is_empty() => {
-            let slot_type = ident(&format!("{}Slot", control.name));
-            quote! {
-                Grid::new().children((
-                    (#value).slots(std::iter::empty::<SlotView<#slot_type>>()),
-                ))
-            }
         }
         ResolvedPlacement::WindowLifetime => quote! { Grid::new().children((#value,)) },
         ResolvedPlacement::TooltipAttachment => unreachable!(),

--- a/crates/tools/reactor/src/generate_winui.rs
+++ b/crates/tools/reactor/src/generate_winui.rs
@@ -505,7 +505,7 @@ pub(crate) fn generate(schema: &ResolvedSchema) -> String {
     let selected_items = schema.controls.iter().filter_map(|control| {
         let selection = control.selection.as_ref()?;
         let control_name = ident(&control.name);
-        let slot = ident(&format!("{}{}", control.name, selection.slot));
+        let event = ident(&format!("{}{}", control.name, selection.event));
         let interface = path_ident(&selection.owner_interface);
         let getter = ident(&selection.selected_item_property);
         let get = if is_default_interface(control, &selection.owner_interface) {
@@ -519,7 +519,7 @@ pub(crate) fn generate(schema: &ResolvedSchema) -> String {
             quote! { Ok(Some(selected)) }
         };
         Some(quote! {
-            (Handle::#control_name(value), SlotId::#slot) => {
+            (Handle::#control_name(value), EventId::#event) => {
                 match #get {
                     Ok(selected) => #selected,
                     Err(error) if error.code().is_ok() => Ok(None),
@@ -531,7 +531,7 @@ pub(crate) fn generate(schema: &ResolvedSchema) -> String {
     let set_selected_items = schema.controls.iter().filter_map(|control| {
         let selection = control.selection.as_ref()?;
         let control_name = ident(&control.name);
-        let slot = ident(&format!("{}{}", control.name, selection.slot));
+        let event = ident(&format!("{}{}", control.name, selection.event));
         let interface = path_ident(&selection.owner_interface);
         let setter = ident(&format!("Set{}", selection.selected_item_property));
         let set = if let Some(item) = selection.selected_item.as_deref() {
@@ -560,7 +560,7 @@ pub(crate) fn generate(schema: &ResolvedSchema) -> String {
             }
         };
         Some(quote! {
-            (Handle::#control_name(value), SlotId::#slot) => #set.map_err(native_error),
+            (Handle::#control_name(value), EventId::#event) => #set.map_err(native_error),
         })
     });
     let selection_item_states = schema.controls.iter().filter_map(|control| {
@@ -759,7 +759,7 @@ pub(crate) fn generate(schema: &ResolvedSchema) -> String {
             handle: &Handle,
             selection: SelectionDescriptor,
         ) -> Result<Option<windows_core::IInspectable>, RuntimeError> {
-            match (handle, selection.slot) {
+            match (handle, selection.event) {
                 #(#selected_items,)*
                 _ => Ok(None),
             }
@@ -770,7 +770,7 @@ pub(crate) fn generate(schema: &ResolvedSchema) -> String {
             selection: SelectionDescriptor,
             selected: &windows_core::IInspectable,
         ) -> Result<(), RuntimeError> {
-            match (handle, selection.slot) {
+            match (handle, selection.event) {
                 #(#set_selected_items)*
                 _ => Ok(()),
             }

--- a/crates/tools/reactor/src/schema.rs
+++ b/crates/tools/reactor/src/schema.rs
@@ -521,7 +521,7 @@ pub(crate) enum SlotTarget {
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct Selection {
-    pub(crate) slot: String,
+    pub(crate) slots: Vec<String>,
     pub(crate) item: String,
     pub(crate) selected_property: String,
     pub(crate) selected_item_property: String,
@@ -604,7 +604,7 @@ pub(crate) struct ResolvedSlot {
 }
 
 pub(crate) struct ResolvedSelection {
-    pub(crate) slot: String,
+    pub(crate) slots: Vec<String>,
     pub(crate) item: String,
     pub(crate) selected_property: String,
     pub(crate) selected_item_property: String,
@@ -1718,7 +1718,7 @@ impl Schema {
                         &format!("get_{}", selection.payload_property),
                     );
                     Ok(ResolvedSelection {
-                        slot: selection.slot,
+                        slots: selection.slots,
                         item: selection.item,
                         selected_property: selection.selected_property,
                         selected_item_property: selection.selected_item_property,
@@ -1807,21 +1807,36 @@ fn validate_selections(controls: &[ResolvedControl]) -> Result<(), String> {
         let Some(selection) = control.selection.as_ref() else {
             continue;
         };
-        let slot = control
-            .slots
-            .iter()
-            .find(|slot| slot.name == selection.slot)
-            .ok_or_else(|| {
-                format!(
-                    "{} selection names missing slot {}",
-                    control.type_name, selection.slot
-                )
-            })?;
-        if !matches!(&slot.shape, SlotShape::Collection(_)) {
+        if selection.slots.is_empty() {
             return Err(format!(
-                "{} selection slot {} is not a collection",
-                control.type_name, selection.slot
+                "{} selection must name at least one slot",
+                control.type_name
             ));
+        }
+        let mut unique_slots = HashSet::new();
+        for selection_slot in &selection.slots {
+            if !unique_slots.insert(selection_slot) {
+                return Err(format!(
+                    "{} selection names duplicate slot {}",
+                    control.type_name, selection_slot
+                ));
+            }
+            let slot = control
+                .slots
+                .iter()
+                .find(|slot| slot.name == *selection_slot)
+                .ok_or_else(|| {
+                    format!(
+                        "{} selection names missing slot {}",
+                        control.type_name, selection_slot
+                    )
+                })?;
+            if !matches!(&slot.shape, SlotShape::Collection(_)) {
+                return Err(format!(
+                    "{} selection slot {} is not a collection",
+                    control.type_name, selection_slot
+                ));
+            }
         }
         let event = control
             .events
@@ -2037,14 +2052,24 @@ mod tests {
         let metadata = MetadataResolver::load(&workspace_path("crates/tools/reactor/winmd"));
         let cases = [
             (
-                "slot = \"MenuItems\"",
-                "slot = \"Missing\"",
+                "slots = [\"MenuItems\", \"FooterMenuItems\"]",
+                "slots = [\"Missing\"]",
                 "selection names missing slot Missing",
             ),
             (
-                "slot = \"MenuItems\"",
-                "slot = \"Content\"",
+                "slots = [\"MenuItems\", \"FooterMenuItems\"]",
+                "slots = [\"Content\"]",
                 "selection slot Content is not a collection",
+            ),
+            (
+                "slots = [\"MenuItems\", \"FooterMenuItems\"]",
+                "slots = []",
+                "selection must name at least one slot",
+            ),
+            (
+                "slots = [\"MenuItems\", \"FooterMenuItems\"]",
+                "slots = [\"MenuItems\", \"MenuItems\"]",
+                "selection names duplicate slot MenuItems",
             ),
             (
                 "item = \"NavigationViewItem\"",

--- a/crates/tools/reactor/src/winui.toml
+++ b/crates/tools/reactor/src/winui.toml
@@ -508,7 +508,7 @@ name = "SelectionChanged"
 field = "on_selected_tag_changed"
 
 [control.selection]
-slot = "MenuItems"
+slots = ["MenuItems", "FooterMenuItems"]
 item = "NavigationViewItem"
 selected_property = "IsSelected"
 selected_item_property = "SelectedItem"
@@ -530,6 +530,10 @@ name = "PaneFooter"
 
 [[control.slot]]
 name = "MenuItems"
+collection = true
+
+[[control.slot]]
+name = "FooterMenuItems"
 collection = true
 
 [[control]]
@@ -838,7 +842,7 @@ name = "SelectionChanged"
 field = "on_selected_tag_changed"
 
 [control.selection]
-slot = "Items"
+slots = ["Items"]
 item = "ListBoxItem"
 selected_property = "IsSelected"
 selected_item_property = "SelectedItem"
@@ -1106,7 +1110,7 @@ name = "SelectionChanged"
 field = "on_selected_text_changed"
 
 [control.selection]
-slot = "Items"
+slots = ["Items"]
 item = "SelectorBarItem"
 selected_property = "IsSelected"
 selected_item_property = "SelectedItem"

--- a/docs/crates/windows-reactor.md
+++ b/docs/crates/windows-reactor.md
@@ -139,8 +139,29 @@ Border::new()
 
 Use `content` for a control with one child, such as a button or border. Use `children` for a
 container with an ordered set of children. Tuples are convenient because the children may have
-different control types. Put `content` or `children` last in a builder chain because it finishes
-the control and returns a `View`.
+different control types. For these ordinary content and container controls, put `content` or
+`children` last in a builder chain because it finishes the control and returns a `View`.
+
+Controls with several named content areas expose one builder method for each area. The method
+signature distinguishes a single view from a keyed collection:
+
+```rust,ignore
+NavigationView::new()
+    .menu_items([
+        ("home", NavigationViewItem::new().content("Home")),
+        ("files", NavigationViewItem::new().content("Files")),
+    ])
+    .footer_menu_items([(
+        "settings",
+        NavigationViewItem::new().content("Settings"),
+    )])
+    .content("Page content")
+    .into()
+```
+
+These named methods remain part of the control builder, so properties and other named areas can be
+chained after them. The compiler rejects passing one view to a collection area or a collection to
+a single-view area. Assigning the same named area more than once replaces its earlier value.
 
 Values that implement `Into<View>` can be used directly with these methods. In particular, use a
 `&str` or `String` for ordinary text and reach for `TextBlock` only to set font, layout,


### PR DESCRIPTION
Add `FooterMenuItems` to `NavigationView`'s shared selection domain and demonstrate it in the navigation sample:

```
cargo run -p reactor-navigation-view-pane
```

While I was at it, I noticed that slot infrastructure was overly complicated. I replaced the generic public slot API with generated shape-safe named content methods so invalid single-versus-collection combinations fail at compile time.

Fixes: #4893
