### PR TITLE
`windows-clang` const dependency

### DIFF
--- a/crates/libs/clang/src/const.rs
+++ b/crates/libs/clang/src/const.rs
@@ -48,6 +48,34 @@ impl Const {
         }))
     }
 
+    /// Restore a named cast that batch evaluation folded to a plain integer.
+    pub(crate) fn apply_cast_type(
+        &mut self,
+        namespace: &str,
+        ref_map: &HashMap<String, String>,
+        type_name: &str,
+    ) {
+        let Some(bits) = const_value_bits(&self.value) else {
+            return;
+        };
+        if let Some(value) = named_cast_value(namespace, ref_map, None, type_name, bits, false) {
+            self.value = value;
+            self.ty = None;
+        }
+    }
+
+    /// Return the local type dependency retained by a named cast, if canonicalization keeps it.
+    pub(crate) fn cast_type_dependency(
+        namespace: &str,
+        ref_map: &HashMap<String, String>,
+        type_name: &str,
+    ) -> Option<String> {
+        match named_cast_value(namespace, ref_map, None, type_name, 0, false)? {
+            metadata::Value::EnumValue(name, _) => Some(name.name),
+            _ => None,
+        }
+    }
+
     /// Parse file-scope floating-point `const` variables that flat metadata would otherwise lose.
     pub fn parse_var_decl(cursor: &Cursor) -> Option<Self> {
         let name = cursor.name();
@@ -932,7 +960,17 @@ fn parse_named_cast(
 ) -> Option<metadata::Value> {
     let (digits, _suffix) = split_int_suffix(lit);
     let raw: u64 = parse_int_digits(digits)?;
+    named_cast_value(namespace, ref_map, header_names, type_name, raw, negate)
+}
 
+fn named_cast_value(
+    namespace: &str,
+    ref_map: &HashMap<String, String>,
+    header_names: Option<&HashMap<String, String>>,
+    type_name: &str,
+    raw: u64,
+    negate: bool,
+) -> Option<metadata::Value> {
     if let Some(ty) = semantic_scalar(type_name) {
         return scalar_value(&ty, raw, negate);
     }
@@ -979,6 +1017,73 @@ fn parse_named_cast(
         metadata::TypeName::named(ns, type_name),
         Box::new(metadata::Value::I64(v)),
     ))
+}
+
+fn const_value_bits(value: &metadata::Value) -> Option<u64> {
+    Some(match value {
+        metadata::Value::Bool(v) => *v as u64,
+        metadata::Value::U8(v) => *v as u64,
+        metadata::Value::I8(v) => *v as i64 as u64,
+        metadata::Value::U16(v) => *v as u64,
+        metadata::Value::I16(v) => *v as i64 as u64,
+        metadata::Value::U32(v) => *v as u64,
+        metadata::Value::I32(v) => *v as i64 as u64,
+        metadata::Value::U64(v) => *v,
+        metadata::Value::I64(v) => *v as u64,
+        metadata::Value::USize(v) => *v,
+        metadata::Value::ISize(v) => *v as u64,
+        _ => return None,
+    })
+}
+
+/// Return the leading named cast in a deferred macro body.
+pub(crate) fn detect_leading_cast_type(
+    body: &[(CXTokenKind, String)],
+    is_type: impl core::ops::Fn(&str) -> bool,
+) -> Option<String> {
+    let mut body = body;
+    while body.len() > 2 && outer_parens_wrap(body) {
+        body = &body[1..body.len() - 1];
+    }
+    if let [
+        (CXToken_Punctuation, lp),
+        (CXToken_Identifier, ty),
+        (CXToken_Punctuation, rp),
+        rest @ ..,
+    ] = body
+        && lp == "("
+        && rp == ")"
+        && !rest.is_empty()
+        && is_type(ty)
+    {
+        return Some(ty.clone());
+    }
+    None
+}
+
+fn outer_parens_wrap(body: &[(CXTokenKind, String)]) -> bool {
+    let (Some((CXToken_Punctuation, first)), Some((CXToken_Punctuation, last))) =
+        (body.first(), body.last())
+    else {
+        return false;
+    };
+    if first != "(" || last != ")" {
+        return false;
+    }
+    let mut depth = 0i32;
+    for (index, (kind, token)) in body.iter().enumerate() {
+        if *kind == CXToken_Punctuation {
+            match token.as_str() {
+                "(" => depth += 1,
+                ")" => depth -= 1,
+                _ => {}
+            }
+        }
+        if depth == 0 && index + 1 != body.len() {
+            return false;
+        }
+    }
+    depth == 0
 }
 
 /// Parse a named cast of a complemented integer literal such as `(SOCKET)(~0)`.
@@ -1306,5 +1411,27 @@ mod tests {
             native_integer_value(i64::MAX as u64, i64::MAX, &metadata::Type::ISize),
             I64(i64::MAX)
         );
+    }
+
+    #[test]
+    fn leading_cast_requires_a_type_name() {
+        let token = |kind, value: &str| (kind, value.to_string());
+        let cast = vec![
+            token(CXToken_Punctuation, "("),
+            token(CXToken_Punctuation, "("),
+            token(CXToken_Identifier, "Status"),
+            token(CXToken_Punctuation, ")"),
+            token(CXToken_Punctuation, "("),
+            token(CXToken_Literal, "1"),
+            token(CXToken_Punctuation, "+"),
+            token(CXToken_Literal, "2"),
+            token(CXToken_Punctuation, ")"),
+            token(CXToken_Punctuation, ")"),
+        ];
+        assert_eq!(
+            detect_leading_cast_type(&cast, |name| name == "Status"),
+            Some("Status".to_string())
+        );
+        assert_eq!(detect_leading_cast_type(&cast, |_| false), None);
     }
 }

--- a/crates/libs/clang/src/cx.rs
+++ b/crates/libs/clang/src/cx.rs
@@ -866,13 +866,12 @@ impl Type {
                         .to_string()
                 };
                 let definition = decl.definition();
-                if self.kind() == CXType_Record
-                    && parser.header_root.is_none()
+                if parser.header_root.is_none()
                     && ns == parser.namespace
                     && decl.has_definition()
                     && (!definition.is_from_main_file() || !parser.symbols.is_empty())
                 {
-                    parser.pending_records.push(definition);
+                    parser.pending_definitions.push(definition);
                 }
                 // Incomplete namespaced records remain unresolved. Deciding whether a particular
                 // use can be represented by an opaque declaration requires usage-shape analysis.

--- a/crates/libs/clang/src/lib.rs
+++ b/crates/libs/clang/src/lib.rs
@@ -78,10 +78,14 @@ pub(crate) struct Parser<'a> {
     pub tag_rename: &'a HashMap<String, String>,
     /// Enum reprs taken from integer typedefs in the C flags/enum idiom.
     pub enum_merge: &'a HashMap<String, &'static str>,
+    /// Typedef declarations visible through this translation unit's include graph.
+    pub typedefs: &'a HashMap<String, Cursor>,
     pub tu: &'a TranslationUnit,
     pub pending_typedefs: Vec<Cursor>,
     pub pending_records: Vec<Cursor>,
     pub pending_macros: Vec<String>,
+    pub pending_macro_casts: HashMap<String, String>,
+    pub pending_constant_refs: HashSet<String>,
     processing_dependency: bool,
     /// Per-header mode: incomplete pointer-only records emitted as opaque structs.
     pub pending_opaque: Vec<(String, String)>,
@@ -111,6 +115,11 @@ struct NamespaceSpec<'a> {
     symbols: &'a HashSet<String>,
 }
 
+struct PendingMacros {
+    names: Vec<String>,
+    casts: HashMap<String, String>,
+}
+
 impl<'a> Parser<'a> {
     #[expect(clippy::too_many_arguments)]
     fn new(
@@ -120,6 +129,7 @@ impl<'a> Parser<'a> {
         ref_map: &'a HashMap<String, String>,
         tag_rename: &'a HashMap<String, String>,
         enum_merge: &'a HashMap<String, &'static str>,
+        typedefs: &'a HashMap<String, Cursor>,
         macro_defs: &'a HashMap<String, Vec<String>>,
         tu: &'a TranslationUnit,
         symbols: &'a HashSet<String>,
@@ -133,10 +143,13 @@ impl<'a> Parser<'a> {
             header_names: None,
             tag_rename,
             enum_merge,
+            typedefs,
             tu,
             pending_typedefs: vec![],
             pending_records: vec![],
             pending_macros: vec![],
+            pending_macro_casts: HashMap::new(),
+            pending_constant_refs: HashSet::new(),
             processing_dependency: false,
             pending_opaque: vec![],
             flag_enums: HashSet::new(),
@@ -155,6 +168,12 @@ impl<'a> Parser<'a> {
             return;
         }
         collector.insert(Item::Fn(item));
+    }
+
+    fn track_constant_refs(&mut self, item: &Item) {
+        if self.header_root.is_none() {
+            item_refs(item, &mut self.pending_constant_refs);
+        }
     }
 
     /// Processes one cursor, inserting items or queuing macros for the second pass.
@@ -343,12 +362,17 @@ impl<'a> Parser<'a> {
                 }
             }
             CXCursor_MacroDefinition => {
+                let name = child.name();
+                self.pending_macros.retain(|pending| pending != &name);
+                self.pending_macro_casts.remove(&name);
                 if let Some(c) = Const::parse(child, self)? {
-                    collector.insert(Item::Const(c));
+                    let item = Item::Const(c);
+                    self.track_constant_refs(&item);
+                    collector.insert(item);
                 } else if !child.is_macro_builtin()
                     && !child.is_macro_function_like()
-                    && !child.name().is_empty()
-                    && !child.name().starts_with('_')
+                    && !name.is_empty()
+                    && !name.starts_with('_')
                 {
                     // Non-type keywords and string literals are not integer constants.
                     let tokens = self.tu.tokenize(child.extent());
@@ -374,7 +398,19 @@ impl<'a> Parser<'a> {
                         && body_is_balanced
                     {
                         // Defer object-like macro constants to the batch evaluator.
-                        self.pending_macros.push(child.name());
+                        if self.header_root.is_none() {
+                            let body: Vec<_> = tokens.iter().skip(1).cloned().collect();
+                            if let Some(cast) = detect_leading_cast_type(&body, |name| {
+                                self.typedefs.contains_key(name)
+                                    || self.ref_map.contains_key(name)
+                                    || semantic_scalar(name).is_some()
+                                    || fundamental_scalar(name).is_some()
+                                    || pointer_sized_abi(name).is_some()
+                            }) {
+                                self.pending_macro_casts.insert(name.clone(), cast);
+                            }
+                        }
+                        self.pending_macros.push(name);
                     }
                 }
             }
@@ -444,12 +480,14 @@ impl<'a> Parser<'a> {
                     && !self.ref_map.contains_key(&name)
                     && !collector.contains_key(&name)
                 {
-                    collector.insert(Item::PropertyKeyConst(PropertyKeyConst {
+                    let item = Item::PropertyKeyConst(PropertyKeyConst {
                         name,
                         ty: ty.to_string(),
                         uuid,
                         pid,
-                    }));
+                    });
+                    self.track_constant_refs(&item);
+                    collector.insert(item);
                 }
             }
             // `IID_XXX` variables can provide UUIDs missing from interface declarations.
@@ -471,7 +509,9 @@ impl<'a> Parser<'a> {
                     && !self.ref_map.contains_key(&c.name)
                     && !collector.contains_key(&c.name)
                 {
-                    collector.insert(Item::Const(c));
+                    let item = Item::Const(c);
+                    self.track_constant_refs(&item);
+                    collector.insert(item);
                 }
             }
             _ => {}
@@ -1244,6 +1284,7 @@ impl Clang {
 
         let empty_ref: HashMap<String, String> = HashMap::new();
         let empty_symbols: HashSet<String> = HashSet::new();
+        let typedefs = build_typedef_map(tu);
         let mut all_opaque: Vec<(String, String)> = vec![];
         // Macro constants are per-bucket values but are deduplicated globally.
         let mut all_consts: Vec<(String, Vec<String>)> = vec![];
@@ -1257,6 +1298,7 @@ impl Clang {
                 &empty_ref,
                 &tag_rename,
                 &enum_merge,
+                &typedefs,
                 &macro_defs,
                 tu,
                 &empty_symbols,
@@ -1419,14 +1461,24 @@ impl Clang {
 
             for (input, tu) in &parsed.h_tus {
                 let pending = self.process_tu(tu, &mut collector, &ref_map, spec)?;
-                for c in Const::evaluate_macros(input, &pending, &parsed.index, &arg_refs)? {
+                for mut c in
+                    Const::evaluate_macros(input, &pending.names, &parsed.index, &arg_refs)?
+                {
+                    if let Some(cast) = pending.casts.get(&c.name) {
+                        c.apply_cast_type(spec.namespace, &ref_map, cast);
+                    }
                     collector.insert(Item::Const(c));
                 }
             }
 
             for (content, tu) in &parsed.str_tus {
                 let pending = self.process_tu(tu, &mut collector, &ref_map, spec)?;
-                for c in Const::evaluate_macros_str(content, &pending, &parsed.index, &arg_refs)? {
+                for mut c in
+                    Const::evaluate_macros_str(content, &pending.names, &parsed.index, &arg_refs)?
+                {
+                    if let Some(cast) = pending.casts.get(&c.name) {
+                        c.apply_cast_type(spec.namespace, &ref_map, cast);
+                    }
                     collector.insert(Item::Const(c));
                 }
             }
@@ -1444,7 +1496,7 @@ impl Clang {
         collector: &mut Collector,
         ref_map: &HashMap<String, String>,
         spec: &NamespaceSpec<'_>,
-    ) -> Result<Vec<String>, Error> {
+    ) -> Result<PendingMacros, Error> {
         for diag in tu.diagnostics() {
             if diag.is_err() {
                 return Err(Error::new(
@@ -1462,6 +1514,7 @@ impl Clang {
         // Give nested records synthetic names keyed by tag or source location.
         assign_nested_names(tu, &mut tag_rename);
         let enum_merge = merge_enum_typedef_idiom(tu, &mut tag_rename);
+        let typedefs = build_typedef_map(tu);
         let macro_defs = collect_macro_defs(tu);
 
         let mut parser = Parser::new(
@@ -1471,6 +1524,7 @@ impl Clang {
             ref_map,
             &tag_rename,
             &enum_merge,
+            &typedefs,
             &macro_defs,
             tu,
             spec.symbols,
@@ -1498,6 +1552,24 @@ impl Clang {
             }
 
             parser.process_cursor(child, collector, false)?;
+        }
+
+        // Constants have no type cursor, so queue local typedefs named by their values or by casts
+        // whose expressions require batch evaluation.
+        let mut referenced = std::mem::take(&mut parser.pending_constant_refs);
+        referenced.extend(
+            parser
+                .pending_macro_casts
+                .values()
+                .filter_map(|cast| Const::cast_type_dependency(spec.namespace, ref_map, cast)),
+        );
+        for name in referenced {
+            if !collector.contains_key(&name)
+                && !parser.ref_map.contains_key(&name)
+                && let Some(cursor) = parser.typedefs.get(&name)
+            {
+                parser.pending_typedefs.push(*cursor);
+            }
         }
 
         // Drain referenced type dependencies; parsing one definition can enqueue more.
@@ -1541,7 +1613,10 @@ impl Clang {
         // Apply `IID_IFoo` variables to interfaces that lack `uuid` attributes.
         collector.apply_iid_vars(&parser.iid_vars);
 
-        Ok(parser.pending_macros)
+        Ok(PendingMacros {
+            names: parser.pending_macros,
+            casts: parser.pending_macro_casts,
+        })
     }
 }
 

--- a/crates/libs/clang/src/lib.rs
+++ b/crates/libs/clang/src/lib.rs
@@ -82,9 +82,8 @@ pub(crate) struct Parser<'a> {
     pub typedefs: &'a HashMap<String, Cursor>,
     pub tu: &'a TranslationUnit,
     pub pending_typedefs: Vec<Cursor>,
-    pub pending_records: Vec<Cursor>,
-    pub pending_macros: Vec<String>,
-    pub pending_macro_casts: HashMap<String, String>,
+    pub pending_definitions: Vec<Cursor>,
+    pending_macros: BTreeMap<String, PendingMacro>,
     pub pending_constant_refs: HashSet<String>,
     processing_dependency: bool,
     /// Per-header mode: incomplete pointer-only records emitted as opaque structs.
@@ -120,6 +119,11 @@ struct PendingMacros {
     casts: HashMap<String, String>,
 }
 
+enum PendingMacro {
+    Direct(Const),
+    Evaluate(Option<String>),
+}
+
 impl<'a> Parser<'a> {
     #[expect(clippy::too_many_arguments)]
     fn new(
@@ -146,9 +150,8 @@ impl<'a> Parser<'a> {
             typedefs,
             tu,
             pending_typedefs: vec![],
-            pending_records: vec![],
-            pending_macros: vec![],
-            pending_macro_casts: HashMap::new(),
+            pending_definitions: vec![],
+            pending_macros: BTreeMap::new(),
             pending_constant_refs: HashSet::new(),
             processing_dependency: false,
             pending_opaque: vec![],
@@ -173,6 +176,23 @@ impl<'a> Parser<'a> {
     fn track_constant_refs(&mut self, item: &Item) {
         if self.header_root.is_none() {
             item_refs(item, &mut self.pending_constant_refs);
+        }
+    }
+
+    fn finalize_direct_macros(&mut self, collector: &mut Collector) {
+        let pending = std::mem::take(&mut self.pending_macros);
+        for (name, state) in pending {
+            match state {
+                PendingMacro::Direct(c) => {
+                    let item = Item::Const(c);
+                    self.track_constant_refs(&item);
+                    collector.insert(item);
+                }
+                PendingMacro::Evaluate(cast) => {
+                    self.pending_macros
+                        .insert(name, PendingMacro::Evaluate(cast));
+                }
+            }
         }
     }
 
@@ -363,12 +383,16 @@ impl<'a> Parser<'a> {
             }
             CXCursor_MacroDefinition => {
                 let name = child.name();
-                self.pending_macros.retain(|pending| pending != &name);
-                self.pending_macro_casts.remove(&name);
+                let namespaced = self.header_root.is_none();
+                if namespaced {
+                    self.pending_macros.remove(&name);
+                }
                 if let Some(c) = Const::parse(child, self)? {
-                    let item = Item::Const(c);
-                    self.track_constant_refs(&item);
-                    collector.insert(item);
+                    if namespaced {
+                        self.pending_macros.insert(name, PendingMacro::Direct(c));
+                    } else {
+                        collector.insert(Item::Const(c));
+                    }
                 } else if !child.is_macro_builtin()
                     && !child.is_macro_function_like()
                     && !name.is_empty()
@@ -398,19 +422,21 @@ impl<'a> Parser<'a> {
                         && body_is_balanced
                     {
                         // Defer object-like macro constants to the batch evaluator.
-                        if self.header_root.is_none() {
+                        if namespaced {
                             let body: Vec<_> = tokens.iter().skip(1).cloned().collect();
-                            if let Some(cast) = detect_leading_cast_type(&body, |name| {
+                            let cast = detect_leading_cast_type(&body, |name| {
                                 self.typedefs.contains_key(name)
                                     || self.ref_map.contains_key(name)
                                     || semantic_scalar(name).is_some()
                                     || fundamental_scalar(name).is_some()
                                     || pointer_sized_abi(name).is_some()
-                            }) {
-                                self.pending_macro_casts.insert(name.clone(), cast);
-                            }
+                            });
+                            self.pending_macros
+                                .insert(name, PendingMacro::Evaluate(cast));
+                        } else {
+                            self.pending_macros
+                                .insert(name, PendingMacro::Evaluate(None));
                         }
-                        self.pending_macros.push(name);
                     }
                 }
             }
@@ -1311,11 +1337,12 @@ impl Clang {
                 parser.process_cursor(child, collector, extern_c)?;
             }
 
+            parser.finalize_direct_macros(collector);
             collector.apply_iid_vars(&parser.iid_vars);
 
             let pending = std::mem::take(&mut parser.pending_macros);
             if !pending.is_empty() {
-                all_consts.push((stem.clone(), pending));
+                all_consts.push((stem.clone(), pending.into_keys().collect()));
             }
             for (_ns, name) in std::mem::take(&mut parser.pending_opaque) {
                 all_opaque.push((stem.clone(), name));
@@ -1554,17 +1581,23 @@ impl Clang {
             parser.process_cursor(child, collector, false)?;
         }
 
+        parser.finalize_direct_macros(collector);
+
         // Constants have no type cursor, so queue local typedefs named by their values or by casts
         // whose expressions require batch evaluation.
         let mut referenced = std::mem::take(&mut parser.pending_constant_refs);
         referenced.extend(
             parser
-                .pending_macro_casts
+                .pending_macros
                 .values()
+                .filter_map(|state| match state {
+                    PendingMacro::Evaluate(cast) => cast.as_deref(),
+                    PendingMacro::Direct(_) => None,
+                })
                 .filter_map(|cast| Const::cast_type_dependency(spec.namespace, ref_map, cast)),
         );
         for name in referenced {
-            if !collector.contains_key(&name)
+            if !collector.get(&name).is_some_and(Item::is_type)
                 && !parser.ref_map.contains_key(&name)
                 && let Some(cursor) = parser.typedefs.get(&name)
             {
@@ -1574,11 +1607,11 @@ impl Clang {
 
         // Drain referenced type dependencies; parsing one definition can enqueue more.
         let mut seen_typedefs: HashSet<String> = HashSet::new();
-        let mut seen_records: HashSet<String> = HashSet::new();
+        let mut seen_definitions: HashSet<String> = HashSet::new();
         let mut typedef_index = 0;
-        let mut record_index = 0;
+        let mut definition_index = 0;
         while typedef_index < parser.pending_typedefs.len()
-            || record_index < parser.pending_records.len()
+            || definition_index < parser.pending_definitions.len()
         {
             while typedef_index < parser.pending_typedefs.len() {
                 let cursor = parser.pending_typedefs[typedef_index];
@@ -1586,7 +1619,7 @@ impl Clang {
                 let name = cursor.name();
                 // Skip anything already resolved.
                 if !seen_typedefs.insert(name.clone())
-                    || collector.contains_key(&name)
+                    || collector.get(&name).is_some_and(Item::is_type)
                     || parser.ref_map.contains_key(&name)
                 {
                     continue;
@@ -1598,10 +1631,10 @@ impl Clang {
                 }
             }
 
-            while record_index < parser.pending_records.len() {
-                let cursor = parser.pending_records[record_index];
-                record_index += 1;
-                if seen_records.insert(cursor.usr()) {
+            while definition_index < parser.pending_definitions.len() {
+                let cursor = parser.pending_definitions[definition_index];
+                definition_index += 1;
+                if seen_definitions.insert(cursor.usr()) {
                     parser.processing_dependency = true;
                     let result = parser.process_cursor(cursor, collector, false);
                     parser.processing_dependency = false;
@@ -1613,10 +1646,16 @@ impl Clang {
         // Apply `IID_IFoo` variables to interfaces that lack `uuid` attributes.
         collector.apply_iid_vars(&parser.iid_vars);
 
-        Ok(PendingMacros {
-            names: parser.pending_macros,
-            casts: parser.pending_macro_casts,
-        })
+        let names = parser.pending_macros.keys().cloned().collect();
+        let casts = parser
+            .pending_macros
+            .into_iter()
+            .filter_map(|(name, state)| match state {
+                PendingMacro::Evaluate(Some(cast)) => Some((name, cast)),
+                PendingMacro::Evaluate(None) | PendingMacro::Direct(_) => None,
+            })
+            .collect();
+        Ok(PendingMacros { names, casts })
     }
 }
 

--- a/crates/libs/clang/src/naming.rs
+++ b/crates/libs/clang/src/naming.rs
@@ -24,6 +24,23 @@ pub(crate) fn build_tag_rename_map(tu: &TranslationUnit) -> HashMap<String, Stri
     map
 }
 
+/// Index typedef declarations visible in one translation unit.
+pub(crate) fn build_typedef_map(tu: &TranslationUnit) -> HashMap<String, Cursor> {
+    fn collect(cursor: Cursor, map: &mut HashMap<String, Cursor>) {
+        for child in cursor.children() {
+            if child.kind() == CXCursor_LinkageSpec {
+                collect(child, map);
+            } else if child.kind() == CXCursor_TypedefDecl {
+                map.entry(child.name()).or_insert(child);
+            }
+        }
+    }
+
+    let mut map = HashMap::new();
+    collect(tu.cursor(), &mut map);
+    map
+}
+
 /// Merge `enum _FOO { ... }; typedef DWORD FOO;` into one public enum.
 ///
 /// The typedef supplies the backing type and signedness; the enum supplies the members.

--- a/crates/libs/clang/src/typedef.rs
+++ b/crates/libs/clang/src/typedef.rs
@@ -103,7 +103,7 @@ impl Typedef {
                 .get(&tag)
                 .cloned()
                 .unwrap_or_else(|| tag.clone());
-            if parser.header_root.is_none() && inner_kind == CXType_Record {
+            if parser.header_root.is_none() {
                 // Pull the backing definition into namespaced output before deciding whether this
                 // typedef is the public name or a secondary alias.
                 inner.to_type(parser);

--- a/crates/tests/libs/clang/input/const_dependency.hpp
+++ b/crates/tests/libs/clang/input/const_dependency.hpp
@@ -9,3 +9,15 @@
 #define STATUS_REDEFINED ((ChainedStatus)(1 + 2))
 #undef STATUS_REDEFINED
 #define STATUS_REDEFINED (4 + 5)
+#define STATUS_DIRECT_REDEFINED ((UnusedStatus)1)
+#undef STATUS_DIRECT_REDEFINED
+#define STATUS_DIRECT_REDEFINED 9
+#define STATUS_DROPPED_REDEFINITION ((UnusedStatus)2)
+#undef STATUS_DROPPED_REDEFINITION
+#define STATUS_DROPPED_REDEFINITION(value) value
+#define STATUS_ENUM ((ConstantState)1)
+
+typedef unsigned int MacroNameCollision;
+#define MacroNameCollision 1
+#undef MacroNameCollision
+#define MacroNameCollision(value) value

--- a/crates/tests/libs/clang/input/const_dependency.hpp
+++ b/crates/tests/libs/clang/input/const_dependency.hpp
@@ -1,0 +1,11 @@
+#include "const_dependency_inc.inl"
+
+#define STATUS_LITERAL ((IncludedStatus)7)
+#define STATUS_CHAINED ((ChainedStatus)9)
+#define STATUS_EVALUATED ((IncludedStatus)(1 + 2))
+#define STATUS_FUNDAMENTAL ((DWORD)(1 + 2))
+#define STATUS_BASE 4
+#define STATUS_NONCAST ((STATUS_BASE) + 1)
+#define STATUS_REDEFINED ((ChainedStatus)(1 + 2))
+#undef STATUS_REDEFINED
+#define STATUS_REDEFINED (4 + 5)

--- a/crates/tests/libs/clang/input/const_dependency_inc.inl
+++ b/crates/tests/libs/clang/input/const_dependency_inc.inl
@@ -1,0 +1,3 @@
+typedef unsigned short IncludedStatus;
+typedef IncludedStatus ChainedStatus;
+typedef unsigned long DWORD;

--- a/crates/tests/libs/clang/input/const_dependency_inc.inl
+++ b/crates/tests/libs/clang/input/const_dependency_inc.inl
@@ -1,3 +1,8 @@
 typedef unsigned short IncludedStatus;
 typedef IncludedStatus ChainedStatus;
 typedef unsigned long DWORD;
+typedef unsigned short UnusedStatus;
+
+typedef enum _ConstantState : unsigned int {
+    ConstantStateReady = 1,
+} ConstantState;

--- a/crates/tests/libs/clang/input/const_dependency_type_collision.hpp
+++ b/crates/tests/libs/clang/input/const_dependency_type_collision.hpp
@@ -1,0 +1,3 @@
+typedef unsigned short CollisionStatus;
+
+#define COLLISION_STATUS_VALUE ((CollisionStatus)3)

--- a/crates/tests/libs/clang/input/const_dependency_value_collision.hpp
+++ b/crates/tests/libs/clang/input/const_dependency_value_collision.hpp
@@ -1,0 +1,1 @@
+#define CollisionStatus 5

--- a/crates/tests/libs/clang/tests/clang.rs
+++ b/crates/tests/libs/clang/tests/clang.rs
@@ -530,6 +530,39 @@ fn namespaced_record_dependencies_preserve_layout() {
         .unwrap();
 }
 
+#[test]
+fn namespaced_constants_retain_type_dependencies() {
+    let scratch = std::path::Path::new(env!("OUT_DIR")).join("const_dependency");
+    std::fs::create_dir_all(&scratch).unwrap();
+    let rdl = scratch.join("out.rdl");
+
+    {
+        let _guard = test_clang::libclang_guard();
+        windows_clang::clang()
+            .input("input/const_dependency.hpp")
+            .output(&rdl)
+            .namespace("ConstDependency")
+            .write()
+            .unwrap();
+    }
+
+    let contents = std::fs::read_to_string(&rdl).unwrap();
+    assert!(contents.contains("type IncludedStatus = u16"));
+    assert!(contents.contains("type ChainedStatus = u16"));
+    assert!(contents.contains("STATUS_LITERAL: IncludedStatus = 7"));
+    assert!(contents.contains("STATUS_CHAINED: ChainedStatus = 9"));
+    assert!(contents.contains("STATUS_EVALUATED: IncludedStatus = 3"));
+    assert!(contents.contains("STATUS_FUNDAMENTAL: u32 = 3"));
+    assert!(contents.contains("STATUS_NONCAST: i32 = 5"));
+    assert!(contents.contains("STATUS_REDEFINED: i32 = 9"));
+    assert!(!contents.contains("type DWORD"));
+    windows_rdl::reader()
+        .input(&rdl)
+        .output(scratch.join("out.winmd"))
+        .write()
+        .unwrap();
+}
+
 fn run(name: &str) {
     let input_path = format!("input/{name}.h");
     let expected_path = format!("expected/{name}.rdl");

--- a/crates/tests/libs/clang/tests/clang.rs
+++ b/crates/tests/libs/clang/tests/clang.rs
@@ -555,10 +555,40 @@ fn namespaced_constants_retain_type_dependencies() {
     assert!(contents.contains("STATUS_FUNDAMENTAL: u32 = 3"));
     assert!(contents.contains("STATUS_NONCAST: i32 = 5"));
     assert!(contents.contains("STATUS_REDEFINED: i32 = 9"));
+    assert!(contents.contains("STATUS_DIRECT_REDEFINED: i32 = 9"));
+    assert!(!contents.contains("STATUS_DROPPED_REDEFINITION"));
+    assert!(contents.contains("#[repr(u32)]"));
+    assert!(contents.contains("enum ConstantState"));
+    assert!(contents.contains("ConstantStateReady = 1"));
+    assert!(contents.contains("STATUS_ENUM: ConstantState = 1"));
     assert!(!contents.contains("type DWORD"));
+    assert!(!contents.contains("type UnusedStatus"));
+    assert!(contents.contains("type MacroNameCollision = u32"));
     windows_rdl::reader()
         .input(&rdl)
         .output(scratch.join("out.winmd"))
+        .write()
+        .unwrap();
+
+    let collision_rdl = scratch.join("collision.rdl");
+    {
+        let _guard = test_clang::libclang_guard();
+        windows_clang::clang()
+            .input("input/const_dependency_value_collision.hpp")
+            .input("input/const_dependency_type_collision.hpp")
+            .output(&collision_rdl)
+            .namespace("ConstDependencyCollision")
+            .write()
+            .unwrap();
+    }
+
+    let collision = std::fs::read_to_string(&collision_rdl).unwrap();
+    assert!(collision.contains("type CollisionStatus = u16"));
+    assert!(collision.contains("COLLISION_STATUS_VALUE: CollisionStatus = 3"));
+    assert!(!collision.contains("const CollisionStatus"));
+    windows_rdl::reader()
+        .input(&collision_rdl)
+        .output(scratch.join("collision.winmd"))
         .write()
         .unwrap();
 }

--- a/docs/crates/windows-clang.md
+++ b/docs/crates/windows-clang.md
@@ -151,13 +151,15 @@ The scraper preserves:
 - SAL and IDL optionality, buffer sizing, retval, and interface-selection annotations;
 - `uuid`, `noreturn`, alignment, `dllimport`, and deprecation attributes;
 - calling conventions, packing, unions, scoped enums, bit fields, and typedefs;
-- explicit constant casts and C integer literal types;
+- explicit constant casts, including casts whose expressions require batch evaluation, and C
+  integer literal types;
 - GUID values from `DEFINE_GUID`, `DEFINE_OLEGUID`, and `DEFINE_KNOWN_FOLDER`;
 - `DEFINE_ENUM_FLAG_OPERATORS` as a flags-enum signal;
 - symbol-to-DLL mappings recovered from import libraries.
 
 Namespaced scrapes follow referenced record definitions from included headers. Available layouts
 are emitted for both by-value and pointer dependencies; they are not replaced with opaque records.
+Typedefs referenced only by constants are retained in the same namespace.
 Per-header scrapes discover the same definitions globally and retain them in their owning header
 partition.
 


### PR DESCRIPTION
This fixes `windows-clang` namespaced scrapes dropping typedefs that are referenced only by constants.

Typed constants now retain typedefs from included headers, including chained aliases and casts around expressions that need batch evaluation. Macro redefinitions discard stale cast information, and parenthesized value expressions are not mistaken for type casts.

The change is limited to declarations visible within each translation unit and does not attempt to reconcile types across independent inputs. Win32/WDK and WebView regeneration remain output-neutral.

Fixes item 13 in #4902.