### PR TITLE
`windows-clang` alias normalization 

### DIFF
--- a/crates/libs/clang/src/canon.rs
+++ b/crates/libs/clang/src/canon.rs
@@ -29,6 +29,8 @@ pub(crate) fn resolve_typedef(cursor: &Type, parser: &mut Parser<'_>) -> metadat
     // name; an external one is scheduled for a follow-up pass.
     if let Some(ns) = parser.ref_map.get(&name) {
         metadata::Type::value_named(ns, &name)
+    } else if let Some(ty) = interface_alias(cursor, parser) {
+        ty
     } else if let Some(ty) = universal_alias(parser.namespace, &name) {
         ty
     } else if let Some(scalar) = collapse_scalar_typedef(&name, cursor) {

--- a/crates/libs/clang/src/canon.rs
+++ b/crates/libs/clang/src/canon.rs
@@ -422,8 +422,9 @@ fn decay_array_param(
     }
 }
 
-/// Resolve a parameter's metadata type. Fields, returns and constants keep their named aliases and
-/// array shapes; only parameters are collapsed and decayed.
+/// Resolve a parameter's metadata type after general typedef canonicalization. This path also
+/// decays arrays, collapses remaining pointer aliases, applies SAL constness, and normalizes
+/// pointer shapes.
 pub(crate) fn param_metadata_type(
     cursor_ty: &Type,
     annotation: &ParamAnnotation,

--- a/crates/libs/clang/src/typedef.rs
+++ b/crates/libs/clang/src/typedef.rs
@@ -79,8 +79,8 @@ impl Typedef {
             return Ok(None);
         }
 
-        // Flat Win32 scrapes collapse COM interface pointer aliases to the interface type.
-        if parser.header_root.is_some() && is_interface_alias(&underlying) {
+        // COM interfaces already carry their native pointer in metadata.
+        if is_interface_alias(&underlying) {
             return Ok(None);
         }
 

--- a/crates/tests/libs/clang/expected/interface_alias.rdl
+++ b/crates/tests/libs/clang/expected/interface_alias.rdl
@@ -1,0 +1,25 @@
+#[win32]
+mod Test {
+    #[library("")]
+    extern fn AcceptDirect(value: IExample);
+    #[library("")]
+    extern fn AcceptExternal(value: Shared::IExternal);
+    #[library("")]
+    extern fn AcceptPointer(value: IExample);
+    #[library("")]
+    extern fn GetDirect(value: *mut IExample);
+    #[library("")]
+    extern fn GetExternal(value: *mut Shared::IExternal);
+    #[library("")]
+    extern fn GetPointer(value: *mut IExample);
+    #[guid(0x11111111_1111_1111_1111_111111111111)]
+    interface IExample {
+        fn Method(&self,);
+    }
+    #[library("")]
+    extern fn ReturnDirect() -> IExample;
+    #[library("")]
+    extern fn ReturnExternal() -> Shared::IExternal;
+    #[library("")]
+    extern fn ReturnPointer() -> IExample;
+}

--- a/crates/tests/libs/clang/input/interface_alias.h
+++ b/crates/tests/libs/clang/input/interface_alias.h
@@ -1,0 +1,26 @@
+//! reference interface_alias_ref
+
+struct __declspec(uuid("11111111-1111-1111-1111-111111111111")) IExample {
+    virtual void Method() = 0;
+};
+
+typedef IExample EXAMPLE;
+typedef IExample *PEXAMPLE;
+
+void AcceptDirect(EXAMPLE value);
+void AcceptPointer(PEXAMPLE value);
+EXAMPLE ReturnDirect(void);
+PEXAMPLE ReturnPointer(void);
+void GetDirect(EXAMPLE **value);
+void GetPointer(PEXAMPLE *value);
+
+struct __declspec(uuid("22222222-2222-2222-2222-222222222222")) IExternal {
+    virtual void Method() = 0;
+};
+
+typedef IExternal EXTERNAL;
+typedef IExternal *PEXTERNAL;
+
+void AcceptExternal(PEXTERNAL value);
+PEXTERNAL ReturnExternal(void);
+void GetExternal(PEXTERNAL *value);

--- a/crates/tests/libs/clang/input/interface_alias_ref.rdl
+++ b/crates/tests/libs/clang/input/interface_alias_ref.rdl
@@ -1,0 +1,7 @@
+#[win32]
+mod Shared {
+    #[guid(0x22222222_2222_2222_2222_222222222222)]
+    interface IExternal {
+        fn Method(&self);
+    }
+}

--- a/docs/crates/windows-clang.md
+++ b/docs/crates/windows-clang.md
@@ -157,8 +157,8 @@ The scraper preserves:
 - symbol-to-DLL mappings recovered from import libraries.
 
 Some C portability spellings are canonicalized for metadata consumers. Examples include fixed-width
-integer typedefs, pointer-sized integer typedefs, Windows string wrappers, pointer aliases in
-parameters, GUID aliases, and Direct2D compatibility aliases. These rules live in `canon.rs`.
+integer typedefs, pointer-sized integer typedefs, Windows string wrappers, COM interface aliases,
+GUID aliases, and Direct2D compatibility aliases. These rules live in `canon.rs`.
 `HRESULT` always maps to the `Windows.Foundation.HResult` metadata system type rather than a local
 integer typedef.
 Parameter SAL can change pointer constness because it expresses the function's read/write contract.


### PR DESCRIPTION
This updates `windows-clang` to consistently resolve COM interface typedef aliases to their underlying interface type. Aliases such as `typedef IFoo NAME` and `typedef IFoo *PNAME` now behave the same in namespaced and per-header scrapes.

Previously, parameter-specific normalization could make an alias appear correct in function parameters while return types retained the alias as an ordinary value type. Return values, parameters, and out-pointers now preserve the correct COM interface ABI, and redundant alias typedefs are no longer emitted.

Exact types supplied by reference metadata still take precedence, and aliases to reference-owned interfaces retain the external namespace. Regenerating the WebView and Win32 metadata produced no tracked output changes.