### PR TITLE
`windows-clang` track record definitions

### DIFF
--- a/crates/libs/clang/src/canon.rs
+++ b/crates/libs/clang/src/canon.rs
@@ -39,7 +39,7 @@ pub(crate) fn resolve_typedef(cursor: &Type, parser: &mut Parser<'_>) -> metadat
         ty
     } else if let Some(scalar) = collapse_scalar_typedef(&name, cursor) {
         scalar
-    } else if decl.is_from_main_file() {
+    } else if decl.is_from_main_file() && parser.symbols.is_empty() {
         metadata::Type::value_named(parser.namespace, &name)
     } else {
         parser.pending_typedefs.push(decl);

--- a/crates/libs/clang/src/cx.rs
+++ b/crates/libs/clang/src/cx.rs
@@ -865,13 +865,14 @@ impl Type {
                         .map_or(parser.namespace, |s| s.as_str())
                         .to_string()
                 };
+                let definition = decl.definition();
                 if self.kind() == CXType_Record
                     && parser.header_root.is_none()
                     && ns == parser.namespace
-                    && !decl.is_from_main_file()
                     && decl.has_definition()
+                    && (!definition.is_from_main_file() || !parser.symbols.is_empty())
                 {
-                    parser.pending_records.push(decl.definition());
+                    parser.pending_records.push(definition);
                 }
                 // Incomplete namespaced records remain unresolved. Deciding whether a particular
                 // use can be represented by an opaque declaration requires usage-shape analysis.

--- a/crates/libs/clang/src/cx.rs
+++ b/crates/libs/clang/src/cx.rs
@@ -865,6 +865,16 @@ impl Type {
                         .map_or(parser.namespace, |s| s.as_str())
                         .to_string()
                 };
+                if self.kind() == CXType_Record
+                    && parser.header_root.is_none()
+                    && ns == parser.namespace
+                    && !decl.is_from_main_file()
+                    && decl.has_definition()
+                {
+                    parser.pending_records.push(decl.definition());
+                }
+                // Incomplete namespaced records remain unresolved. Deciding whether a particular
+                // use can be represented by an opaque declaration requires usage-shape analysis.
                 // Pointer-only incomplete records need an opaque forward declaration target.
                 if parser.header_root.is_some()
                     && !is_anonymous_name(&name)

--- a/crates/libs/clang/src/lib.rs
+++ b/crates/libs/clang/src/lib.rs
@@ -80,7 +80,9 @@ pub(crate) struct Parser<'a> {
     pub enum_merge: &'a HashMap<String, &'static str>,
     pub tu: &'a TranslationUnit,
     pub pending_typedefs: Vec<Cursor>,
+    pub pending_records: Vec<Cursor>,
     pub pending_macros: Vec<String>,
+    processing_dependency: bool,
     /// Per-header mode: incomplete pointer-only records emitted as opaque structs.
     pub pending_opaque: Vec<(String, String)>,
     /// Enum names for which `DEFINE_ENUM_FLAG_OPERATORS(X)` was seen.
@@ -133,7 +135,9 @@ impl<'a> Parser<'a> {
             enum_merge,
             tu,
             pending_typedefs: vec![],
+            pending_records: vec![],
             pending_macros: vec![],
+            processing_dependency: false,
             pending_opaque: vec![],
             flag_enums: HashSet::new(),
             iid_vars: HashMap::new(),
@@ -160,9 +164,8 @@ impl<'a> Parser<'a> {
         collector: &mut Collector,
         extern_c: bool,
     ) -> Result<(), Error> {
-        // Allowlist mode emits only named functions as roots. Bare tag dependencies are
-        // not scheduled here; a missing one fails later as an unresolved reference.
-        if !self.symbols.is_empty() {
+        // Allowlist mode emits only named functions as roots. Queued dependencies bypass it.
+        if !self.processing_dependency && !self.symbols.is_empty() {
             match child.kind() {
                 CXCursor_FunctionDecl
                     if !child.is_definition()
@@ -1497,24 +1500,41 @@ impl Clang {
             parser.process_cursor(child, collector, false)?;
         }
 
-        // Drain referenced typedef dependencies; parsing them can enqueue more.
-        let mut seen: HashSet<String> = HashSet::new();
-        let mut i = 0;
-        while i < parser.pending_typedefs.len() {
-            let cursor = parser.pending_typedefs[i];
-            i += 1;
-            let name = cursor.name();
-            // Skip anything already resolved.
-            if !seen.insert(name.clone())
-                || collector.contains_key(&name)
-                || parser.ref_map.contains_key(&name)
-            {
-                continue;
+        // Drain referenced type dependencies; parsing one definition can enqueue more.
+        let mut seen_typedefs: HashSet<String> = HashSet::new();
+        let mut seen_records: HashSet<String> = HashSet::new();
+        let mut typedef_index = 0;
+        let mut record_index = 0;
+        while typedef_index < parser.pending_typedefs.len()
+            || record_index < parser.pending_records.len()
+        {
+            while typedef_index < parser.pending_typedefs.len() {
+                let cursor = parser.pending_typedefs[typedef_index];
+                typedef_index += 1;
+                let name = cursor.name();
+                // Skip anything already resolved.
+                if !seen_typedefs.insert(name.clone())
+                    || collector.contains_key(&name)
+                    || parser.ref_map.contains_key(&name)
+                {
+                    continue;
+                }
+                if let Some(cb) = Callback::parse(cursor, &mut parser)? {
+                    collector.insert(Item::Callback(cb));
+                } else if let Some(td) = Typedef::parse(cursor, &mut parser)? {
+                    collector.insert(Item::Typedef(td));
+                }
             }
-            if let Some(cb) = Callback::parse(cursor, &mut parser)? {
-                collector.insert(Item::Callback(cb));
-            } else if let Some(td) = Typedef::parse(cursor, &mut parser)? {
-                collector.insert(Item::Typedef(td));
+
+            while record_index < parser.pending_records.len() {
+                let cursor = parser.pending_records[record_index];
+                record_index += 1;
+                if seen_records.insert(cursor.usr()) {
+                    parser.processing_dependency = true;
+                    let result = parser.process_cursor(cursor, collector, false);
+                    parser.processing_dependency = false;
+                    result?;
+                }
             }
         }
 

--- a/crates/libs/clang/src/typedef.rs
+++ b/crates/libs/clang/src/typedef.rs
@@ -103,7 +103,7 @@ impl Typedef {
                 .get(&tag)
                 .cloned()
                 .unwrap_or_else(|| tag.clone());
-            if parser.header_root.is_none() && !is_anonymous_name(&tag) {
+            if parser.header_root.is_none() && inner_kind == CXType_Record {
                 // Pull the backing definition into namespaced output before deciding whether this
                 // typedef is the public name or a secondary alias.
                 inner.to_type(parser);

--- a/crates/libs/clang/src/typedef.rs
+++ b/crates/libs/clang/src/typedef.rs
@@ -98,16 +98,18 @@ impl Typedef {
                 underlying
             };
             let tag = inner.ty().name();
-            if parser.header_root.is_none() || is_anonymous_name(&tag) {
-                // Legacy mode or an anonymous tag already emitted under this typedef name.
-                return Ok(None);
-            }
             let public = parser
                 .tag_rename
                 .get(&tag)
                 .cloned()
                 .unwrap_or_else(|| tag.clone());
-            if name == public
+            if parser.header_root.is_none() && !is_anonymous_name(&tag) {
+                // Pull the backing definition into namespaced output before deciding whether this
+                // typedef is the public name or a secondary alias.
+                inner.to_type(parser);
+            }
+            if is_anonymous_name(&tag)
+                || name == public
                 || (name == tag
                     && inner_kind == CXType_Enum
                     && parser.enum_merge.contains_key(&public))

--- a/crates/tests/libs/clang/input/record_dependency.hpp
+++ b/crates/tests/libs/clang/input/record_dependency.hpp
@@ -5,6 +5,7 @@ typedef struct Envelope {
     struct _RemoteValue direct_value;
     RemoteAlias alias_value;
     PointerValue* pointer;
+    AnonymousValue anonymous_value;
 } Envelope;
 
 RemoteValue ReturnRemote(void);
@@ -12,3 +13,4 @@ void AcceptRemote(RemoteValue value);
 struct _RemoteValue ReturnDirect(void);
 RemoteAlias ReturnAlias(void);
 PointerValue* ReturnPointer(void);
+AnonymousValue ReturnAnonymous(void);

--- a/crates/tests/libs/clang/input/record_dependency.hpp
+++ b/crates/tests/libs/clang/input/record_dependency.hpp
@@ -1,4 +1,14 @@
+struct IncludedForward;
+
 #include "record_dependency_inc.inl"
+
+struct LocalRecord {
+    int value;
+};
+
+typedef struct _LocalAlias {
+    int alias;
+} LocalAlias;
 
 typedef struct Envelope {
     RemoteValue value;
@@ -14,3 +24,6 @@ struct _RemoteValue ReturnDirect(void);
 RemoteAlias ReturnAlias(void);
 PointerValue* ReturnPointer(void);
 AnonymousValue ReturnAnonymous(void);
+struct LocalRecord ReturnLocalRecord(void);
+LocalAlias ReturnLocalAlias(void);
+struct IncludedForward ReturnIncludedForward(void);

--- a/crates/tests/libs/clang/input/record_dependency.hpp
+++ b/crates/tests/libs/clang/input/record_dependency.hpp
@@ -1,0 +1,14 @@
+#include "record_dependency_inc.inl"
+
+typedef struct Envelope {
+    RemoteValue value;
+    struct _RemoteValue direct_value;
+    RemoteAlias alias_value;
+    PointerValue* pointer;
+} Envelope;
+
+RemoteValue ReturnRemote(void);
+void AcceptRemote(RemoteValue value);
+struct _RemoteValue ReturnDirect(void);
+RemoteAlias ReturnAlias(void);
+PointerValue* ReturnPointer(void);

--- a/crates/tests/libs/clang/input/record_dependency_inc.inl
+++ b/crates/tests/libs/clang/input/record_dependency_inc.inl
@@ -1,0 +1,14 @@
+typedef struct NestedValue {
+    short code;
+} NestedValue;
+
+typedef struct _RemoteValue {
+    long long payload;
+    NestedValue nested;
+} RemoteValue;
+
+typedef struct _RemoteValue RemoteAlias;
+
+typedef struct PointerValue {
+    unsigned int payload;
+} PointerValue;

--- a/crates/tests/libs/clang/input/record_dependency_inc.inl
+++ b/crates/tests/libs/clang/input/record_dependency_inc.inl
@@ -16,3 +16,7 @@ typedef struct PointerValue {
 typedef struct {
     int marker;
 } AnonymousValue;
+
+typedef struct IncludedForward {
+    int included;
+} IncludedForward;

--- a/crates/tests/libs/clang/input/record_dependency_inc.inl
+++ b/crates/tests/libs/clang/input/record_dependency_inc.inl
@@ -12,3 +12,7 @@ typedef struct _RemoteValue RemoteAlias;
 typedef struct PointerValue {
     unsigned int payload;
 } PointerValue;
+
+typedef struct {
+    int marker;
+} AnonymousValue;

--- a/crates/tests/libs/clang/tests/clang.rs
+++ b/crates/tests/libs/clang/tests/clang.rs
@@ -461,11 +461,14 @@ fn namespaced_record_dependencies_preserve_layout() {
     assert!(contents.contains("code: i16"));
     assert!(contents.contains("struct PointerValue"));
     assert!(contents.contains("payload: u32"));
+    assert!(contents.contains("struct AnonymousValue"));
+    assert!(contents.contains("marker: i32"));
     assert!(contents.contains("type RemoteAlias = RemoteValue"));
     assert!(contents.contains("alias_value: RemoteAlias"));
     assert!(contents.contains("fn ReturnDirect() -> RemoteValue"));
     assert!(contents.contains("fn ReturnAlias() -> RemoteAlias"));
     assert!(contents.contains("fn ReturnPointer() -> *mut PointerValue"));
+    assert!(contents.contains("fn ReturnAnonymous() -> AnonymousValue"));
 
     windows_rdl::reader()
         .input(&rdl)
@@ -493,6 +496,7 @@ fn namespaced_record_dependencies_preserve_layout() {
     assert!(!main_contents.contains("struct RemoteValue"));
     assert!(!main_contents.contains("struct NestedValue"));
     assert!(!main_contents.contains("struct PointerValue"));
+    assert!(!main_contents.contains("struct AnonymousValue"));
     assert!(dependency_contents.contains("struct RemoteValue"));
     assert!(dependency_contents.contains("payload: i64"));
     assert!(dependency_contents.contains("nested: NestedValue"));
@@ -500,6 +504,8 @@ fn namespaced_record_dependencies_preserve_layout() {
     assert!(dependency_contents.contains("code: i16"));
     assert!(dependency_contents.contains("struct PointerValue"));
     assert!(dependency_contents.contains("payload: u32"));
+    assert!(dependency_contents.contains("struct AnonymousValue"));
+    assert!(dependency_contents.contains("marker: i32"));
     assert!(dependency_contents.contains("type RemoteAlias = RemoteValue"));
 
     windows_rdl::reader()

--- a/crates/tests/libs/clang/tests/clang.rs
+++ b/crates/tests/libs/clang/tests/clang.rs
@@ -417,6 +417,99 @@ fn semantic_scalars_are_universal() {
         .unwrap();
 }
 
+#[test]
+fn namespaced_record_dependencies_preserve_layout() {
+    let scratch = std::path::Path::new(env!("OUT_DIR")).join("record_dependency");
+    std::fs::create_dir_all(&scratch).unwrap();
+
+    let rdl = scratch.join("record_dependency.rdl");
+    let symbols_rdl = scratch.join("record_dependency_symbols.rdl");
+    let flat = scratch.join("flat");
+    std::fs::create_dir_all(&flat).unwrap();
+    {
+        let _guard = test_clang::libclang_guard();
+        windows_clang::clang()
+            .input("input/record_dependency.hpp")
+            .output(&rdl)
+            .namespace("RecordDependency")
+            .library("test.dll")
+            .write()
+            .unwrap();
+
+        windows_clang::clang()
+            .input("input/record_dependency.hpp")
+            .output(&symbols_rdl)
+            .namespace("RecordDependencySymbols")
+            .library("test.dll")
+            .symbol("ReturnRemote")
+            .write()
+            .unwrap();
+
+        windows_clang::clang()
+            .input("input/record_dependency.hpp")
+            .output(&flat)
+            .namespace("RecordDependency")
+            .write_by_header()
+            .unwrap();
+    }
+
+    let contents = std::fs::read_to_string(&rdl).unwrap();
+    assert!(contents.contains("struct RemoteValue"));
+    assert!(contents.contains("payload: i64"));
+    assert!(contents.contains("nested: NestedValue"));
+    assert!(contents.contains("struct NestedValue"));
+    assert!(contents.contains("code: i16"));
+    assert!(contents.contains("struct PointerValue"));
+    assert!(contents.contains("payload: u32"));
+    assert!(contents.contains("type RemoteAlias = RemoteValue"));
+    assert!(contents.contains("alias_value: RemoteAlias"));
+    assert!(contents.contains("fn ReturnDirect() -> RemoteValue"));
+    assert!(contents.contains("fn ReturnAlias() -> RemoteAlias"));
+    assert!(contents.contains("fn ReturnPointer() -> *mut PointerValue"));
+
+    windows_rdl::reader()
+        .input(&rdl)
+        .output(scratch.join("record_dependency.winmd"))
+        .write()
+        .unwrap();
+
+    let symbols = std::fs::read_to_string(&symbols_rdl).unwrap();
+    assert!(symbols.contains("fn ReturnRemote() -> RemoteValue"));
+    assert!(symbols.contains("struct RemoteValue"));
+    assert!(symbols.contains("payload: i64"));
+    assert!(symbols.contains("nested: NestedValue"));
+    assert!(symbols.contains("struct NestedValue"));
+    assert!(!symbols.contains("struct Envelope"));
+    windows_rdl::reader()
+        .input(&symbols_rdl)
+        .output(scratch.join("record_dependency_symbols.winmd"))
+        .write()
+        .unwrap();
+
+    let flat_main = flat.join("record_dependency.rdl");
+    let flat_dependency = flat.join("record_dependency_inc.rdl");
+    let main_contents = std::fs::read_to_string(&flat_main).unwrap();
+    let dependency_contents = std::fs::read_to_string(&flat_dependency).unwrap();
+    assert!(!main_contents.contains("struct RemoteValue"));
+    assert!(!main_contents.contains("struct NestedValue"));
+    assert!(!main_contents.contains("struct PointerValue"));
+    assert!(dependency_contents.contains("struct RemoteValue"));
+    assert!(dependency_contents.contains("payload: i64"));
+    assert!(dependency_contents.contains("nested: NestedValue"));
+    assert!(dependency_contents.contains("struct NestedValue"));
+    assert!(dependency_contents.contains("code: i16"));
+    assert!(dependency_contents.contains("struct PointerValue"));
+    assert!(dependency_contents.contains("payload: u32"));
+    assert!(dependency_contents.contains("type RemoteAlias = RemoteValue"));
+
+    windows_rdl::reader()
+        .input(flat_main)
+        .input(flat_dependency)
+        .output(scratch.join("record_dependency_flat.winmd"))
+        .write()
+        .unwrap();
+}
+
 fn run(name: &str) {
     let input_path = format!("input/{name}.h");
     let expected_path = format!("expected/{name}.rdl");

--- a/crates/tests/libs/clang/tests/clang.rs
+++ b/crates/tests/libs/clang/tests/clang.rs
@@ -441,7 +441,12 @@ fn namespaced_record_dependencies_preserve_layout() {
             .output(&symbols_rdl)
             .namespace("RecordDependencySymbols")
             .library("test.dll")
-            .symbol("ReturnRemote")
+            .symbols([
+                "ReturnRemote",
+                "ReturnLocalRecord",
+                "ReturnLocalAlias",
+                "ReturnIncludedForward",
+            ])
             .write()
             .unwrap();
 
@@ -482,6 +487,15 @@ fn namespaced_record_dependencies_preserve_layout() {
     assert!(symbols.contains("payload: i64"));
     assert!(symbols.contains("nested: NestedValue"));
     assert!(symbols.contains("struct NestedValue"));
+    assert!(symbols.contains("fn ReturnLocalRecord() -> LocalRecord"));
+    assert!(symbols.contains("struct LocalRecord"));
+    assert!(symbols.contains("value: i32"));
+    assert!(symbols.contains("fn ReturnLocalAlias() -> LocalAlias"));
+    assert!(symbols.contains("struct LocalAlias"));
+    assert!(symbols.contains("alias: i32"));
+    assert!(symbols.contains("fn ReturnIncludedForward() -> IncludedForward"));
+    assert!(symbols.contains("struct IncludedForward"));
+    assert!(symbols.contains("included: i32"));
     assert!(!symbols.contains("struct Envelope"));
     windows_rdl::reader()
         .input(&symbols_rdl)

--- a/docs/crates/windows-clang.md
+++ b/docs/crates/windows-clang.md
@@ -156,6 +156,11 @@ The scraper preserves:
 - `DEFINE_ENUM_FLAG_OPERATORS` as a flags-enum signal;
 - symbol-to-DLL mappings recovered from import libraries.
 
+Namespaced scrapes follow referenced record definitions from included headers. Available layouts
+are emitted for both by-value and pointer dependencies; they are not replaced with opaque records.
+Per-header scrapes discover the same definitions globally and retain them in their owning header
+partition.
+
 Some C portability spellings are canonicalized for metadata consumers. Examples include fixed-width
 integer typedefs, pointer-sized integer typedefs, Windows string wrappers, COM interface aliases,
 GUID aliases, and Direct2D compatibility aliases. These rules live in `canon.rs`.


### PR DESCRIPTION
This fixes `windows-clang` namespaced scrapes dropping record definitions that come from included headers.

Previously, a generated RDL file could reference one of these records without emitting its definition, causing RDL-to-winmd generation to fail. Referenced records are now followed and emitted with their real layouts, including nested record dependencies and secondary typedef aliases.

This works for records used by value or through pointers, including symbol-filtered scrapes. Per-header scrapes continue to keep definitions in their owning header partition. The change does not invent layouts for genuinely incomplete records.