### PR TITLE
`windows-clang` header extension compat

### DIFF
--- a/crates/libs/clang/readme.md
+++ b/crates/libs/clang/readme.md
@@ -15,8 +15,8 @@ Start by adding the following to your Cargo.toml file:
 version = "0.100"
 ```
 
-Point it at one or more headers and write the resulting per-header RDL, then feed that RDL to
-`windows_rdl::reader()` to compile a `.winmd`:
+Point it at one or more `.h`, `.hpp`, `.hxx`, or `.hh` headers and write the resulting per-header
+RDL, then feed that RDL to `windows_rdl::reader()` to compile a `.winmd`:
 
 ```rust,no_run
 windows_clang::clang()

--- a/crates/libs/clang/src/lib.rs
+++ b/crates/libs/clang/src/lib.rs
@@ -547,7 +547,7 @@ impl Clang {
         Self::default()
     }
 
-    /// Adds an input header (`.h`) file or directory.
+    /// Adds an input header (`.h`, `.hpp`, `.hxx`, or `.hh`) file or directory.
     pub fn input(&mut self, input: impl AsRef<Path>) -> &mut Self {
         self.input.push(input.as_ref().to_path_buf());
         self
@@ -886,7 +886,7 @@ impl Clang {
 
     /// Parses inputs once and returns the libclang state that keeps the TUs valid.
     fn parse_inputs(&self) -> Result<ParsedInputs, Error> {
-        let h_paths = expand_input_files(&self.input, "h")?;
+        let h_paths = expand_header_inputs(&self.input)?;
         let library = Library::new()?;
         let index = Index::new()?;
 
@@ -1525,6 +1525,62 @@ struct ParsedInputs {
     str_tus: Vec<(String, TranslationUnit)>,
     index: Index,
     _library: Library,
+}
+
+const HEADER_EXTENSIONS: [&str; 4] = ["h", "hpp", "hxx", "hh"];
+
+fn expand_header_inputs<P: AsRef<Path>>(inputs: &[P]) -> Result<Vec<PathBuf>, Error> {
+    let mut paths = vec![];
+
+    for input in inputs {
+        let path = input.as_ref();
+        let display = path.to_string_lossy();
+
+        if path.is_dir() {
+            let previous_len = paths.len();
+
+            for entry_path in path
+                .read_dir()
+                .map_err(|_| Error::new("failed to read directory", &display, 0, 0))?
+                .flatten()
+                .map(|entry| entry.path())
+            {
+                if entry_path.is_file()
+                    && entry_path.extension().is_some_and(|extension| {
+                        HEADER_EXTENSIONS
+                            .iter()
+                            .any(|expected| extension.eq_ignore_ascii_case(expected))
+                    })
+                {
+                    paths.push(entry_path);
+                }
+            }
+
+            if paths.len() == previous_len {
+                return Err(Error::new(
+                    "failed to find .h, .hpp, .hxx, or .hh files in directory",
+                    &display,
+                    0,
+                    0,
+                ));
+            }
+        } else if path.extension().is_some_and(|extension| {
+            HEADER_EXTENSIONS
+                .iter()
+                .any(|expected| extension.eq_ignore_ascii_case(expected))
+        }) {
+            paths.push(path.to_path_buf());
+        } else {
+            return Err(Error::new(
+                "expected .h, .hpp, .hxx, or .hh file",
+                &display,
+                0,
+                0,
+            ));
+        }
+    }
+
+    Ok(paths)
 }
 
 /// Keep one stable definition when separate headers repeat an equivalent typedef.

--- a/crates/tests/libs/clang/tests/clang.rs
+++ b/crates/tests/libs/clang/tests/clang.rs
@@ -13,6 +13,64 @@ fn reference_rejects_non_winmd_input() {
 }
 
 #[test]
+fn accepts_c_and_cpp_header_extensions() {
+    let scratch = std::path::Path::new(env!("OUT_DIR")).join("header_extensions");
+    std::fs::create_dir_all(&scratch).unwrap();
+
+    let headers = [
+        ("one.H", "typedef int HeaderOne;"),
+        ("two.HpP", "typedef int HeaderTwo;"),
+        ("three.hXx", "typedef int HeaderThree;"),
+        ("four.HH", "typedef int HeaderFour;"),
+    ];
+    let paths: Vec<_> = headers
+        .iter()
+        .map(|(name, contents)| {
+            let path = scratch.join(name);
+            std::fs::write(&path, contents).unwrap();
+            path
+        })
+        .collect();
+
+    let _guard = test_clang::libclang_guard();
+
+    let explicit_output = scratch.join("explicit.rdl");
+    windows_clang::clang()
+        .inputs(&paths)
+        .args(["-x", "c++"])
+        .output(&explicit_output)
+        .namespace("Test")
+        .write()
+        .unwrap();
+
+    let directory_output = scratch.join("directory.rdl");
+    windows_clang::clang()
+        .input(&scratch)
+        .args(["-x", "c++"])
+        .output(&directory_output)
+        .namespace("Test")
+        .write()
+        .unwrap();
+
+    let explicit = std::fs::read_to_string(explicit_output).unwrap();
+    let directory = std::fs::read_to_string(directory_output).unwrap();
+    for name in ["HeaderOne", "HeaderTwo", "HeaderThree", "HeaderFour"] {
+        assert!(explicit.contains(name));
+        assert!(directory.contains(name));
+    }
+}
+
+#[test]
+fn rejects_non_header_input_extension() {
+    let error = windows_clang::clang()
+        .input("input.txt")
+        .output("unused.rdl")
+        .write()
+        .unwrap_err();
+    assert_eq!(error.message, "expected .h, .hpp, .hxx, or .hh file");
+}
+
+#[test]
 fn terminals_require_output() {
     let write = windows_clang::clang().write().unwrap_err();
     assert_eq!(write.message, "output is required");

--- a/docs/crates/windows-clang.md
+++ b/docs/crates/windows-clang.md
@@ -49,7 +49,7 @@ emitted as declarations owned by the input header. List each owning header expli
 
 | Builder input | Purpose |
 | --- | --- |
-| `input`, `inputs` | Header files or directories containing `.h` files. |
+| `input`, `inputs` | `.h`, `.hpp`, `.hxx`, or `.hh` files, or directories containing them. |
 | `arg`, `args`, `target` | libclang language, include, define, extension, and target options. |
 | `reference*` | Existing metadata used for type resolution and duplicate suppression. |
 | `resolution*` | Metadata used only to classify `ABI::Windows::*` projection declarations. |


### PR DESCRIPTION
This updates `windows-clang` to accept the common C and C++ header extensions `.h`, `.hpp`, `.hxx`, and `.hh`. These extensions now work both when passing header files directly and when passing a directory to scan for headers, with case-insensitive extension matching.

Existing `.h` behavior is unchanged, unsupported file types are still rejected, and the generic `.rdl` and `.winmd` input handling is unaffected. Tests cover explicit paths, directory scanning, mixed-case extensions, and invalid inputs.