### PR TITLE
`windows-clang` primitive normalization

### DIFF
--- a/crates/libs/clang/src/canon.rs
+++ b/crates/libs/clang/src/canon.rs
@@ -1,7 +1,8 @@
 //! Canonical C header type mappings for Win32 metadata.
 //!
 //! [`resolve_typedef`] handles references. [`param_metadata_type`] adds parameter-only rules.
-//! Definition suppression in `typedef.rs`, `const.rs`, and `lib.rs` must match these mappings.
+//! Definition suppression in `typedef.rs`, `const.rs`, `cx.rs`, and `lib.rs` must match these
+//! mappings.
 
 use super::*;
 
@@ -10,6 +11,9 @@ pub(crate) fn resolve_typedef(cursor: &Type, parser: &mut Parser<'_>) -> metadat
     let decl = cursor.ty();
     let name = decl.name();
     if let Some(ty) = canonical_hresult(&name) {
+        return ty;
+    }
+    if let Some(ty) = semantic_scalar(&name) {
         return ty;
     }
 
@@ -52,9 +56,6 @@ fn flat_canonical(
     cursor: &Type,
     parser: &mut Parser<'_>,
 ) -> Option<metadata::Type> {
-    if let Some(scalar) = semantic_scalar(name) {
-        return Some(scalar);
-    }
     if let Some(scalar) = fundamental_scalar(name) {
         return Some(scalar);
     }
@@ -201,17 +202,56 @@ pub(crate) fn fundamental_scalar(name: &str) -> Option<metadata::Type> {
     })
 }
 
+struct SemanticScalar {
+    ty: metadata::Type,
+    declaration: SemanticScalarDeclaration,
+}
+
+enum SemanticScalarDeclaration {
+    Typedef,
+    Record,
+}
+
+impl SemanticScalarDeclaration {
+    fn matches(&self, kind: CXCursorKind) -> bool {
+        match self {
+            Self::Typedef => kind == CXCursor_TypedefDecl,
+            Self::Record => matches!(kind, CXCursor_StructDecl | CXCursor_UnionDecl),
+        }
+    }
+}
+
 /// Named Win32 types whose canonical projection is a primitive, not their header shape:
 /// `BOOLEAN` -> `bool` (a semantically-boolean `BYTE`) and `LARGE_INTEGER`/`ULARGE_INTEGER` ->
 /// `i64`/`u64` (64-bit overlay unions every consumer uses as one scalar). Collapsed at every
 /// reference like `DWORD` -> `u32`. Name-keyed because the collapse cannot be structural
 /// (`BOOLEAN` is byte-identical to `BYTE`, and RPC's lowercase `boolean` stays `u8`); the
-/// definitions are suppressed in `typedef.rs` (`BOOLEAN`) and `lib.rs` (the union records).
+/// declaration kind keeps definition suppression paired with each reference mapping.
 pub(crate) fn semantic_scalar(name: &str) -> Option<metadata::Type> {
+    semantic_scalar_entry(name).map(|entry| entry.ty)
+}
+
+/// Returns the scalar only when `kind` is the declaration replaced by the canonical mapping.
+pub(crate) fn semantic_scalar_definition(name: &str, kind: CXCursorKind) -> Option<metadata::Type> {
+    semantic_scalar_entry(name)
+        .filter(|entry| entry.declaration.matches(kind))
+        .map(|entry| entry.ty)
+}
+
+fn semantic_scalar_entry(name: &str) -> Option<SemanticScalar> {
     Some(match name {
-        "BOOLEAN" => metadata::Type::Bool,
-        "LARGE_INTEGER" => metadata::Type::I64,
-        "ULARGE_INTEGER" => metadata::Type::U64,
+        "BOOLEAN" => SemanticScalar {
+            ty: metadata::Type::Bool,
+            declaration: SemanticScalarDeclaration::Typedef,
+        },
+        "LARGE_INTEGER" => SemanticScalar {
+            ty: metadata::Type::I64,
+            declaration: SemanticScalarDeclaration::Record,
+        },
+        "ULARGE_INTEGER" => SemanticScalar {
+            ty: metadata::Type::U64,
+            declaration: SemanticScalarDeclaration::Record,
+        },
         _ => return None,
     })
 }

--- a/crates/libs/clang/src/const.rs
+++ b/crates/libs/clang/src/const.rs
@@ -933,6 +933,10 @@ fn parse_named_cast(
     let (digits, _suffix) = split_int_suffix(lit);
     let raw: u64 = parse_int_digits(digits)?;
 
+    if let Some(ty) = semantic_scalar(type_name) {
+        return scalar_value(&ty, raw, negate);
+    }
+
     // Collapsed scalar typedefs have no emitted name; preserved seed scalars/enums stay named.
     if !ref_map.contains_key(type_name)
         && let Some(ty) = fundamental_scalar(type_name)
@@ -988,6 +992,10 @@ fn parse_named_complement(
     let (digits, suffix) = split_int_suffix(lit);
     let raw = parse_int_digits(digits)?;
     let value = integer_complement_value(raw, int_literal_is_decimal(digits), suffix)?;
+
+    if let Some(ty) = semantic_scalar(type_name) {
+        return cast_integer_value(&ty, &value);
+    }
 
     if !ref_map.contains_key(type_name) && pointer_sized_abi(type_name).is_some() {
         return None;
@@ -1107,6 +1115,10 @@ fn parse_nested_cast(
     let raw: u64 = parse_int_digits(digits)?;
     let inner_value = inner_scalar_value(inner, raw, negate);
 
+    if let Some(ty) = semantic_scalar(outer) {
+        return cast_integer_value(&ty, &inner_value);
+    }
+
     let ns = header_names
         .and_then(|m| m.get(outer))
         .or_else(|| ref_map.get(outer))
@@ -1140,6 +1152,7 @@ fn scalar_value(ty: &metadata::Type, raw: u64, negate: bool) -> Option<metadata:
         raw as i64
     };
     Some(match ty {
+        metadata::Type::Bool => metadata::Value::Bool(signed != 0),
         metadata::Type::U8 => metadata::Value::U8(signed as u8),
         metadata::Type::U16 => metadata::Value::U16(signed as u16),
         metadata::Type::U32 => metadata::Value::U32(signed as u32),

--- a/crates/libs/clang/src/cx.rs
+++ b/crates/libs/clang/src/cx.rs
@@ -846,6 +846,9 @@ impl Type {
                 if self.kind() == CXType_Enum && is_anonymous_name(&name) {
                     return decl.enum_repr().to_type(parser);
                 }
+                if let Some(scalar) = semantic_scalar_definition(&name, decl.kind()) {
+                    return scalar;
+                }
                 // Flat scrape Numerics aliases collapse to the shared Numerics projection.
                 if parser.header_root.is_some()
                     && let Some(num) = numerics_alias(&name)

--- a/crates/libs/clang/src/lib.rs
+++ b/crates/libs/clang/src/lib.rs
@@ -193,6 +193,10 @@ impl<'a> Parser<'a> {
                 } else {
                     self.tag_rename.get(&tag_name).cloned().unwrap_or(tag_name)
                 };
+                // Scalar records collapse to primitives; skip before lifting nested records.
+                if semantic_scalar_definition(&name, child.kind()).is_some() {
+                    return Ok(());
+                }
                 // Numerics aliases collapse to shared value types; skip before lifting overlays.
                 if numerics_alias(&name).is_some() {
                     return Ok(());
@@ -224,6 +228,9 @@ impl<'a> Parser<'a> {
                 let tag_name = child.name();
                 if !is_anonymous_name(&tag_name) && !tag_name.ends_with("__") {
                     let name = self.tag_rename.get(&tag_name).cloned().unwrap_or(tag_name);
+                    if semantic_scalar_definition(&name, child.kind()).is_some() {
+                        return Ok(());
+                    }
                     // Do not clobber a real definition aliased by another tag.
                     if !self.ref_map.contains_key(&name) && !collector.contains_key(&name) {
                         collector.insert(Item::Struct(Struct::opaque(&name)));
@@ -241,7 +248,7 @@ impl<'a> Parser<'a> {
                     self.tag_rename.get(&tag_name).cloned().unwrap_or(tag_name)
                 };
                 // Scalar overlay unions collapse to scalars; skip before lifting overlays.
-                if semantic_scalar(&name).is_some() {
+                if semantic_scalar_definition(&name, child.kind()).is_some() {
                     return Ok(());
                 }
                 // Lift nested records first so field type references resolve.

--- a/crates/libs/clang/src/typedef.rs
+++ b/crates/libs/clang/src/typedef.rs
@@ -69,8 +69,8 @@ impl Typedef {
             return Ok(None);
         }
 
-        // Semantic scalar aliases such as `BOOLEAN` collapse to primitives.
-        if parser.header_root.is_some() && semantic_scalar(&name).is_some() {
+        // Semantic scalar typedefs such as `BOOLEAN` collapse to primitives in every mode.
+        if semantic_scalar_definition(&name, CXCursor_TypedefDecl).is_some() {
             return Ok(None);
         }
 

--- a/crates/libs/rdl/src/reader/mod.rs
+++ b/crates/libs/rdl/src/reader/mod.rs
@@ -687,6 +687,13 @@ impl Encoder<'_> {
         }
 
         let value = match ty {
+            metadata::Type::Bool => match value {
+                syn::Expr::Lit(syn::ExprLit {
+                    lit: syn::Lit::Bool(value),
+                    ..
+                }) => metadata::Value::Bool(value.value),
+                _ => return self.err(value, "value not valid"),
+            },
             metadata::Type::I8 => metadata::Value::I8(self.encode_lit_sint(value, 8)? as i8),
             metadata::Type::U8 => metadata::Value::U8(self.encode_lit_uint(value, 8)? as u8),
             metadata::Type::I16 => metadata::Value::I16(self.encode_lit_sint(value, 16)? as i16),

--- a/crates/tests/libs/clang/expected/foundation_seed.rdl
+++ b/crates/tests/libs/clang/expected/foundation_seed.rdl
@@ -4,7 +4,7 @@ mod Windows {
         mod System {
             mod Memory {
                 #[library("test.dll")]
-                extern fn DoThing(enabled: super::super::Foundation::BOOL, count: u32, index: u32, lp: super::super::Foundation::LPARAM, wp: super::super::Foundation::WPARAM, lr: super::super::Foundation::LRESULT, status: super::super::Foundation::NTSTATUS, flag: super::super::Foundation::BOOLEAN) -> HRESULT;
+                extern fn DoThing(enabled: super::super::Foundation::BOOL, count: u32, index: u32, lp: super::super::Foundation::LPARAM, wp: super::super::Foundation::WPARAM, lr: super::super::Foundation::LRESULT, status: super::super::Foundation::NTSTATUS, flag: bool) -> HRESULT;
                 #[library("test.dll")]
                 extern fn OpenThing(reserved: *mut void) -> super::super::Foundation::HANDLE;
             }

--- a/crates/tests/libs/clang/input/foundation_seed.h
+++ b/crates/tests/libs/clang/input/foundation_seed.h
@@ -4,11 +4,11 @@
 
 // A leaf namespace built with NO upstream Windows.Win32.winmd — only the small
 // hand-authored Foundation seed as reference. BOOL, LPARAM/WPARAM/LRESULT, NTSTATUS,
-// BOOLEAN, and the opaque HANDLE must resolve to the named Foundation types. HRESULT
-// resolves to the Windows.Foundation.HResult system type. The universal C fundamentals
-// (DWORD, UINT) must collapse to u32 and a raw `void *` must stay `*mut void` (the seed
-// names HANDLE specifically, not every void pointer). Neither kind leaks a per-namespace
-// `type` alias here.
+// and the opaque HANDLE must resolve to the named Foundation types. HRESULT resolves
+// to the Windows.Foundation.HResult system type, and BOOLEAN universally maps to bool.
+// The universal C fundamentals (DWORD, UINT) must collapse to u32 and a raw `void *`
+// must stay `*mut void` (the seed names HANDLE specifically, not every void pointer).
+// Neither kind leaks a per-namespace `type` alias here.
 #include "foundation_seed_inc.inl"
 
 HRESULT DoThing(BOOL enabled, DWORD count, UINT index, LPARAM lp, WPARAM wp, LRESULT lr, NTSTATUS status, BOOLEAN flag);

--- a/crates/tests/libs/clang/input/foundation_seed.rdl
+++ b/crates/tests/libs/clang/input/foundation_seed.rdl
@@ -12,7 +12,6 @@ mod Windows {
     mod Win32 {
         mod Foundation {
             type BOOL = i32;
-            type BOOLEAN = u8;
             type HANDLE = *mut void;
             type LPARAM = isize;
             type LRESULT = isize;

--- a/crates/tests/libs/clang/input/foundation_seed_inc.inl
+++ b/crates/tests/libs/clang/input/foundation_seed_inc.inl
@@ -1,8 +1,8 @@
 // Fundamental typedefs as they appear in the Windows SDK system headers
 // (winnt.h / windef.h / basetsd.h). They reach the scraper as *included*
 // declarations, not main-file ones — exactly as they would in a real namespace
-// build. The semantic ones are preserved by the Foundation seed reference; the
-// universal C fundamentals (DWORD, UINT) collapse to primitives.
+// build. The named scalar types are preserved by the Foundation seed reference;
+// BOOLEAN and the universal C fundamentals (DWORD, UINT) collapse to primitives.
 typedef int BOOL;
 typedef unsigned char BOOLEAN;
 typedef long HRESULT;

--- a/crates/tests/libs/clang/tests/clang.rs
+++ b/crates/tests/libs/clang/tests/clang.rs
@@ -227,6 +227,196 @@ fn namespaced_hresult_survives_the_binding_round_trip() {
     assert!(sys.contains("fn IncludedStatus() -> super::HRESULT"));
 }
 
+#[test]
+fn semantic_scalars_are_universal() {
+    let scratch = std::path::Path::new(env!("OUT_DIR")).join("semantic_scalars");
+    std::fs::create_dir_all(&scratch).unwrap();
+
+    let header = scratch.join("semantic.h");
+    std::fs::write(
+        &header,
+        "typedef unsigned char BOOLEAN;\n\
+         typedef union _LARGE_INTEGER { long long QuadPart; } LARGE_INTEGER;\n\
+         typedef union _ULARGE_INTEGER { unsigned long long QuadPart; } ULARGE_INTEGER;\n\
+         typedef BOOLEAN *PBOOLEAN;\n\
+         typedef LARGE_INTEGER *PLARGE_INTEGER;\n\
+         typedef ULARGE_INTEGER *PULARGE_INTEGER;\n\
+         typedef struct Holder {\n\
+             BOOLEAN Boolean;\n\
+             LARGE_INTEGER Signed;\n\
+             ULARGE_INTEGER Unsigned;\n\
+             union _LARGE_INTEGER DirectSigned;\n\
+             union _ULARGE_INTEGER DirectUnsigned;\n\
+         } Holder;\n\
+         #define BOOLEAN_TRUE ((BOOLEAN)1)\n\
+         #define BOOLEAN_COMPLEMENT (BOOLEAN)(~0)\n\
+         BOOLEAN ReadBoolean(void);\n\
+         LARGE_INTEGER ReadSigned(void);\n\
+         ULARGE_INTEGER ReadUnsigned(void);\n\
+         union _LARGE_INTEGER ReadDirectSigned(void);\n\
+         union _ULARGE_INTEGER ReadDirectUnsigned(void);\n\
+         void GetValues(PBOOLEAN boolean, PLARGE_INTEGER signed_value,\n\
+                        PULARGE_INTEGER unsigned_value);",
+    )
+    .unwrap();
+
+    let midl_header = scratch.join("midl.h");
+    std::fs::write(
+        &midl_header,
+        "typedef unsigned char BOOLEAN;\n\
+         typedef struct _LARGE_INTEGER { long long QuadPart; } LARGE_INTEGER;\n\
+         typedef struct _ULARGE_INTEGER { unsigned long long QuadPart; } ULARGE_INTEGER;\n\
+         typedef struct MidlHolder {\n\
+             BOOLEAN Boolean;\n\
+             LARGE_INTEGER Signed;\n\
+             ULARGE_INTEGER Unsigned;\n\
+             struct _LARGE_INTEGER DirectSigned;\n\
+             struct _ULARGE_INTEGER DirectUnsigned;\n\
+         } MidlHolder;\n\
+         LARGE_INTEGER ReadSigned(void);\n\
+         ULARGE_INTEGER ReadUnsigned(void);",
+    )
+    .unwrap();
+
+    let forward_header = scratch.join("forward.h");
+    std::fs::write(
+        &forward_header,
+        "typedef union _LARGE_INTEGER LARGE_INTEGER;\n\
+         typedef union _ULARGE_INTEGER ULARGE_INTEGER;\n\
+         void UseForward(union _LARGE_INTEGER *signed_value,\n\
+                         union _ULARGE_INTEGER *unsigned_value);",
+    )
+    .unwrap();
+
+    let hostile_reference = scratch.join("reference.winmd");
+    windows_rdl::reader()
+        .input_text(
+            "#[win32] mod Other {\n\
+                 type BOOLEAN = u8;\n\
+                 struct LARGE_INTEGER { LowPart: u32, HighPart: i32 }\n\
+                 struct ULARGE_INTEGER { LowPart: u32, HighPart: u32 }\n\
+             }",
+        )
+        .output(&hostile_reference)
+        .write()
+        .unwrap();
+
+    let direct_rdl = scratch.join("direct.rdl");
+    let referenced_rdl = scratch.join("referenced.rdl");
+    let midl_rdl = scratch.join("midl.rdl");
+    let forward_rdl = scratch.join("forward.rdl");
+    let flat_dir = scratch.join("flat");
+    std::fs::create_dir_all(&flat_dir).unwrap();
+    {
+        let _guard = test_clang::libclang_guard();
+
+        windows_clang::clang()
+            .input(&header)
+            .output(&direct_rdl)
+            .namespace("Direct")
+            .library("test.dll")
+            .write()
+            .unwrap();
+
+        windows_clang::clang()
+            .input(&forward_header)
+            .output(&forward_rdl)
+            .namespace("Forward")
+            .library("test.dll")
+            .write()
+            .unwrap();
+
+        windows_clang::clang()
+            .input(&midl_header)
+            .output(&midl_rdl)
+            .namespace("Midl")
+            .library("test.dll")
+            .write()
+            .unwrap();
+
+        windows_clang::clang()
+            .input(&header)
+            .reference(&hostile_reference)
+            .output(&referenced_rdl)
+            .namespace("Referenced")
+            .library("test.dll")
+            .write()
+            .unwrap();
+
+        windows_clang::clang()
+            .input(&header)
+            .output(&flat_dir)
+            .namespace("Flat")
+            .write_by_header()
+            .unwrap();
+    }
+
+    for path in [
+        direct_rdl.as_path(),
+        referenced_rdl.as_path(),
+        flat_dir.join("semantic.rdl").as_path(),
+    ] {
+        let contents = std::fs::read_to_string(path).unwrap();
+        assert!(!contents.contains("type BOOLEAN"));
+        for declaration in [
+            "struct LARGE_INTEGER {",
+            "union LARGE_INTEGER {",
+            "struct ULARGE_INTEGER {",
+            "union ULARGE_INTEGER {",
+        ] {
+            assert!(!contents.contains(declaration));
+        }
+        assert!(!contents.contains("Other::"));
+        assert!(contents.contains("Boolean: bool"));
+        assert!(contents.contains("Signed: i64"));
+        assert!(contents.contains("Unsigned: u64"));
+        assert!(contents.contains("DirectSigned: i64"));
+        assert!(contents.contains("DirectUnsigned: u64"));
+        assert!(contents.contains("const BOOLEAN_TRUE: bool = true"));
+        assert!(contents.contains("const BOOLEAN_COMPLEMENT: bool = true"));
+        assert!(contents.contains("fn ReadBoolean() -> bool"));
+        assert!(contents.contains("fn ReadSigned() -> i64"));
+        assert!(contents.contains("fn ReadUnsigned() -> u64"));
+        assert!(contents.contains("fn ReadDirectSigned() -> i64"));
+        assert!(contents.contains("fn ReadDirectUnsigned() -> u64"));
+        assert!(contents.contains("boolean: *mut bool"));
+        assert!(contents.contains("signed_value: *mut i64"));
+        assert!(contents.contains("unsigned_value: *mut u64"));
+    }
+
+    let midl = std::fs::read_to_string(&midl_rdl).unwrap();
+    for declaration in ["struct LARGE_INTEGER {", "struct ULARGE_INTEGER {"] {
+        assert!(!midl.contains(declaration));
+    }
+    assert!(midl.contains("Boolean: bool"));
+    assert!(midl.contains("Signed: i64"));
+    assert!(midl.contains("Unsigned: u64"));
+    assert!(midl.contains("DirectSigned: i64"));
+    assert!(midl.contains("DirectUnsigned: u64"));
+    assert!(midl.contains("fn ReadSigned() -> i64"));
+    assert!(midl.contains("fn ReadUnsigned() -> u64"));
+
+    let forward = std::fs::read_to_string(&forward_rdl).unwrap();
+    for declaration in [
+        "struct LARGE_INTEGER {",
+        "union LARGE_INTEGER {",
+        "struct ULARGE_INTEGER {",
+        "union ULARGE_INTEGER {",
+    ] {
+        assert!(!forward.contains(declaration));
+    }
+    assert!(forward.contains("signed_value: *mut i64"));
+    assert!(forward.contains("unsigned_value: *mut u64"));
+
+    let winmd = scratch.join("out.winmd");
+    windows_rdl::reader()
+        .input(&direct_rdl)
+        .input(&referenced_rdl)
+        .output(winmd)
+        .write()
+        .unwrap();
+}
+
 fn run(name: &str) {
     let input_path = format!("input/{name}.h");
     let expected_path = format!("expected/{name}.rdl");

--- a/crates/tests/libs/rdl/input/const.rdl
+++ b/crates/tests/libs/rdl/input/const.rdl
@@ -12,4 +12,6 @@ mod Test {
     const J: isize = 18446744073709551615u64;
     const K: usize = -1i32;
     const L: usize = -1i64;
+    const M: bool = true;
+    const N: bool = false;
 }

--- a/docs/crates/windows-clang.md
+++ b/docs/crates/windows-clang.md
@@ -160,7 +160,8 @@ Some C portability spellings are canonicalized for metadata consumers. Examples 
 integer typedefs, pointer-sized integer typedefs, Windows string wrappers, COM interface aliases,
 GUID aliases, and Direct2D compatibility aliases. These rules live in `canon.rs`.
 `HRESULT` always maps to the `Windows.Foundation.HResult` metadata system type rather than a local
-integer typedef.
+integer typedef. `BOOLEAN`, `LARGE_INTEGER`, and `ULARGE_INTEGER` always map to `bool`, `i64`, and
+`u64` in both namespaced and per-header scrapes.
 Parameter SAL can change pointer constness because it expresses the function's read/write contract.
 Direction is also checked against COM interface pointer shape. A direct `IFoo*` is an input
 interface reference even if a local SDK declaration incorrectly marks it `[out]`; a returned


### PR DESCRIPTION
This updates `windows-clang` to consistently map `BOOLEAN`, `LARGE_INTEGER`, and `ULARGE_INTEGER` to `bool`, `i64`, and `u64`. Namespaced and per-header scrapes now use the same canonical types, including typedef references, direct struct or union tags, fields, parameters, returns, pointers, and forward declarations.

Previously, a namespaced scrape could suppress a `LARGE_INTEGER` union while still emitting references to that missing type. The result could also depend on reference metadata, with an external definition overriding the established primitive mapping. Reference conversion and declaration suppression now come from the same declaration-aware mapping, so the scraper neither emits dangling references nor keeps shadow definitions.

The RDL reader now supports Boolean constants so canonical `BOOLEAN` constants survive the RDL-to-winmd round trip. The mapping remains limited to these exact Windows type names, and regenerating the WebView and Win32/WDK metadata produced no tracked output changes.