### PR TITLE
Fix for newer Windows runner images

### DIFF
--- a/.github/workflows/slim_errors.yml
+++ b/.github/workflows/slim_errors.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/checkout@v7
         
       - name: Update toolchain
-        run: rustup update --no-self-update stable && rustup default stable-${{ matrix.target }}
+        run: rustup update --no-self-update stable && rustup default stable-x86_64-pc-windows-msvc
         
       - name: Add toolchain target
         run: rustup target add ${{ matrix.target }}
@@ -54,4 +54,4 @@ jobs:
         with:
           key: ${{ matrix.target }}
       - name: Test
-        run: cargo test -p test_result
+        run: cargo test -p test_result --target ${{ matrix.target }}


### PR DESCRIPTION
This fixes an intermittent `slim_errors` CI failure caused by newer Windows runner images rejecting the i686 Rust toolchain as a host toolchain. The workflow now uses the x64 Rust host for both matrix jobs, installs the requested target, and passes that target explicitly to `cargo test`. This matches the existing main test workflow while preserving i686 test coverage