### PR TITLE
`windows-reactor` optimized keyboard input

### DIFF
--- a/crates/libs/reactor/public-api.txt
+++ b/crates/libs/reactor/public-api.txt
@@ -604,6 +604,7 @@ pub fn windows_reactor::Border::corner_radius(self, impl core::convert::Into<win
 pub fn windows_reactor::Border::corner_radius_optional<T>(self, core::option::Option<T>) -> Self where T: core::convert::Into<windows_reactor::CornerRadius>
 pub fn windows_reactor::Border::drop_policy(self, impl core::convert::Into<core::option::Option<windows_reactor::DragDropPolicy>>) -> Self
 pub fn windows_reactor::Border::element_ref(self, &windows_reactor::ElementRef<Self>) -> Self
+pub fn windows_reactor::Border::focus_on_pointer_release(self, impl core::convert::Into<core::option::Option<bool>>) -> Self
 pub fn windows_reactor::Border::is_tab_stop(self, impl core::convert::Into<core::option::Option<bool>>) -> Self
 pub fn windows_reactor::Border::new() -> Self
 pub fn windows_reactor::Border::on_character_received(self, windows_reactor::RoutedCallback<windows_reactor::CharacterEventInfo>) -> Self

--- a/crates/libs/reactor/public-api.txt
+++ b/crates/libs/reactor/public-api.txt
@@ -98,6 +98,11 @@ pub enum windows_reactor::DroppedData
 pub windows_reactor::DroppedData::StorageItems(alloc::vec::Vec<windows_reactor::DroppedStorageItem>)
 pub windows_reactor::DroppedData::Text(alloc::string::String)
 pub windows_reactor::DroppedData::Unsupported
+pub enum windows_reactor::ElementFocusState
+pub windows_reactor::ElementFocusState::Keyboard
+pub windows_reactor::ElementFocusState::Pointer
+pub windows_reactor::ElementFocusState::Programmatic
+pub windows_reactor::ElementFocusState::Unfocused
 pub enum windows_reactor::FlyoutPlacement
 pub windows_reactor::FlyoutPlacement::Auto
 pub windows_reactor::FlyoutPlacement::Bottom
@@ -177,6 +182,9 @@ pub windows_reactor::PasswordRevealMode::Hidden
 pub windows_reactor::PasswordRevealMode::Peek
 pub windows_reactor::PasswordRevealMode::Visible
 pub enum windows_reactor::PumpDiagnostic
+pub windows_reactor::PumpDiagnostic::HandledInputDropped
+pub windows_reactor::PumpDiagnostic::HandledInputDropped::event: windows_reactor::generated::EventId
+pub windows_reactor::PumpDiagnostic::HandledInputDropped::node: windows_reactor::core::arena::NodeId
 pub windows_reactor::PumpDiagnostic::VirtualRowRootCount
 pub windows_reactor::PumpDiagnostic::VirtualRowRootCount::actual: usize
 pub windows_reactor::PumpDiagnostic::VirtualRowRootCount::collection: windows_reactor::core::arena::NodeId
@@ -584,6 +592,7 @@ pub fn windows_reactor::BitmapIcon::vertical_alignment(self, impl core::convert:
 pub fn windows_reactor::BitmapIcon::width(self, impl core::convert::Into<core::option::Option<f64>>) -> Self where Self: core::marker::Sized
 pub struct windows_reactor::Border
 impl windows_reactor::Border
+pub fn windows_reactor::Border::allow_focus_on_interaction(self, impl core::convert::Into<core::option::Option<bool>>) -> Self
 pub fn windows_reactor::Border::background(self, impl core::convert::Into<windows_reactor::Brush>) -> Self
 pub fn windows_reactor::Border::background_optional<T>(self, core::option::Option<T>) -> Self where T: core::convert::Into<windows_reactor::Brush>
 pub fn windows_reactor::Border::border_brush(self, impl core::convert::Into<windows_reactor::Brush>) -> Self
@@ -594,11 +603,17 @@ pub fn windows_reactor::Border::capture_pointer_on_press(self, impl core::conver
 pub fn windows_reactor::Border::corner_radius(self, impl core::convert::Into<windows_reactor::CornerRadius>) -> Self
 pub fn windows_reactor::Border::corner_radius_optional<T>(self, core::option::Option<T>) -> Self where T: core::convert::Into<windows_reactor::CornerRadius>
 pub fn windows_reactor::Border::drop_policy(self, impl core::convert::Into<core::option::Option<windows_reactor::DragDropPolicy>>) -> Self
+pub fn windows_reactor::Border::element_ref(self, &windows_reactor::ElementRef<Self>) -> Self
+pub fn windows_reactor::Border::is_tab_stop(self, impl core::convert::Into<core::option::Option<bool>>) -> Self
 pub fn windows_reactor::Border::new() -> Self
+pub fn windows_reactor::Border::on_character_received(self, windows_reactor::RoutedCallback<windows_reactor::CharacterEventInfo>) -> Self
 pub fn windows_reactor::Border::on_drag_enter(self, impl windows_reactor::IntoPayloadCallback<windows_reactor::DragKind>) -> Self
 pub fn windows_reactor::Border::on_drag_leave(self, impl windows_reactor::IntoUnitCallback) -> Self
 pub fn windows_reactor::Border::on_drag_over(self, impl windows_reactor::IntoPayloadCallback<windows_reactor::DragKind>) -> Self
 pub fn windows_reactor::Border::on_drop(self, impl windows_reactor::IntoPayloadCallback<windows_reactor::DroppedData>) -> Self
+pub fn windows_reactor::Border::on_got_focus(self, impl windows_reactor::IntoPayloadCallback<windows_reactor::FocusEventInfo>) -> Self
+pub fn windows_reactor::Border::on_key_up(self, windows_reactor::RoutedCallback<windows_reactor::KeyEventInfo>) -> Self
+pub fn windows_reactor::Border::on_lost_focus(self, impl windows_reactor::IntoPayloadCallback<windows_reactor::FocusEventInfo>) -> Self
 pub fn windows_reactor::Border::on_pointer_canceled(self, impl windows_reactor::IntoUnitCallback) -> Self
 pub fn windows_reactor::Border::on_pointer_capture_lost(self, impl windows_reactor::IntoUnitCallback) -> Self
 pub fn windows_reactor::Border::on_pointer_entered(self, impl windows_reactor::IntoPayloadCallback<windows_reactor::PointerEventInfo>) -> Self
@@ -606,6 +621,7 @@ pub fn windows_reactor::Border::on_pointer_exited(self, impl windows_reactor::In
 pub fn windows_reactor::Border::on_pointer_moved(self, impl windows_reactor::IntoPayloadCallback<windows_reactor::PointerEventInfo>) -> Self
 pub fn windows_reactor::Border::on_pointer_pressed(self, impl windows_reactor::IntoPayloadCallback<windows_reactor::PointerEventInfo>) -> Self
 pub fn windows_reactor::Border::on_pointer_released(self, impl windows_reactor::IntoPayloadCallback<windows_reactor::PointerEventInfo>) -> Self
+pub fn windows_reactor::Border::on_preview_key_down(self, windows_reactor::RoutedCallback<windows_reactor::KeyEventInfo>) -> Self
 pub fn windows_reactor::Border::opacity_transition(self, impl core::convert::Into<core::option::Option<core::time::Duration>>) -> Self
 pub fn windows_reactor::Border::padding(self, impl core::convert::Into<windows_reactor::Thickness>) -> Self
 pub fn windows_reactor::Border::padding_optional<T>(self, core::option::Option<T>) -> Self where T: core::convert::Into<windows_reactor::Thickness>
@@ -615,6 +631,7 @@ impl core::convert::From<windows_reactor::Border> for windows_reactor::View
 pub fn windows_reactor::View::from(windows_reactor::Border) -> Self
 impl windows_reactor::ContentControl for windows_reactor::Border
 pub fn windows_reactor::Border::content(self, impl core::convert::Into<windows_reactor::View>) -> windows_reactor::View
+impl windows_reactor::FocusControl for windows_reactor::Border
 impl windows_reactor::LayoutControl for windows_reactor::Border
 pub fn windows_reactor::Border::exit_transition(self, windows_reactor::ExitTransition) -> Self where Self: core::marker::Sized
 pub fn windows_reactor::Border::height(self, impl core::convert::Into<core::option::Option<f64>>) -> Self where Self: core::marker::Sized
@@ -628,6 +645,7 @@ pub fn windows_reactor::Border::min_width(self, impl core::convert::Into<core::o
 pub fn windows_reactor::Border::opacity(self, impl core::convert::Into<core::option::Option<f64>>) -> Self where Self: core::marker::Sized
 pub fn windows_reactor::Border::vertical_alignment(self, impl core::convert::Into<core::option::Option<windows_reactor::VerticalAlignment>>) -> Self where Self: core::marker::Sized
 pub fn windows_reactor::Border::width(self, impl core::convert::Into<core::option::Option<f64>>) -> Self where Self: core::marker::Sized
+impl windows_reactor::ReferenceControl for windows_reactor::Border
 pub struct windows_reactor::BreadcrumbBar
 impl windows_reactor::BreadcrumbBar
 pub fn windows_reactor::BreadcrumbBar::items_source<I, S>(self, I) -> Self where I: core::iter::traits::collect::IntoIterator<Item = S>, S: core::convert::Into<alloc::string::String>
@@ -764,6 +782,10 @@ pub fn windows_reactor::Canvas::min_width(self, impl core::convert::Into<core::o
 pub fn windows_reactor::Canvas::opacity(self, impl core::convert::Into<core::option::Option<f64>>) -> Self where Self: core::marker::Sized
 pub fn windows_reactor::Canvas::vertical_alignment(self, impl core::convert::Into<core::option::Option<windows_reactor::VerticalAlignment>>) -> Self where Self: core::marker::Sized
 pub fn windows_reactor::Canvas::width(self, impl core::convert::Into<core::option::Option<f64>>) -> Self where Self: core::marker::Sized
+pub struct windows_reactor::CharacterEventInfo
+pub windows_reactor::CharacterEventInfo::character: u16
+pub windows_reactor::CharacterEventInfo::modifiers: windows_reactor::InputModifiers
+pub windows_reactor::CharacterEventInfo::status: windows_reactor::PhysicalKeyStatus
 pub struct windows_reactor::CheckBox
 impl windows_reactor::CheckBox
 pub fn windows_reactor::CheckBox::element_ref(self, &windows_reactor::ElementRef<Self>) -> Self
@@ -1135,6 +1157,9 @@ impl windows_reactor::Flyout
 pub fn windows_reactor::Flyout::placement(self, windows_reactor::FlyoutPlacement) -> Self
 pub fn windows_reactor::Flyout::rich(impl core::convert::Into<windows_reactor::View>) -> Self
 pub fn windows_reactor::Flyout::text(impl core::convert::Into<alloc::string::String>) -> Self
+pub struct windows_reactor::FocusEventInfo
+pub windows_reactor::FocusEventInfo::is_direct: bool
+pub windows_reactor::FocusEventInfo::state: windows_reactor::ElementFocusState
 pub struct windows_reactor::FontIcon
 impl windows_reactor::FontIcon
 pub fn windows_reactor::FontIcon::glyph(self, impl core::convert::Into<alloc::string::String>) -> Self
@@ -1372,6 +1397,19 @@ pub fn windows_reactor::InfoBar::min_width(self, impl core::convert::Into<core::
 pub fn windows_reactor::InfoBar::opacity(self, impl core::convert::Into<core::option::Option<f64>>) -> Self where Self: core::marker::Sized
 pub fn windows_reactor::InfoBar::vertical_alignment(self, impl core::convert::Into<core::option::Option<windows_reactor::VerticalAlignment>>) -> Self where Self: core::marker::Sized
 pub fn windows_reactor::InfoBar::width(self, impl core::convert::Into<core::option::Option<f64>>) -> Self where Self: core::marker::Sized
+pub struct windows_reactor::InputModifiers(_)
+impl windows_reactor::InputModifiers
+pub const windows_reactor::InputModifiers::ALT: Self
+pub const windows_reactor::InputModifiers::CONTROL: Self
+pub const windows_reactor::InputModifiers::NONE: Self
+pub const windows_reactor::InputModifiers::SHIFT: Self
+pub const windows_reactor::InputModifiers::WINDOWS: Self
+pub const fn windows_reactor::InputModifiers::contains(self, Self) -> bool
+impl core::ops::bit::BitOr for windows_reactor::InputModifiers
+pub type windows_reactor::InputModifiers::Output = windows_reactor::InputModifiers
+pub fn windows_reactor::InputModifiers::bitor(self, Self) -> Self::Output
+impl core::ops::bit::BitOrAssign for windows_reactor::InputModifiers
+pub fn windows_reactor::InputModifiers::bitor_assign(&mut self, Self)
 pub struct windows_reactor::ItemsRepeater
 impl windows_reactor::ItemsRepeater
 pub fn windows_reactor::ItemsRepeater::item(self, impl core::convert::Into<windows_reactor::Key>, impl core::convert::Into<windows_reactor::View>) -> Self
@@ -1410,6 +1448,11 @@ pub fn windows_reactor::KeyAccelerator::new(windows_reactor::AcceleratorKey, win
 pub struct windows_reactor::KeyAccelerators
 impl windows_reactor::KeyAccelerators
 pub fn windows_reactor::KeyAccelerators::new(impl core::iter::traits::collect::IntoIterator<Item = windows_reactor::KeyAccelerator>) -> Self
+pub struct windows_reactor::KeyEventInfo
+pub windows_reactor::KeyEventInfo::key: windows_reactor::VirtualKey
+pub windows_reactor::KeyEventInfo::modifiers: windows_reactor::InputModifiers
+pub windows_reactor::KeyEventInfo::original_key: windows_reactor::VirtualKey
+pub windows_reactor::KeyEventInfo::status: windows_reactor::PhysicalKeyStatus
 pub struct windows_reactor::KeyedView
 impl windows_reactor::KeyedView
 pub fn windows_reactor::KeyedView::key(&self) -> &windows_reactor::Key
@@ -1744,6 +1787,13 @@ pub fn windows_reactor::PersonPicture::min_width(self, impl core::convert::Into<
 pub fn windows_reactor::PersonPicture::opacity(self, impl core::convert::Into<core::option::Option<f64>>) -> Self where Self: core::marker::Sized
 pub fn windows_reactor::PersonPicture::vertical_alignment(self, impl core::convert::Into<core::option::Option<windows_reactor::VerticalAlignment>>) -> Self where Self: core::marker::Sized
 pub fn windows_reactor::PersonPicture::width(self, impl core::convert::Into<core::option::Option<f64>>) -> Self where Self: core::marker::Sized
+pub struct windows_reactor::PhysicalKeyStatus
+pub windows_reactor::PhysicalKeyStatus::is_extended: bool
+pub windows_reactor::PhysicalKeyStatus::is_menu_down: bool
+pub windows_reactor::PhysicalKeyStatus::is_released: bool
+pub windows_reactor::PhysicalKeyStatus::repeat_count: u32
+pub windows_reactor::PhysicalKeyStatus::scan_code: u32
+pub windows_reactor::PhysicalKeyStatus::was_down: bool
 pub struct windows_reactor::Pivot
 impl windows_reactor::Pivot
 pub fn windows_reactor::Pivot::items<T>(self, impl core::iter::traits::collect::IntoIterator<Item = T>) -> Self where T: core::convert::Into<windows_reactor::KeyedView>
@@ -2067,6 +2117,19 @@ pub windows_reactor::RichTextRun::is_italic: bool
 pub windows_reactor::RichTextRun::text: alloc::string::String
 impl windows_reactor::RichTextRun
 pub fn windows_reactor::RichTextRun::plain(impl core::convert::Into<alloc::string::String>) -> Self
+pub struct windows_reactor::RoutedCallback<T>
+impl<T> core::clone::Clone for windows_reactor::RoutedCallback<T>
+pub fn windows_reactor::RoutedCallback<T>::clone(&self) -> Self
+impl<T> core::cmp::PartialEq for windows_reactor::RoutedCallback<T>
+pub fn windows_reactor::RoutedCallback<T>::eq(&self, &Self) -> bool
+impl<T> core::fmt::Debug for windows_reactor::RoutedCallback<T>
+pub fn windows_reactor::RoutedCallback<T>::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub struct windows_reactor::RoutedMessage<M>
+impl<M> windows_reactor::RoutedMessage<M>
+pub fn windows_reactor::RoutedMessage<M>::bubble(M) -> Self
+pub fn windows_reactor::RoutedMessage<M>::bubble_without_message() -> Self
+pub fn windows_reactor::RoutedMessage<M>::handled(M) -> Self
+pub fn windows_reactor::RoutedMessage<M>::handled_without_message() -> Self
 pub struct windows_reactor::ScrollView
 impl windows_reactor::ScrollView
 pub fn windows_reactor::ScrollView::horizontal_scroll_bar_visibility(self, impl core::convert::Into<core::option::Option<windows_reactor::ScrollingScrollBarVisibility>>) -> Self
@@ -2790,6 +2853,7 @@ pub fn windows_reactor::ViewContext<C>::forward(&self) -> windows_reactor::Callb
 pub fn windows_reactor::ViewContext<C>::message(&self, <C as windows_reactor::Component>::Message) -> windows_reactor::Callback<()> where <C as windows_reactor::Component>::Message: core::clone::Clone
 pub fn windows_reactor::ViewContext<C>::on_color_scheme(&mut self, impl windows_reactor::IntoPayloadCallback<windows_reactor::ColorScheme>)
 pub fn windows_reactor::ViewContext<C>::on_window_size(&mut self, impl windows_reactor::IntoPayloadCallback<windows_reactor::WindowSize>)
+pub fn windows_reactor::ViewContext<C>::routed_callback<T>(&self, impl core::ops::function::Fn(T) -> windows_reactor::RoutedMessage<<C as windows_reactor::Component>::Message> + 'static) -> windows_reactor::RoutedCallback<T>
 pub fn windows_reactor::ViewContext<C>::sender(&self) -> windows_reactor::LocalSender<<C as windows_reactor::Component>::Message>
 pub fn windows_reactor::ViewContext<C>::use_context<T: core::clone::Clone + 'static>(&mut self, &windows_reactor::Context<T>) -> T
 pub fn windows_reactor::ViewContext<C>::use_effect<D>(&mut self, impl core::convert::Into<windows_reactor::EffectKey>, D, impl core::ops::function::FnOnce() -> core::option::Option<alloc::boxed::Box<dyn core::ops::function::FnOnce()>> + 'static) where D: core::cmp::PartialEq + 'static
@@ -2816,6 +2880,52 @@ pub fn windows_reactor::Viewbox::min_width(self, impl core::convert::Into<core::
 pub fn windows_reactor::Viewbox::opacity(self, impl core::convert::Into<core::option::Option<f64>>) -> Self where Self: core::marker::Sized
 pub fn windows_reactor::Viewbox::vertical_alignment(self, impl core::convert::Into<core::option::Option<windows_reactor::VerticalAlignment>>) -> Self where Self: core::marker::Sized
 pub fn windows_reactor::Viewbox::width(self, impl core::convert::Into<core::option::Option<f64>>) -> Self where Self: core::marker::Sized
+pub struct windows_reactor::VirtualKey(pub u32)
+impl windows_reactor::VirtualKey
+pub const windows_reactor::VirtualKey::A: Self
+pub const windows_reactor::VirtualKey::B: Self
+pub const windows_reactor::VirtualKey::BACK: Self
+pub const windows_reactor::VirtualKey::C: Self
+pub const windows_reactor::VirtualKey::CONTROL: Self
+pub const windows_reactor::VirtualKey::D: Self
+pub const windows_reactor::VirtualKey::DELETE: Self
+pub const windows_reactor::VirtualKey::DOWN: Self
+pub const windows_reactor::VirtualKey::E: Self
+pub const windows_reactor::VirtualKey::END: Self
+pub const windows_reactor::VirtualKey::ENTER: Self
+pub const windows_reactor::VirtualKey::ESCAPE: Self
+pub const windows_reactor::VirtualKey::F: Self
+pub const windows_reactor::VirtualKey::G: Self
+pub const windows_reactor::VirtualKey::H: Self
+pub const windows_reactor::VirtualKey::HOME: Self
+pub const windows_reactor::VirtualKey::I: Self
+pub const windows_reactor::VirtualKey::INSERT: Self
+pub const windows_reactor::VirtualKey::J: Self
+pub const windows_reactor::VirtualKey::K: Self
+pub const windows_reactor::VirtualKey::L: Self
+pub const windows_reactor::VirtualKey::LEFT: Self
+pub const windows_reactor::VirtualKey::M: Self
+pub const windows_reactor::VirtualKey::MENU: Self
+pub const windows_reactor::VirtualKey::N: Self
+pub const windows_reactor::VirtualKey::O: Self
+pub const windows_reactor::VirtualKey::P: Self
+pub const windows_reactor::VirtualKey::PAGE_DOWN: Self
+pub const windows_reactor::VirtualKey::PAGE_UP: Self
+pub const windows_reactor::VirtualKey::Q: Self
+pub const windows_reactor::VirtualKey::R: Self
+pub const windows_reactor::VirtualKey::RIGHT: Self
+pub const windows_reactor::VirtualKey::S: Self
+pub const windows_reactor::VirtualKey::SHIFT: Self
+pub const windows_reactor::VirtualKey::SPACE: Self
+pub const windows_reactor::VirtualKey::T: Self
+pub const windows_reactor::VirtualKey::TAB: Self
+pub const windows_reactor::VirtualKey::U: Self
+pub const windows_reactor::VirtualKey::UP: Self
+pub const windows_reactor::VirtualKey::V: Self
+pub const windows_reactor::VirtualKey::W: Self
+pub const windows_reactor::VirtualKey::X: Self
+pub const windows_reactor::VirtualKey::Y: Self
+pub const windows_reactor::VirtualKey::Z: Self
 pub struct windows_reactor::VirtualSource
 impl windows_reactor::VirtualSource
 pub fn windows_reactor::VirtualSource::is_empty(&self) -> bool
@@ -2957,6 +3067,7 @@ pub fn T::flyout(self, impl core::convert::Into<alloc::string::String>) -> windo
 pub fn T::flyout_with(self, windows_reactor::Flyout) -> windows_reactor::View
 pub trait windows_reactor::FocusControl: windows_reactor::ReferenceControl
 impl windows_reactor::FocusControl for windows_reactor::AutoSuggestBox
+impl windows_reactor::FocusControl for windows_reactor::Border
 impl windows_reactor::FocusControl for windows_reactor::Button
 impl windows_reactor::FocusControl for windows_reactor::CheckBox
 impl windows_reactor::FocusControl for windows_reactor::ComboBox
@@ -4031,6 +4142,7 @@ impl<T> windows_reactor::MenuExt for T where T: core::convert::Into<windows_reac
 pub fn T::menu(self, windows_reactor::Menu) -> windows_reactor::View
 pub trait windows_reactor::ReferenceControl: windows_reactor::reference::sealed::Sealed + 'static
 impl windows_reactor::ReferenceControl for windows_reactor::AutoSuggestBox
+impl windows_reactor::ReferenceControl for windows_reactor::Border
 impl windows_reactor::ReferenceControl for windows_reactor::Button
 impl windows_reactor::ReferenceControl for windows_reactor::CheckBox
 impl windows_reactor::ReferenceControl for windows_reactor::ComboBox

--- a/crates/libs/reactor/readme.md
+++ b/crates/libs/reactor/readme.md
@@ -62,7 +62,7 @@ fn keyboard_surface<C: Component<Message = Message>>(
 ) -> View {
     Border::new()
         .is_tab_stop(true)
-        .allow_focus_on_interaction(true)
+        .focus_on_pointer_release(true)
         .on_preview_key_down(context.routed_callback(|info: KeyEventInfo| {
             if info.key == VirtualKey::LEFT {
                 RoutedMessage::handled(Message::MoveLeft)

--- a/crates/libs/reactor/readme.md
+++ b/crates/libs/reactor/readme.md
@@ -50,6 +50,34 @@ fn main() {
 }
 ```
 
+Focusable custom surfaces can make synchronous WinUI routing decisions without running component
+updates inside native callbacks:
+
+```rust,no_run
+use windows_reactor::*;
+
+fn keyboard_surface<C: Component<Message = Message>>(
+    context: &mut ViewContext<C>,
+    content: impl Into<View>,
+) -> View {
+    Border::new()
+        .is_tab_stop(true)
+        .allow_focus_on_interaction(true)
+        .on_preview_key_down(context.routed_callback(|info: KeyEventInfo| {
+            if info.key == VirtualKey::LEFT {
+                RoutedMessage::handled(Message::MoveLeft)
+            } else {
+                RoutedMessage::bubble_without_message()
+            }
+        }))
+        .content(content)
+}
+
+enum Message {
+    MoveLeft,
+}
+```
+
 Native operations that need the owning HWND can be staged from a component update:
 
 ```rust,ignore

--- a/crates/libs/reactor/src/app/mod.rs
+++ b/crates/libs/reactor/src/app/mod.rs
@@ -1076,6 +1076,8 @@ pub(crate) fn dispatch_native_events(token: WindowToken) {
                 .borrow_mut()
                 .push(dispatch_started.elapsed().as_secs_f64() * 1_000_000.0);
         });
+        #[cfg(feature = "test")]
+        finish_live_text_input_dispatch();
         for diagnostic in live.drain_diagnostics() {
             match diagnostic {
                 PumpDiagnostic::HandledInputDropped { node, event } => {

--- a/crates/libs/reactor/src/app/mod.rs
+++ b/crates/libs/reactor/src/app/mod.rs
@@ -1078,6 +1078,13 @@ pub(crate) fn dispatch_native_events(token: WindowToken) {
         });
         for diagnostic in live.drain_diagnostics() {
             match diagnostic {
+                PumpDiagnostic::HandledInputDropped { node, event } => {
+                    let message =
+                        format!("handled input {event:?} for {node:?} could not be delivered");
+                    #[cfg(feature = "test")]
+                    test::record_live_diagnostic(message.clone());
+                    eprintln!("windows-reactor warning: {message}");
+                }
                 PumpDiagnostic::WindowOpenRejected { error } => {
                     let message = format!("runtime window open was rejected: {error:?}");
                     #[cfg(feature = "test")]

--- a/crates/libs/reactor/src/app/test.rs
+++ b/crates/libs/reactor/src/app/test.rs
@@ -119,6 +119,38 @@ pub fn schedule_live_window_handle(
     }
 }
 
+pub fn schedule_live_input_probe(
+    callback: impl Fn(LiveInputProbeStage) + 'static,
+    completion: impl FnOnce(Result<LiveInputProbe, String>) + 'static,
+) -> windows_core::Result<()> {
+    let dispatcher = DispatcherQueue::GetForCurrentThread()?;
+    let callback = RefCell::new(Some(callback));
+    let completion = RefCell::new(Some(completion));
+    let handler = DispatcherQueueHandler::new(move || {
+        let result = HOST.with(|host| {
+            let window = host
+                .borrow()
+                .as_ref()
+                .and_then(LiveHost::primary)
+                .and_then(|live| live.live_window().ok())
+                .ok_or_else(|| "live primary window is unavailable".to_string())?;
+            subscribe_live_input_probe(&window, callback.take().unwrap())
+                .map_err(|error| error.to_string())
+        });
+        if let Some(completion) = completion.take() {
+            completion(result);
+        }
+    });
+    if dispatcher.TryEnqueueWithPriority(DispatcherQueuePriority::Low, &handler)? {
+        Ok(())
+    } else {
+        Err(windows_core::Error::new(
+            E_FAIL,
+            "dispatcher rejected live input probe request",
+        ))
+    }
+}
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum LiveProbe {
     ContentDialogLifecycle,

--- a/crates/libs/reactor/src/core/component/mod.rs
+++ b/crates/libs/reactor/src/core/component/mod.rs
@@ -806,6 +806,37 @@ struct ComponentQueue {
     wake: Option<Rc<dyn Fn()>>,
 }
 
+pub(crate) struct DeferredMessage {
+    queue: Rc<RefCell<ComponentQueue>>,
+    envelope: Option<MessageEnvelope>,
+}
+
+impl DeferredMessage {
+    pub(crate) fn enqueue(mut self) -> bool {
+        let envelope = self.envelope.take().unwrap();
+        let wake = {
+            let mut queue = self.queue.borrow_mut();
+            if !queue.open
+                || !queue.active.contains(&envelope.token.scope)
+                || queue.envelopes.len() >= LOCAL_MESSAGE_QUEUE_CAPACITY
+            {
+                return false;
+            }
+            let wake = queue
+                .envelopes
+                .is_empty()
+                .then(|| queue.wake.clone())
+                .flatten();
+            queue.envelopes.push_back(envelope);
+            wake
+        };
+        if let Some(wake) = wake {
+            wake();
+        }
+        true
+    }
+}
+
 /// Sends typed messages to a component's queued update loop.
 ///
 /// Delivery never calls [`Component::update`] inline. A send returns `false` when the component
@@ -863,6 +894,26 @@ impl<M: 'static> LocalSender<M> {
         true
     }
 
+    pub(crate) fn defer(&self, message: M) -> Option<DeferredMessage> {
+        {
+            let queue = self.queue.borrow();
+            if !queue.open
+                || !queue.active.contains(&self.token.scope)
+                || queue.envelopes.len() >= LOCAL_MESSAGE_QUEUE_CAPACITY
+            {
+                return None;
+            }
+        }
+        Some(DeferredMessage {
+            queue: Rc::clone(&self.queue),
+            envelope: Some(MessageEnvelope {
+                control: None,
+                token: self.token,
+                payload: Box::new(message),
+            }),
+        })
+    }
+
     /// Adapts values into queued component messages.
     ///
     /// Captureless mapper functions retain callback identity across publications. Capturing
@@ -879,6 +930,21 @@ impl<M: 'static> LocalSender<M> {
             })
         } else {
             Callback::new_with_acceptance(move |value| sender.send(map(value)))
+        }
+    }
+
+    pub(crate) fn routed_callback<T, F>(&self, map: F) -> RoutedCallback<T>
+    where
+        F: Fn(T) -> RoutedMessage<M> + 'static,
+    {
+        let sender = self.clone();
+        if size_of::<F>() == 0 {
+            let source = CallbackSource::new(Rc::as_ptr(&self.queue) as usize, self.token);
+            RoutedCallback::new_identified(source, TypeId::of::<F>(), move |value| {
+                RoutedDispatch::from_message(map(value), &sender)
+            })
+        } else {
+            RoutedCallback::new(move |value| RoutedDispatch::from_message(map(value), &sender))
         }
     }
 
@@ -1047,6 +1113,16 @@ impl<C: Component> ViewContext<C> {
     /// Creates a callback that maps its argument to a queued component message.
     pub fn callback<T>(&self, map: impl Fn(T) -> C::Message + 'static) -> Callback<T> {
         self.sender.callback(map)
+    }
+
+    /// Creates a synchronous routing decision that queues any resulting component message.
+    ///
+    /// The mapper runs in the native input callback. Component updates remain deferred.
+    pub fn routed_callback<T>(
+        &self,
+        map: impl Fn(T) -> RoutedMessage<C::Message> + 'static,
+    ) -> RoutedCallback<T> {
+        self.sender.routed_callback(map)
     }
 
     /// Creates a callback that forwards its argument as a queued component message.

--- a/crates/libs/reactor/src/core/component/mod.rs
+++ b/crates/libs/reactor/src/core/component/mod.rs
@@ -811,29 +811,37 @@ pub(crate) struct DeferredMessage {
     envelope: Option<MessageEnvelope>,
 }
 
+pub(crate) enum DeferredEnqueue {
+    Enqueued,
+    Full,
+    Rejected,
+}
+
 impl DeferredMessage {
-    pub(crate) fn enqueue(mut self) -> bool {
-        let envelope = self.envelope.take().unwrap();
+    pub(crate) fn enqueue(&mut self) -> DeferredEnqueue {
         let wake = {
             let mut queue = self.queue.borrow_mut();
-            if !queue.open
-                || !queue.active.contains(&envelope.token.scope)
-                || queue.envelopes.len() >= LOCAL_MESSAGE_QUEUE_CAPACITY
-            {
-                return false;
+            let Some(envelope) = self.envelope.as_ref() else {
+                return DeferredEnqueue::Rejected;
+            };
+            if !queue.open || !queue.active.contains(&envelope.token.scope) {
+                return DeferredEnqueue::Rejected;
+            }
+            if queue.envelopes.len() >= LOCAL_MESSAGE_QUEUE_CAPACITY {
+                return DeferredEnqueue::Full;
             }
             let wake = queue
                 .envelopes
                 .is_empty()
                 .then(|| queue.wake.clone())
                 .flatten();
-            queue.envelopes.push_back(envelope);
+            queue.envelopes.push_back(self.envelope.take().unwrap());
             wake
         };
         if let Some(wake) = wake {
             wake();
         }
-        true
+        DeferredEnqueue::Enqueued
     }
 }
 

--- a/crates/libs/reactor/src/core/mod.rs
+++ b/crates/libs/reactor/src/core/mod.rs
@@ -14,7 +14,7 @@ mod virtual_model;
 pub use arena::*;
 pub(crate) use component::{
     ComponentDeclarationError, ComponentRender, ComponentStore, ComponentToken, ComponentView,
-    ContextDependencies, ContextDependency, ContextProvision, ContextSnapshot,
+    ContextDependencies, ContextDependency, ContextProvision, ContextSnapshot, DeferredMessage,
 };
 pub use engine::*;
 pub use keyed::*;

--- a/crates/libs/reactor/src/core/mod.rs
+++ b/crates/libs/reactor/src/core/mod.rs
@@ -14,7 +14,8 @@ mod virtual_model;
 pub use arena::*;
 pub(crate) use component::{
     ComponentDeclarationError, ComponentRender, ComponentStore, ComponentToken, ComponentView,
-    ContextDependencies, ContextDependency, ContextProvision, ContextSnapshot, DeferredMessage,
+    ContextDependencies, ContextDependency, ContextProvision, ContextSnapshot, DeferredEnqueue,
+    DeferredMessage,
 };
 pub use engine::*;
 pub use keyed::*;

--- a/crates/libs/reactor/src/core/pump/mod.rs
+++ b/crates/libs/reactor/src/core/pump/mod.rs
@@ -78,6 +78,10 @@ impl From<ComponentDeclarationError> for PumpError {
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum PumpDiagnostic {
+    HandledInputDropped {
+        node: NodeId,
+        event: EventId,
+    },
     WindowOpenRejected {
         error: RuntimeError,
     },

--- a/crates/libs/reactor/src/core/pump/native_work.rs
+++ b/crates/libs/reactor/src/core/pump/native_work.rs
@@ -373,15 +373,25 @@ impl<R: NativeRuntime> Pump<R> {
                 }
                 native.desired.observe_event(event.event, &event.payload)
             };
-            if let Some(message) = event.take_routed_message() {
-                if message.enqueue() {
-                    dispatched += 1;
-                } else if event.claimed_handled() {
-                    self.diagnostics
-                        .push_back(PumpDiagnostic::HandledInputDropped {
-                            node: event.node,
-                            event: event.event,
+            if let Some(message) = event.routed_message_mut() {
+                match message.enqueue() {
+                    DeferredEnqueue::Enqueued => dispatched += 1,
+                    DeferredEnqueue::Full => {
+                        self.events.push_front(NativeWork {
+                            identity,
+                            work: event,
                         });
+                        break;
+                    }
+                    DeferredEnqueue::Rejected => {
+                        if event.claimed_handled() {
+                            self.diagnostics
+                                .push_back(PumpDiagnostic::HandledInputDropped {
+                                    node: event.node,
+                                    event: event.event,
+                                });
+                        }
+                    }
                 }
                 continue;
             }

--- a/crates/libs/reactor/src/core/pump/native_work.rs
+++ b/crates/libs/reactor/src/core/pump/native_work.rs
@@ -298,10 +298,17 @@ impl<R: NativeRuntime> Pump<R> {
                 break;
             };
             let identity = queued.identity;
+            let mut event = queued.work;
             if identity != self.identity {
+                if event.claimed_handled() {
+                    self.diagnostics
+                        .push_back(PumpDiagnostic::HandledInputDropped {
+                            node: event.node,
+                            event: event.event,
+                        });
+                }
                 continue;
             }
-            let event = queued.work;
             if matches!(
                 event.event,
                 EventId::OwnedCommandInvoked | EventId::OwnedMenuItemInvoked
@@ -335,16 +342,49 @@ impl<R: NativeRuntime> Pump<R> {
             }
             let observation = {
                 let Some(native) = self.tree.try_native(event.node) else {
+                    if event.claimed_handled() {
+                        self.diagnostics
+                            .push_back(PumpDiagnostic::HandledInputDropped {
+                                node: event.node,
+                                event: event.event,
+                            });
+                    }
                     continue;
                 };
                 let Some(state) = native.events.get(&event.event) else {
+                    if event.claimed_handled() {
+                        self.diagnostics
+                            .push_back(PumpDiagnostic::HandledInputDropped {
+                                node: event.node,
+                                event: event.event,
+                            });
+                    }
                     continue;
                 };
                 if !state.active || state.revision != event.revision {
+                    if event.claimed_handled() {
+                        self.diagnostics
+                            .push_back(PumpDiagnostic::HandledInputDropped {
+                                node: event.node,
+                                event: event.event,
+                            });
+                    }
                     continue;
                 }
                 native.desired.observe_event(event.event, &event.payload)
             };
+            if let Some(message) = event.take_routed_message() {
+                if message.enqueue() {
+                    dispatched += 1;
+                } else if event.claimed_handled() {
+                    self.diagnostics
+                        .push_back(PumpDiagnostic::HandledInputDropped {
+                            node: event.node,
+                            event: event.event,
+                        });
+                }
+                continue;
+            }
             let selection_observation = match &event.payload {
                 EventPayload::SelectionChange(selected) => match selection_for_event(event.event) {
                     Some(selection) => self.observe_selection(event.node, selection, selected.item),

--- a/crates/libs/reactor/src/core/pump/planner/element.rs
+++ b/crates/libs/reactor/src/core/pump/planner/element.rs
@@ -460,6 +460,15 @@ impl<R: NativeRuntime> Pump<R> {
             desired_events.push((event, active));
         });
         for (event, active) in desired_events {
+            let current_callback = native.desired.routed_callback(event);
+            let desired_callback = desired.routed_callback(event);
+            if current_callback != desired_callback {
+                plan.post_publish_commands.push(Command::SetRoutedCallback {
+                    node,
+                    event,
+                    callback: desired_callback,
+                });
+            }
             let state = native.events.entry(event).or_insert(EventState {
                 revision: 0,
                 active: false,
@@ -598,6 +607,13 @@ impl<R: NativeRuntime> Pump<R> {
         }
         for (event, state) in &tree.native(node).events {
             if state.active {
+                if let Some(callback) = props.routed_callback(*event) {
+                    plan.push(Command::SetRoutedCallback {
+                        node,
+                        event: *event,
+                        callback: Some(callback),
+                    });
+                }
                 plan.push(Command::SubscribeEvent {
                     node,
                     event: *event,

--- a/crates/libs/reactor/src/core/pump/planner/element.rs
+++ b/crates/libs/reactor/src/core/pump/planner/element.rs
@@ -462,21 +462,23 @@ impl<R: NativeRuntime> Pump<R> {
         for (event, active) in desired_events {
             let current_callback = native.desired.routed_callback(event);
             let desired_callback = desired.routed_callback(event);
-            if current_callback != desired_callback {
-                plan.post_publish_commands.push(Command::SetRoutedCallback {
-                    node,
-                    event,
-                    callback: desired_callback,
-                });
-            }
+            let callback_changed = current_callback != desired_callback;
             let state = native.events.entry(event).or_insert(EventState {
                 revision: 0,
                 active: false,
             });
+            let becoming_active = !state.active && active;
             if state.active != active {
                 state.revision = state.revision.checked_add(1).unwrap();
                 state.active = active;
                 if active {
+                    if callback_changed {
+                        plan.push(Command::SetRoutedCallback {
+                            node,
+                            event,
+                            callback: desired_callback.clone(),
+                        });
+                    }
                     plan.push(Command::SubscribeEvent {
                         node,
                         event,
@@ -485,6 +487,13 @@ impl<R: NativeRuntime> Pump<R> {
                 } else {
                     plan.push(Command::UnsubscribeEvent { node, event });
                 }
+            }
+            if callback_changed && !becoming_active {
+                plan.post_publish_commands.push(Command::SetRoutedCallback {
+                    node,
+                    event,
+                    callback: desired_callback,
+                });
             }
         }
         Ok(())

--- a/crates/libs/reactor/src/core/pump/tests/mod.rs
+++ b/crates/libs/reactor/src/core/pump/tests/mod.rs
@@ -26,6 +26,7 @@ mod pointer_events;
 mod properties_native_failure;
 mod resource_overrides;
 mod rich_text;
+mod routed_input;
 mod scrolling_properties;
 mod slots;
 mod tooltips;

--- a/crates/libs/reactor/src/core/pump/tests/pointer_events.rs
+++ b/crates/libs/reactor/src/core/pump/tests/pointer_events.rs
@@ -69,7 +69,7 @@ fn removing_pointer_callback_retires_its_revision() {
 }
 
 #[test]
-fn pointer_capture_policy_and_completion_callbacks_reconcile() {
+fn pointer_policies_and_completion_callbacks_reconcile() {
     let completed = Rc::new(RefCell::new(Vec::new()));
     let released = Rc::clone(&completed);
     let lost = Rc::clone(&completed);
@@ -78,6 +78,7 @@ fn pointer_capture_policy_and_completion_callbacks_reconcile() {
     pump.mount(
         Border::new()
             .capture_pointer_on_press(true)
+            .focus_on_pointer_release(true)
             .on_pointer_released(move |_| released.borrow_mut().push("released"))
             .on_pointer_capture_lost(move || lost.borrow_mut().push("lost"))
             .on_pointer_canceled(move || canceled.borrow_mut().push("canceled"))
@@ -89,11 +90,22 @@ fn pointer_capture_policy_and_completion_callbacks_reconcile() {
         pump.event_revision(root, EventId::BorderPointerPressed)
             .is_some()
     );
+    assert!(
+        pump.event_revision(root, EventId::BorderPointerReleased)
+            .is_some()
+    );
     assert_eq!(
         pump.runtime()
             .node(root)
             .unwrap()
             .property(PropertyId::BorderCapturePointerOnPress),
+        Some(&PropertyValue::Bool(true))
+    );
+    assert_eq!(
+        pump.runtime()
+            .node(root)
+            .unwrap()
+            .property(PropertyId::BorderFocusOnPointerRelease),
         Some(&PropertyValue::Bool(true))
     );
 
@@ -112,13 +124,39 @@ fn pointer_capture_policy_and_completion_callbacks_reconcile() {
     assert_eq!(pump.dispatch_events(), Ok(3));
     assert_eq!(&*completed.borrow(), &["released", "lost", "canceled"]);
 
-    pump.update(Border::new().into()).unwrap();
+    pump.update(Border::new().focus_on_pointer_release(true).into())
+        .unwrap();
     assert_eq!(
         pump.runtime()
             .node(root)
             .unwrap()
             .property(PropertyId::BorderCapturePointerOnPress),
         None
+    );
+    assert!(
+        pump.event_revision(root, EventId::BorderPointerPressed)
+            .is_none()
+    );
+    assert!(
+        pump.event_revision(root, EventId::BorderPointerReleased)
+            .is_some()
+    );
+
+    pump.update(Border::new().capture_pointer_on_press(true).into())
+        .unwrap();
+    assert!(
+        pump.event_revision(root, EventId::BorderPointerPressed)
+            .is_some()
+    );
+    assert!(
+        pump.event_revision(root, EventId::BorderPointerReleased)
+            .is_some()
+    );
+
+    pump.update(Border::new().into()).unwrap();
+    assert!(
+        pump.event_revision(root, EventId::BorderPointerReleased)
+            .is_none()
     );
 }
 

--- a/crates/libs/reactor/src/core/pump/tests/routed_input.rs
+++ b/crates/libs/reactor/src/core/pump/tests/routed_input.rs
@@ -17,6 +17,7 @@ impl PartialEq for Input {
 enum Message {
     Bubble,
     Disable,
+    Enable,
     Key,
     Pointer,
 }
@@ -44,6 +45,7 @@ impl Component for RoutedInput {
         match message {
             Message::Bubble => self.handled = false,
             Message::Disable => self.enabled = false,
+            Message::Enable => self.enabled = true,
             Message::Key => self.updates.borrow_mut().push("key"),
             Message::Pointer => self.updates.borrow_mut().push("pointer"),
         }
@@ -187,6 +189,46 @@ fn routed_callback_updates_without_resubscribing() {
 }
 
 #[test]
+fn routed_callback_installs_before_new_subscription() {
+    let (mut pump, border, _, sender, _) = setup();
+    let sender = sender.borrow();
+    let sender = sender.as_ref().unwrap();
+    assert!(sender.send(Message::Disable));
+    assert_eq!(pump.dispatch_components(1), Ok(1));
+    assert!(sender.send(Message::Enable));
+    assert_eq!(pump.dispatch_components(1), Ok(1));
+
+    let commands = pump.runtime().commands().last().unwrap();
+    let callback = commands
+        .iter()
+        .position(|command| {
+            matches!(
+                command,
+                Command::SetRoutedCallback {
+                    node,
+                    event: EventId::BorderPreviewKeyDown,
+                    callback: Some(_),
+                } if *node == border
+            )
+        })
+        .unwrap();
+    let subscription = commands
+        .iter()
+        .position(|command| {
+            matches!(
+                command,
+                Command::SubscribeEvent {
+                    node,
+                    event: EventId::BorderPreviewKeyDown,
+                    ..
+                } if *node == border
+            )
+        })
+        .unwrap();
+    assert!(callback < subscription);
+}
+
+#[test]
 fn full_component_queue_bubbles_input() {
     let (mut pump, border, revision, sender, _) = setup();
     let sender = sender.borrow();
@@ -201,6 +243,38 @@ fn full_component_queue_bubbles_input() {
             .route_key(border, EventId::BorderPreviewKeyDown, revision, key())
     );
     assert_eq!(pump.dispatch_events(), Ok(0));
+}
+
+#[test]
+fn accepted_input_waits_for_component_queue_capacity() {
+    let (mut pump, border, revision, sender, updates) = setup();
+    let sender = sender.borrow();
+    let sender = sender.as_ref().unwrap();
+    for _ in 1..component::LOCAL_MESSAGE_QUEUE_CAPACITY {
+        assert!(sender.send(Message::Pointer));
+    }
+
+    assert!(
+        pump.runtime_mut()
+            .route_key(border, EventId::BorderPreviewKeyDown, revision, key())
+    );
+    assert!(
+        pump.runtime_mut()
+            .route_key(border, EventId::BorderPreviewKeyDown, revision, key())
+    );
+
+    assert_eq!(pump.dispatch_events(), Ok(1));
+    assert_eq!(pump.dispatch_components(1), Ok(1));
+    assert_eq!(pump.dispatch_events(), Ok(1));
+    assert!(pump.drain_diagnostics().is_empty());
+
+    assert_eq!(
+        pump.dispatch_components(component::LOCAL_MESSAGE_QUEUE_CAPACITY),
+        Ok(component::LOCAL_MESSAGE_QUEUE_CAPACITY)
+    );
+    let updates = updates.borrow();
+    assert_eq!(updates.len(), component::LOCAL_MESSAGE_QUEUE_CAPACITY + 1);
+    assert_eq!(&updates[updates.len() - 2..], &["key", "key"],);
 }
 
 #[test]

--- a/crates/libs/reactor/src/core/pump/tests/routed_input.rs
+++ b/crates/libs/reactor/src/core/pump/tests/routed_input.rs
@@ -1,0 +1,249 @@
+use super::*;
+use std::cell::RefCell;
+use std::rc::Rc;
+
+#[derive(Clone)]
+struct Input {
+    sender: Rc<RefCell<Option<LocalSender<Message>>>>,
+    updates: Rc<RefCell<Vec<&'static str>>>,
+}
+
+impl PartialEq for Input {
+    fn eq(&self, other: &Self) -> bool {
+        Rc::ptr_eq(&self.sender, &other.sender) && Rc::ptr_eq(&self.updates, &other.updates)
+    }
+}
+
+enum Message {
+    Bubble,
+    Disable,
+    Key,
+    Pointer,
+}
+
+struct RoutedInput {
+    enabled: bool,
+    handled: bool,
+    updates: Rc<RefCell<Vec<&'static str>>>,
+}
+
+impl Component for RoutedInput {
+    type Input = Input;
+    type Message = Message;
+
+    fn create(input: &Self::Input, context: &ComponentContext<Self>) -> Self {
+        *input.sender.borrow_mut() = Some(context.sender());
+        Self {
+            enabled: true,
+            handled: true,
+            updates: Rc::clone(&input.updates),
+        }
+    }
+
+    fn update(&mut self, message: Self::Message, _context: &ComponentContext<Self>) {
+        match message {
+            Message::Bubble => self.handled = false,
+            Message::Disable => self.enabled = false,
+            Message::Key => self.updates.borrow_mut().push("key"),
+            Message::Pointer => self.updates.borrow_mut().push("pointer"),
+        }
+    }
+
+    fn view(&self, _input: &Self::Input, context: &mut ViewContext<Self>) -> View {
+        let border = Border::new().on_pointer_pressed(context.callback(|_| Message::Pointer));
+        if self.enabled {
+            let handled = self.handled;
+            border
+                .on_preview_key_down(context.routed_callback(move |_| {
+                    if handled {
+                        RoutedMessage::handled(Message::Key)
+                    } else {
+                        RoutedMessage::bubble(Message::Key)
+                    }
+                }))
+                .into()
+        } else {
+            border.into()
+        }
+    }
+}
+
+fn setup() -> (
+    Pump<RecordingRuntime>,
+    NodeId,
+    u32,
+    Rc<RefCell<Option<LocalSender<Message>>>>,
+    Rc<RefCell<Vec<&'static str>>>,
+) {
+    let sender = Rc::new(RefCell::new(None));
+    let updates = Rc::new(RefCell::new(Vec::new()));
+    let mut pump = Pump::new(RecordingRuntime::default());
+    pump.mount_view(View::component::<RoutedInput>(Input {
+        sender: Rc::clone(&sender),
+        updates: Rc::clone(&updates),
+    }))
+    .unwrap();
+    let border = pump
+        .runtime()
+        .commands()
+        .iter()
+        .flatten()
+        .find_map(|command| match command {
+            Command::Create {
+                node,
+                kind: MountedKind::Border,
+            } => Some(*node),
+            _ => None,
+        })
+        .unwrap();
+    let revision = pump
+        .event_revision(border, EventId::BorderPreviewKeyDown)
+        .unwrap();
+    (pump, border, revision, sender, updates)
+}
+
+fn key() -> KeyEventInfo {
+    KeyEventInfo {
+        key: VirtualKey::A,
+        original_key: VirtualKey::A,
+        status: PhysicalKeyStatus::default(),
+        modifiers: InputModifiers::CONTROL,
+    }
+}
+
+#[test]
+fn routed_input_decides_handled_synchronously_and_updates_later() {
+    let (mut pump, border, revision, _, updates) = setup();
+
+    assert!(
+        pump.runtime_mut()
+            .route_key(border, EventId::BorderPreviewKeyDown, revision, key())
+    );
+    assert!(updates.borrow().is_empty());
+    assert_eq!(pump.dispatch_events(), Ok(1));
+    assert!(updates.borrow().is_empty());
+    assert_eq!(pump.dispatch_components(1), Ok(1));
+    assert_eq!(&*updates.borrow(), &["key"]);
+}
+
+#[test]
+fn routed_input_preserves_native_event_order() {
+    let (mut pump, border, revision, _, updates) = setup();
+    let pointer_revision = pump
+        .event_revision(border, EventId::BorderPointerPressed)
+        .unwrap();
+    pump.queue_event(QueuedEvent::new(
+        border,
+        EventId::BorderPointerPressed,
+        pointer_revision,
+        EventPayload::PointerEventInfo(PointerEventInfo::default()),
+    ));
+    assert!(
+        pump.runtime_mut()
+            .route_key(border, EventId::BorderPreviewKeyDown, revision, key())
+    );
+
+    assert_eq!(pump.dispatch_events(), Ok(2));
+    assert_eq!(pump.dispatch_components(2), Ok(2));
+    assert_eq!(&*updates.borrow(), &["pointer", "key"]);
+}
+
+#[test]
+fn stale_handled_input_is_diagnosed() {
+    let (mut pump, border, revision, sender, _) = setup();
+    assert!(
+        pump.runtime_mut()
+            .route_key(border, EventId::BorderPreviewKeyDown, revision, key())
+    );
+    assert!(sender.borrow().as_ref().unwrap().send(Message::Disable));
+    assert_eq!(pump.dispatch_components(1), Ok(1));
+
+    assert_eq!(pump.dispatch_events(), Ok(0));
+    assert_eq!(
+        pump.drain_diagnostics(),
+        [PumpDiagnostic::HandledInputDropped {
+            node: border,
+            event: EventId::BorderPreviewKeyDown,
+        }]
+    );
+}
+
+#[test]
+fn routed_callback_updates_without_resubscribing() {
+    let (mut pump, border, revision, sender, _) = setup();
+    assert!(sender.borrow().as_ref().unwrap().send(Message::Bubble));
+    assert_eq!(pump.dispatch_components(1), Ok(1));
+    assert_eq!(
+        pump.event_revision(border, EventId::BorderPreviewKeyDown),
+        Some(revision)
+    );
+
+    assert!(
+        !pump
+            .runtime_mut()
+            .route_key(border, EventId::BorderPreviewKeyDown, revision, key())
+    );
+    assert_eq!(pump.dispatch_events(), Ok(1));
+}
+
+#[test]
+fn full_component_queue_bubbles_input() {
+    let (mut pump, border, revision, sender, _) = setup();
+    let sender = sender.borrow();
+    let sender = sender.as_ref().unwrap();
+    for _ in 0..component::LOCAL_MESSAGE_QUEUE_CAPACITY {
+        assert!(sender.send(Message::Key));
+    }
+
+    assert!(
+        !pump
+            .runtime_mut()
+            .route_key(border, EventId::BorderPreviewKeyDown, revision, key())
+    );
+    assert_eq!(pump.dispatch_events(), Ok(0));
+}
+
+#[test]
+fn focus_events_preserve_state_and_directness() {
+    let observed = Rc::new(RefCell::new(Vec::new()));
+    let got = Rc::clone(&observed);
+    let lost = Rc::clone(&observed);
+    let mut pump = Pump::new(RecordingRuntime::default());
+    pump.mount(
+        Border::new()
+            .on_got_focus(move |info| got.borrow_mut().push(info))
+            .on_lost_focus(move |info| lost.borrow_mut().push(info))
+            .into(),
+    )
+    .unwrap();
+    let border = pump.root().unwrap();
+    let got_revision = pump
+        .event_revision(border, EventId::BorderGotFocus)
+        .unwrap();
+    let lost_revision = pump
+        .event_revision(border, EventId::BorderLostFocus)
+        .unwrap();
+    let direct = FocusEventInfo {
+        state: ElementFocusState::Keyboard,
+        is_direct: true,
+    };
+    let descendant = FocusEventInfo {
+        state: ElementFocusState::Unfocused,
+        is_direct: false,
+    };
+    pump.queue_event(QueuedEvent::new(
+        border,
+        EventId::BorderGotFocus,
+        got_revision,
+        EventPayload::FocusEventInfo(direct),
+    ));
+    pump.queue_event(QueuedEvent::new(
+        border,
+        EventId::BorderLostFocus,
+        lost_revision,
+        EventPayload::FocusEventInfo(descendant),
+    ));
+
+    assert_eq!(pump.dispatch_events(), Ok(2));
+    assert_eq!(&*observed.borrow(), &[direct, descendant]);
+}

--- a/crates/libs/reactor/src/core/runtime.rs
+++ b/crates/libs/reactor/src/core/runtime.rs
@@ -158,6 +158,8 @@ pub struct QueuedEvent {
     pub revision: u32,
     pub payload: EventPayload,
     invoke_callback: bool,
+    routed_message: Option<DeferredMessage>,
+    claimed_handled: bool,
 }
 
 impl QueuedEvent {
@@ -168,6 +170,8 @@ impl QueuedEvent {
             revision,
             payload,
             invoke_callback: true,
+            routed_message: None,
+            claimed_handled: false,
         }
     }
 
@@ -183,11 +187,40 @@ impl QueuedEvent {
             revision,
             payload,
             invoke_callback: false,
+            routed_message: None,
+            claimed_handled: false,
+        }
+    }
+
+    pub(crate) fn routed(
+        node: NodeId,
+        event: EventId,
+        revision: u32,
+        payload: EventPayload,
+        message: DeferredMessage,
+        claimed_handled: bool,
+    ) -> Self {
+        Self {
+            node,
+            event,
+            revision,
+            payload,
+            invoke_callback: false,
+            routed_message: Some(message),
+            claimed_handled,
         }
     }
 
     pub(crate) fn invokes_callback(&self) -> bool {
         self.invoke_callback
+    }
+
+    pub(crate) fn take_routed_message(&mut self) -> Option<DeferredMessage> {
+        self.routed_message.take()
+    }
+
+    pub(crate) fn claimed_handled(&self) -> bool {
+        self.claimed_handled
     }
 }
 
@@ -368,6 +401,11 @@ pub enum Command {
     UnsubscribeEvent {
         node: NodeId,
         event: EventId,
+    },
+    SetRoutedCallback {
+        node: NodeId,
+        event: EventId,
+        callback: Option<RoutedEventCallback>,
     },
     SetSlot {
         parent: NodeId,

--- a/crates/libs/reactor/src/core/runtime.rs
+++ b/crates/libs/reactor/src/core/runtime.rs
@@ -215,8 +215,8 @@ impl QueuedEvent {
         self.invoke_callback
     }
 
-    pub(crate) fn take_routed_message(&mut self) -> Option<DeferredMessage> {
-        self.routed_message.take()
+    pub(crate) fn routed_message_mut(&mut self) -> Option<&mut DeferredMessage> {
+        self.routed_message.as_mut()
     }
 
     pub(crate) fn claimed_handled(&self) -> bool {

--- a/crates/libs/reactor/src/element.rs
+++ b/crates/libs/reactor/src/element.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use super::*;
-use crate::core::{ComponentToken, ComponentView, ContextProvision};
+use crate::core::{ComponentToken, ComponentView, ContextProvision, DeferredMessage};
 
 pub(crate) fn validate_image_uri(value: &str) -> windows_core::Result<()> {
     native::validate_native_image_uri(value)
@@ -2034,6 +2034,285 @@ impl<T> PartialEq for Callback<T> {
                 .as_deref()
                 .zip(other.identity.as_deref())
                 .is_some_and(|(left, right)| left.equals(right))
+    }
+}
+
+/// A component message and synchronous routed-event handling decision.
+pub struct RoutedMessage<M> {
+    message: Option<M>,
+    handled: bool,
+}
+
+impl<M> RoutedMessage<M> {
+    /// Handles the native event and queues `message`.
+    pub fn handled(message: M) -> Self {
+        Self {
+            message: Some(message),
+            handled: true,
+        }
+    }
+
+    /// Leaves the native event unhandled and queues `message`.
+    pub fn bubble(message: M) -> Self {
+        Self {
+            message: Some(message),
+            handled: false,
+        }
+    }
+
+    /// Handles the native event without queuing a component message.
+    pub fn handled_without_message() -> Self {
+        Self {
+            message: None,
+            handled: true,
+        }
+    }
+
+    /// Leaves the native event unhandled without queuing a component message.
+    pub fn bubble_without_message() -> Self {
+        Self {
+            message: None,
+            handled: false,
+        }
+    }
+}
+
+pub(crate) struct RoutedDispatch {
+    pub(crate) message: Option<DeferredMessage>,
+    pub(crate) handled: bool,
+}
+
+impl RoutedDispatch {
+    pub(crate) fn from_message<M: 'static>(
+        value: RoutedMessage<M>,
+        sender: &LocalSender<M>,
+    ) -> Self {
+        let Some(message) = value.message else {
+            return Self {
+                message: None,
+                handled: value.handled,
+            };
+        };
+        match sender.defer(message) {
+            Some(message) => Self {
+                message: Some(message),
+                handled: value.handled,
+            },
+            None => Self {
+                message: None,
+                handled: false,
+            },
+        }
+    }
+}
+
+/// A synchronous routed-input decision created by [`ViewContext::routed_callback`].
+pub struct RoutedCallback<T> {
+    callback: Rc<dyn Fn(T) -> RoutedDispatch>,
+    identity: Option<Rc<dyn ErasedCallbackIdentity>>,
+}
+
+impl<T> RoutedCallback<T> {
+    pub(crate) fn new(callback: impl Fn(T) -> RoutedDispatch + 'static) -> Self {
+        Self {
+            callback: Rc::new(callback),
+            identity: None,
+        }
+    }
+
+    pub(crate) fn new_identified<K>(
+        source: CallbackSource,
+        key: K,
+        callback: impl Fn(T) -> RoutedDispatch + 'static,
+    ) -> Self
+    where
+        K: PartialEq + 'static,
+    {
+        Self {
+            callback: Rc::new(callback),
+            identity: Some(Rc::new(TypedCallbackIdentity { key, source })),
+        }
+    }
+
+    pub(crate) fn call(&self, value: T) -> RoutedDispatch {
+        (self.callback)(value)
+    }
+}
+
+impl<T> Clone for RoutedCallback<T> {
+    fn clone(&self) -> Self {
+        Self {
+            callback: Rc::clone(&self.callback),
+            identity: self.identity.clone(),
+        }
+    }
+}
+
+impl<T> fmt::Debug for RoutedCallback<T> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_tuple("RoutedCallback")
+            .field(&Rc::as_ptr(&self.callback))
+            .finish()
+    }
+}
+
+impl<T> PartialEq for RoutedCallback<T> {
+    fn eq(&self, other: &Self) -> bool {
+        Rc::ptr_eq(&self.callback, &other.callback)
+            || self
+                .identity
+                .as_deref()
+                .zip(other.identity.as_deref())
+                .is_some_and(|(left, right)| left.equals(right))
+    }
+}
+
+/// A Windows virtual-key value.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub struct VirtualKey(pub u32);
+
+impl VirtualKey {
+    pub const BACK: Self = Self(0x08);
+    pub const TAB: Self = Self(0x09);
+    pub const ENTER: Self = Self(0x0d);
+    pub const SHIFT: Self = Self(0x10);
+    pub const CONTROL: Self = Self(0x11);
+    pub const MENU: Self = Self(0x12);
+    pub const ESCAPE: Self = Self(0x1b);
+    pub const SPACE: Self = Self(0x20);
+    pub const PAGE_UP: Self = Self(0x21);
+    pub const PAGE_DOWN: Self = Self(0x22);
+    pub const END: Self = Self(0x23);
+    pub const HOME: Self = Self(0x24);
+    pub const LEFT: Self = Self(0x25);
+    pub const UP: Self = Self(0x26);
+    pub const RIGHT: Self = Self(0x27);
+    pub const DOWN: Self = Self(0x28);
+    pub const INSERT: Self = Self(0x2d);
+    pub const DELETE: Self = Self(0x2e);
+    pub const A: Self = Self(0x41);
+    pub const B: Self = Self(0x42);
+    pub const C: Self = Self(0x43);
+    pub const D: Self = Self(0x44);
+    pub const E: Self = Self(0x45);
+    pub const F: Self = Self(0x46);
+    pub const G: Self = Self(0x47);
+    pub const H: Self = Self(0x48);
+    pub const I: Self = Self(0x49);
+    pub const J: Self = Self(0x4a);
+    pub const K: Self = Self(0x4b);
+    pub const L: Self = Self(0x4c);
+    pub const M: Self = Self(0x4d);
+    pub const N: Self = Self(0x4e);
+    pub const O: Self = Self(0x4f);
+    pub const P: Self = Self(0x50);
+    pub const Q: Self = Self(0x51);
+    pub const R: Self = Self(0x52);
+    pub const S: Self = Self(0x53);
+    pub const T: Self = Self(0x54);
+    pub const U: Self = Self(0x55);
+    pub const V: Self = Self(0x56);
+    pub const W: Self = Self(0x57);
+    pub const X: Self = Self(0x58);
+    pub const Y: Self = Self(0x59);
+    pub const Z: Self = Self(0x5a);
+}
+
+/// Modifier keys pressed when an input event was raised.
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
+pub struct InputModifiers(u8);
+
+impl InputModifiers {
+    pub const NONE: Self = Self(0);
+    pub const SHIFT: Self = Self(1 << 0);
+    pub const CONTROL: Self = Self(1 << 1);
+    pub const ALT: Self = Self(1 << 2);
+    pub const WINDOWS: Self = Self(1 << 3);
+
+    pub const fn contains(self, value: Self) -> bool {
+        self.0 & value.0 == value.0
+    }
+}
+
+impl std::ops::BitOr for InputModifiers {
+    type Output = Self;
+
+    fn bitor(self, rhs: Self) -> Self::Output {
+        Self(self.0 | rhs.0)
+    }
+}
+
+impl std::ops::BitOrAssign for InputModifiers {
+    fn bitor_assign(&mut self, rhs: Self) {
+        self.0 |= rhs.0;
+    }
+}
+
+/// Physical status attached to a keyboard or character event.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct PhysicalKeyStatus {
+    pub repeat_count: u32,
+    pub scan_code: u32,
+    pub is_extended: bool,
+    pub is_menu_down: bool,
+    pub was_down: bool,
+    pub is_released: bool,
+}
+
+/// Owned data captured from a WinUI key event.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct KeyEventInfo {
+    pub key: VirtualKey,
+    pub original_key: VirtualKey,
+    pub status: PhysicalKeyStatus,
+    pub modifiers: InputModifiers,
+}
+
+/// Owned data captured from a WinUI character event.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct CharacterEventInfo {
+    pub character: u16,
+    pub status: PhysicalKeyStatus,
+    pub modifiers: InputModifiers,
+}
+
+/// How an element received keyboard focus.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ElementFocusState {
+    Unfocused,
+    Pointer,
+    Keyboard,
+    Programmatic,
+}
+
+/// Owned data captured from a WinUI focus event.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct FocusEventInfo {
+    pub state: ElementFocusState,
+    pub is_direct: bool,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+#[doc(hidden)]
+pub enum RoutedEventCallback {
+    KeyEventInfo(RoutedCallback<KeyEventInfo>),
+    CharacterEventInfo(RoutedCallback<CharacterEventInfo>),
+}
+
+impl RoutedEventCallback {
+    pub(crate) fn key(&self, value: KeyEventInfo) -> Option<RoutedDispatch> {
+        match self {
+            Self::KeyEventInfo(callback) => Some(callback.call(value)),
+            Self::CharacterEventInfo(_) => None,
+        }
+    }
+
+    pub(crate) fn character(&self, value: CharacterEventInfo) -> Option<RoutedDispatch> {
+        match self {
+            Self::CharacterEventInfo(callback) => Some(callback.call(value)),
+            Self::KeyEventInfo(_) => None,
+        }
     }
 }
 

--- a/crates/libs/reactor/src/generated.rs
+++ b/crates/libs/reactor/src/generated.rs
@@ -16,6 +16,11 @@ pub(crate) struct BorderEvents {
     on_pointer_released: Option<Callback<PointerEventInfo>>,
     on_pointer_capture_lost: Option<Callback<()>>,
     on_pointer_canceled: Option<Callback<()>>,
+    on_preview_key_down: Option<RoutedCallback<KeyEventInfo>>,
+    on_key_up: Option<RoutedCallback<KeyEventInfo>>,
+    on_character_received: Option<RoutedCallback<CharacterEventInfo>>,
+    on_got_focus: Option<Callback<FocusEventInfo>>,
+    on_lost_focus: Option<Callback<FocusEventInfo>>,
 }
 #[derive(Clone, Debug, Default, PartialEq)]
 pub(crate) struct AutoSuggestBoxEvents {
@@ -699,6 +704,8 @@ pub mod public {
     }
     #[derive(Clone, Debug, Default, PartialEq)]
     pub struct Border {
+        is_tab_stop: Property<bool>,
+        allow_focus_on_interaction: Property<bool>,
         padding: Property<Thickness>,
         border_thickness: Property<Thickness>,
         corner_radius: Property<CornerRadius>,
@@ -710,12 +717,27 @@ pub mod public {
         capture_pointer_on_press: Property<bool>,
         drop_policy: Property<DragDropPolicy>,
         events: Option<std::rc::Rc<BorderEvents>>,
+        reference: Option<NativeElementRef>,
         element_state: Option<std::rc::Rc<ElementState>>,
         content: Option<Box<Element>>,
     }
     impl Border {
         pub fn new() -> Self {
             Self::default()
+        }
+        pub fn element_ref(mut self, reference: &ElementRef<Self>) -> Self {
+            self.reference = Some(reference.binding());
+            self
+        }
+        pub fn is_tab_stop(mut self, value: impl Into<Option<bool>>) -> Self {
+            let value = value.into();
+            self.is_tab_stop = Property::from(value);
+            self
+        }
+        pub fn allow_focus_on_interaction(mut self, value: impl Into<Option<bool>>) -> Self {
+            let value = value.into();
+            self.allow_focus_on_interaction = Property::from(value);
+            self
         }
         pub fn padding(mut self, value: impl Into<Thickness>) -> Self {
             let value = value.into();
@@ -942,6 +964,49 @@ pub mod public {
             .on_pointer_canceled = Some(callback.into_unit_callback());
             self
         }
+        pub fn on_preview_key_down(mut self, callback: RoutedCallback<KeyEventInfo>) -> Self {
+            std::rc::Rc::make_mut(
+                self.events
+                    .get_or_insert_with(|| std::rc::Rc::new(Default::default())),
+            )
+            .on_preview_key_down = Some(callback);
+            self
+        }
+        pub fn on_key_up(mut self, callback: RoutedCallback<KeyEventInfo>) -> Self {
+            std::rc::Rc::make_mut(
+                self.events
+                    .get_or_insert_with(|| std::rc::Rc::new(Default::default())),
+            )
+            .on_key_up = Some(callback);
+            self
+        }
+        pub fn on_character_received(
+            mut self,
+            callback: RoutedCallback<CharacterEventInfo>,
+        ) -> Self {
+            std::rc::Rc::make_mut(
+                self.events
+                    .get_or_insert_with(|| std::rc::Rc::new(Default::default())),
+            )
+            .on_character_received = Some(callback);
+            self
+        }
+        pub fn on_got_focus(mut self, callback: impl IntoPayloadCallback<FocusEventInfo>) -> Self {
+            std::rc::Rc::make_mut(
+                self.events
+                    .get_or_insert_with(|| std::rc::Rc::new(Default::default())),
+            )
+            .on_got_focus = Some(callback.into_payload_callback());
+            self
+        }
+        pub fn on_lost_focus(mut self, callback: impl IntoPayloadCallback<FocusEventInfo>) -> Self {
+            std::rc::Rc::make_mut(
+                self.events
+                    .get_or_insert_with(|| std::rc::Rc::new(Default::default())),
+            )
+            .on_lost_focus = Some(callback.into_payload_callback());
+            self
+        }
     }
     impl sealed::Sealed for Border {}
     impl sealed::NativeControl for Border {
@@ -949,6 +1014,8 @@ pub mod public {
             self.into()
         }
     }
+    impl crate::reference::sealed::Sealed for Border {}
+    impl crate::reference::ReferenceControl for Border {}
     impl sealed::LayoutControl for Border {
         fn element_state_mut(&mut self) -> &mut Option<std::rc::Rc<ElementState>> {
             &mut self.element_state
@@ -957,6 +1024,7 @@ pub mod public {
     impl LayoutControl for Border {}
     impl sealed::ContentControl for Border {}
     impl ContentControl for Border {}
+    impl FocusControl for Border {}
     #[cfg(test)]
     impl NativeContentTestExt for Border {
         fn native_content(mut self, content: impl Into<Element>) -> Self {
@@ -6640,6 +6708,8 @@ pub mod public {
                 Self::Border(value) => {
                     let value = std::rc::Rc::unwrap_or_clone(value);
                     let Border {
+                        is_tab_stop,
+                        allow_focus_on_interaction,
                         padding,
                         border_thickness,
                         corner_radius,
@@ -6651,12 +6721,15 @@ pub mod public {
                         capture_pointer_on_press,
                         drop_policy,
                         events,
+                        reference,
                         element_state,
                         content,
                     } = value;
                     ElementParts {
                         kind: MountedKind::Border,
                         props: MountedProps::Border(std::rc::Rc::new(BorderMountedProps {
+                            is_tab_stop,
+                            allow_focus_on_interaction,
                             padding,
                             border_thickness,
                             corner_radius,
@@ -6669,7 +6742,7 @@ pub mod public {
                             drop_policy,
                             events,
                         })),
-                        reference: None,
+                        reference,
                         element_state,
                         window_title_bar: None,
                         structure: ElementStructure::Content(content.map(|element| *element)),
@@ -8417,7 +8490,9 @@ pub mod public {
                         && value.on_click == mounted.on_click
                 }
                 (Self::Border(value), MountedProps::Border(mounted)) => {
-                    true && value.padding == mounted.padding
+                    true && value.is_tab_stop == mounted.is_tab_stop
+                        && value.allow_focus_on_interaction == mounted.allow_focus_on_interaction
+                        && value.padding == mounted.padding
                         && value.border_thickness == mounted.border_thickness
                         && value.corner_radius == mounted.corner_radius
                         && value.background == mounted.background
@@ -8826,7 +8901,7 @@ pub mod public {
                 Self::Button(value) => value.reference.as_ref(),
                 Self::HyperlinkButton(value) => value.reference.as_ref(),
                 Self::RepeatButton(_) => None,
-                Self::Border(_) => None,
+                Self::Border(value) => value.reference.as_ref(),
                 Self::BreadcrumbBar(_) => None,
                 Self::StackPanel(_) => None,
                 Self::VariableSizedWrapGrid(_) => None,
@@ -9255,6 +9330,41 @@ pub mod public {
                             .as_ref()
                             .is_some_and(|events| events.on_pointer_canceled.is_some()),
                     );
+                    visit(
+                        EventId::BorderPreviewKeyDown,
+                        value
+                            .events
+                            .as_ref()
+                            .is_some_and(|events| events.on_preview_key_down.is_some()),
+                    );
+                    visit(
+                        EventId::BorderKeyUp,
+                        value
+                            .events
+                            .as_ref()
+                            .is_some_and(|events| events.on_key_up.is_some()),
+                    );
+                    visit(
+                        EventId::BorderCharacterReceived,
+                        value
+                            .events
+                            .as_ref()
+                            .is_some_and(|events| events.on_character_received.is_some()),
+                    );
+                    visit(
+                        EventId::BorderGotFocus,
+                        value
+                            .events
+                            .as_ref()
+                            .is_some_and(|events| events.on_got_focus.is_some()),
+                    );
+                    visit(
+                        EventId::BorderLostFocus,
+                        value
+                            .events
+                            .as_ref()
+                            .is_some_and(|events| events.on_lost_focus.is_some()),
+                    );
                 }
                 Self::BreadcrumbBar(value) => {
                     visit(
@@ -9535,6 +9645,7 @@ pub trait MountedPropsExt {
 pub trait MountedEventsExt {
     fn visit_events(&self, visit: &mut dyn FnMut(EventId, bool));
     fn dispatch_event(&self, event: EventId, payload: &EventPayload) -> Option<bool>;
+    fn routed_callback(&self, event: EventId) -> Option<RoutedEventCallback>;
     fn observe_event(
         &self,
         event: EventId,
@@ -9688,6 +9799,20 @@ impl MountedPropsExt for MountedProps {
                 );
             }
             Self::Border(values) => {
+                visit(
+                    PropertyId::BorderIsTabStop,
+                    match &values.is_tab_stop {
+                        Property::Inherited => None,
+                        Property::Set(value) => Some(PropertyValueRef::Bool(*value)),
+                    },
+                );
+                visit(
+                    PropertyId::BorderAllowFocusOnInteraction,
+                    match &values.allow_focus_on_interaction {
+                        Property::Inherited => None,
+                        Property::Set(value) => Some(PropertyValueRef::Bool(*value)),
+                    },
+                );
                 visit(
                     PropertyId::BorderPadding,
                     match &values.padding {
@@ -11573,6 +11698,41 @@ impl MountedEventsExt for MountedProps {
                         .as_ref()
                         .is_some_and(|events| events.on_pointer_canceled.is_some()),
                 );
+                visit(
+                    EventId::BorderPreviewKeyDown,
+                    values
+                        .events
+                        .as_ref()
+                        .is_some_and(|events| events.on_preview_key_down.is_some()),
+                );
+                visit(
+                    EventId::BorderKeyUp,
+                    values
+                        .events
+                        .as_ref()
+                        .is_some_and(|events| events.on_key_up.is_some()),
+                );
+                visit(
+                    EventId::BorderCharacterReceived,
+                    values
+                        .events
+                        .as_ref()
+                        .is_some_and(|events| events.on_character_received.is_some()),
+                );
+                visit(
+                    EventId::BorderGotFocus,
+                    values
+                        .events
+                        .as_ref()
+                        .is_some_and(|events| events.on_got_focus.is_some()),
+                );
+                visit(
+                    EventId::BorderLostFocus,
+                    values
+                        .events
+                        .as_ref()
+                        .is_some_and(|events| events.on_lost_focus.is_some()),
+                );
             }
             Self::BreadcrumbBar(values) => {
                 visit(
@@ -11923,6 +12083,24 @@ impl MountedEventsExt for MountedProps {
                 .as_ref()
                 .and_then(|events| events.on_pointer_canceled.as_ref())
                 .map(|callback| callback.call(())),
+            (
+                Self::Border(values),
+                EventId::BorderGotFocus,
+                EventPayload::FocusEventInfo(value),
+            ) => values
+                .events
+                .as_ref()
+                .and_then(|events| events.on_got_focus.as_ref())
+                .map(|callback| callback.call(*value)),
+            (
+                Self::Border(values),
+                EventId::BorderLostFocus,
+                EventPayload::FocusEventInfo(value),
+            ) => values
+                .events
+                .as_ref()
+                .and_then(|events| events.on_lost_focus.as_ref())
+                .map(|callback| callback.call(*value)),
             (
                 Self::BreadcrumbBar(values),
                 EventId::BreadcrumbBarItemClicked,
@@ -12282,6 +12460,26 @@ impl MountedEventsExt for MountedProps {
                 .on_text_changed
                 .as_ref()
                 .map(|callback| callback.call(value.clone())),
+            _ => None,
+        }
+    }
+    fn routed_callback(&self, event: EventId) -> Option<RoutedEventCallback> {
+        match (self, event) {
+            (Self::Border(values), EventId::BorderPreviewKeyDown) => values
+                .events
+                .as_ref()
+                .and_then(|events| events.on_preview_key_down.clone())
+                .map(RoutedEventCallback::KeyEventInfo),
+            (Self::Border(values), EventId::BorderKeyUp) => values
+                .events
+                .as_ref()
+                .and_then(|events| events.on_key_up.clone())
+                .map(RoutedEventCallback::KeyEventInfo),
+            (Self::Border(values), EventId::BorderCharacterReceived) => values
+                .events
+                .as_ref()
+                .and_then(|events| events.on_character_received.clone())
+                .map(RoutedEventCallback::CharacterEventInfo),
             _ => None,
         }
     }
@@ -12709,6 +12907,8 @@ impl PartialEq for RepeatButtonMountedProps {
 }
 #[derive(Clone, Debug)]
 pub(crate) struct BorderMountedProps {
+    is_tab_stop: Property<bool>,
+    allow_focus_on_interaction: Property<bool>,
     padding: Property<Thickness>,
     border_thickness: Property<Thickness>,
     corner_radius: Property<CornerRadius>,
@@ -12723,7 +12923,9 @@ pub(crate) struct BorderMountedProps {
 }
 impl PartialEq for BorderMountedProps {
     fn eq(&self, other: &Self) -> bool {
-        true && self.padding == other.padding
+        true && self.is_tab_stop == other.is_tab_stop
+            && self.allow_focus_on_interaction == other.allow_focus_on_interaction
+            && self.padding == other.padding
             && self.border_thickness == other.border_thickness
             && self.corner_radius == other.corner_radius
             && self.background == other.background
@@ -13884,6 +14086,8 @@ pub enum PropertyId {
     RepeatButtonDelay,
     RepeatButtonInterval,
     RepeatButtonIsEnabled,
+    BorderIsTabStop,
+    BorderAllowFocusOnInteraction,
     BorderPadding,
     BorderBorderThickness,
     BorderCornerRadius,
@@ -14114,6 +14318,11 @@ pub enum EventId {
     BorderPointerReleased,
     BorderPointerCaptureLost,
     BorderPointerCanceled,
+    BorderPreviewKeyDown,
+    BorderKeyUp,
+    BorderCharacterReceived,
+    BorderGotFocus,
+    BorderLostFocus,
     BreadcrumbBarItemClicked,
     TextBoxTextChanged,
     AutoSuggestBoxTextChanged,
@@ -14623,11 +14832,14 @@ pub struct SelectionChange {
 #[derive(Clone, Debug)]
 pub enum EventPayload {
     Bool(bool),
+    CharacterEventInfo(CharacterEventInfo),
     Color(Color),
     ContentDialogResult(ContentDialogResult),
     DragKind(DragKind),
     DroppedData(DroppedData),
     F64(f64),
+    FocusEventInfo(FocusEventInfo),
+    KeyEventInfo(KeyEventInfo),
     NavigationViewDisplayMode(NavigationViewDisplayMode),
     OptionalDateTime(Option<windows_time::DateTime>),
     OptionalF64(Option<f64>),
@@ -14644,11 +14856,14 @@ impl PartialEq for EventPayload {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
             (Self::Bool(left), Self::Bool(right)) => left == right,
+            (Self::CharacterEventInfo(left), Self::CharacterEventInfo(right)) => left == right,
             (Self::Color(left), Self::Color(right)) => left == right,
             (Self::ContentDialogResult(left), Self::ContentDialogResult(right)) => left == right,
             (Self::DragKind(left), Self::DragKind(right)) => left == right,
             (Self::DroppedData(left), Self::DroppedData(right)) => left == right,
             (Self::F64(left), Self::F64(right)) => f64_eq(*left, *right),
+            (Self::FocusEventInfo(left), Self::FocusEventInfo(right)) => left == right,
+            (Self::KeyEventInfo(left), Self::KeyEventInfo(right)) => left == right,
             (Self::NavigationViewDisplayMode(left), Self::NavigationViewDisplayMode(right)) => {
                 left == right
             }
@@ -14992,6 +15207,28 @@ const REPEAT_BUTTON_EVENTS: &[EventDescriptor] = &[EventDescriptor {
 const REPEAT_BUTTON_SLOTS: &[SlotDescriptor] = &[];
 const BORDER_PROPERTIES: &[PropertyDescriptor] = &[
     PropertyDescriptor {
+        id: PropertyId::BorderIsTabStop,
+        name: "IsTabStop",
+        field: "is_tab_stop",
+        value: "Bool",
+        interface: "Microsoft.UI.Xaml.IUIElement",
+        clearable: true,
+        feedback: None,
+        feedback_contract: None,
+        observes_feedback: false,
+    },
+    PropertyDescriptor {
+        id: PropertyId::BorderAllowFocusOnInteraction,
+        name: "AllowFocusOnInteraction",
+        field: "allow_focus_on_interaction",
+        value: "Bool",
+        interface: "Microsoft.UI.Xaml.IFrameworkElement",
+        clearable: true,
+        feedback: None,
+        feedback_contract: None,
+        observes_feedback: false,
+    },
+    PropertyDescriptor {
         id: PropertyId::BorderPadding,
         name: "Padding",
         field: "padding",
@@ -15178,6 +15415,41 @@ const BORDER_EVENTS: &[EventDescriptor] = &[
         name: "PointerCanceled",
         field: "on_pointer_canceled",
         payload: "Unit",
+        interface: "Microsoft.UI.Xaml.IUIElement",
+    },
+    EventDescriptor {
+        id: EventId::BorderPreviewKeyDown,
+        name: "PreviewKeyDown",
+        field: "on_preview_key_down",
+        payload: "KeyEventInfo",
+        interface: "Microsoft.UI.Xaml.IUIElement",
+    },
+    EventDescriptor {
+        id: EventId::BorderKeyUp,
+        name: "KeyUp",
+        field: "on_key_up",
+        payload: "KeyEventInfo",
+        interface: "Microsoft.UI.Xaml.IUIElement",
+    },
+    EventDescriptor {
+        id: EventId::BorderCharacterReceived,
+        name: "CharacterReceived",
+        field: "on_character_received",
+        payload: "CharacterEventInfo",
+        interface: "Microsoft.UI.Xaml.IUIElement",
+    },
+    EventDescriptor {
+        id: EventId::BorderGotFocus,
+        name: "GotFocus",
+        field: "on_got_focus",
+        payload: "FocusEventInfo",
+        interface: "Microsoft.UI.Xaml.IUIElement",
+    },
+    EventDescriptor {
+        id: EventId::BorderLostFocus,
+        name: "LostFocus",
+        field: "on_lost_focus",
+        payload: "FocusEventInfo",
         interface: "Microsoft.UI.Xaml.IUIElement",
     },
 ];
@@ -18309,7 +18581,7 @@ pub const CONTROLS: &[ControlDescriptor] = &[
         name: "Border",
         type_name: "Microsoft.UI.Xaml.Controls.Border",
         role: ControlRole::Content,
-        capabilities: &[Capability::Layout, Capability::Content],
+        capabilities: &[Capability::Layout, Capability::Content, Capability::Focus],
         properties: BORDER_PROPERTIES,
         events: BORDER_EVENTS,
         slots: BORDER_SLOTS,

--- a/crates/libs/reactor/src/generated.rs
+++ b/crates/libs/reactor/src/generated.rs
@@ -715,6 +715,7 @@ pub mod public {
         scale: Property<f64>,
         scale_transition: Property<std::time::Duration>,
         capture_pointer_on_press: Property<bool>,
+        focus_on_pointer_release: Property<bool>,
         drop_policy: Property<DragDropPolicy>,
         events: Option<std::rc::Rc<BorderEvents>>,
         reference: Option<NativeElementRef>,
@@ -854,6 +855,11 @@ pub mod public {
         pub fn capture_pointer_on_press(mut self, value: impl Into<Option<bool>>) -> Self {
             let value = value.into();
             self.capture_pointer_on_press = Property::from(value);
+            self
+        }
+        pub fn focus_on_pointer_release(mut self, value: impl Into<Option<bool>>) -> Self {
+            let value = value.into();
+            self.focus_on_pointer_release = Property::from(value);
             self
         }
         pub fn drop_policy(mut self, value: impl Into<Option<DragDropPolicy>>) -> Self {
@@ -6719,6 +6725,7 @@ pub mod public {
                         scale,
                         scale_transition,
                         capture_pointer_on_press,
+                        focus_on_pointer_release,
                         drop_policy,
                         events,
                         reference,
@@ -6739,6 +6746,7 @@ pub mod public {
                             scale,
                             scale_transition,
                             capture_pointer_on_press,
+                            focus_on_pointer_release,
                             drop_policy,
                             events,
                         })),
@@ -8501,6 +8509,7 @@ pub mod public {
                         && f64_property_eq(&value.scale, &mounted.scale)
                         && value.scale_transition == mounted.scale_transition
                         && value.capture_pointer_on_press == mounted.capture_pointer_on_press
+                        && value.focus_on_pointer_release == mounted.focus_on_pointer_release
                         && value.drop_policy == mounted.drop_policy
                         && value.events == mounted.events
                 }
@@ -9314,7 +9323,9 @@ pub mod public {
                         value
                             .events
                             .as_ref()
-                            .is_some_and(|events| events.on_pointer_released.is_some()),
+                            .is_some_and(|events| events.on_pointer_released.is_some())
+                            || !matches!(value.capture_pointer_on_press, Property::Inherited)
+                            || !matches!(value.focus_on_pointer_release, Property::Inherited),
                     );
                     visit(
                         EventId::BorderPointerCaptureLost,
@@ -9876,6 +9887,13 @@ impl MountedPropsExt for MountedProps {
                 visit(
                     PropertyId::BorderCapturePointerOnPress,
                     match &values.capture_pointer_on_press {
+                        Property::Inherited => None,
+                        Property::Set(value) => Some(PropertyValueRef::Bool(*value)),
+                    },
+                );
+                visit(
+                    PropertyId::BorderFocusOnPointerRelease,
+                    match &values.focus_on_pointer_release {
                         Property::Inherited => None,
                         Property::Set(value) => Some(PropertyValueRef::Bool(*value)),
                     },
@@ -11682,7 +11700,9 @@ impl MountedEventsExt for MountedProps {
                     values
                         .events
                         .as_ref()
-                        .is_some_and(|events| events.on_pointer_released.is_some()),
+                        .is_some_and(|events| events.on_pointer_released.is_some())
+                        || !matches!(values.capture_pointer_on_press, Property::Inherited)
+                        || !matches!(values.focus_on_pointer_release, Property::Inherited),
                 );
                 visit(
                     EventId::BorderPointerCaptureLost,
@@ -12918,6 +12938,7 @@ pub(crate) struct BorderMountedProps {
     scale: Property<f64>,
     scale_transition: Property<std::time::Duration>,
     capture_pointer_on_press: Property<bool>,
+    focus_on_pointer_release: Property<bool>,
     drop_policy: Property<DragDropPolicy>,
     events: Option<std::rc::Rc<BorderEvents>>,
 }
@@ -12934,6 +12955,7 @@ impl PartialEq for BorderMountedProps {
             && f64_property_eq(&self.scale, &other.scale)
             && self.scale_transition == other.scale_transition
             && self.capture_pointer_on_press == other.capture_pointer_on_press
+            && self.focus_on_pointer_release == other.focus_on_pointer_release
             && self.drop_policy == other.drop_policy
             && self.events == other.events
     }
@@ -14097,6 +14119,7 @@ pub enum PropertyId {
     BorderScale,
     BorderScaleTransition,
     BorderCapturePointerOnPress,
+    BorderFocusOnPointerRelease,
     BorderAllowDrop,
     BreadcrumbBarItemsSource,
     StackPanelOrientation,
@@ -15320,6 +15343,17 @@ const BORDER_PROPERTIES: &[PropertyDescriptor] = &[
         id: PropertyId::BorderCapturePointerOnPress,
         name: "CapturePointerOnPress",
         field: "capture_pointer_on_press",
+        value: "Bool",
+        interface: "Microsoft.UI.Xaml.IUIElement",
+        clearable: true,
+        feedback: None,
+        feedback_contract: None,
+        observes_feedback: false,
+    },
+    PropertyDescriptor {
+        id: PropertyId::BorderFocusOnPointerRelease,
+        name: "FocusOnPointerRelease",
+        field: "focus_on_pointer_release",
         value: "Bool",
         interface: "Microsoft.UI.Xaml.IUIElement",
         clearable: true,

--- a/crates/libs/reactor/src/native/mod.rs
+++ b/crates/libs/reactor/src/native/mod.rs
@@ -10,5 +10,9 @@ pub(crate) enum FeedbackExpectation {
 mod winui;
 
 #[cfg(feature = "test")]
-pub use winui::test::{schedule_live_test_exit, subscribe_live_rendering};
+pub(crate) use winui::test::subscribe_live_input_probe;
+#[cfg(feature = "test")]
+pub use winui::test::{
+    LiveInputProbe, LiveInputProbeStage, schedule_live_test_exit, subscribe_live_rendering,
+};
 pub use winui::*;

--- a/crates/libs/reactor/src/native/mod.rs
+++ b/crates/libs/reactor/src/native/mod.rs
@@ -10,9 +10,9 @@ pub(crate) enum FeedbackExpectation {
 mod winui;
 
 #[cfg(feature = "test")]
-pub(crate) use winui::test::subscribe_live_input_probe;
-#[cfg(feature = "test")]
 pub use winui::test::{
     LiveInputProbe, LiveInputProbeStage, schedule_live_test_exit, subscribe_live_rendering,
 };
+#[cfg(feature = "test")]
+pub(crate) use winui::test::{finish_live_text_input_dispatch, subscribe_live_input_probe};
 pub use winui::*;

--- a/crates/libs/reactor/src/native/winui/bindings.rs
+++ b/crates/libs/reactor/src/native/winui/bindings.rs
@@ -2,6 +2,7 @@ windows_core::link!("api-ms-win-appmodel-runtime-l1-1-5.dll" "system" fn AddPack
 windows_core::link!("ole32.dll" "system" fn CoInitializeEx(pvreserved : *const core::ffi::c_void, dwcoinit : u32) -> windows_core::HRESULT);
 windows_core::link!("kernel32.dll" "system" fn GetCurrentPackageFullName(packagefullnamelength : *mut u32, packagefullname : windows_core::PWSTR) -> i32);
 windows_core::link!("user32.dll" "system" fn GetDpiForWindow(hwnd : HWND) -> u32);
+windows_core::link!("user32.dll" "system" fn GetKeyboardState(lpkeystate : *mut u8) -> windows_core::BOOL);
 windows_core::link!("kernel32.dll" "system" fn GetProcessHeap() -> HANDLE);
 windows_core::link!("kernel32.dll" "system" fn HeapFree(hheap : HANDLE, dwflags : u32, lpmem : *mut core::ffi::c_void) -> windows_core::BOOL);
 windows_core::link!("user32.dll" "system" fn MessageBoxW(hwnd : HWND, lptext : windows_core::PCWSTR, lpcaption : windows_core::PCWSTR, utype : u32) -> i32);
@@ -1544,6 +1545,35 @@ unsafe impl Send for Canvas {}
 unsafe impl Sync for Canvas {}
 #[repr(transparent)]
 #[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CharacterReceivedRoutedEventArgs(windows_core::IUnknown);
+windows_core::imp::interface_hierarchy!(
+    CharacterReceivedRoutedEventArgs,
+    windows_core::IUnknown,
+    windows_core::IInspectable
+);
+windows_core::imp::required_hierarchy!(CharacterReceivedRoutedEventArgs, RoutedEventArgs);
+impl windows_core::RuntimeType for CharacterReceivedRoutedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer =
+        windows_core::imp::ConstBuffer::for_class::<Self, ICharacterReceivedRoutedEventArgs>();
+}
+unsafe impl windows_core::Interface for CharacterReceivedRoutedEventArgs {
+    type Vtable = <ICharacterReceivedRoutedEventArgs as windows_core::Interface>::Vtable;
+    const IID: windows_core::GUID =
+        <ICharacterReceivedRoutedEventArgs as windows_core::Interface>::IID;
+}
+impl core::ops::Deref for CharacterReceivedRoutedEventArgs {
+    type Target = ICharacterReceivedRoutedEventArgs;
+    fn deref(&self) -> &Self::Target {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl windows_core::RuntimeName for CharacterReceivedRoutedEventArgs {
+    const NAME: &'static str = "Microsoft.UI.Xaml.Input.CharacterReceivedRoutedEventArgs";
+}
+unsafe impl Send for CharacterReceivedRoutedEventArgs {}
+unsafe impl Sync for CharacterReceivedRoutedEventArgs {}
+#[repr(transparent)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct CheckBox(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(
     CheckBox,
@@ -2373,6 +2403,33 @@ impl windows_core::RuntimeType for ContentDialogResult {
 }
 #[repr(transparent)]
 #[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ContentIsland(windows_core::IUnknown);
+windows_core::imp::interface_hierarchy!(
+    ContentIsland,
+    windows_core::IUnknown,
+    windows_core::IInspectable
+);
+impl windows_core::RuntimeType for ContentIsland {
+    const SIGNATURE: windows_core::imp::ConstBuffer =
+        windows_core::imp::ConstBuffer::for_class::<Self, IContentIsland>();
+}
+unsafe impl windows_core::Interface for ContentIsland {
+    type Vtable = <IContentIsland as windows_core::Interface>::Vtable;
+    const IID: windows_core::GUID = <IContentIsland as windows_core::Interface>::IID;
+}
+impl core::ops::Deref for ContentIsland {
+    type Target = IContentIsland;
+    fn deref(&self) -> &Self::Target {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl windows_core::RuntimeName for ContentIsland {
+    const NAME: &'static str = "Microsoft.UI.Content.ContentIsland";
+}
+unsafe impl Send for ContentIsland {}
+unsafe impl Sync for ContentIsland {}
+#[repr(transparent)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Control(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(
     Control,
@@ -2468,6 +2525,24 @@ impl windows_core::RuntimeName for Control {
 }
 unsafe impl Send for Control {}
 unsafe impl Sync for Control {}
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct CorePhysicalKeyStatus {
+    pub repeat_count: u32,
+    pub scan_code: u32,
+    pub is_extended_key: bool,
+    pub is_menu_key_down: bool,
+    pub was_key_down: bool,
+    pub is_key_released: bool,
+}
+impl windows_core::imp::TypeKind for CorePhysicalKeyStatus {
+    type TypeKind = windows_core::imp::CopyType;
+}
+impl windows_core::RuntimeType for CorePhysicalKeyStatus {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::from_slice(
+        b"struct(Windows.UI.Core.CorePhysicalKeyStatus;u4;u4;b1;b1;b1;b1)",
+    );
+}
 #[repr(transparent)]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct CoreWebView2(windows_core::IUnknown);
@@ -4111,6 +4186,16 @@ impl FrameworkElement {
         Self::IFrameworkElementStatics(|this| unsafe {
             let mut result__ = core::mem::zeroed();
             (windows_core::Interface::vtable(this).MarginProperty)(
+                windows_core::Interface::as_raw(this),
+                &mut result__,
+            )
+            .and_then(|| windows_core::imp::Type::from_abi(result__))
+        })
+    }
+    pub(crate) fn AllowFocusOnInteractionProperty() -> windows_core::Result<DependencyProperty> {
+        Self::IFrameworkElementStatics(|this| unsafe {
+            let mut result__ = core::mem::zeroed();
+            (windows_core::Interface::vtable(this).AllowFocusOnInteractionProperty)(
                 windows_core::Interface::as_raw(this),
                 &mut result__,
             )
@@ -6627,6 +6712,59 @@ pub struct ICanvasStatics_Vtbl {
     ) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
+    ICharacterReceivedRoutedEventArgs,
+    ICharacterReceivedRoutedEventArgs_Vtbl,
+    0xe26ca5bb_34c3_5c1e_9a16_00b80b07a899
+);
+impl windows_core::RuntimeType for ICharacterReceivedRoutedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer =
+        windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
+impl ICharacterReceivedRoutedEventArgs {
+    pub(crate) fn Character(&self) -> windows_core::Result<u16> {
+        unsafe {
+            let mut result__ = core::mem::zeroed();
+            (windows_core::Interface::vtable(self).Character)(
+                windows_core::Interface::as_raw(self),
+                &mut result__,
+            )
+            .map(|| result__)
+        }
+    }
+    pub(crate) fn KeyStatus(&self) -> windows_core::Result<CorePhysicalKeyStatus> {
+        unsafe {
+            let mut result__ = core::mem::zeroed();
+            (windows_core::Interface::vtable(self).KeyStatus)(
+                windows_core::Interface::as_raw(self),
+                &mut result__,
+            )
+            .map(|| result__)
+        }
+    }
+    pub(crate) fn SetHandled(&self, value: bool) -> windows_core::Result<()> {
+        unsafe {
+            (windows_core::Interface::vtable(self).SetHandled)(
+                windows_core::Interface::as_raw(self),
+                value,
+            )
+            .ok()
+        }
+    }
+}
+#[repr(C)]
+pub struct ICharacterReceivedRoutedEventArgs_Vtbl {
+    pub base__: windows_core::IInspectable_Vtbl,
+    pub Character:
+        unsafe extern "system" fn(*mut core::ffi::c_void, *mut u16) -> windows_core::HRESULT,
+    pub KeyStatus: unsafe extern "system" fn(
+        *mut core::ffi::c_void,
+        *mut CorePhysicalKeyStatus,
+    ) -> windows_core::HRESULT,
+    Handled: usize,
+    pub SetHandled:
+        unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
+}
+windows_core::imp::define_interface!(
     ICheckBox,
     ICheckBox_Vtbl,
     0xc5830000_4c9d_5fdd_9346_674c71cd80c5
@@ -7598,6 +7736,19 @@ pub struct IContentDialogStatics_Vtbl {
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
+}
+windows_core::imp::define_interface!(
+    IContentIsland,
+    IContentIsland_Vtbl,
+    0x5b2504ba_361c_50aa_bd6e_4122c6d93889
+);
+impl windows_core::RuntimeType for IContentIsland {
+    const SIGNATURE: windows_core::imp::ConstBuffer =
+        windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
+#[repr(C)]
+pub struct IContentIsland_Vtbl {
+    pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(
     IControl,
@@ -9327,6 +9478,15 @@ impl IFrameworkElement {
             .ok()
         }
     }
+    pub(crate) fn SetAllowFocusOnInteraction(&self, value: bool) -> windows_core::Result<()> {
+        unsafe {
+            (windows_core::Interface::vtable(self).SetAllowFocusOnInteraction)(
+                windows_core::Interface::as_raw(self),
+                value,
+            )
+            .ok()
+        }
+    }
     pub(crate) fn SetStyle<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<Style>,
@@ -9519,7 +9679,8 @@ pub struct IFrameworkElement_Vtbl {
     DataContext: usize,
     SetDataContext: usize,
     AllowFocusOnInteraction: usize,
-    SetAllowFocusOnInteraction: usize,
+    pub SetAllowFocusOnInteraction:
+        unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
     FocusVisualMargin: usize,
     SetFocusVisualMargin: usize,
     FocusVisualSecondaryThickness: usize,
@@ -9636,7 +9797,10 @@ pub struct IFrameworkElementStatics_Vtbl {
     ) -> windows_core::HRESULT,
     NameProperty: usize,
     DataContextProperty: usize,
-    AllowFocusOnInteractionProperty: usize,
+    pub AllowFocusOnInteractionProperty: unsafe extern "system" fn(
+        *mut core::ffi::c_void,
+        *mut *mut core::ffi::c_void,
+    ) -> windows_core::HRESULT,
     FocusVisualMarginProperty: usize,
     FocusVisualSecondaryThicknessProperty: usize,
     FocusVisualPrimaryThicknessProperty: usize,
@@ -10494,6 +10658,107 @@ pub struct IInline_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(
+    IInputKeyboardSource,
+    IInputKeyboardSource_Vtbl,
+    0xed61b906_16ad_5df7_a550_5e6f7d2229f7
+);
+impl windows_core::RuntimeType for IInputKeyboardSource {
+    const SIGNATURE: windows_core::imp::ConstBuffer =
+        windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
+#[repr(C)]
+pub struct IInputKeyboardSource_Vtbl {
+    pub base__: windows_core::IInspectable_Vtbl,
+}
+windows_core::imp::define_interface!(
+    IInputKeyboardSource2,
+    IInputKeyboardSource2_Vtbl,
+    0x79d1c9b6_b3c9_5ec2_8a5b_707088787f78
+);
+impl windows_core::RuntimeType for IInputKeyboardSource2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer =
+        windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
+impl IInputKeyboardSource2 {
+    pub(crate) fn KeyDown<F>(&self, handler: F) -> windows_core::Result<windows_core::EventRevoker>
+    where
+        F: Fn(windows_core::Ref<InputKeyboardSource>, windows_core::Ref<KeyEventArgs>) + 'static,
+    {
+        let handler: TypedEventHandler<InputKeyboardSource, KeyEventArgs> = {
+            let com = windows_core::imp::DelegateBox::<
+                TypedEventHandler<InputKeyboardSource, KeyEventArgs>,
+                F,
+            >::new(
+                &TypedEventHandlerBox::<InputKeyboardSource, KeyEventArgs, F>::VTABLE,
+                handler,
+            );
+            unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
+        };
+        unsafe {
+            let mut result__ = core::mem::zeroed();
+            let token__ = (windows_core::Interface::vtable(self).KeyDown)(
+                windows_core::Interface::as_raw(self),
+                windows_core::Interface::as_raw(&handler),
+                &mut result__,
+            )
+            .map(|| result__)?;
+            Ok(windows_core::EventRevoker::new(
+                self.clone(),
+                token__,
+                windows_core::Interface::vtable(self).RemoveKeyDown,
+            ))
+        }
+    }
+}
+#[repr(C)]
+pub struct IInputKeyboardSource2_Vtbl {
+    pub base__: windows_core::IInspectable_Vtbl,
+    GetCurrentKeyState: usize,
+    GetKeyState: usize,
+    CharacterReceived: usize,
+    RemoveCharacterReceived: usize,
+    ContextMenuKey: usize,
+    RemoveContextMenuKey: usize,
+    pub KeyDown: unsafe extern "system" fn(
+        *mut core::ffi::c_void,
+        *mut core::ffi::c_void,
+        *mut i64,
+    ) -> windows_core::HRESULT,
+    pub RemoveKeyDown:
+        unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
+}
+windows_core::imp::define_interface!(
+    IInputKeyboardSourceStatics2,
+    IInputKeyboardSourceStatics2_Vtbl,
+    0x8857518c_2899_5f11_9b64_0ad83234824b
+);
+impl windows_core::RuntimeType for IInputKeyboardSourceStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer =
+        windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
+#[repr(C)]
+pub struct IInputKeyboardSourceStatics2_Vtbl {
+    pub base__: windows_core::IInspectable_Vtbl,
+    pub GetForIsland: unsafe extern "system" fn(
+        *mut core::ffi::c_void,
+        *mut core::ffi::c_void,
+        *mut *mut core::ffi::c_void,
+    ) -> windows_core::HRESULT,
+}
+windows_core::imp::define_interface!(
+    IInputObject,
+    IInputObject_Vtbl,
+    0x42edbc88_d386_544d_b1b8_68617fe68282
+);
+impl windows_core::RuntimeType for IInputObject {
+    const SIGNATURE: windows_core::imp::ConstBuffer =
+        windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
+#[repr(C)]
+pub struct IInputObject_Vtbl {
+    pub base__: windows_core::IInspectable_Vtbl,
+}
+windows_core::imp::define_interface!(
     IItemContainer,
     IItemContainer_Vtbl,
     0x6332a67f_7fd9_53c7_afd8_cfa1237cf6d1
@@ -10708,6 +10973,84 @@ pub struct IItemsRepeaterFactory_Vtbl {
         *mut *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
+}
+windows_core::imp::define_interface!(
+    IKeyEventArgs,
+    IKeyEventArgs_Vtbl,
+    0x40d5bb74_977e_5194_8039_9f6c44427bbb
+);
+impl windows_core::RuntimeType for IKeyEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer =
+        windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
+#[repr(C)]
+pub struct IKeyEventArgs_Vtbl {
+    pub base__: windows_core::IInspectable_Vtbl,
+}
+windows_core::imp::define_interface!(
+    IKeyRoutedEventArgs,
+    IKeyRoutedEventArgs_Vtbl,
+    0xee357007_a2d6_5c75_9431_05fd66ec7915
+);
+impl windows_core::RuntimeType for IKeyRoutedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer =
+        windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
+impl IKeyRoutedEventArgs {
+    pub(crate) fn Key(&self) -> windows_core::Result<VirtualKey> {
+        unsafe {
+            let mut result__ = core::mem::zeroed();
+            (windows_core::Interface::vtable(self).Key)(
+                windows_core::Interface::as_raw(self),
+                &mut result__,
+            )
+            .map(|| result__)
+        }
+    }
+    pub(crate) fn KeyStatus(&self) -> windows_core::Result<CorePhysicalKeyStatus> {
+        unsafe {
+            let mut result__ = core::mem::zeroed();
+            (windows_core::Interface::vtable(self).KeyStatus)(
+                windows_core::Interface::as_raw(self),
+                &mut result__,
+            )
+            .map(|| result__)
+        }
+    }
+    pub(crate) fn SetHandled(&self, value: bool) -> windows_core::Result<()> {
+        unsafe {
+            (windows_core::Interface::vtable(self).SetHandled)(
+                windows_core::Interface::as_raw(self),
+                value,
+            )
+            .ok()
+        }
+    }
+    pub(crate) fn OriginalKey(&self) -> windows_core::Result<VirtualKey> {
+        unsafe {
+            let mut result__ = core::mem::zeroed();
+            (windows_core::Interface::vtable(self).OriginalKey)(
+                windows_core::Interface::as_raw(self),
+                &mut result__,
+            )
+            .map(|| result__)
+        }
+    }
+}
+#[repr(C)]
+pub struct IKeyRoutedEventArgs_Vtbl {
+    pub base__: windows_core::IInspectable_Vtbl,
+    pub Key:
+        unsafe extern "system" fn(*mut core::ffi::c_void, *mut VirtualKey) -> windows_core::HRESULT,
+    pub KeyStatus: unsafe extern "system" fn(
+        *mut core::ffi::c_void,
+        *mut CorePhysicalKeyStatus,
+    ) -> windows_core::HRESULT,
+    Handled: usize,
+    pub SetHandled:
+        unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
+    pub OriginalKey:
+        unsafe extern "system" fn(*mut core::ffi::c_void, *mut VirtualKey) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
     IKeyboardAccelerator,
@@ -14989,9 +15332,25 @@ impl windows_core::RuntimeType for IRoutedEventArgs {
     const SIGNATURE: windows_core::imp::ConstBuffer =
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
+impl IRoutedEventArgs {
+    pub(crate) fn OriginalSource(&self) -> windows_core::Result<windows_core::IInspectable> {
+        unsafe {
+            let mut result__ = core::mem::zeroed();
+            (windows_core::Interface::vtable(self).OriginalSource)(
+                windows_core::Interface::as_raw(self),
+                &mut result__,
+            )
+            .and_then(|| windows_core::imp::Type::from_abi(result__))
+        }
+    }
+}
 #[repr(C)]
 pub struct IRoutedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
+    pub OriginalSource: unsafe extern "system" fn(
+        *mut core::ffi::c_void,
+        *mut *mut core::ffi::c_void,
+    ) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
     IRowDefinition,
@@ -19129,6 +19488,142 @@ impl IUIElement {
             .ok()
         }
     }
+    pub(crate) fn FocusState(&self) -> windows_core::Result<FocusState> {
+        unsafe {
+            let mut result__ = core::mem::zeroed();
+            (windows_core::Interface::vtable(self).FocusState)(
+                windows_core::Interface::as_raw(self),
+                &mut result__,
+            )
+            .map(|| result__)
+        }
+    }
+    pub(crate) fn SetIsTabStop(&self, value: bool) -> windows_core::Result<()> {
+        unsafe {
+            (windows_core::Interface::vtable(self).SetIsTabStop)(
+                windows_core::Interface::as_raw(self),
+                value,
+            )
+            .ok()
+        }
+    }
+    pub(crate) fn KeyUp<F>(&self, handler: F) -> windows_core::Result<windows_core::EventRevoker>
+    where
+        F: Fn(windows_core::Ref<windows_core::IInspectable>, windows_core::Ref<KeyRoutedEventArgs>)
+            + 'static,
+    {
+        let handler: KeyEventHandler = {
+            let com = windows_core::imp::DelegateBox::<KeyEventHandler, F>::new(
+                &KeyEventHandlerBox::<F>::VTABLE,
+                handler,
+            );
+            unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
+        };
+        unsafe {
+            let mut result__ = core::mem::zeroed();
+            let token__ = (windows_core::Interface::vtable(self).KeyUp)(
+                windows_core::Interface::as_raw(self),
+                windows_core::Interface::as_raw(&handler),
+                &mut result__,
+            )
+            .map(|| result__)?;
+            Ok(windows_core::EventRevoker::new(
+                self.clone(),
+                token__,
+                windows_core::Interface::vtable(self).RemoveKeyUp,
+            ))
+        }
+    }
+    pub(crate) fn GotFocus<F>(&self, handler: F) -> windows_core::Result<windows_core::EventRevoker>
+    where
+        F: Fn(windows_core::Ref<windows_core::IInspectable>, windows_core::Ref<RoutedEventArgs>)
+            + 'static,
+    {
+        let handler: RoutedEventHandler = {
+            let com = windows_core::imp::DelegateBox::<RoutedEventHandler, F>::new(
+                &RoutedEventHandlerBox::<F>::VTABLE,
+                handler,
+            );
+            unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
+        };
+        unsafe {
+            let mut result__ = core::mem::zeroed();
+            let token__ = (windows_core::Interface::vtable(self).GotFocus)(
+                windows_core::Interface::as_raw(self),
+                windows_core::Interface::as_raw(&handler),
+                &mut result__,
+            )
+            .map(|| result__)?;
+            Ok(windows_core::EventRevoker::new(
+                self.clone(),
+                token__,
+                windows_core::Interface::vtable(self).RemoveGotFocus,
+            ))
+        }
+    }
+    pub(crate) fn LostFocus<F>(
+        &self,
+        handler: F,
+    ) -> windows_core::Result<windows_core::EventRevoker>
+    where
+        F: Fn(windows_core::Ref<windows_core::IInspectable>, windows_core::Ref<RoutedEventArgs>)
+            + 'static,
+    {
+        let handler: RoutedEventHandler = {
+            let com = windows_core::imp::DelegateBox::<RoutedEventHandler, F>::new(
+                &RoutedEventHandlerBox::<F>::VTABLE,
+                handler,
+            );
+            unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
+        };
+        unsafe {
+            let mut result__ = core::mem::zeroed();
+            let token__ = (windows_core::Interface::vtable(self).LostFocus)(
+                windows_core::Interface::as_raw(self),
+                windows_core::Interface::as_raw(&handler),
+                &mut result__,
+            )
+            .map(|| result__)?;
+            Ok(windows_core::EventRevoker::new(
+                self.clone(),
+                token__,
+                windows_core::Interface::vtable(self).RemoveLostFocus,
+            ))
+        }
+    }
+    pub(crate) fn CharacterReceived<F>(
+        &self,
+        handler: F,
+    ) -> windows_core::Result<windows_core::EventRevoker>
+    where
+        F: Fn(windows_core::Ref<UIElement>, windows_core::Ref<CharacterReceivedRoutedEventArgs>)
+            + 'static,
+    {
+        let handler: TypedEventHandler<UIElement, CharacterReceivedRoutedEventArgs> = {
+            let com = windows_core::imp::DelegateBox::<
+                TypedEventHandler<UIElement, CharacterReceivedRoutedEventArgs>,
+                F,
+            >::new(
+                &TypedEventHandlerBox::<UIElement, CharacterReceivedRoutedEventArgs, F>::VTABLE,
+                handler,
+            );
+            unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
+        };
+        unsafe {
+            let mut result__ = core::mem::zeroed();
+            let token__ = (windows_core::Interface::vtable(self).CharacterReceived)(
+                windows_core::Interface::as_raw(self),
+                windows_core::Interface::as_raw(&handler),
+                &mut result__,
+            )
+            .map(|| result__)?;
+            Ok(windows_core::EventRevoker::new(
+                self.clone(),
+                token__,
+                windows_core::Interface::vtable(self).RemoveCharacterReceived,
+            ))
+        }
+    }
     pub(crate) fn DragEnter<F>(
         &self,
         handler: F,
@@ -19467,6 +19962,36 @@ impl IUIElement {
             ))
         }
     }
+    pub(crate) fn PreviewKeyDown<F>(
+        &self,
+        handler: F,
+    ) -> windows_core::Result<windows_core::EventRevoker>
+    where
+        F: Fn(windows_core::Ref<windows_core::IInspectable>, windows_core::Ref<KeyRoutedEventArgs>)
+            + 'static,
+    {
+        let handler: KeyEventHandler = {
+            let com = windows_core::imp::DelegateBox::<KeyEventHandler, F>::new(
+                &KeyEventHandlerBox::<F>::VTABLE,
+                handler,
+            );
+            unsafe { core::mem::transmute(windows_core::imp::box_new(com)) }
+        };
+        unsafe {
+            let mut result__ = core::mem::zeroed();
+            let token__ = (windows_core::Interface::vtable(self).PreviewKeyDown)(
+                windows_core::Interface::as_raw(self),
+                windows_core::Interface::as_raw(&handler),
+                &mut result__,
+            )
+            .map(|| result__)?;
+            Ok(windows_core::EventRevoker::new(
+                self.clone(),
+                token__,
+                windows_core::Interface::vtable(self).RemovePreviewKeyDown,
+            ))
+        }
+    }
     pub(crate) fn CapturePointer<P0>(&self, value: P0) -> windows_core::Result<bool>
     where
         P0: windows_core::Param<Pointer>,
@@ -19659,7 +20184,8 @@ pub struct IUIElement_Vtbl {
     SetShadow: usize,
     RasterizationScale: usize,
     SetRasterizationScale: usize,
-    FocusState: usize,
+    pub FocusState:
+        unsafe extern "system" fn(*mut core::ffi::c_void, *mut FocusState) -> windows_core::HRESULT,
     UseSystemFocusVisuals: usize,
     SetUseSystemFocusVisuals: usize,
     XYFocusLeft: usize,
@@ -19671,23 +20197,44 @@ pub struct IUIElement_Vtbl {
     XYFocusDown: usize,
     SetXYFocusDown: usize,
     IsTabStop: usize,
-    SetIsTabStop: usize,
+    pub SetIsTabStop:
+        unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
     TabIndex: usize,
     SetTabIndex: usize,
-    KeyUp: usize,
-    RemoveKeyUp: usize,
+    pub KeyUp: unsafe extern "system" fn(
+        *mut core::ffi::c_void,
+        *mut core::ffi::c_void,
+        *mut i64,
+    ) -> windows_core::HRESULT,
+    pub RemoveKeyUp:
+        unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
     KeyDown: usize,
     RemoveKeyDown: usize,
-    GotFocus: usize,
-    RemoveGotFocus: usize,
-    LostFocus: usize,
-    RemoveLostFocus: usize,
+    pub GotFocus: unsafe extern "system" fn(
+        *mut core::ffi::c_void,
+        *mut core::ffi::c_void,
+        *mut i64,
+    ) -> windows_core::HRESULT,
+    pub RemoveGotFocus:
+        unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
+    pub LostFocus: unsafe extern "system" fn(
+        *mut core::ffi::c_void,
+        *mut core::ffi::c_void,
+        *mut i64,
+    ) -> windows_core::HRESULT,
+    pub RemoveLostFocus:
+        unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
     DragStarting: usize,
     RemoveDragStarting: usize,
     DropCompleted: usize,
     RemoveDropCompleted: usize,
-    CharacterReceived: usize,
-    RemoveCharacterReceived: usize,
+    pub CharacterReceived: unsafe extern "system" fn(
+        *mut core::ffi::c_void,
+        *mut core::ffi::c_void,
+        *mut i64,
+    ) -> windows_core::HRESULT,
+    pub RemoveCharacterReceived:
+        unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
     pub DragEnter: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
@@ -19802,8 +20349,13 @@ pub struct IUIElement_Vtbl {
     RemoveLosingFocus: usize,
     NoFocusCandidateFound: usize,
     RemoveNoFocusCandidateFound: usize,
-    PreviewKeyDown: usize,
-    RemovePreviewKeyDown: usize,
+    pub PreviewKeyDown: unsafe extern "system" fn(
+        *mut core::ffi::c_void,
+        *mut core::ffi::c_void,
+        *mut i64,
+    ) -> windows_core::HRESULT,
+    pub RemovePreviewKeyDown:
+        unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
     PreviewKeyUp: usize,
     RemovePreviewKeyUp: usize,
     BringIntoViewRequested: usize,
@@ -19913,6 +20465,55 @@ pub struct IUIElementStatics_Vtbl {
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
     pub OpacityProperty: unsafe extern "system" fn(
+        *mut core::ffi::c_void,
+        *mut *mut core::ffi::c_void,
+    ) -> windows_core::HRESULT,
+    ClipProperty: usize,
+    RenderTransformProperty: usize,
+    ProjectionProperty: usize,
+    Transform3DProperty: usize,
+    RenderTransformOriginProperty: usize,
+    IsHitTestVisibleProperty: usize,
+    VisibilityProperty: usize,
+    UseLayoutRoundingProperty: usize,
+    TransitionsProperty: usize,
+    CacheModeProperty: usize,
+    IsTapEnabledProperty: usize,
+    IsDoubleTapEnabledProperty: usize,
+    CanDragProperty: usize,
+    IsRightTapEnabledProperty: usize,
+    IsHoldingEnabledProperty: usize,
+    ManipulationModeProperty: usize,
+    PointerCapturesProperty: usize,
+    ContextFlyoutProperty: usize,
+    CompositeModeProperty: usize,
+    LightsProperty: usize,
+    CanBeScrollAnchorProperty: usize,
+    ExitDisplayModeOnAccessKeyInvokedProperty: usize,
+    IsAccessKeyScopeProperty: usize,
+    AccessKeyScopeOwnerProperty: usize,
+    AccessKeyProperty: usize,
+    KeyTipPlacementModeProperty: usize,
+    KeyTipHorizontalOffsetProperty: usize,
+    KeyTipVerticalOffsetProperty: usize,
+    KeyTipTargetProperty: usize,
+    XYFocusKeyboardNavigationProperty: usize,
+    XYFocusUpNavigationStrategyProperty: usize,
+    XYFocusDownNavigationStrategyProperty: usize,
+    XYFocusLeftNavigationStrategyProperty: usize,
+    XYFocusRightNavigationStrategyProperty: usize,
+    KeyboardAcceleratorPlacementTargetProperty: usize,
+    KeyboardAcceleratorPlacementModeProperty: usize,
+    HighContrastAdjustmentProperty: usize,
+    TabFocusNavigationProperty: usize,
+    ShadowProperty: usize,
+    FocusStateProperty: usize,
+    UseSystemFocusVisualsProperty: usize,
+    XYFocusLeftProperty: usize,
+    XYFocusRightProperty: usize,
+    XYFocusUpProperty: usize,
+    XYFocusDownProperty: usize,
+    pub IsTabStopProperty: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut *mut core::ffi::c_void,
     ) -> windows_core::HRESULT,
@@ -20282,6 +20883,16 @@ impl windows_core::RuntimeType for IWindow {
         windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 impl IWindow {
+    pub(crate) fn Content(&self) -> windows_core::Result<UIElement> {
+        unsafe {
+            let mut result__ = core::mem::zeroed();
+            (windows_core::Interface::vtable(self).Content)(
+                windows_core::Interface::as_raw(self),
+                &mut result__,
+            )
+            .and_then(|| windows_core::imp::Type::from_abi(result__))
+        }
+    }
     pub(crate) fn SetContent<P0>(&self, value: P0) -> windows_core::Result<()>
     where
         P0: windows_core::Param<UIElement>,
@@ -20372,7 +20983,10 @@ pub struct IWindow_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     Bounds: usize,
     Visible: usize,
-    Content: usize,
+    pub Content: unsafe extern "system" fn(
+        *mut core::ffi::c_void,
+        *mut *mut core::ffi::c_void,
+    ) -> windows_core::HRESULT,
     pub SetContent: unsafe extern "system" fn(
         *mut core::ffi::c_void,
         *mut core::ffi::c_void,
@@ -20827,6 +21441,35 @@ pub struct IXamlRoot_Vtbl {
     ) -> windows_core::HRESULT,
     pub RemoveChanged:
         unsafe extern "system" fn(*mut core::ffi::c_void, i64) -> windows_core::HRESULT,
+}
+windows_core::imp::define_interface!(
+    IXamlRoot4,
+    IXamlRoot4_Vtbl,
+    0x377bec22_632b_52be_b26f_5edf7838e5ca
+);
+impl windows_core::RuntimeType for IXamlRoot4 {
+    const SIGNATURE: windows_core::imp::ConstBuffer =
+        windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
+impl IXamlRoot4 {
+    pub(crate) fn ContentIsland(&self) -> windows_core::Result<ContentIsland> {
+        unsafe {
+            let mut result__ = core::mem::zeroed();
+            (windows_core::Interface::vtable(self).ContentIsland)(
+                windows_core::Interface::as_raw(self),
+                &mut result__,
+            )
+            .and_then(|| windows_core::imp::Type::from_abi(result__))
+        }
+    }
+}
+#[repr(C)]
+pub struct IXamlRoot4_Vtbl {
+    pub base__: windows_core::IInspectable_Vtbl,
+    pub ContentIsland: unsafe extern "system" fn(
+        *mut core::ffi::c_void,
+        *mut *mut core::ffi::c_void,
+    ) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(
     IXamlRootChangedEventArgs,
@@ -21381,6 +22024,89 @@ unsafe impl Send for InlineCollection {}
 unsafe impl Sync for InlineCollection {}
 #[repr(transparent)]
 #[derive(Clone, Debug, Eq, PartialEq)]
+pub struct InputKeyboardSource(windows_core::IUnknown);
+windows_core::imp::interface_hierarchy!(
+    InputKeyboardSource,
+    windows_core::IUnknown,
+    windows_core::IInspectable
+);
+windows_core::imp::required_hierarchy!(InputKeyboardSource, InputObject);
+impl InputKeyboardSource {
+    pub(crate) fn GetForIsland<P0>(island: P0) -> windows_core::Result<Self>
+    where
+        P0: windows_core::Param<ContentIsland>,
+    {
+        Self::IInputKeyboardSourceStatics2(|this| unsafe {
+            let mut result__ = core::mem::zeroed();
+            (windows_core::Interface::vtable(this).GetForIsland)(
+                windows_core::Interface::as_raw(this),
+                island.param().abi(),
+                &mut result__,
+            )
+            .and_then(|| windows_core::imp::Type::from_abi(result__))
+        })
+    }
+    fn IInputKeyboardSourceStatics2<
+        R,
+        F: FnOnce(&IInputKeyboardSourceStatics2) -> windows_core::Result<R>,
+    >(
+        callback: F,
+    ) -> windows_core::Result<R> {
+        static SHARED: windows_core::imp::FactoryCache<
+            InputKeyboardSource,
+            IInputKeyboardSourceStatics2,
+        > = windows_core::imp::FactoryCache::new();
+        SHARED.call(callback)
+    }
+}
+impl windows_core::RuntimeType for InputKeyboardSource {
+    const SIGNATURE: windows_core::imp::ConstBuffer =
+        windows_core::imp::ConstBuffer::for_class::<Self, IInputKeyboardSource>();
+}
+unsafe impl windows_core::Interface for InputKeyboardSource {
+    type Vtable = <IInputKeyboardSource as windows_core::Interface>::Vtable;
+    const IID: windows_core::GUID = <IInputKeyboardSource as windows_core::Interface>::IID;
+}
+impl core::ops::Deref for InputKeyboardSource {
+    type Target = IInputKeyboardSource;
+    fn deref(&self) -> &Self::Target {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl windows_core::RuntimeName for InputKeyboardSource {
+    const NAME: &'static str = "Microsoft.UI.Input.InputKeyboardSource";
+}
+unsafe impl Send for InputKeyboardSource {}
+unsafe impl Sync for InputKeyboardSource {}
+#[repr(transparent)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct InputObject(windows_core::IUnknown);
+windows_core::imp::interface_hierarchy!(
+    InputObject,
+    windows_core::IUnknown,
+    windows_core::IInspectable
+);
+impl windows_core::RuntimeType for InputObject {
+    const SIGNATURE: windows_core::imp::ConstBuffer =
+        windows_core::imp::ConstBuffer::for_class::<Self, IInputObject>();
+}
+unsafe impl windows_core::Interface for InputObject {
+    type Vtable = <IInputObject as windows_core::Interface>::Vtable;
+    const IID: windows_core::GUID = <IInputObject as windows_core::Interface>::IID;
+}
+impl core::ops::Deref for InputObject {
+    type Target = IInputObject;
+    fn deref(&self) -> &Self::Target {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl windows_core::RuntimeName for InputObject {
+    const NAME: &'static str = "Microsoft.UI.Input.InputObject";
+}
+unsafe impl Send for InputObject {}
+unsafe impl Sync for InputObject {}
+#[repr(transparent)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ItemCollection(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(
     ItemCollection,
@@ -21571,6 +22297,112 @@ impl windows_core::RuntimeName for ItemsRepeater {
 }
 unsafe impl Send for ItemsRepeater {}
 unsafe impl Sync for ItemsRepeater {}
+#[repr(transparent)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct KeyEventArgs(windows_core::IUnknown);
+windows_core::imp::interface_hierarchy!(
+    KeyEventArgs,
+    windows_core::IUnknown,
+    windows_core::IInspectable
+);
+impl windows_core::RuntimeType for KeyEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer =
+        windows_core::imp::ConstBuffer::for_class::<Self, IKeyEventArgs>();
+}
+unsafe impl windows_core::Interface for KeyEventArgs {
+    type Vtable = <IKeyEventArgs as windows_core::Interface>::Vtable;
+    const IID: windows_core::GUID = <IKeyEventArgs as windows_core::Interface>::IID;
+}
+impl core::ops::Deref for KeyEventArgs {
+    type Target = IKeyEventArgs;
+    fn deref(&self) -> &Self::Target {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl windows_core::RuntimeName for KeyEventArgs {
+    const NAME: &'static str = "Microsoft.UI.Input.KeyEventArgs";
+}
+unsafe impl Send for KeyEventArgs {}
+unsafe impl Sync for KeyEventArgs {}
+windows_core::imp::define_interface!(
+    KeyEventHandler,
+    KeyEventHandler_Vtbl,
+    0xdb68e7cc_9a2b_527d_9989_25284daccc03
+);
+impl windows_core::RuntimeType for KeyEventHandler {
+    const SIGNATURE: windows_core::imp::ConstBuffer =
+        windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
+#[repr(C)]
+pub struct KeyEventHandler_Vtbl {
+    base__: windows_core::IUnknown_Vtbl,
+    Invoke: unsafe extern "system" fn(
+        this: *mut core::ffi::c_void,
+        sender: *mut core::ffi::c_void,
+        e: *mut core::ffi::c_void,
+    ) -> windows_core::HRESULT,
+}
+struct KeyEventHandlerBox<
+    F: Fn(windows_core::Ref<windows_core::IInspectable>, windows_core::Ref<KeyRoutedEventArgs>)
+        + 'static,
+>(core::marker::PhantomData<(fn() -> F,)>);
+impl<
+    F: Fn(windows_core::Ref<windows_core::IInspectable>, windows_core::Ref<KeyRoutedEventArgs>)
+        + 'static,
+> KeyEventHandlerBox<F>
+{
+    const VTABLE: KeyEventHandler_Vtbl = KeyEventHandler_Vtbl {
+        base__: windows_core::IUnknown_Vtbl {
+            QueryInterface: windows_core::imp::DelegateBox::<KeyEventHandler, F>::QueryInterface,
+            AddRef: windows_core::imp::DelegateBox::<KeyEventHandler, F>::AddRef,
+            Release: windows_core::imp::DelegateBox::<KeyEventHandler, F>::Release,
+        },
+        Invoke: Self::Invoke,
+    };
+    unsafe extern "system" fn Invoke(
+        this: *mut core::ffi::c_void,
+        sender: *mut core::ffi::c_void,
+        e: *mut core::ffi::c_void,
+    ) -> windows_core::HRESULT {
+        unsafe {
+            let this = &mut *(this as *mut *mut core::ffi::c_void
+                as *mut windows_core::imp::DelegateBox<KeyEventHandler, F>);
+            (this.invoke)(
+                core::mem::transmute_copy(&sender),
+                core::mem::transmute_copy(&e),
+            );
+            windows_core::HRESULT(0)
+        }
+    }
+}
+#[repr(transparent)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct KeyRoutedEventArgs(windows_core::IUnknown);
+windows_core::imp::interface_hierarchy!(
+    KeyRoutedEventArgs,
+    windows_core::IUnknown,
+    windows_core::IInspectable
+);
+windows_core::imp::required_hierarchy!(KeyRoutedEventArgs, RoutedEventArgs);
+impl windows_core::RuntimeType for KeyRoutedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer =
+        windows_core::imp::ConstBuffer::for_class::<Self, IKeyRoutedEventArgs>();
+}
+unsafe impl windows_core::Interface for KeyRoutedEventArgs {
+    type Vtable = <IKeyRoutedEventArgs as windows_core::Interface>::Vtable;
+    const IID: windows_core::GUID = <IKeyRoutedEventArgs as windows_core::Interface>::IID;
+}
+impl core::ops::Deref for KeyRoutedEventArgs {
+    type Target = IKeyRoutedEventArgs;
+    fn deref(&self) -> &Self::Target {
+        unsafe { core::mem::transmute(self) }
+    }
+}
+impl windows_core::RuntimeName for KeyRoutedEventArgs {
+    const NAME: &'static str = "Microsoft.UI.Xaml.Input.KeyRoutedEventArgs";
+}
+unsafe impl Send for KeyRoutedEventArgs {}
+unsafe impl Sync for KeyRoutedEventArgs {}
 #[repr(transparent)]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct KeyboardAccelerator(windows_core::IUnknown);
@@ -28632,6 +29464,16 @@ impl UIElement {
         Self::IUIElementStatics(|this| unsafe {
             let mut result__ = core::mem::zeroed();
             (windows_core::Interface::vtable(this).OpacityProperty)(
+                windows_core::Interface::as_raw(this),
+                &mut result__,
+            )
+            .and_then(|| windows_core::imp::Type::from_abi(result__))
+        })
+    }
+    pub(crate) fn IsTabStopProperty() -> windows_core::Result<DependencyProperty> {
+        Self::IUIElementStatics(|this| unsafe {
+            let mut result__ = core::mem::zeroed();
+            (windows_core::Interface::vtable(this).IsTabStopProperty)(
                 windows_core::Interface::as_raw(this),
                 &mut result__,
             )

--- a/crates/libs/reactor/src/native/winui/generated.rs
+++ b/crates/libs/reactor/src/native/winui/generated.rs
@@ -979,6 +979,22 @@ pub fn set_property(
             .map_err(native_error)?
             .SetIsEnabled(*value)
             .map_err(native_error),
+        (Handle::Border(control), PropertyId::BorderIsTabStop, PropertyValue::Bool(value)) => {
+            control
+                .cast::<IUIElement>()
+                .map_err(native_error)?
+                .SetIsTabStop(*value)
+                .map_err(native_error)
+        }
+        (
+            Handle::Border(control),
+            PropertyId::BorderAllowFocusOnInteraction,
+            PropertyValue::Bool(value),
+        ) => control
+            .cast::<IFrameworkElement>()
+            .map_err(native_error)?
+            .SetAllowFocusOnInteraction(*value)
+            .map_err(native_error),
         (Handle::Border(control), PropertyId::BorderPadding, PropertyValue::Thickness(value)) => {
             control
                 .SetPadding({
@@ -3021,6 +3037,15 @@ pub fn clear_property(handle: &Handle, property: PropertyId) -> Result<(), Runti
         (Handle::RepeatButton(_), PropertyId::RepeatButtonIsEnabled) => dependency_object
             .ClearValue(&bindings::Control::IsEnabledProperty().map_err(native_error)?)
             .map_err(native_error),
+        (Handle::Border(_), PropertyId::BorderIsTabStop) => dependency_object
+            .ClearValue(&bindings::UIElement::IsTabStopProperty().map_err(native_error)?)
+            .map_err(native_error),
+        (Handle::Border(_), PropertyId::BorderAllowFocusOnInteraction) => dependency_object
+            .ClearValue(
+                &bindings::FrameworkElement::AllowFocusOnInteractionProperty()
+                    .map_err(native_error)?,
+            )
+            .map_err(native_error),
         (Handle::Border(_), PropertyId::BorderPadding) => dependency_object
             .ClearValue(&bindings::Border::PaddingProperty().map_err(native_error)?)
             .map_err(native_error),
@@ -4950,6 +4975,163 @@ pub fn subscribe_event(
                     revision,
                     EventPayload::Unit,
                 );
+            })
+        }
+        .map(|revoker| NativeSubscription::Event {
+            _revoker: revoker,
+            revision,
+        })
+        .map_err(native_error),
+        (Handle::Border(value), EventId::BorderPreviewKeyDown) => {
+            let source = value.cast::<IUIElement>().map_err(native_error)?;
+            source.PreviewKeyDown(move |_, args| {
+                let result = args
+                    .as_ref()
+                    .ok_or_else(windows_core::Error::empty)
+                    .and_then(key_event_info);
+                match result {
+                    Ok(info) => {
+                        let handled =
+                            sink.route_key(node, EventId::BorderPreviewKeyDown, revision, info);
+                        if let Some(args) = args.as_ref() {
+                            _ = args.SetHandled(handled);
+                        }
+                    }
+                    Err(error) => {
+                        sink.error(
+                            node,
+                            EventId::BorderPreviewKeyDown,
+                            revision,
+                            native_error(error),
+                        );
+                    }
+                }
+            })
+        }
+        .map(|revoker| NativeSubscription::Event {
+            _revoker: revoker,
+            revision,
+        })
+        .map_err(native_error),
+        (Handle::Border(value), EventId::BorderKeyUp) => {
+            let source = value.cast::<IUIElement>().map_err(native_error)?;
+            source.KeyUp(move |_, args| {
+                let result = args
+                    .as_ref()
+                    .ok_or_else(windows_core::Error::empty)
+                    .and_then(key_event_info);
+                match result {
+                    Ok(info) => {
+                        let handled = sink.route_key(node, EventId::BorderKeyUp, revision, info);
+                        if let Some(args) = args.as_ref() {
+                            _ = args.SetHandled(handled);
+                        }
+                    }
+                    Err(error) => {
+                        sink.error(node, EventId::BorderKeyUp, revision, native_error(error));
+                    }
+                }
+            })
+        }
+        .map(|revoker| NativeSubscription::Event {
+            _revoker: revoker,
+            revision,
+        })
+        .map_err(native_error),
+        (Handle::Border(value), EventId::BorderCharacterReceived) => {
+            let source = value.cast::<IUIElement>().map_err(native_error)?;
+            source.CharacterReceived(move |_, args| {
+                let result = args
+                    .as_ref()
+                    .ok_or_else(windows_core::Error::empty)
+                    .and_then(character_event_info);
+                match result {
+                    Ok(info) => {
+                        let handled = sink.route_character(
+                            node,
+                            EventId::BorderCharacterReceived,
+                            revision,
+                            info,
+                        );
+                        if let Some(args) = args.as_ref() {
+                            _ = args.SetHandled(handled);
+                        }
+                    }
+                    Err(error) => {
+                        sink.error(
+                            node,
+                            EventId::BorderCharacterReceived,
+                            revision,
+                            native_error(error),
+                        );
+                    }
+                }
+            })
+        }
+        .map(|revoker| NativeSubscription::Event {
+            _revoker: revoker,
+            revision,
+        })
+        .map_err(native_error),
+        (Handle::Border(value), EventId::BorderGotFocus) => {
+            let source = value.cast::<IUIElement>().map_err(native_error)?;
+            source.GotFocus({
+                let element = value.cast::<UIElement>().map_err(native_error)?;
+                move |_, args| {
+                    let result = args
+                        .as_ref()
+                        .ok_or_else(windows_core::Error::empty)
+                        .and_then(|args| focus_event_info(&element, args));
+                    match result {
+                        Ok(info) => sink.enqueue(
+                            node,
+                            EventId::BorderGotFocus,
+                            revision,
+                            EventPayload::FocusEventInfo(info),
+                        ),
+                        Err(error) => {
+                            sink.error(
+                                node,
+                                EventId::BorderGotFocus,
+                                revision,
+                                native_error(error),
+                            );
+                        }
+                    }
+                }
+            })
+        }
+        .map(|revoker| NativeSubscription::Event {
+            _revoker: revoker,
+            revision,
+        })
+        .map_err(native_error),
+        (Handle::Border(value), EventId::BorderLostFocus) => {
+            let source = value.cast::<IUIElement>().map_err(native_error)?;
+            source.LostFocus({
+                let element = value.cast::<UIElement>().map_err(native_error)?;
+                move |_, args| {
+                    let result = args
+                        .as_ref()
+                        .ok_or_else(windows_core::Error::empty)
+                        .and_then(|args| focus_event_info(&element, args));
+                    match result {
+                        Ok(info) => sink.enqueue(
+                            node,
+                            EventId::BorderLostFocus,
+                            revision,
+                            EventPayload::FocusEventInfo(info),
+                        ),
+                        Err(error) => {
+                            sink.error(
+                                node,
+                                EventId::BorderLostFocus,
+                                revision,
+                                native_error(error),
+                            );
+                        }
+                    }
+                }
             })
         }
         .map(|revoker| NativeSubscription::Event {

--- a/crates/libs/reactor/src/native/winui/generated.rs
+++ b/crates/libs/reactor/src/native/winui/generated.rs
@@ -5173,19 +5173,31 @@ pub fn subscribe_event(
         (Handle::TextBox(value), EventId::TextBoxTextChanged) => {
             let event_source = (*value).clone();
             value.TextChanged({
-                move |_, _| match event_source.Text() {
-                    Ok(value) => sink.enqueue(
-                        node,
-                        EventId::TextBoxTextChanged,
-                        revision,
-                        EventPayload::Str(value),
-                    ),
-                    Err(error) => sink.error(
-                        node,
-                        EventId::TextBoxTextChanged,
-                        revision,
-                        native_error(error),
-                    ),
+                move |_, _| {
+                    #[cfg(feature = "test")]
+                    test::record_live_input_probe_stage(
+                        test::LiveInputProbeStage::NativeTextChanged,
+                    );
+                    match event_source.Text() {
+                        Ok(value) => {
+                            #[cfg(feature = "test")]
+                            test::record_live_input_probe_stage(
+                                test::LiveInputProbeStage::NativeTextReady,
+                            );
+                            sink.enqueue(
+                                node,
+                                EventId::TextBoxTextChanged,
+                                revision,
+                                EventPayload::Str(value),
+                            );
+                        }
+                        Err(error) => sink.error(
+                            node,
+                            EventId::TextBoxTextChanged,
+                            revision,
+                            native_error(error),
+                        ),
+                    }
                 }
             })
         }

--- a/crates/libs/reactor/src/native/winui/generated.rs
+++ b/crates/libs/reactor/src/native/winui/generated.rs
@@ -5005,8 +5005,15 @@ pub fn subscribe_event(
                     Ok(info) => {
                         let handled =
                             sink.route_key(node, EventId::BorderPreviewKeyDown, revision, info);
-                        if let Some(args) = args.as_ref() {
-                            _ = args.SetHandled(handled);
+                        if let Some(args) = args.as_ref()
+                            && let Err(error) = args.SetHandled(handled)
+                        {
+                            sink.error(
+                                node,
+                                EventId::BorderPreviewKeyDown,
+                                revision,
+                                native_error(error),
+                            );
                         }
                     }
                     Err(error) => {
@@ -5035,8 +5042,10 @@ pub fn subscribe_event(
                 match result {
                     Ok(info) => {
                         let handled = sink.route_key(node, EventId::BorderKeyUp, revision, info);
-                        if let Some(args) = args.as_ref() {
-                            _ = args.SetHandled(handled);
+                        if let Some(args) = args.as_ref()
+                            && let Err(error) = args.SetHandled(handled)
+                        {
+                            sink.error(node, EventId::BorderKeyUp, revision, native_error(error));
                         }
                     }
                     Err(error) => {
@@ -5065,8 +5074,15 @@ pub fn subscribe_event(
                             revision,
                             info,
                         );
-                        if let Some(args) = args.as_ref() {
-                            _ = args.SetHandled(handled);
+                        if let Some(args) = args.as_ref()
+                            && let Err(error) = args.SetHandled(handled)
+                        {
+                            sink.error(
+                                node,
+                                EventId::BorderCharacterReceived,
+                                revision,
+                                native_error(error),
+                            );
                         }
                     }
                     Err(error) => {

--- a/crates/libs/reactor/src/native/winui/generated.rs
+++ b/crates/libs/reactor/src/native/winui/generated.rs
@@ -1124,6 +1124,9 @@ pub fn set_property(
         (Handle::Border(_), PropertyId::BorderCapturePointerOnPress, PropertyValue::Bool(_)) => {
             Err(RuntimeError::UnsupportedKind)
         }
+        (Handle::Border(_), PropertyId::BorderFocusOnPointerRelease, PropertyValue::Bool(_)) => {
+            Err(RuntimeError::UnsupportedKind)
+        }
         (Handle::Border(_), PropertyId::BorderAllowDrop, PropertyValue::DragDropPolicy(_)) => {
             Err(RuntimeError::UnsupportedKind)
         }
@@ -3083,6 +3086,9 @@ pub fn clear_property(handle: &Handle, property: PropertyId) -> Result<(), Runti
         (Handle::Border(_), PropertyId::BorderCapturePointerOnPress) => {
             Err(RuntimeError::UnsupportedKind)
         }
+        (Handle::Border(_), PropertyId::BorderFocusOnPointerRelease) => {
+            Err(RuntimeError::UnsupportedKind)
+        }
         (Handle::Border(_), PropertyId::BorderAllowDrop) => Err(RuntimeError::UnsupportedKind),
         (Handle::BreadcrumbBar(_), PropertyId::BreadcrumbBarItemsSource) => dependency_object
             .ClearValue(&bindings::BreadcrumbBar::ItemsSourceProperty().map_err(native_error)?)
@@ -4757,7 +4763,7 @@ pub fn subscribe_event(
                         }
                     }
                     info.capture_succeeded =
-                        match sink.capture_pointer_on_press(node, &element, args) {
+                        match sink.apply_pointer_press_policy(node, &element, args) {
                             Ok(value) => value,
                             Err(error) => {
                                 sink.error(node, EventId::BorderPointerPressed, revision, error);
@@ -4932,7 +4938,13 @@ pub fn subscribe_event(
                             info.window_y = f64::from(position.y);
                         }
                     }
-                    if let Err(error) = sink.release_pointer_after_event(node, &element, args) {
+                    if let Err(error) = sink.apply_pointer_release_policy(
+                        node,
+                        EventId::BorderPointerReleased,
+                        revision,
+                        &element,
+                        args,
+                    ) {
                         sink.error(node, EventId::BorderPointerReleased, revision, error);
                         return;
                     }
@@ -5081,7 +5093,14 @@ pub fn subscribe_event(
                     let result = args
                         .as_ref()
                         .ok_or_else(windows_core::Error::empty)
-                        .and_then(|args| focus_event_info(&element, args));
+                        .and_then(|args| {
+                            focus_event_info(
+                                &element,
+                                args,
+                                sink.take_pending_focus_state(node),
+                                true,
+                            )
+                        });
                     match result {
                         Ok(info) => sink.enqueue(
                             node,
@@ -5114,7 +5133,7 @@ pub fn subscribe_event(
                     let result = args
                         .as_ref()
                         .ok_or_else(windows_core::Error::empty)
-                        .and_then(|args| focus_event_info(&element, args));
+                        .and_then(|args| focus_event_info(&element, args, None, false));
                     match result {
                         Ok(info) => sink.enqueue(
                             node,

--- a/crates/libs/reactor/src/native/winui/mod.rs
+++ b/crates/libs/reactor/src/native/winui/mod.rs
@@ -130,6 +130,18 @@ pub enum NativeSubscription {
     },
 }
 
+#[derive(Clone, Copy, Default)]
+struct PointerInteractionPolicy {
+    capture: bool,
+    focus_on_release: bool,
+}
+
+impl PointerInteractionPolicy {
+    fn is_empty(self) -> bool {
+        !self.capture && !self.focus_on_release
+    }
+}
+
 impl Drop for NativeSubscription {
     fn drop(&mut self) {
         if let Self::Property {
@@ -159,7 +171,8 @@ pub struct WinUiRuntime {
     drop_policies: Rc<RefCell<HashMap<NodeId, DragDropPolicy>>>,
     flyouts: HashMap<NodeId, (bindings::Flyout, NodeId)>,
     owned_menus: HashMap<NodeId, NativeOwnedMenu>,
-    pointer_capture: Rc<RefCell<HashMap<NodeId, bool>>>,
+    pending_focus_states: Rc<RefCell<HashMap<NodeId, ElementFocusState>>>,
+    pointer_policies: Rc<RefCell<HashMap<NodeId, PointerInteractionPolicy>>>,
     routed_callbacks: Rc<RefCell<HashMap<(NodeId, EventId), RoutedEventCallback>>>,
     resource_override_keys: HashMap<NodeId, HashSet<String>>,
     command_bar_flyouts: HashMap<NodeId, NativeCommandBarFlyout>,
@@ -1316,6 +1329,44 @@ impl WinUiRuntime {
         Ok(())
     }
 
+    fn set_pointer_policy(
+        &self,
+        node: NodeId,
+        property: PropertyId,
+        value: &PropertyValue,
+    ) -> Result<(), RuntimeError> {
+        let PropertyValue::Bool(value) = value else {
+            return Err(RuntimeError::UnsupportedKind);
+        };
+        let element = self.ui_element(node)?;
+        let mut policy = self
+            .pointer_policies
+            .borrow()
+            .get(&node)
+            .copied()
+            .unwrap_or_default();
+        match property {
+            PropertyId::BorderCapturePointerOnPress => {
+                policy.capture = *value;
+                if !value {
+                    element.ReleasePointerCaptures().map_err(native_error)?;
+                }
+            }
+            PropertyId::BorderFocusOnPointerRelease => policy.focus_on_release = *value,
+            _ => return Err(RuntimeError::UnsupportedKind),
+        }
+        if policy.is_empty() {
+            self.pointer_policies.borrow_mut().remove(&node);
+        } else {
+            self.pointer_policies.borrow_mut().insert(node, policy);
+        }
+        Ok(())
+    }
+
+    fn clear_pointer_policy(&self, node: NodeId, property: PropertyId) -> Result<(), RuntimeError> {
+        self.set_pointer_policy(node, property, &PropertyValue::Bool(false))
+    }
+
     fn apply_one(&mut self, command: &Command) -> Result<(), RuntimeError> {
         match command {
             Command::CreateApplication { node } => {
@@ -1497,9 +1548,43 @@ impl WinUiRuntime {
 
             Command::Focus { node, completion } => {
                 let result = self.ui_element(*node).and_then(|element| {
-                    element
+                    self.pending_focus_states
+                        .borrow_mut()
+                        .insert(*node, ElementFocusState::Programmatic);
+                    match element
                         .Focus(FocusState::Programmatic)
                         .map_err(native_error)
+                    {
+                        Ok(true) => {
+                            let pending = Rc::clone(&self.pending_focus_states);
+                            let focus_node = *node;
+                            let cleanup = DispatcherQueueHandler::new(move || {
+                                pending.borrow_mut().remove(&focus_node);
+                            });
+                            let accepted = DispatcherQueue::GetForCurrentThread()
+                                .and_then(|dispatcher| {
+                                    dispatcher.TryEnqueueWithPriority(
+                                        DispatcherQueuePriority::Low,
+                                        &cleanup,
+                                    )
+                                })
+                                .map_err(native_error)?;
+                            if accepted {
+                                Ok(true)
+                            } else {
+                                self.pending_focus_states.borrow_mut().remove(node);
+                                Err(RuntimeError::DispatcherRejected)
+                            }
+                        }
+                        Ok(false) => {
+                            self.pending_focus_states.borrow_mut().remove(node);
+                            Ok(false)
+                        }
+                        Err(error) => {
+                            self.pending_focus_states.borrow_mut().remove(node);
+                            Err(error)
+                        }
+                    }
                 });
                 _ = completion.call(result);
             }
@@ -1948,21 +2033,12 @@ impl WinUiRuntime {
                         .insert((*node, event), expectation);
                 }
                 let (result, observation) = self.with_selection_suppressed(selection_owner, || {
-                    let result = if *property == PropertyId::BorderCapturePointerOnPress {
-                        match value {
-                            PropertyValue::Bool(true) => self.ui_element(*node).map(|_| {
-                                self.pointer_capture.borrow_mut().insert(*node, true);
-                            }),
-                            PropertyValue::Bool(false) => self
-                                .ui_element(*node)
-                                .and_then(|element| {
-                                    element.ReleasePointerCaptures().map_err(native_error)
-                                })
-                                .map(|_| {
-                                    self.pointer_capture.borrow_mut().remove(node);
-                                }),
-                            _ => Err(RuntimeError::UnsupportedKind),
-                        }
+                    let result = if matches!(
+                        property,
+                        PropertyId::BorderCapturePointerOnPress
+                            | PropertyId::BorderFocusOnPointerRelease
+                    ) {
+                        self.set_pointer_policy(*node, *property, value)
                     } else if *property == PropertyId::BorderAllowDrop {
                         match value {
                             PropertyValue::DragDropPolicy(policy) => self
@@ -2041,12 +2117,12 @@ impl WinUiRuntime {
                         .insert((*node, event), expectation);
                 }
                 let result = self.with_selection_suppressed(selection_owner, || {
-                    let result = if *property == PropertyId::BorderCapturePointerOnPress {
-                        self.ui_element(*node)?
-                            .ReleasePointerCaptures()
-                            .map_err(native_error)?;
-                        self.pointer_capture.borrow_mut().remove(node);
-                        Ok(())
+                    let result = if matches!(
+                        property,
+                        PropertyId::BorderCapturePointerOnPress
+                            | PropertyId::BorderFocusOnPointerRelease
+                    ) {
+                        self.clear_pointer_policy(*node, *property)
                     } else if *property == PropertyId::BorderAllowDrop {
                         self.ui_element(*node)?
                             .SetAllowDrop(false)
@@ -3027,7 +3103,8 @@ impl WinUiRuntime {
             encoded_image_nodes: Rc::clone(&self.encoded_image_nodes),
             feedback: Rc::clone(&self.feedback),
             content_dialogs: Rc::clone(&self.content_dialogs),
-            pointer_capture: Rc::clone(&self.pointer_capture),
+            pending_focus_states: Rc::clone(&self.pending_focus_states),
+            pointer_policies: Rc::clone(&self.pointer_policies),
             routed_callbacks: Rc::clone(&self.routed_callbacks),
             selection_items: Rc::clone(&self.selection_items),
             dispatcher,
@@ -3110,7 +3187,8 @@ pub struct EventSink {
     encoded_image_nodes: Rc<RefCell<HashSet<NodeId>>>,
     feedback: Rc<RefCell<HashMap<(NodeId, EventId), FeedbackExpectation>>>,
     content_dialogs: Rc<RefCell<ContentDialogScheduler>>,
-    pointer_capture: Rc<RefCell<HashMap<NodeId, bool>>>,
+    pending_focus_states: Rc<RefCell<HashMap<NodeId, ElementFocusState>>>,
+    pointer_policies: Rc<RefCell<HashMap<NodeId, PointerInteractionPolicy>>>,
     routed_callbacks: Rc<RefCell<HashMap<(NodeId, EventId), RoutedEventCallback>>>,
     selection_items: Rc<RefCell<Vec<(NodeId, windows_core::IInspectable)>>>,
     dispatcher: DispatcherQueue,
@@ -3199,13 +3277,16 @@ impl EventSink {
         }
     }
 
-    pub fn capture_pointer_on_press(
+    pub fn apply_pointer_press_policy(
         &self,
         node: NodeId,
         element: &UIElement,
         args: windows_core::InRef<'_, PointerRoutedEventArgs>,
     ) -> Result<bool, RuntimeError> {
-        if !self.pointer_capture.borrow().contains_key(&node) {
+        let Some(policy) = self.pointer_policies.borrow().get(&node).copied() else {
+            return Ok(false);
+        };
+        if !policy.capture {
             return Ok(false);
         }
         let Some(args) = args.as_ref() else {
@@ -3215,22 +3296,85 @@ impl EventSink {
         element.CapturePointer(&pointer).map_err(native_error)
     }
 
-    pub fn release_pointer_after_event(
+    pub fn apply_pointer_release_policy(
         &self,
         node: NodeId,
+        event: EventId,
+        revision: u32,
         element: &UIElement,
         args: windows_core::InRef<'_, PointerRoutedEventArgs>,
     ) -> Result<(), RuntimeError> {
-        if !self.pointer_capture.borrow().contains_key(&node) {
-            return Ok(());
-        }
-        let Some(args) = args.as_ref() else {
+        let Some(policy) = self.pointer_policies.borrow().get(&node).copied() else {
             return Ok(());
         };
-        let pointer = args.Pointer().map_err(native_error)?;
-        element
-            .ReleasePointerCapture(&pointer)
-            .map_err(native_error)
+        if policy.capture
+            && let Some(args) = args.as_ref()
+        {
+            let pointer = args.Pointer().map_err(native_error)?;
+            element
+                .ReleasePointerCapture(&pointer)
+                .map_err(native_error)?;
+        }
+        if policy.focus_on_release {
+            let sink = self.clone();
+            let element = element.clone();
+            let handler = DispatcherQueueHandler::new(move || {
+                if sink.current_identity.get() != Some(sink.identity)
+                    || !sink
+                        .pointer_policies
+                        .borrow()
+                        .get(&node)
+                        .is_some_and(|policy| policy.focus_on_release)
+                {
+                    return;
+                }
+                sink.pending_focus_states
+                    .borrow_mut()
+                    .insert(node, ElementFocusState::Pointer);
+                match element.Focus(FocusState::Pointer).map_err(native_error) {
+                    Ok(true) => {
+                        let pending = Rc::clone(&sink.pending_focus_states);
+                        let cleanup = DispatcherQueueHandler::new(move || {
+                            pending.borrow_mut().remove(&node);
+                        });
+                        match sink
+                            .dispatcher
+                            .TryEnqueueWithPriority(DispatcherQueuePriority::Low, &cleanup)
+                            .map_err(native_error)
+                        {
+                            Ok(true) => {}
+                            Ok(false) => {
+                                sink.pending_focus_states.borrow_mut().remove(&node);
+                                sink.error(node, event, revision, RuntimeError::DispatcherRejected);
+                            }
+                            Err(error) => {
+                                sink.pending_focus_states.borrow_mut().remove(&node);
+                                sink.error(node, event, revision, error);
+                            }
+                        }
+                    }
+                    Ok(false) => {
+                        sink.pending_focus_states.borrow_mut().remove(&node);
+                    }
+                    Err(error) => {
+                        sink.pending_focus_states.borrow_mut().remove(&node);
+                        sink.error(node, event, revision, error);
+                    }
+                }
+            });
+            let accepted = self
+                .dispatcher
+                .TryEnqueueWithPriority(DispatcherQueuePriority::Normal, &handler)
+                .map_err(native_error)?;
+            if !accepted {
+                return Err(RuntimeError::DispatcherRejected);
+            }
+        }
+        Ok(())
+    }
+
+    pub fn take_pending_focus_state(&self, node: NodeId) -> Option<ElementFocusState> {
+        self.pending_focus_states.borrow_mut().remove(&node)
     }
 
     fn content_dialog_root_ready(
@@ -3789,7 +3933,8 @@ impl NativeRuntime for WinUiRuntime {
         self.host_events.borrow_mut().clear();
         self.feedback.borrow_mut().clear();
         self.drop_policies.borrow_mut().clear();
-        self.pointer_capture.borrow_mut().clear();
+        self.pending_focus_states.borrow_mut().clear();
+        self.pointer_policies.borrow_mut().clear();
         self.routed_callbacks.borrow_mut().clear();
         self.resource_override_keys.clear();
         self.controlled_collection_indices.clear();
@@ -4190,7 +4335,8 @@ impl WinUiRuntime {
         self.observation_subscriptions
             .retain(|(subscription_node, _), _| *subscription_node != node);
         self.drop_policies.borrow_mut().remove(&node);
-        self.pointer_capture.borrow_mut().remove(&node);
+        self.pending_focus_states.borrow_mut().remove(&node);
+        self.pointer_policies.borrow_mut().remove(&node);
         self.routed_callbacks
             .borrow_mut()
             .retain(|(callback_node, _), _| *callback_node != node);
@@ -4381,15 +4527,26 @@ fn character_event_info(
 fn focus_event_info(
     element: &UIElement,
     args: &RoutedEventArgs,
+    pending_focus_state: Option<ElementFocusState>,
+    got_focus: bool,
 ) -> windows_core::Result<FocusEventInfo> {
     let original = args.OriginalSource()?;
     let is_direct =
         element.cast::<windows_core::IUnknown>()? == original.cast::<windows_core::IUnknown>()?;
-    let state = match element.FocusState()? {
-        FocusState::Pointer => ElementFocusState::Pointer,
-        FocusState::Keyboard => ElementFocusState::Keyboard,
-        FocusState::Programmatic => ElementFocusState::Programmatic,
-        _ => ElementFocusState::Unfocused,
+    let state = if got_focus {
+        // FocusState can still describe the previous state while GotFocus is being raised.
+        if let Some(state) = pending_focus_state {
+            state
+        } else {
+            match element.FocusState()? {
+                FocusState::Pointer => ElementFocusState::Pointer,
+                FocusState::Keyboard => ElementFocusState::Keyboard,
+                FocusState::Programmatic => ElementFocusState::Programmatic,
+                _ => ElementFocusState::Unfocused,
+            }
+        }
+    } else {
+        ElementFocusState::Unfocused
     };
     Ok(FocusEventInfo { state, is_direct })
 }

--- a/crates/libs/reactor/src/native/winui/mod.rs
+++ b/crates/libs/reactor/src/native/winui/mod.rs
@@ -8,6 +8,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 
 use super::*;
+use crate::VirtualKey as ReactorVirtualKey;
 use windows_core::Interface;
 
 windows_core::link!("kernel32.dll" "system" fn FindResourceW(module: *mut std::ffi::c_void, name: *const u16, resource_type: *const u16) -> *mut std::ffi::c_void);
@@ -159,6 +160,7 @@ pub struct WinUiRuntime {
     flyouts: HashMap<NodeId, (bindings::Flyout, NodeId)>,
     owned_menus: HashMap<NodeId, NativeOwnedMenu>,
     pointer_capture: Rc<RefCell<HashMap<NodeId, bool>>>,
+    routed_callbacks: Rc<RefCell<HashMap<(NodeId, EventId), RoutedEventCallback>>>,
     resource_override_keys: HashMap<NodeId, HashSet<String>>,
     command_bar_flyouts: HashMap<NodeId, NativeCommandBarFlyout>,
     identity: Rc<Cell<Option<WindowToken>>>,
@@ -1267,30 +1269,30 @@ impl WinUiRuntime {
             let value = KeyboardAccelerator::new().map_err(native_error)?;
             value
                 .SetKey(match accelerator.key {
-                    AcceleratorKey::Left => VirtualKey::Left,
-                    AcceleratorKey::Up => VirtualKey::Up,
-                    AcceleratorKey::Right => VirtualKey::Right,
-                    AcceleratorKey::Down => VirtualKey::Down,
-                    AcceleratorKey::Space => VirtualKey::Space,
-                    AcceleratorKey::N => VirtualKey::N,
-                    AcceleratorKey::P => VirtualKey::P,
-                    AcceleratorKey::R => VirtualKey::R,
-                    AcceleratorKey::NumberPad0 => VirtualKey::NumberPad0,
-                    AcceleratorKey::NumberPad1 => VirtualKey::NumberPad1,
-                    AcceleratorKey::NumberPad2 => VirtualKey::NumberPad2,
-                    AcceleratorKey::NumberPad3 => VirtualKey::NumberPad3,
-                    AcceleratorKey::NumberPad4 => VirtualKey::NumberPad4,
-                    AcceleratorKey::NumberPad5 => VirtualKey::NumberPad5,
-                    AcceleratorKey::NumberPad6 => VirtualKey::NumberPad6,
-                    AcceleratorKey::NumberPad7 => VirtualKey::NumberPad7,
-                    AcceleratorKey::NumberPad8 => VirtualKey::NumberPad8,
-                    AcceleratorKey::NumberPad9 => VirtualKey::NumberPad9,
-                    AcceleratorKey::Divide => VirtualKey::Divide,
-                    AcceleratorKey::Multiply => VirtualKey::Multiply,
-                    AcceleratorKey::Subtract => VirtualKey::Subtract,
-                    AcceleratorKey::Add => VirtualKey::Add,
-                    AcceleratorKey::Decimal => VirtualKey::Decimal,
-                    AcceleratorKey::Enter => VirtualKey::Enter,
+                    AcceleratorKey::Left => bindings::VirtualKey::Left,
+                    AcceleratorKey::Up => bindings::VirtualKey::Up,
+                    AcceleratorKey::Right => bindings::VirtualKey::Right,
+                    AcceleratorKey::Down => bindings::VirtualKey::Down,
+                    AcceleratorKey::Space => bindings::VirtualKey::Space,
+                    AcceleratorKey::N => bindings::VirtualKey::N,
+                    AcceleratorKey::P => bindings::VirtualKey::P,
+                    AcceleratorKey::R => bindings::VirtualKey::R,
+                    AcceleratorKey::NumberPad0 => bindings::VirtualKey::NumberPad0,
+                    AcceleratorKey::NumberPad1 => bindings::VirtualKey::NumberPad1,
+                    AcceleratorKey::NumberPad2 => bindings::VirtualKey::NumberPad2,
+                    AcceleratorKey::NumberPad3 => bindings::VirtualKey::NumberPad3,
+                    AcceleratorKey::NumberPad4 => bindings::VirtualKey::NumberPad4,
+                    AcceleratorKey::NumberPad5 => bindings::VirtualKey::NumberPad5,
+                    AcceleratorKey::NumberPad6 => bindings::VirtualKey::NumberPad6,
+                    AcceleratorKey::NumberPad7 => bindings::VirtualKey::NumberPad7,
+                    AcceleratorKey::NumberPad8 => bindings::VirtualKey::NumberPad8,
+                    AcceleratorKey::NumberPad9 => bindings::VirtualKey::NumberPad9,
+                    AcceleratorKey::Divide => bindings::VirtualKey::Divide,
+                    AcceleratorKey::Multiply => bindings::VirtualKey::Multiply,
+                    AcceleratorKey::Subtract => bindings::VirtualKey::Subtract,
+                    AcceleratorKey::Add => bindings::VirtualKey::Add,
+                    AcceleratorKey::Decimal => bindings::VirtualKey::Decimal,
+                    AcceleratorKey::Enter => bindings::VirtualKey::Enter,
                 })
                 .map_err(native_error)?;
             value
@@ -2459,6 +2461,18 @@ impl WinUiRuntime {
                 Some(slot) => self.move_slot_child(*parent, *slot, *child, *index)?,
                 None => self.move_child(*parent, *child, *index)?,
             },
+            Command::SetRoutedCallback {
+                node,
+                event,
+                callback,
+            } => {
+                let mut callbacks = self.routed_callbacks.borrow_mut();
+                if let Some(callback) = callback {
+                    callbacks.insert((*node, *event), callback.clone());
+                } else {
+                    callbacks.remove(&(*node, *event));
+                }
+            }
         }
         Ok(())
     }
@@ -3014,6 +3028,7 @@ impl WinUiRuntime {
             feedback: Rc::clone(&self.feedback),
             content_dialogs: Rc::clone(&self.content_dialogs),
             pointer_capture: Rc::clone(&self.pointer_capture),
+            routed_callbacks: Rc::clone(&self.routed_callbacks),
             selection_items: Rc::clone(&self.selection_items),
             dispatcher,
             identity,
@@ -3096,6 +3111,7 @@ pub struct EventSink {
     feedback: Rc<RefCell<HashMap<(NodeId, EventId), FeedbackExpectation>>>,
     content_dialogs: Rc<RefCell<ContentDialogScheduler>>,
     pointer_capture: Rc<RefCell<HashMap<NodeId, bool>>>,
+    routed_callbacks: Rc<RefCell<HashMap<(NodeId, EventId), RoutedEventCallback>>>,
     selection_items: Rc<RefCell<Vec<(NodeId, windows_core::IInspectable)>>>,
     dispatcher: DispatcherQueue,
     identity: WindowToken,
@@ -3271,6 +3287,76 @@ impl EventSink {
             work: QueuedEvent::new(node, event, revision, payload),
         });
         self.schedule();
+    }
+
+    pub fn route_key(
+        &self,
+        node: NodeId,
+        event: EventId,
+        revision: u32,
+        value: KeyEventInfo,
+    ) -> bool {
+        self.route(
+            node,
+            event,
+            revision,
+            EventPayload::KeyEventInfo(value),
+            |callback| callback.key(value),
+        )
+    }
+
+    pub fn route_character(
+        &self,
+        node: NodeId,
+        event: EventId,
+        revision: u32,
+        value: CharacterEventInfo,
+    ) -> bool {
+        self.route(
+            node,
+            event,
+            revision,
+            EventPayload::CharacterEventInfo(value),
+            |callback| callback.character(value),
+        )
+    }
+
+    fn route(
+        &self,
+        node: NodeId,
+        event: EventId,
+        revision: u32,
+        payload: EventPayload,
+        invoke: impl FnOnce(&RoutedEventCallback) -> Option<RoutedDispatch>,
+    ) -> bool {
+        if self.current_identity.get() != Some(self.identity) {
+            return false;
+        }
+        let callback = self.routed_callbacks.borrow().get(&(node, event)).cloned();
+        let Some(callback) = callback else {
+            return false;
+        };
+        let dispatch =
+            match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| invoke(&callback))) {
+                Ok(Some(dispatch)) => dispatch,
+                Ok(None) => return false,
+                Err(_) => std::process::abort(),
+            };
+        if let Some(message) = dispatch.message {
+            self.queue.borrow_mut().push(NativeWork {
+                identity: self.identity,
+                work: QueuedEvent::routed(
+                    node,
+                    event,
+                    revision,
+                    payload,
+                    message,
+                    dispatch.handled,
+                ),
+            });
+            self.schedule();
+        }
+        dispatch.handled
     }
 
     pub fn observe(&self, node: NodeId, event: EventId, revision: u32, payload: EventPayload) {
@@ -3604,6 +3690,7 @@ impl NativeRuntime for WinUiRuntime {
                 continue;
             }
             if let Err(error) = self.apply_one(command) {
+                self.routed_callbacks.borrow_mut().clear();
                 eprintln!("windows-reactor failed command {index}: {command:?}: {error:?}");
                 return Err(NativeApplyError {
                     command: index,
@@ -3703,6 +3790,7 @@ impl NativeRuntime for WinUiRuntime {
         self.feedback.borrow_mut().clear();
         self.drop_policies.borrow_mut().clear();
         self.pointer_capture.borrow_mut().clear();
+        self.routed_callbacks.borrow_mut().clear();
         self.resource_override_keys.clear();
         self.controlled_collection_indices.clear();
         self.selection_owners.clear();
@@ -4103,6 +4191,9 @@ impl WinUiRuntime {
             .retain(|(subscription_node, _), _| *subscription_node != node);
         self.drop_policies.borrow_mut().remove(&node);
         self.pointer_capture.borrow_mut().remove(&node);
+        self.routed_callbacks
+            .borrow_mut()
+            .retain(|(callback_node, _), _| *callback_node != node);
         if self.resource_override_keys.contains_key(&node) {
             self.clear_resource_overrides(node)?;
         }
@@ -4234,6 +4325,73 @@ fn native_drag_operation(operation: DragDropOperation) -> DataPackageOperation {
         DragDropOperation::Move => DataPackageOperation::Move,
         DragDropOperation::Link => DataPackageOperation::Link,
     }
+}
+
+fn input_modifiers() -> InputModifiers {
+    let mut keys = [0u8; 256];
+    if !unsafe { GetKeyboardState(keys.as_mut_ptr()) }.as_bool() {
+        return InputModifiers::NONE;
+    }
+    let mut modifiers = InputModifiers::NONE;
+    if keys[0x10] & 0x80 != 0 {
+        modifiers |= InputModifiers::SHIFT;
+    }
+    if keys[0x11] & 0x80 != 0 {
+        modifiers |= InputModifiers::CONTROL;
+    }
+    if keys[0x12] & 0x80 != 0 {
+        modifiers |= InputModifiers::ALT;
+    }
+    if keys[0x5b] & 0x80 != 0 || keys[0x5c] & 0x80 != 0 {
+        modifiers |= InputModifiers::WINDOWS;
+    }
+    modifiers
+}
+
+fn physical_key_status(value: CorePhysicalKeyStatus) -> PhysicalKeyStatus {
+    PhysicalKeyStatus {
+        repeat_count: value.repeat_count,
+        scan_code: value.scan_code,
+        is_extended: value.is_extended_key,
+        is_menu_down: value.is_menu_key_down,
+        was_down: value.was_key_down,
+        is_released: value.is_key_released,
+    }
+}
+
+fn key_event_info(args: &KeyRoutedEventArgs) -> windows_core::Result<KeyEventInfo> {
+    Ok(KeyEventInfo {
+        key: ReactorVirtualKey(args.Key()?.0 as u32),
+        original_key: ReactorVirtualKey(args.OriginalKey()?.0 as u32),
+        status: physical_key_status(args.KeyStatus()?),
+        modifiers: input_modifiers(),
+    })
+}
+
+fn character_event_info(
+    args: &CharacterReceivedRoutedEventArgs,
+) -> windows_core::Result<CharacterEventInfo> {
+    Ok(CharacterEventInfo {
+        character: args.Character()?,
+        status: physical_key_status(args.KeyStatus()?),
+        modifiers: input_modifiers(),
+    })
+}
+
+fn focus_event_info(
+    element: &UIElement,
+    args: &RoutedEventArgs,
+) -> windows_core::Result<FocusEventInfo> {
+    let original = args.OriginalSource()?;
+    let is_direct =
+        element.cast::<windows_core::IUnknown>()? == original.cast::<windows_core::IUnknown>()?;
+    let state = match element.FocusState()? {
+        FocusState::Pointer => ElementFocusState::Pointer,
+        FocusState::Keyboard => ElementFocusState::Keyboard,
+        FocusState::Programmatic => ElementFocusState::Programmatic,
+        _ => ElementFocusState::Unfocused,
+    };
+    Ok(FocusEventInfo { state, is_direct })
 }
 
 fn native_error(error: windows_core::Error) -> RuntimeError {

--- a/crates/libs/reactor/src/native/winui/mod.rs
+++ b/crates/libs/reactor/src/native/winui/mod.rs
@@ -4473,10 +4473,10 @@ fn native_drag_operation(operation: DragDropOperation) -> DataPackageOperation {
     }
 }
 
-fn input_modifiers() -> InputModifiers {
+fn input_modifiers() -> windows_core::Result<InputModifiers> {
     let mut keys = [0u8; 256];
     if !unsafe { GetKeyboardState(keys.as_mut_ptr()) }.as_bool() {
-        return InputModifiers::NONE;
+        return Err(windows_core::Error::from_thread());
     }
     let mut modifiers = InputModifiers::NONE;
     if keys[0x10] & 0x80 != 0 {
@@ -4491,7 +4491,7 @@ fn input_modifiers() -> InputModifiers {
     if keys[0x5b] & 0x80 != 0 || keys[0x5c] & 0x80 != 0 {
         modifiers |= InputModifiers::WINDOWS;
     }
-    modifiers
+    Ok(modifiers)
 }
 
 fn physical_key_status(value: CorePhysicalKeyStatus) -> PhysicalKeyStatus {
@@ -4510,7 +4510,7 @@ fn key_event_info(args: &KeyRoutedEventArgs) -> windows_core::Result<KeyEventInf
         key: ReactorVirtualKey(args.Key()?.0 as u32),
         original_key: ReactorVirtualKey(args.OriginalKey()?.0 as u32),
         status: physical_key_status(args.KeyStatus()?),
-        modifiers: input_modifiers(),
+        modifiers: input_modifiers()?,
     })
 }
 
@@ -4520,7 +4520,7 @@ fn character_event_info(
     Ok(CharacterEventInfo {
         character: args.Character()?,
         status: physical_key_status(args.KeyStatus()?),
-        modifiers: input_modifiers(),
+        modifiers: input_modifiers()?,
     })
 }
 

--- a/crates/libs/reactor/src/native/winui/test.rs
+++ b/crates/libs/reactor/src/native/winui/test.rs
@@ -3,6 +3,7 @@ use windows_core::EventRevoker;
 
 const INPUT_PROBE_SUBCLASS_ID: usize = 0x0052_5449_4E50_5554;
 const WM_KEYDOWN: u32 = 0x0100;
+const WM_CHAR: u32 = 0x0102;
 const WM_SYSKEYDOWN: u32 = 0x0104;
 
 type SubclassProc = Option<
@@ -17,12 +18,17 @@ windows_core::link!("user32.dll" "system" fn GetFocus() -> *mut std::ffi::c_void
 thread_local! {
     static INPUT_PROBE_CALLBACK: RefCell<Option<Rc<dyn Fn(LiveInputProbeStage)>>> =
         const { RefCell::new(None) };
+    static TEXT_INPUT_PENDING: Cell<usize> = const { Cell::new(0) };
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum LiveInputProbeStage {
     RawWindowMessage,
     InputKeyboardSource,
+    RawCharacter,
+    NativeTextChanged,
+    NativeTextReady,
+    ReactorDispatchComplete,
 }
 
 pub struct LiveInputProbe {
@@ -78,6 +84,7 @@ impl Drop for LiveInputProbe {
             );
         }
         let _ = INPUT_PROBE_CALLBACK.try_with(|callback| callback.borrow_mut().take());
+        let _ = TEXT_INPUT_PENDING.try_with(|pending| pending.set(0));
     }
 }
 
@@ -90,13 +97,29 @@ unsafe extern "system" fn live_input_probe_subclass(
     _data: usize,
 ) -> isize {
     if matches!(message, WM_KEYDOWN | WM_SYSKEYDOWN) {
-        let _ = INPUT_PROBE_CALLBACK.try_with(|callback| {
-            if let Some(callback) = callback.borrow().as_ref() {
-                callback(LiveInputProbeStage::RawWindowMessage);
-            }
-        });
+        record_live_input_probe_stage(LiveInputProbeStage::RawWindowMessage);
+    } else if message == WM_CHAR {
+        record_live_input_probe_stage(LiveInputProbeStage::RawCharacter);
     }
     unsafe { DefSubclassProc(hwnd, message, wparam, lparam) }
+}
+
+pub(crate) fn record_live_input_probe_stage(stage: LiveInputProbeStage) {
+    if stage == LiveInputProbeStage::NativeTextChanged {
+        TEXT_INPUT_PENDING.with(|pending| pending.set(pending.get() + 1));
+    }
+    let _ = INPUT_PROBE_CALLBACK.try_with(|callback| {
+        if let Some(callback) = callback.borrow().as_ref() {
+            callback(stage);
+        }
+    });
+}
+
+pub(crate) fn finish_live_text_input_dispatch() {
+    let pending = TEXT_INPUT_PENDING.with(|pending| pending.replace(0));
+    for _ in 0..pending {
+        record_live_input_probe_stage(LiveInputProbeStage::ReactorDispatchComplete);
+    }
 }
 
 pub(crate) fn native_window_handle(window: &Window) -> windows_core::Result<isize> {
@@ -131,6 +154,7 @@ pub(crate) fn subscribe_live_input_probe(
             "only one live input probe may be active"
         );
     });
+    TEXT_INPUT_PENDING.with(|pending| pending.set(0));
     if unsafe {
         SetWindowSubclass(
             hwnd,

--- a/crates/libs/reactor/src/native/winui/test.rs
+++ b/crates/libs/reactor/src/native/winui/test.rs
@@ -1,6 +1,104 @@
 use super::*;
 use windows_core::EventRevoker;
 
+const INPUT_PROBE_SUBCLASS_ID: usize = 0x0052_5449_4E50_5554;
+const WM_KEYDOWN: u32 = 0x0100;
+const WM_SYSKEYDOWN: u32 = 0x0104;
+
+type SubclassProc = Option<
+    unsafe extern "system" fn(*mut std::ffi::c_void, u32, usize, isize, usize, usize) -> isize,
+>;
+
+windows_core::link!("comctl32.dll" "system" fn DefSubclassProc(hwnd: *mut std::ffi::c_void, message: u32, wparam: usize, lparam: isize) -> isize);
+windows_core::link!("comctl32.dll" "system" fn RemoveWindowSubclass(hwnd: *mut std::ffi::c_void, callback: SubclassProc, id: usize) -> i32);
+windows_core::link!("comctl32.dll" "system" fn SetWindowSubclass(hwnd: *mut std::ffi::c_void, callback: SubclassProc, id: usize, data: usize) -> i32);
+windows_core::link!("user32.dll" "system" fn GetFocus() -> *mut std::ffi::c_void);
+
+thread_local! {
+    static INPUT_PROBE_CALLBACK: RefCell<Option<Rc<dyn Fn(LiveInputProbeStage)>>> =
+        const { RefCell::new(None) };
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum LiveInputProbeStage {
+    RawWindowMessage,
+    InputKeyboardSource,
+}
+
+pub struct LiveInputProbe {
+    input_hwnd: *mut std::ffi::c_void,
+    window_hwnd: *mut std::ffi::c_void,
+    _keyboard: EventRevoker,
+}
+
+impl LiveInputProbe {
+    pub fn window_handle(&self) -> isize {
+        self.window_hwnd as isize
+    }
+
+    pub fn retarget_raw_input(&mut self) -> windows_core::Result<()> {
+        let input_hwnd = unsafe { GetFocus() };
+        if input_hwnd.is_null() {
+            return Err(windows_core::Error::from_thread());
+        }
+        if input_hwnd == self.input_hwnd {
+            return Ok(());
+        }
+
+        if unsafe {
+            SetWindowSubclass(
+                input_hwnd,
+                Some(live_input_probe_subclass),
+                INPUT_PROBE_SUBCLASS_ID,
+                0,
+            )
+        } == 0
+        {
+            return Err(windows_core::Error::from_thread());
+        }
+        unsafe {
+            RemoveWindowSubclass(
+                self.input_hwnd,
+                Some(live_input_probe_subclass),
+                INPUT_PROBE_SUBCLASS_ID,
+            );
+        }
+        self.input_hwnd = input_hwnd;
+        Ok(())
+    }
+}
+
+impl Drop for LiveInputProbe {
+    fn drop(&mut self) {
+        unsafe {
+            RemoveWindowSubclass(
+                self.input_hwnd,
+                Some(live_input_probe_subclass),
+                INPUT_PROBE_SUBCLASS_ID,
+            );
+        }
+        let _ = INPUT_PROBE_CALLBACK.try_with(|callback| callback.borrow_mut().take());
+    }
+}
+
+unsafe extern "system" fn live_input_probe_subclass(
+    hwnd: *mut std::ffi::c_void,
+    message: u32,
+    wparam: usize,
+    lparam: isize,
+    _id: usize,
+    _data: usize,
+) -> isize {
+    if matches!(message, WM_KEYDOWN | WM_SYSKEYDOWN) {
+        let _ = INPUT_PROBE_CALLBACK.try_with(|callback| {
+            if let Some(callback) = callback.borrow().as_ref() {
+                callback(LiveInputProbeStage::RawWindowMessage);
+            }
+        });
+    }
+    unsafe { DefSubclassProc(hwnd, message, wparam, lparam) }
+}
+
 pub(crate) fn native_window_handle(window: &Window) -> windows_core::Result<isize> {
     let mut hwnd = std::ptr::null_mut();
     unsafe {
@@ -10,6 +108,47 @@ pub(crate) fn native_window_handle(window: &Window) -> windows_core::Result<isiz
             .ok()?;
     }
     Ok(hwnd as isize)
+}
+
+pub(crate) fn subscribe_live_input_probe(
+    window: &Window,
+    callback: impl Fn(LiveInputProbeStage) + 'static,
+) -> windows_core::Result<LiveInputProbe> {
+    let callback: Rc<dyn Fn(LiveInputProbeStage)> = Rc::new(callback);
+    let content = window.Content()?.cast::<UIElement>()?;
+    let island = content.XamlRoot()?.cast::<IXamlRoot4>()?.ContentIsland()?;
+    let keyboard = InputKeyboardSource::GetForIsland(&island)?
+        .cast::<IInputKeyboardSource2>()?
+        .KeyDown({
+            let callback = Rc::clone(&callback);
+            move |_, _| callback(LiveInputProbeStage::InputKeyboardSource)
+        })?;
+    let hwnd = native_window_handle(window)? as *mut std::ffi::c_void;
+
+    INPUT_PROBE_CALLBACK.with(|slot| {
+        assert!(
+            slot.borrow_mut().replace(callback).is_none(),
+            "only one live input probe may be active"
+        );
+    });
+    if unsafe {
+        SetWindowSubclass(
+            hwnd,
+            Some(live_input_probe_subclass),
+            INPUT_PROBE_SUBCLASS_ID,
+            0,
+        )
+    } == 0
+    {
+        INPUT_PROBE_CALLBACK.with(|callback| callback.borrow_mut().take());
+        return Err(windows_core::Error::from_thread());
+    }
+
+    Ok(LiveInputProbe {
+        input_hwnd: hwnd,
+        window_hwnd: hwnd,
+        _keyboard: keyboard,
+    })
 }
 
 pub fn subscribe_live_rendering<F>(rendering: F) -> windows_core::Result<EventRevoker>

--- a/crates/libs/reactor/src/native/winui/test.rs
+++ b/crates/libs/reactor/src/native/winui/test.rs
@@ -1,7 +1,7 @@
 use super::*;
 use windows_core::EventRevoker;
 
-const INPUT_PROBE_SUBCLASS_ID: usize = 0x0052_5449_4E50_5554;
+const INPUT_PROBE_SUBCLASS_ID: usize = 0x5254_4950;
 const WM_KEYDOWN: u32 = 0x0100;
 const WM_CHAR: u32 = 0x0102;
 const WM_SYSKEYDOWN: u32 = 0x0104;

--- a/crates/libs/reactor/src/native/winui/test.rs
+++ b/crates/libs/reactor/src/native/winui/test.rs
@@ -31,6 +31,7 @@ pub enum LiveInputProbeStage {
     ReactorDispatchComplete,
 }
 
+#[must_use = "dropping the probe stops input observation"]
 pub struct LiveInputProbe {
     input_hwnd: *mut std::ffi::c_void,
     window_hwnd: *mut std::ffi::c_void,

--- a/crates/libs/reactor/src/test/mod.rs
+++ b/crates/libs/reactor/src/test/mod.rs
@@ -6,8 +6,8 @@ use crate::core::*;
 #[cfg(feature = "test")]
 pub use crate::app::test::{
     LiveProbe, bring_live_virtual_index, clear_live_performance_times, live_virtual_shell_counts,
-    schedule_live_event_subscription_count, schedule_live_probe, schedule_live_window_handle,
-    take_live_diagnostics, take_live_performance_times,
+    schedule_live_event_subscription_count, schedule_live_input_probe, schedule_live_probe,
+    schedule_live_window_handle, take_live_diagnostics, take_live_performance_times,
 };
 #[cfg(feature = "test")]
 pub use crate::core::{
@@ -18,7 +18,9 @@ pub use crate::generated::{
     EventId, EventPayload, PropertyId, PropertyValue, SelectionChange, SlotId,
 };
 #[cfg(feature = "test")]
-pub use crate::native::{schedule_live_test_exit, subscribe_live_rendering};
+pub use crate::native::{
+    LiveInputProbe, LiveInputProbeStage, schedule_live_test_exit, subscribe_live_rendering,
+};
 #[cfg(test)]
 pub(crate) use recording::RecordedContentDialog;
 pub use recording::RecordingRuntime;

--- a/crates/libs/reactor/src/test/recording/mod.rs
+++ b/crates/libs/reactor/src/test/recording/mod.rs
@@ -38,6 +38,7 @@ pub struct RecordingRuntime {
     identity: Option<WindowToken>,
     realizations: Vec<NativeWork<RealizationRequest>>,
     retained_subtrees: HashMap<NodeId, RecordedRetainedSubtree>,
+    routed_callbacks: HashMap<(NodeId, EventId), RoutedEventCallback>,
     source_revisions: HashMap<NodeId, u64>,
     subscriptions: HashSet<(NodeId, EventId)>,
     tooltips: HashMap<NodeId, (NodeId, TooltipPlacement)>,
@@ -74,6 +75,7 @@ impl Default for RecordingRuntime {
             identity: None,
             realizations: Vec::new(),
             retained_subtrees: HashMap::new(),
+            routed_callbacks: HashMap::new(),
             source_revisions: HashMap::new(),
             subscriptions: HashSet::new(),
             tooltips: HashMap::new(),
@@ -94,6 +96,66 @@ impl RecordingRuntime {
     #[cfg(any(test, feature = "test"))]
     pub fn retained_subtrees(&self) -> usize {
         self.retained_subtrees.len()
+    }
+
+    pub fn route_key(
+        &mut self,
+        node: NodeId,
+        event: EventId,
+        revision: u32,
+        value: KeyEventInfo,
+    ) -> bool {
+        let Some(dispatch) = self
+            .routed_callbacks
+            .get(&(node, event))
+            .and_then(|callback| callback.key(value))
+        else {
+            return false;
+        };
+        if let Some(message) = dispatch.message {
+            self.events.push(NativeWork {
+                identity: self.identity.unwrap(),
+                work: QueuedEvent::routed(
+                    node,
+                    event,
+                    revision,
+                    EventPayload::KeyEventInfo(value),
+                    message,
+                    dispatch.handled,
+                ),
+            });
+        }
+        dispatch.handled
+    }
+
+    pub fn route_character(
+        &mut self,
+        node: NodeId,
+        event: EventId,
+        revision: u32,
+        value: CharacterEventInfo,
+    ) -> bool {
+        let Some(dispatch) = self
+            .routed_callbacks
+            .get(&(node, event))
+            .and_then(|callback| callback.character(value))
+        else {
+            return false;
+        };
+        if let Some(message) = dispatch.message {
+            self.events.push(NativeWork {
+                identity: self.identity.unwrap(),
+                work: QueuedEvent::routed(
+                    node,
+                    event,
+                    revision,
+                    EventPayload::CharacterEventInfo(value),
+                    message,
+                    dispatch.handled,
+                ),
+            });
+        }
+        dispatch.handled
     }
 
     #[cfg(any(test, feature = "test"))]
@@ -672,6 +734,8 @@ impl RecordingRuntime {
                 self.source_revisions.remove(node);
                 self.subscriptions
                     .retain(|(subscription_node, _)| subscription_node != node);
+                self.routed_callbacks
+                    .retain(|(callback_node, _), _| callback_node != node);
                 self.window_titles.remove(node);
                 self.window_title_bars.remove(node);
                 self.window_title_bars
@@ -848,6 +912,18 @@ impl RecordingRuntime {
                     .ok_or(RuntimeError::MissingNode(*node))?;
                 if !self.subscriptions.remove(&(*node, *event)) {
                     return Err(RuntimeError::MissingSubscription(*node, *event));
+                }
+            }
+            Command::SetRoutedCallback {
+                node,
+                event,
+                callback,
+            } => {
+                if let Some(callback) = callback {
+                    self.routed_callbacks
+                        .insert((*node, *event), callback.clone());
+                } else {
+                    self.routed_callbacks.remove(&(*node, *event));
                 }
             }
             Command::SetSlot {
@@ -1322,6 +1398,7 @@ impl NativeRuntime for RecordingRuntime {
         self.nodes.clear();
         self.realizations.clear();
         self.retained_subtrees.clear();
+        self.routed_callbacks.clear();
         self.source_revisions.clear();
         self.subscriptions.clear();
         self.tooltips.clear();

--- a/crates/libs/reactor/src/test/recording/tests.rs
+++ b/crates/libs/reactor/src/test/recording/tests.rs
@@ -48,6 +48,64 @@ fn records_native_property_observations_without_commands() {
 }
 
 #[test]
+fn records_routed_callback_decisions_and_removal() {
+    let mut runtime = RecordingRuntime::default();
+    let event = EventId::BorderPreviewKeyDown;
+    let key = KeyEventInfo {
+        key: VirtualKey::A,
+        original_key: VirtualKey::A,
+        status: PhysicalKeyStatus::default(),
+        modifiers: InputModifiers::NONE,
+    };
+    let character = CharacterEventInfo {
+        character: b'a'.into(),
+        status: PhysicalKeyStatus::default(),
+        modifiers: InputModifiers::NONE,
+    };
+
+    assert!(!runtime.route_key(ROOT, event, 1, key));
+    runtime
+        .apply(&[Command::SetRoutedCallback {
+            node: ROOT,
+            event,
+            callback: Some(RoutedEventCallback::KeyEventInfo(RoutedCallback::new(
+                |_| RoutedDispatch {
+                    message: None,
+                    handled: true,
+                },
+            ))),
+        }])
+        .unwrap();
+    assert!(runtime.route_key(ROOT, event, 1, key));
+    assert!(!runtime.route_character(ROOT, event, 1, character));
+    assert!(runtime.drain_events().is_empty());
+
+    runtime
+        .apply(&[Command::SetRoutedCallback {
+            node: ROOT,
+            event,
+            callback: Some(RoutedEventCallback::CharacterEventInfo(
+                RoutedCallback::new(|_| RoutedDispatch {
+                    message: None,
+                    handled: false,
+                }),
+            )),
+        }])
+        .unwrap();
+    assert!(!runtime.route_key(ROOT, event, 2, key));
+    assert!(!runtime.route_character(ROOT, event, 2, character));
+
+    runtime
+        .apply(&[Command::SetRoutedCallback {
+            node: ROOT,
+            event,
+            callback: None,
+        }])
+        .unwrap();
+    assert!(!runtime.route_character(ROOT, event, 3, character));
+}
+
+#[test]
 fn records_tree_and_property_mutations() {
     let mut runtime = RecordingRuntime::default();
     runtime

--- a/crates/samples/canvas/editor/src/main.rs
+++ b/crates/samples/canvas/editor/src/main.rs
@@ -27,6 +27,7 @@ struct Shape {
     x: f32,
     y: f32,
     color: ColorF,
+    label: Vec<u16>,
     path: Option<Path>,
     built_at: Option<(f32, f32)>,
 }
@@ -38,6 +39,7 @@ impl Shape {
             x,
             y,
             color,
+            label: Vec::new(),
             path: None,
             built_at: None,
         }
@@ -49,6 +51,7 @@ struct Model {
     kind: Kind,
     selected: Option<usize>,
     drag_offset: Option<(f32, f32)>,
+    focused: bool,
     next_color: usize,
 }
 
@@ -59,6 +62,7 @@ impl Model {
             kind: Kind::Star,
             selected: None,
             drag_offset: None,
+            focused: false,
             next_color: 0,
         }
     }
@@ -87,6 +91,11 @@ enum Message {
     Pressed(PointerEventInfo),
     Moved(PointerEventInfo),
     Released,
+    MoveSelected(f32, f32),
+    DeleteSelected,
+    Backspace,
+    Character(u16),
+    FocusChanged(bool),
     Select(Kind),
     Clear,
 }
@@ -139,6 +148,29 @@ impl Component for Sample {
             }
             Message::Moved(_) => {}
             Message::Released => model.drag_offset = None,
+            Message::MoveSelected(dx, dy) => {
+                if let Some(shape) = model.selected.and_then(|index| model.shapes.get_mut(index)) {
+                    shape.x += dx;
+                    shape.y += dy;
+                }
+            }
+            Message::DeleteSelected => {
+                if let Some(index) = model.selected.take() {
+                    model.shapes.remove(index);
+                    model.drag_offset = None;
+                }
+            }
+            Message::Backspace => {
+                if let Some(shape) = model.selected.and_then(|index| model.shapes.get_mut(index)) {
+                    pop_utf16_character(&mut shape.label);
+                }
+            }
+            Message::Character(character) => {
+                if let Some(shape) = model.selected.and_then(|index| model.shapes.get_mut(index)) {
+                    shape.label.push(character);
+                }
+            }
+            Message::FocusChanged(focused) => model.focused = focused,
             Message::Select(kind) => model.kind = kind,
             Message::Clear => {
                 model.shapes.clear();
@@ -153,8 +185,23 @@ impl Component for Sample {
     fn view(&self, _input: &(), context: &mut ViewContext<Self>) -> View {
         context.window_title("Canvas editor");
         context.window_visuals(WindowVisuals::new().backdrop(WindowBackdrop::Mica));
+        let selected = self.model.borrow().selected.is_some();
         let model = Rc::clone(&self.model);
         let surface = Border::new()
+            .is_tab_stop(true)
+            .allow_focus_on_interaction(true)
+            .on_preview_key_down(context.routed_callback(move |info| route_key(info, selected)))
+            .on_character_received(context.routed_callback(move |info: CharacterEventInfo| {
+                if selected && info.character >= 0x20 {
+                    RoutedMessage::handled(Message::Character(info.character))
+                } else {
+                    RoutedMessage::bubble_without_message()
+                }
+            }))
+            .on_got_focus(
+                context.callback(|info: FocusEventInfo| Message::FocusChanged(info.is_direct)),
+            )
+            .on_lost_focus(context.callback(|_| Message::FocusChanged(false)))
             .on_pointer_pressed(context.callback(Message::Pressed))
             .on_pointer_moved(context.callback(Message::Moved))
             .on_pointer_released(context.callback(|_| Message::Released))
@@ -189,6 +236,40 @@ impl Component for Sample {
     }
 }
 
+fn route_key(info: KeyEventInfo, selected: bool) -> RoutedMessage<Message> {
+    if !selected {
+        return RoutedMessage::bubble_without_message();
+    }
+    let distance = if info.modifiers.contains(InputModifiers::SHIFT) {
+        16.0
+    } else {
+        4.0
+    };
+    let message = match info.key {
+        VirtualKey::LEFT => Message::MoveSelected(-distance, 0.0),
+        VirtualKey::UP => Message::MoveSelected(0.0, -distance),
+        VirtualKey::RIGHT => Message::MoveSelected(distance, 0.0),
+        VirtualKey::DOWN => Message::MoveSelected(0.0, distance),
+        VirtualKey::DELETE => Message::DeleteSelected,
+        VirtualKey::BACK => Message::Backspace,
+        _ => return RoutedMessage::bubble_without_message(),
+    };
+    RoutedMessage::handled(message)
+}
+
+fn pop_utf16_character(value: &mut Vec<u16>) {
+    let Some(last) = value.pop() else {
+        return;
+    };
+    if (0xDC00..=0xDFFF).contains(&last)
+        && value
+            .last()
+            .is_some_and(|previous| (0xD800..=0xDBFF).contains(previous))
+    {
+        value.pop();
+    }
+}
+
 fn draw(ctx: &DrawContext<'_>, model: &RefCell<Model>) -> Result<()> {
     ctx.clear(ColorF::new(0.11, 0.12, 0.16, 1.0));
 
@@ -218,6 +299,7 @@ fn draw(ctx: &DrawContext<'_>, model: &RefCell<Model>) -> Result<()> {
     let device_changed = ctx.device_changed();
     let mut m = model.borrow_mut();
     let selected = m.selected;
+    let focused = m.focused;
 
     for (i, s) in m.shapes.iter_mut().enumerate() {
         if device_changed || s.built_at != Some((s.x, s.y)) {
@@ -232,7 +314,12 @@ fn draw(ctx: &DrawContext<'_>, model: &RefCell<Model>) -> Result<()> {
         ctx.fill_path(path, &brush);
 
         if Some(i) == selected {
-            let brush = ctx.create_solid_brush(ColorF::WHITE)?;
+            let color = if focused {
+                ColorF::new(0.45, 0.75, 1.0, 1.0)
+            } else {
+                ColorF::WHITE
+            };
+            let brush = ctx.create_solid_brush(color)?;
             let b = path.compute_bounds();
             let pad = 4.0;
             ctx.draw_rect(
@@ -241,12 +328,19 @@ fn draw(ctx: &DrawContext<'_>, model: &RefCell<Model>) -> Result<()> {
                 1.5,
             );
         }
+        if !s.label.is_empty() {
+            let label = String::from_utf16_lossy(&s.label);
+            let format = TextFormat::with_weight("Segoe UI", 14.0, CanvasFontWeight::BOLD)?;
+            let brush = ctx.create_solid_brush(ColorF::WHITE)?;
+            let rect = Rect::new(s.x - SIZE, s.y - 10.0, s.x + SIZE, s.y + 20.0);
+            ctx.draw_text(&label, &format, &rect, &brush);
+        }
     }
 
     let format = TextFormat::with_weight("Segoe UI", 16.0, CanvasFontWeight::BOLD)?;
     let brush = ctx.create_solid_brush(ColorF::WHITE)?;
     let label = format!(
-        "{} shape(s)  ·  tool: {}  ·  click to add, left-drag to move, right-click to delete",
+        "{} shape(s) | tool: {} | click to focus, arrows to move, type to label, Delete to remove",
         m.shapes.len(),
         m.kind.label()
     );

--- a/crates/samples/canvas/editor/src/main.rs
+++ b/crates/samples/canvas/editor/src/main.rs
@@ -27,7 +27,6 @@ struct Shape {
     x: f32,
     y: f32,
     color: ColorF,
-    label: Vec<u16>,
     path: Option<Path>,
     built_at: Option<(f32, f32)>,
 }
@@ -39,7 +38,6 @@ impl Shape {
             x,
             y,
             color,
-            label: Vec::new(),
             path: None,
             built_at: None,
         }
@@ -51,7 +49,6 @@ struct Model {
     kind: Kind,
     selected: Option<usize>,
     drag_offset: Option<(f32, f32)>,
-    focused: bool,
     next_color: usize,
 }
 
@@ -62,7 +59,6 @@ impl Model {
             kind: Kind::Star,
             selected: None,
             drag_offset: None,
-            focused: false,
             next_color: 0,
         }
     }
@@ -91,11 +87,6 @@ enum Message {
     Pressed(PointerEventInfo),
     Moved(PointerEventInfo),
     Released,
-    MoveSelected(f32, f32),
-    DeleteSelected,
-    Backspace,
-    Character(u16),
-    FocusChanged(bool),
     Select(Kind),
     Clear,
 }
@@ -148,29 +139,6 @@ impl Component for Sample {
             }
             Message::Moved(_) => {}
             Message::Released => model.drag_offset = None,
-            Message::MoveSelected(dx, dy) => {
-                if let Some(shape) = model.selected.and_then(|index| model.shapes.get_mut(index)) {
-                    shape.x += dx;
-                    shape.y += dy;
-                }
-            }
-            Message::DeleteSelected => {
-                if let Some(index) = model.selected.take() {
-                    model.shapes.remove(index);
-                    model.drag_offset = None;
-                }
-            }
-            Message::Backspace => {
-                if let Some(shape) = model.selected.and_then(|index| model.shapes.get_mut(index)) {
-                    pop_utf16_character(&mut shape.label);
-                }
-            }
-            Message::Character(character) => {
-                if let Some(shape) = model.selected.and_then(|index| model.shapes.get_mut(index)) {
-                    shape.label.push(character);
-                }
-            }
-            Message::FocusChanged(focused) => model.focused = focused,
             Message::Select(kind) => model.kind = kind,
             Message::Clear => {
                 model.shapes.clear();
@@ -185,23 +153,8 @@ impl Component for Sample {
     fn view(&self, _input: &(), context: &mut ViewContext<Self>) -> View {
         context.window_title("Canvas editor");
         context.window_visuals(WindowVisuals::new().backdrop(WindowBackdrop::Mica));
-        let selected = self.model.borrow().selected.is_some();
         let model = Rc::clone(&self.model);
         let surface = Border::new()
-            .is_tab_stop(true)
-            .allow_focus_on_interaction(true)
-            .on_preview_key_down(context.routed_callback(move |info| route_key(info, selected)))
-            .on_character_received(context.routed_callback(move |info: CharacterEventInfo| {
-                if selected && info.character >= 0x20 {
-                    RoutedMessage::handled(Message::Character(info.character))
-                } else {
-                    RoutedMessage::bubble_without_message()
-                }
-            }))
-            .on_got_focus(
-                context.callback(|info: FocusEventInfo| Message::FocusChanged(info.is_direct)),
-            )
-            .on_lost_focus(context.callback(|_| Message::FocusChanged(false)))
             .on_pointer_pressed(context.callback(Message::Pressed))
             .on_pointer_moved(context.callback(Message::Moved))
             .on_pointer_released(context.callback(|_| Message::Released))
@@ -236,40 +189,6 @@ impl Component for Sample {
     }
 }
 
-fn route_key(info: KeyEventInfo, selected: bool) -> RoutedMessage<Message> {
-    if !selected {
-        return RoutedMessage::bubble_without_message();
-    }
-    let distance = if info.modifiers.contains(InputModifiers::SHIFT) {
-        16.0
-    } else {
-        4.0
-    };
-    let message = match info.key {
-        VirtualKey::LEFT => Message::MoveSelected(-distance, 0.0),
-        VirtualKey::UP => Message::MoveSelected(0.0, -distance),
-        VirtualKey::RIGHT => Message::MoveSelected(distance, 0.0),
-        VirtualKey::DOWN => Message::MoveSelected(0.0, distance),
-        VirtualKey::DELETE => Message::DeleteSelected,
-        VirtualKey::BACK => Message::Backspace,
-        _ => return RoutedMessage::bubble_without_message(),
-    };
-    RoutedMessage::handled(message)
-}
-
-fn pop_utf16_character(value: &mut Vec<u16>) {
-    let Some(last) = value.pop() else {
-        return;
-    };
-    if (0xDC00..=0xDFFF).contains(&last)
-        && value
-            .last()
-            .is_some_and(|previous| (0xD800..=0xDBFF).contains(previous))
-    {
-        value.pop();
-    }
-}
-
 fn draw(ctx: &DrawContext<'_>, model: &RefCell<Model>) -> Result<()> {
     ctx.clear(ColorF::new(0.11, 0.12, 0.16, 1.0));
 
@@ -299,7 +218,6 @@ fn draw(ctx: &DrawContext<'_>, model: &RefCell<Model>) -> Result<()> {
     let device_changed = ctx.device_changed();
     let mut m = model.borrow_mut();
     let selected = m.selected;
-    let focused = m.focused;
 
     for (i, s) in m.shapes.iter_mut().enumerate() {
         if device_changed || s.built_at != Some((s.x, s.y)) {
@@ -314,12 +232,7 @@ fn draw(ctx: &DrawContext<'_>, model: &RefCell<Model>) -> Result<()> {
         ctx.fill_path(path, &brush);
 
         if Some(i) == selected {
-            let color = if focused {
-                ColorF::new(0.45, 0.75, 1.0, 1.0)
-            } else {
-                ColorF::WHITE
-            };
-            let brush = ctx.create_solid_brush(color)?;
+            let brush = ctx.create_solid_brush(ColorF::WHITE)?;
             let b = path.compute_bounds();
             let pad = 4.0;
             ctx.draw_rect(
@@ -328,19 +241,12 @@ fn draw(ctx: &DrawContext<'_>, model: &RefCell<Model>) -> Result<()> {
                 1.5,
             );
         }
-        if !s.label.is_empty() {
-            let label = String::from_utf16_lossy(&s.label);
-            let format = TextFormat::with_weight("Segoe UI", 14.0, CanvasFontWeight::BOLD)?;
-            let brush = ctx.create_solid_brush(ColorF::WHITE)?;
-            let rect = Rect::new(s.x - SIZE, s.y - 10.0, s.x + SIZE, s.y + 20.0);
-            ctx.draw_text(&label, &format, &rect, &brush);
-        }
     }
 
     let format = TextFormat::with_weight("Segoe UI", 16.0, CanvasFontWeight::BOLD)?;
     let brush = ctx.create_solid_brush(ColorF::WHITE)?;
     let label = format!(
-        "{} shape(s) | tool: {} | click to focus, arrows to move, type to label, Delete to remove",
+        "{} shape(s)  ·  tool: {}  ·  click to add, left-drag to move, right-click to delete",
         m.shapes.len(),
         m.kind.label()
     );

--- a/crates/samples/canvas/keyboard/Cargo.toml
+++ b/crates/samples/canvas/keyboard/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "canvas-keyboard"
+version = "0.0.0"
+edition = "2024"
+publish = false
+
+[dependencies]
+windows-canvas = { workspace = true, features = ["reactor"] }
+windows-reactor = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/samples/canvas/keyboard/src/main.rs
+++ b/crates/samples/canvas/keyboard/src/main.rs
@@ -5,21 +5,15 @@ use std::rc::Rc;
 use windows_canvas::*;
 use windows_reactor::*;
 
-#[derive(Clone)]
-struct DrawSnapshot {
-    text: String,
-    marker: f32,
-}
-
 enum Message {
     Key(KeyEventInfo),
     Character(u16),
     Focus(bool),
+    Clear,
 }
 
 struct Sample {
     text: Vec<u16>,
-    marker: f32,
     focused: bool,
     status: String,
     format: Rc<RefCell<Option<TextFormat>>>,
@@ -33,7 +27,6 @@ impl Component for Sample {
     fn create(_input: &(), _context: &ComponentContext<Self>) -> Self {
         Self {
             text: "Type here".encode_utf16().collect(),
-            marker: 0.5,
             focused: false,
             status: "Click the canvas or press Tab to focus".to_string(),
             format: Rc::new(RefCell::new(None)),
@@ -44,16 +37,7 @@ impl Component for Sample {
     fn update(&mut self, message: Message, _context: &ComponentContext<Self>) {
         match message {
             Message::Key(info) => {
-                let step = if info.modifiers.contains(InputModifiers::SHIFT) {
-                    0.2
-                } else {
-                    0.05
-                };
                 match info.key {
-                    VirtualKey::LEFT => self.marker = (self.marker - step).max(0.0),
-                    VirtualKey::RIGHT => self.marker = (self.marker + step).min(1.0),
-                    VirtualKey::HOME => self.marker = 0.0,
-                    VirtualKey::END => self.marker = 1.0,
                     VirtualKey::BACK => pop_utf16_character(&mut self.text),
                     VirtualKey::DELETE => self.text.clear(),
                     _ => {}
@@ -70,10 +54,14 @@ impl Component for Sample {
             Message::Focus(focused) => {
                 self.focused = focused;
                 self.status = if focused {
-                    "Focused - type text or move the square with Left/Right".to_string()
+                    "Canvas focused - type text, Backspace, or Delete".to_string()
                 } else {
                     "Not focused - click the canvas or press Tab".to_string()
                 };
+            }
+            Message::Clear => {
+                self.text.clear();
+                self.status = "Text cleared - click the canvas or press Shift+Tab".to_string();
             }
         }
         self.invalidator.invalidate();
@@ -83,13 +71,9 @@ impl Component for Sample {
         context.window_title("Canvas keyboard input");
         context.window_visuals(WindowVisuals::new().backdrop(WindowBackdrop::Mica));
 
-        let snapshot = DrawSnapshot {
-            text: String::from_utf16_lossy(&self.text),
-            marker: self.marker,
-        };
+        let text = String::from_utf16_lossy(&self.text);
         let format = Rc::clone(&self.format);
-        let canvas =
-            canvas_invalidated(&self.invalidator, move |ctx| draw(ctx, &snapshot, &format));
+        let canvas = canvas_invalidated(&self.invalidator, move |ctx| draw(ctx, &text, &format));
         let surface = Border::new()
             .is_tab_stop(true)
             .focus_on_pointer_release(true)
@@ -115,12 +99,17 @@ impl Component for Sample {
             .content(canvas);
 
         Grid::new()
-            .rows([GridLength::Auto, GridLength::STAR, GridLength::Auto])
+            .rows([
+                GridLength::Auto,
+                GridLength::STAR,
+                GridLength::Auto,
+                GridLength::Auto,
+            ])
             .row_spacing(12.0)
             .margin(Thickness::uniform(24.0))
             .children((
                 TextBlock::new()
-                    .text("Type on Canvas; use arrows to move the square")
+                    .text("Type on the Canvas, then use the button to transfer focus")
                     .font_size(18.0)
                     .font_weight(FontWeight::BOLD),
                 surface,
@@ -128,20 +117,17 @@ impl Component for Sample {
                     .text(self.status.clone())
                     .font_size(14.0)
                     .grid_row(2),
+                Button::new()
+                    .horizontal_alignment(HorizontalAlignment::Left)
+                    .grid_row(3)
+                    .on_click(context.callback(|()| Message::Clear))
+                    .content("Clear text"),
             ))
     }
 }
 
 fn route_key(info: KeyEventInfo) -> RoutedMessage<Message> {
-    if matches!(
-        info.key,
-        VirtualKey::LEFT
-            | VirtualKey::RIGHT
-            | VirtualKey::HOME
-            | VirtualKey::END
-            | VirtualKey::BACK
-            | VirtualKey::DELETE
-    ) {
+    if matches!(info.key, VirtualKey::BACK | VirtualKey::DELETE) {
         RoutedMessage::handled(Message::Key(info))
     } else {
         RoutedMessage::bubble_without_message()
@@ -161,11 +147,7 @@ fn pop_utf16_character(text: &mut Vec<u16>) {
     }
 }
 
-fn draw(
-    ctx: &DrawContext,
-    snapshot: &DrawSnapshot,
-    current_format: &RefCell<Option<TextFormat>>,
-) -> Result<()> {
+fn draw(ctx: &DrawContext, text: &str, current_format: &RefCell<Option<TextFormat>>) -> Result<()> {
     ctx.clear(ColorF::from_rgb8(16, 20, 28));
 
     if current_format.borrow().is_none() {
@@ -174,16 +156,12 @@ fn draw(
     let format = current_format.borrow();
     let text_brush = ctx.create_solid_brush(ColorF::WHITE)?;
     ctx.draw_text(
-        &snapshot.text,
+        text,
         format.as_ref().unwrap(),
         &Rect::new(32.0, 32.0, ctx.width - 32.0, 80.0),
         &text_brush,
     );
 
-    let marker_x = 32.0 + (ctx.width - 96.0).max(0.0) * snapshot.marker;
-    let marker = Rect::from_xywh(marker_x, 120.0, 32.0, 32.0);
-    let marker_brush = ctx.create_solid_brush(ColorF::CORNFLOWER_BLUE)?;
-    ctx.fill_rect(&marker, &marker_brush);
     Ok(())
 }
 

--- a/crates/samples/canvas/keyboard/src/main.rs
+++ b/crates/samples/canvas/keyboard/src/main.rs
@@ -71,6 +71,7 @@ impl Component for Sample {
         let canvas = canvas(move |ctx| draw(ctx, &text, &format));
         let surface = Border::new()
             .is_tab_stop(true)
+            .automation_name("Keyboard input canvas")
             .focus_on_pointer_release(true)
             .background(Color::rgb(16, 20, 28))
             .border_brush(if self.focused {

--- a/crates/samples/canvas/keyboard/src/main.rs
+++ b/crates/samples/canvas/keyboard/src/main.rs
@@ -1,0 +1,285 @@
+#![windows_subsystem = "windows"]
+
+use std::cell::RefCell;
+use std::rc::Rc;
+use windows_canvas::*;
+use windows_reactor::*;
+
+const TEXT_X: f32 = 28.0;
+const TEXT_Y: f32 = 36.0;
+
+struct Editor {
+    text: Vec<u16>,
+    caret: usize,
+    focused: bool,
+    status: String,
+}
+
+impl Editor {
+    fn new() -> Self {
+        let text: Vec<u16> = "Keyboard input on Canvas".encode_utf16().collect();
+        Self {
+            caret: text.len(),
+            text,
+            focused: false,
+            status: "Click the canvas or press Tab to focus".to_string(),
+        }
+    }
+
+    fn previous(&self) -> usize {
+        previous_boundary(&self.text, self.caret)
+    }
+
+    fn next(&self) -> usize {
+        next_boundary(&self.text, self.caret)
+    }
+}
+
+enum Message {
+    Key(KeyEventInfo),
+    Character(u16),
+    Focus(bool),
+    Pressed(PointerEventInfo),
+}
+
+struct Sample {
+    editor: Rc<RefCell<Editor>>,
+    format: Rc<RefCell<Option<TextFormat>>>,
+    layout: Rc<RefCell<Option<TextLayout>>>,
+    invalidator: Invalidator,
+}
+
+impl Component for Sample {
+    type Input = ();
+    type Message = Message;
+
+    fn create(_input: &(), _context: &ComponentContext<Self>) -> Self {
+        Self {
+            editor: Rc::new(RefCell::new(Editor::new())),
+            format: Rc::new(RefCell::new(None)),
+            layout: Rc::new(RefCell::new(None)),
+            invalidator: Invalidator::new(),
+        }
+    }
+
+    fn update(&mut self, message: Message, _context: &ComponentContext<Self>) {
+        let mut editor = self.editor.borrow_mut();
+        match message {
+            Message::Key(info) => {
+                match info.key {
+                    VirtualKey::LEFT => editor.caret = editor.previous(),
+                    VirtualKey::RIGHT => editor.caret = editor.next(),
+                    VirtualKey::HOME => editor.caret = 0,
+                    VirtualKey::END => editor.caret = editor.text.len(),
+                    VirtualKey::BACK => {
+                        let start = editor.previous();
+                        let end = editor.caret;
+                        editor.text.drain(start..end);
+                        editor.caret = start;
+                    }
+                    VirtualKey::DELETE => {
+                        let end = editor.next();
+                        let start = editor.caret;
+                        editor.text.drain(start..end);
+                    }
+                    _ => {}
+                }
+                editor.status = format!(
+                    "{:?} | modifiers: {:?} | repeat: {}",
+                    info.key, info.modifiers, info.status.repeat_count
+                );
+            }
+            Message::Character(character) => {
+                let caret = editor.caret;
+                editor.text.insert(caret, character);
+                editor.caret += 1;
+                editor.status = format!("CharacterReceived: U+{character:04X}");
+            }
+            Message::Focus(focused) => {
+                editor.focused = focused;
+                editor.status = if focused {
+                    "Focused - type or use Left/Right/Home/End/Backspace/Delete".to_string()
+                } else {
+                    "Not focused - click the canvas or press Tab".to_string()
+                };
+            }
+            Message::Pressed(info) => {
+                if let Some(layout) = self.layout.borrow().as_ref() {
+                    let hit = layout.hit_test_point(Vector2::new(
+                        info.x as f32 - TEXT_X,
+                        info.y as f32 - TEXT_Y,
+                    ));
+                    let position = normalize_boundary(
+                        &editor.text,
+                        (hit.text_position as usize).min(editor.text.len()),
+                    );
+                    editor.caret = if hit.is_trailing_hit {
+                        next_boundary(&editor.text, position)
+                    } else {
+                        position
+                    };
+                }
+            }
+        }
+        drop(editor);
+        self.invalidator.invalidate();
+    }
+
+    fn view(&self, _input: &(), context: &mut ViewContext<Self>) -> View {
+        context.window_title("Canvas keyboard input");
+        context.window_visuals(WindowVisuals::new().backdrop(WindowBackdrop::Mica));
+
+        let focused = self.editor.borrow().focused;
+        let editor = Rc::clone(&self.editor);
+        let format = Rc::clone(&self.format);
+        let layout = Rc::clone(&self.layout);
+        let surface = Border::new()
+            .is_tab_stop(true)
+            .allow_focus_on_interaction(true)
+            .background(Color::rgb(16, 20, 28))
+            .border_brush(if focused {
+                Color::rgb(80, 150, 255)
+            } else {
+                Color::rgb(70, 76, 88)
+            })
+            .border_thickness(Thickness::uniform(if focused { 3.0 } else { 1.0 }))
+            .corner_radius(8.0)
+            .on_preview_key_down(context.routed_callback(route_key))
+            .on_character_received(context.routed_callback(|info: CharacterEventInfo| {
+                if info.character >= 0x20 && info.character != 0x7F {
+                    RoutedMessage::handled(Message::Character(info.character))
+                } else {
+                    RoutedMessage::bubble_without_message()
+                }
+            }))
+            .on_got_focus(context.callback(|info: FocusEventInfo| Message::Focus(info.is_direct)))
+            .on_lost_focus(context.callback(|_| Message::Focus(false)))
+            .on_pointer_pressed(context.callback(Message::Pressed))
+            .grid_row(1)
+            .content(canvas_invalidated(&self.invalidator, move |ctx| {
+                draw(ctx, &editor.borrow(), &format, &layout)
+            }));
+
+        let status = self.editor.borrow().status.clone();
+        Grid::new()
+            .rows([GridLength::Auto, GridLength::STAR, GridLength::Auto])
+            .row_spacing(12.0)
+            .margin(Thickness::uniform(24.0))
+            .children((
+                TextBlock::new()
+                    .text("A custom Canvas control using WinUI routed keyboard input")
+                    .font_size(18.0)
+                    .font_weight(FontWeight::BOLD),
+                surface,
+                TextBlock::new().text(status).font_size(14.0).grid_row(2),
+            ))
+    }
+}
+
+fn route_key(info: KeyEventInfo) -> RoutedMessage<Message> {
+    if matches!(
+        info.key,
+        VirtualKey::LEFT
+            | VirtualKey::RIGHT
+            | VirtualKey::HOME
+            | VirtualKey::END
+            | VirtualKey::BACK
+            | VirtualKey::DELETE
+    ) {
+        RoutedMessage::handled(Message::Key(info))
+    } else {
+        RoutedMessage::bubble_without_message()
+    }
+}
+
+fn previous_boundary(text: &[u16], caret: usize) -> usize {
+    if caret >= 2
+        && (0xDC00..=0xDFFF).contains(&text[caret - 1])
+        && (0xD800..=0xDBFF).contains(&text[caret - 2])
+    {
+        caret - 2
+    } else {
+        caret.saturating_sub(1)
+    }
+}
+
+fn next_boundary(text: &[u16], caret: usize) -> usize {
+    if caret + 1 < text.len()
+        && (0xD800..=0xDBFF).contains(&text[caret])
+        && (0xDC00..=0xDFFF).contains(&text[caret + 1])
+    {
+        caret + 2
+    } else {
+        (caret + 1).min(text.len())
+    }
+}
+
+fn normalize_boundary(text: &[u16], caret: usize) -> usize {
+    if caret > 0
+        && caret < text.len()
+        && (0xDC00..=0xDFFF).contains(&text[caret])
+        && (0xD800..=0xDBFF).contains(&text[caret - 1])
+    {
+        caret - 1
+    } else {
+        caret
+    }
+}
+
+fn draw(
+    ctx: &DrawContext,
+    editor: &Editor,
+    current_format: &RefCell<Option<TextFormat>>,
+    current_layout: &RefCell<Option<TextLayout>>,
+) -> Result<()> {
+    ctx.clear(ColorF::from_rgb8(16, 20, 28));
+
+    let text = String::from_utf16_lossy(&editor.text);
+    if current_format.borrow().is_none() {
+        *current_format.borrow_mut() = Some(TextFormat::new("Cascadia Mono", 24.0)?);
+    }
+    let format = current_format.borrow();
+    let layout = TextLayout::new(
+        &text,
+        format.as_ref().unwrap(),
+        (ctx.width - 2.0 * TEXT_X).max(1.0),
+        48.0,
+    )?;
+    let text_brush = ctx.create_solid_brush(ColorF::WHITE)?;
+    ctx.draw_text_layout(Vector2::new(TEXT_X, TEXT_Y), &layout, &text_brush);
+
+    if editor.focused {
+        let caret = if editor.caret == editor.text.len() && editor.caret > 0 {
+            layout.caret_bounds(previous_boundary(&editor.text, editor.caret) as u32, true)
+        } else {
+            layout.caret_bounds(editor.caret as u32, false)
+        };
+        let caret_brush = ctx.create_solid_brush(ColorF::CORNFLOWER_BLUE)?;
+        ctx.draw_line(
+            Vector2::new(TEXT_X + caret.left, TEXT_Y + caret.top),
+            Vector2::new(TEXT_X + caret.left, TEXT_Y + caret.bottom),
+            &caret_brush,
+            2.0,
+        );
+    }
+
+    *current_layout.borrow_mut() = Some(layout);
+    Ok(())
+}
+
+fn main() -> Result<()> {
+    App::run_component::<Sample>(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn utf16_boundaries_keep_surrogate_pairs_together() {
+        let text: Vec<u16> = "a\u{1F642}b".encode_utf16().collect();
+        assert_eq!(previous_boundary(&text, 3), 1);
+        assert_eq!(next_boundary(&text, 1), 3);
+        assert_eq!(normalize_boundary(&text, 2), 1);
+    }
+}

--- a/crates/samples/canvas/keyboard/src/main.rs
+++ b/crates/samples/canvas/keyboard/src/main.rs
@@ -5,47 +5,24 @@ use std::rc::Rc;
 use windows_canvas::*;
 use windows_reactor::*;
 
-const TEXT_X: f32 = 28.0;
-const TEXT_Y: f32 = 36.0;
-
-struct Editor {
-    text: Vec<u16>,
-    caret: usize,
-    focused: bool,
-    status: String,
-}
-
-impl Editor {
-    fn new() -> Self {
-        let text: Vec<u16> = "Keyboard input on Canvas".encode_utf16().collect();
-        Self {
-            caret: text.len(),
-            text,
-            focused: false,
-            status: "Click the canvas or press Tab to focus".to_string(),
-        }
-    }
-
-    fn previous(&self) -> usize {
-        previous_boundary(&self.text, self.caret)
-    }
-
-    fn next(&self) -> usize {
-        next_boundary(&self.text, self.caret)
-    }
+#[derive(Clone)]
+struct DrawSnapshot {
+    text: String,
+    marker: f32,
 }
 
 enum Message {
     Key(KeyEventInfo),
     Character(u16),
     Focus(bool),
-    Pressed(PointerEventInfo),
 }
 
 struct Sample {
-    editor: Rc<RefCell<Editor>>,
+    text: Vec<u16>,
+    marker: f32,
+    focused: bool,
+    status: String,
     format: Rc<RefCell<Option<TextFormat>>>,
-    layout: Rc<RefCell<Option<TextLayout>>>,
     invalidator: Invalidator,
 }
 
@@ -55,73 +32,50 @@ impl Component for Sample {
 
     fn create(_input: &(), _context: &ComponentContext<Self>) -> Self {
         Self {
-            editor: Rc::new(RefCell::new(Editor::new())),
+            text: "Type here".encode_utf16().collect(),
+            marker: 0.5,
+            focused: false,
+            status: "Click the canvas or press Tab to focus".to_string(),
             format: Rc::new(RefCell::new(None)),
-            layout: Rc::new(RefCell::new(None)),
             invalidator: Invalidator::new(),
         }
     }
 
     fn update(&mut self, message: Message, _context: &ComponentContext<Self>) {
-        let mut editor = self.editor.borrow_mut();
         match message {
             Message::Key(info) => {
+                let step = if info.modifiers.contains(InputModifiers::SHIFT) {
+                    0.2
+                } else {
+                    0.05
+                };
                 match info.key {
-                    VirtualKey::LEFT => editor.caret = editor.previous(),
-                    VirtualKey::RIGHT => editor.caret = editor.next(),
-                    VirtualKey::HOME => editor.caret = 0,
-                    VirtualKey::END => editor.caret = editor.text.len(),
-                    VirtualKey::BACK => {
-                        let start = editor.previous();
-                        let end = editor.caret;
-                        editor.text.drain(start..end);
-                        editor.caret = start;
-                    }
-                    VirtualKey::DELETE => {
-                        let end = editor.next();
-                        let start = editor.caret;
-                        editor.text.drain(start..end);
-                    }
+                    VirtualKey::LEFT => self.marker = (self.marker - step).max(0.0),
+                    VirtualKey::RIGHT => self.marker = (self.marker + step).min(1.0),
+                    VirtualKey::HOME => self.marker = 0.0,
+                    VirtualKey::END => self.marker = 1.0,
+                    VirtualKey::BACK => pop_utf16_character(&mut self.text),
+                    VirtualKey::DELETE => self.text.clear(),
                     _ => {}
                 }
-                editor.status = format!(
+                self.status = format!(
                     "{:?} | modifiers: {:?} | repeat: {}",
                     info.key, info.modifiers, info.status.repeat_count
                 );
             }
             Message::Character(character) => {
-                let caret = editor.caret;
-                editor.text.insert(caret, character);
-                editor.caret += 1;
-                editor.status = format!("CharacterReceived: U+{character:04X}");
+                self.text.push(character);
+                self.status = format!("CharacterReceived: U+{character:04X}");
             }
             Message::Focus(focused) => {
-                editor.focused = focused;
-                editor.status = if focused {
-                    "Focused - type or use Left/Right/Home/End/Backspace/Delete".to_string()
+                self.focused = focused;
+                self.status = if focused {
+                    "Focused - type text or move the square with Left/Right".to_string()
                 } else {
                     "Not focused - click the canvas or press Tab".to_string()
                 };
             }
-            Message::Pressed(info) => {
-                if let Some(layout) = self.layout.borrow().as_ref() {
-                    let hit = layout.hit_test_point(Vector2::new(
-                        info.x as f32 - TEXT_X,
-                        info.y as f32 - TEXT_Y,
-                    ));
-                    let position = normalize_boundary(
-                        &editor.text,
-                        (hit.text_position as usize).min(editor.text.len()),
-                    );
-                    editor.caret = if hit.is_trailing_hit {
-                        next_boundary(&editor.text, position)
-                    } else {
-                        position
-                    };
-                }
-            }
         }
-        drop(editor);
         self.invalidator.invalidate();
     }
 
@@ -129,21 +83,25 @@ impl Component for Sample {
         context.window_title("Canvas keyboard input");
         context.window_visuals(WindowVisuals::new().backdrop(WindowBackdrop::Mica));
 
-        let focused = self.editor.borrow().focused;
-        let editor = Rc::clone(&self.editor);
+        let snapshot = DrawSnapshot {
+            text: String::from_utf16_lossy(&self.text),
+            marker: self.marker,
+        };
         let format = Rc::clone(&self.format);
-        let layout = Rc::clone(&self.layout);
+        let canvas =
+            canvas_invalidated(&self.invalidator, move |ctx| draw(ctx, &snapshot, &format));
         let surface = Border::new()
             .is_tab_stop(true)
-            .allow_focus_on_interaction(true)
+            .focus_on_pointer_release(true)
             .background(Color::rgb(16, 20, 28))
-            .border_brush(if focused {
+            .border_brush(if self.focused {
                 Color::rgb(80, 150, 255)
             } else {
                 Color::rgb(70, 76, 88)
             })
-            .border_thickness(Thickness::uniform(if focused { 3.0 } else { 1.0 }))
+            .border_thickness(Thickness::uniform(if self.focused { 3.0 } else { 1.0 }))
             .corner_radius(8.0)
+            .grid_row(1)
             .on_preview_key_down(context.routed_callback(route_key))
             .on_character_received(context.routed_callback(|info: CharacterEventInfo| {
                 if info.character >= 0x20 && info.character != 0x7F {
@@ -154,24 +112,22 @@ impl Component for Sample {
             }))
             .on_got_focus(context.callback(|info: FocusEventInfo| Message::Focus(info.is_direct)))
             .on_lost_focus(context.callback(|_| Message::Focus(false)))
-            .on_pointer_pressed(context.callback(Message::Pressed))
-            .grid_row(1)
-            .content(canvas_invalidated(&self.invalidator, move |ctx| {
-                draw(ctx, &editor.borrow(), &format, &layout)
-            }));
+            .content(canvas);
 
-        let status = self.editor.borrow().status.clone();
         Grid::new()
             .rows([GridLength::Auto, GridLength::STAR, GridLength::Auto])
             .row_spacing(12.0)
             .margin(Thickness::uniform(24.0))
             .children((
                 TextBlock::new()
-                    .text("A custom Canvas control using WinUI routed keyboard input")
+                    .text("Type on Canvas; use arrows to move the square")
                     .font_size(18.0)
                     .font_weight(FontWeight::BOLD),
                 surface,
-                TextBlock::new().text(status).font_size(14.0).grid_row(2),
+                TextBlock::new()
+                    .text(self.status.clone())
+                    .font_size(14.0)
+                    .grid_row(2),
             ))
     }
 }
@@ -192,78 +148,42 @@ fn route_key(info: KeyEventInfo) -> RoutedMessage<Message> {
     }
 }
 
-fn previous_boundary(text: &[u16], caret: usize) -> usize {
-    if caret >= 2
-        && (0xDC00..=0xDFFF).contains(&text[caret - 1])
-        && (0xD800..=0xDBFF).contains(&text[caret - 2])
+fn pop_utf16_character(text: &mut Vec<u16>) {
+    let Some(last) = text.pop() else {
+        return;
+    };
+    if (0xDC00..=0xDFFF).contains(&last)
+        && text
+            .last()
+            .is_some_and(|unit| (0xD800..=0xDBFF).contains(unit))
     {
-        caret - 2
-    } else {
-        caret.saturating_sub(1)
-    }
-}
-
-fn next_boundary(text: &[u16], caret: usize) -> usize {
-    if caret + 1 < text.len()
-        && (0xD800..=0xDBFF).contains(&text[caret])
-        && (0xDC00..=0xDFFF).contains(&text[caret + 1])
-    {
-        caret + 2
-    } else {
-        (caret + 1).min(text.len())
-    }
-}
-
-fn normalize_boundary(text: &[u16], caret: usize) -> usize {
-    if caret > 0
-        && caret < text.len()
-        && (0xDC00..=0xDFFF).contains(&text[caret])
-        && (0xD800..=0xDBFF).contains(&text[caret - 1])
-    {
-        caret - 1
-    } else {
-        caret
+        text.pop();
     }
 }
 
 fn draw(
     ctx: &DrawContext,
-    editor: &Editor,
+    snapshot: &DrawSnapshot,
     current_format: &RefCell<Option<TextFormat>>,
-    current_layout: &RefCell<Option<TextLayout>>,
 ) -> Result<()> {
     ctx.clear(ColorF::from_rgb8(16, 20, 28));
 
-    let text = String::from_utf16_lossy(&editor.text);
     if current_format.borrow().is_none() {
-        *current_format.borrow_mut() = Some(TextFormat::new("Cascadia Mono", 24.0)?);
+        *current_format.borrow_mut() = Some(TextFormat::new("Cascadia Mono", 28.0)?);
     }
     let format = current_format.borrow();
-    let layout = TextLayout::new(
-        &text,
-        format.as_ref().unwrap(),
-        (ctx.width - 2.0 * TEXT_X).max(1.0),
-        48.0,
-    )?;
     let text_brush = ctx.create_solid_brush(ColorF::WHITE)?;
-    ctx.draw_text_layout(Vector2::new(TEXT_X, TEXT_Y), &layout, &text_brush);
+    ctx.draw_text(
+        &snapshot.text,
+        format.as_ref().unwrap(),
+        &Rect::new(32.0, 32.0, ctx.width - 32.0, 80.0),
+        &text_brush,
+    );
 
-    if editor.focused {
-        let caret = if editor.caret == editor.text.len() && editor.caret > 0 {
-            layout.caret_bounds(previous_boundary(&editor.text, editor.caret) as u32, true)
-        } else {
-            layout.caret_bounds(editor.caret as u32, false)
-        };
-        let caret_brush = ctx.create_solid_brush(ColorF::CORNFLOWER_BLUE)?;
-        ctx.draw_line(
-            Vector2::new(TEXT_X + caret.left, TEXT_Y + caret.top),
-            Vector2::new(TEXT_X + caret.left, TEXT_Y + caret.bottom),
-            &caret_brush,
-            2.0,
-        );
-    }
-
-    *current_layout.borrow_mut() = Some(layout);
+    let marker_x = 32.0 + (ctx.width - 96.0).max(0.0) * snapshot.marker;
+    let marker = Rect::from_xywh(marker_x, 120.0, 32.0, 32.0);
+    let marker_brush = ctx.create_solid_brush(ColorF::CORNFLOWER_BLUE)?;
+    ctx.fill_rect(&marker, &marker_brush);
     Ok(())
 }
 
@@ -276,10 +196,9 @@ mod tests {
     use super::*;
 
     #[test]
-    fn utf16_boundaries_keep_surrogate_pairs_together() {
-        let text: Vec<u16> = "a\u{1F642}b".encode_utf16().collect();
-        assert_eq!(previous_boundary(&text, 3), 1);
-        assert_eq!(next_boundary(&text, 1), 3);
-        assert_eq!(normalize_boundary(&text, 2), 1);
+    fn backspace_keeps_surrogate_pairs_together() {
+        let mut text: Vec<u16> = "a\u{1F642}".encode_utf16().collect();
+        pop_utf16_character(&mut text);
+        assert_eq!(text, ['a' as u16]);
     }
 }

--- a/crates/samples/canvas/keyboard/src/main.rs
+++ b/crates/samples/canvas/keyboard/src/main.rs
@@ -1,7 +1,5 @@
 #![windows_subsystem = "windows"]
 
-use std::cell::RefCell;
-use std::rc::Rc;
 use windows_canvas::*;
 use windows_reactor::*;
 
@@ -16,8 +14,7 @@ struct Sample {
     text: Vec<u16>,
     focused: bool,
     status: String,
-    format: Rc<RefCell<Option<TextFormat>>>,
-    invalidator: Invalidator,
+    format: TextFormat,
 }
 
 impl Component for Sample {
@@ -29,8 +26,7 @@ impl Component for Sample {
             text: "Type here".encode_utf16().collect(),
             focused: false,
             status: "Click the canvas or press Tab to focus".to_string(),
-            format: Rc::new(RefCell::new(None)),
-            invalidator: Invalidator::new(),
+            format: TextFormat::new("Cascadia Mono", 28.0).unwrap(),
         }
     }
 
@@ -64,7 +60,6 @@ impl Component for Sample {
                 self.status = "Text cleared - click the canvas or press Shift+Tab".to_string();
             }
         }
-        self.invalidator.invalidate();
     }
 
     fn view(&self, _input: &(), context: &mut ViewContext<Self>) -> View {
@@ -72,8 +67,8 @@ impl Component for Sample {
         context.window_visuals(WindowVisuals::new().backdrop(WindowBackdrop::Mica));
 
         let text = String::from_utf16_lossy(&self.text);
-        let format = Rc::clone(&self.format);
-        let canvas = canvas_invalidated(&self.invalidator, move |ctx| draw(ctx, &text, &format));
+        let format = self.format.clone();
+        let canvas = canvas(move |ctx| draw(ctx, &text, &format));
         let surface = Border::new()
             .is_tab_stop(true)
             .focus_on_pointer_release(true)
@@ -147,17 +142,13 @@ fn pop_utf16_character(text: &mut Vec<u16>) {
     }
 }
 
-fn draw(ctx: &DrawContext, text: &str, current_format: &RefCell<Option<TextFormat>>) -> Result<()> {
+fn draw(ctx: &DrawContext, text: &str, format: &TextFormat) -> Result<()> {
     ctx.clear(ColorF::from_rgb8(16, 20, 28));
 
-    if current_format.borrow().is_none() {
-        *current_format.borrow_mut() = Some(TextFormat::new("Cascadia Mono", 28.0)?);
-    }
-    let format = current_format.borrow();
     let text_brush = ctx.create_solid_brush(ColorF::WHITE)?;
     ctx.draw_text(
         text,
-        format.as_ref().unwrap(),
+        format,
         &Rect::new(32.0, 32.0, ctx.width - 32.0, 80.0),
         &text_brush,
     );

--- a/crates/tests/libs/reactor_bench/Cargo.toml
+++ b/crates/tests/libs/reactor_bench/Cargo.toml
@@ -22,5 +22,9 @@ path = "src/live.rs"
 name = "reactor-live-input"
 path = "src/live_input.rs"
 
+[[bin]]
+name = "reactor-live-notepad"
+path = "src/live_notepad.rs"
+
 [lints]
 workspace = true

--- a/crates/tests/libs/reactor_bench/Cargo.toml
+++ b/crates/tests/libs/reactor_bench/Cargo.toml
@@ -8,7 +8,7 @@ default-run = "test-reactor-bench"
 [dependencies]
 windows-core = { workspace = true }
 windows-reactor = { workspace = true, features = ["test"] }
-windows = { workspace = true, features = ["processthreadsapi", "psapi", "winnt"] }
+windows = { workspace = true, features = ["processthreadsapi", "psapi", "winnt", "winuser"] }
 
 [[bin]]
 name = "test-reactor-bench"
@@ -17,6 +17,10 @@ path = "src/main.rs"
 [[bin]]
 name = "reactor-live-grid"
 path = "src/live.rs"
+
+[[bin]]
+name = "reactor-live-input"
+path = "src/live_input.rs"
 
 [lints]
 workspace = true

--- a/crates/tests/libs/reactor_bench/src/live_input.rs
+++ b/crates/tests/libs/reactor_bench/src/live_input.rs
@@ -132,6 +132,10 @@ impl Measurements {
         match stage {
             LiveInputProbeStage::RawWindowMessage => self.raw.mark(timestamp),
             LiveInputProbeStage::InputKeyboardSource => self.source.mark(timestamp),
+            LiveInputProbeStage::RawCharacter
+            | LiveInputProbeStage::NativeTextChanged
+            | LiveInputProbeStage::NativeTextReady
+            | LiveInputProbeStage::ReactorDispatchComplete => {}
         }
     }
 

--- a/crates/tests/libs/reactor_bench/src/live_input.rs
+++ b/crates/tests/libs/reactor_bench/src/live_input.rs
@@ -1,0 +1,539 @@
+#![windows_subsystem = "console"]
+
+use std::cell::RefCell;
+use std::rc::Rc;
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+use std::sync::{Arc, Condvar, Mutex};
+use std::time::{Duration, Instant};
+
+use windows::Win32::{
+    GetForegroundWindow, HWND, INPUT, INPUT_0, INPUT_KEYBOARD, KEYBDINPUT, KEYEVENTF_KEYUP,
+    SendInput, SetForegroundWindow,
+};
+use windows_reactor::test::{
+    LiveInputProbe, LiveInputProbeStage, clear_live_performance_times, schedule_live_input_probe,
+    schedule_live_test_exit, take_live_performance_times,
+};
+use windows_reactor::*;
+
+const F13: u16 = 0x7C;
+const WAIT_TIMEOUT: Duration = Duration::from_secs(5);
+
+#[derive(Clone, Copy, PartialEq)]
+struct Options {
+    warmup: usize,
+    samples: usize,
+    batch: usize,
+}
+
+impl Default for Options {
+    fn default() -> Self {
+        Self {
+            warmup: 200,
+            samples: 2_000,
+            batch: 256,
+        }
+    }
+}
+
+impl Options {
+    fn parse() -> Result<Option<Self>, String> {
+        let mut options = Self::default();
+        let mut arguments = std::env::args().skip(1);
+        while let Some(argument) = arguments.next() {
+            let target = match argument.as_str() {
+                "--warmup" => &mut options.warmup,
+                "--samples" => &mut options.samples,
+                "--batch" => &mut options.batch,
+                "--help" | "-h" => {
+                    println!(
+                        "reactor-live-input\n\
+                         \n\
+                         Options:\n\
+                           --warmup N   Sequential warmup keys (default: 200)\n\
+                           --samples N  Sequential measured keys (default: 2000)\n\
+                           --batch N    Keys in the throughput burst (default: 256)\n\
+                           -h, --help   Print this help"
+                    );
+                    return Ok(None);
+                }
+                _ => return Err(format!("unknown argument: {argument}")),
+            };
+            let value = arguments
+                .next()
+                .ok_or_else(|| format!("{argument} requires a value"))?;
+            *target = value
+                .parse()
+                .map_err(|_| format!("invalid {argument} value: {value}"))?;
+        }
+        if options.samples == 0 || options.batch == 0 {
+            return Err("--samples and --batch must be greater than zero".to_string());
+        }
+        Ok(Some(options))
+    }
+}
+
+struct Stage {
+    count: AtomicUsize,
+    timestamps: Vec<AtomicU64>,
+}
+
+impl Stage {
+    fn new(capacity: usize) -> Self {
+        Self {
+            count: AtomicUsize::new(0),
+            timestamps: (0..capacity).map(|_| AtomicU64::new(0)).collect(),
+        }
+    }
+
+    fn mark(&self, timestamp: u64) {
+        let index = self.count.fetch_add(1, Ordering::AcqRel);
+        if let Some(slot) = self.timestamps.get(index) {
+            slot.store(timestamp, Ordering::Release);
+        }
+    }
+
+    fn get(&self, index: usize) -> u64 {
+        self.timestamps[index].load(Ordering::Acquire)
+    }
+}
+
+struct Measurements {
+    origin: Instant,
+    starts: Vec<AtomicU64>,
+    raw: Stage,
+    source: Stage,
+    routed: Stage,
+    component: Stage,
+    completion: Condvar,
+    completed: Mutex<usize>,
+}
+
+impl Measurements {
+    fn new(capacity: usize) -> Self {
+        Self {
+            origin: Instant::now(),
+            starts: (0..capacity).map(|_| AtomicU64::new(0)).collect(),
+            raw: Stage::new(capacity),
+            source: Stage::new(capacity),
+            routed: Stage::new(capacity),
+            component: Stage::new(capacity),
+            completion: Condvar::new(),
+            completed: Mutex::new(0),
+        }
+    }
+
+    fn now(&self) -> u64 {
+        self.origin.elapsed().as_nanos() as u64
+    }
+
+    fn mark(&self, stage: LiveInputProbeStage) {
+        let timestamp = self.now();
+        match stage {
+            LiveInputProbeStage::RawWindowMessage => self.raw.mark(timestamp),
+            LiveInputProbeStage::InputKeyboardSource => self.source.mark(timestamp),
+        }
+    }
+
+    fn mark_component(&self) {
+        self.component.mark(self.now());
+        let mut completed = self.completed.lock().unwrap();
+        *completed += 1;
+        self.completion.notify_one();
+    }
+
+    fn wait_for_component(&self, expected: usize) -> Result<(), String> {
+        let completed = self.completed.lock().unwrap();
+        let (completed, timeout) = self
+            .completion
+            .wait_timeout_while(completed, WAIT_TIMEOUT, |completed| *completed < expected)
+            .unwrap();
+        if timeout.timed_out() {
+            Err(format!(
+                "timed out waiting for key {expected}; observed {completed} component updates"
+            ))
+        } else {
+            Ok(())
+        }
+    }
+}
+
+struct Report {
+    samples: usize,
+    raw: Distribution,
+    source: Distribution,
+    routed: Distribution,
+    reactor: Distribution,
+    end_to_end: Distribution,
+    batch: usize,
+    batch_duration: Duration,
+    dispatch: Option<RuntimeDistribution>,
+    native_apply: Option<RuntimeDistribution>,
+}
+
+struct RuntimeDistribution {
+    count: usize,
+    distribution: Distribution,
+}
+
+struct Distribution {
+    median_ns: u64,
+    p95_ns: u64,
+    p99_ns: u64,
+}
+
+impl Distribution {
+    fn from(mut values: Vec<u64>) -> Self {
+        values.sort_unstable();
+        Self {
+            median_ns: percentile(&values, 50),
+            p95_ns: percentile(&values, 95),
+            p99_ns: percentile(&values, 99),
+        }
+    }
+}
+
+fn percentile(values: &[u64], percentile: usize) -> u64 {
+    values[(values.len() - 1) * percentile / 100]
+}
+
+enum Message {
+    Focused(Result<(bool, isize), String>),
+    Key,
+    Report(Box<Result<Report, String>>),
+}
+
+struct LiveInput {
+    options: Options,
+    measurements: Arc<Measurements>,
+    target: ElementRef<Border>,
+    probe: Rc<RefCell<Option<LiveInputProbe>>>,
+}
+
+impl Component for LiveInput {
+    type Input = Options;
+    type Message = Message;
+
+    fn create(options: &Options, _context: &ComponentContext<Self>) -> Self {
+        let capacity = options.warmup + options.samples + options.batch;
+        Self {
+            options: *options,
+            measurements: Arc::new(Measurements::new(capacity)),
+            target: ElementRef::new(),
+            probe: Rc::new(RefCell::new(None)),
+        }
+    }
+
+    fn update(&mut self, message: Message, context: &ComponentContext<Self>) {
+        match message {
+            Message::Focused(Ok((true, hwnd))) => {
+                clear_live_performance_times();
+                let measurements = Arc::clone(&self.measurements);
+                let options = self.options;
+                context.spawn_background(move |_| {
+                    Message::Report(Box::new(run_measurement(options, hwnd, measurements)))
+                });
+            }
+            Message::Focused(Ok((false, _))) => {
+                eprintln!("WinUI rejected the keyboard target focus request");
+                schedule_live_test_exit(false).unwrap();
+            }
+            Message::Focused(Err(error)) => {
+                eprintln!("{error}");
+                schedule_live_test_exit(false).unwrap();
+            }
+            Message::Key => self.measurements.mark_component(),
+            Message::Report(report) => match *report {
+                Ok(mut report) => {
+                    let (dispatch, native_apply) = take_live_performance_times();
+                    report.dispatch = runtime_distribution(dispatch);
+                    report.native_apply = runtime_distribution(native_apply);
+                    print_report(&report);
+                    schedule_live_test_exit(true).unwrap();
+                }
+                Err(error) => {
+                    eprintln!("{error}");
+                    schedule_live_test_exit(false).unwrap();
+                }
+            },
+        }
+    }
+
+    fn view(&self, _options: &Options, context: &mut ViewContext<Self>) -> View {
+        context.window_title("windows-reactor live input measurement");
+
+        let probe = Rc::clone(&self.probe);
+        let target = self.target.clone();
+        let probe_measurements = Arc::clone(&self.measurements);
+        let sender = context.sender();
+        context.use_effect("setup", (), move || {
+            let completion = sender.clone();
+            let result = schedule_live_input_probe(
+                {
+                    let measurements = Arc::clone(&probe_measurements);
+                    move |stage| measurements.mark(stage)
+                },
+                move |result| match result {
+                    Ok(live_probe) => {
+                        let hwnd = live_probe.window_handle();
+                        *probe.borrow_mut() = Some(live_probe);
+                        let focus_completion = completion.clone();
+                        let focused_probe = Rc::clone(&probe);
+                        if !target.request_focus_result(move |result| {
+                            let result = result
+                                .map_err(|error| format!("focus request failed: {error:?}"))
+                                .and_then(|focused| {
+                                    if focused {
+                                        focused_probe
+                                            .borrow_mut()
+                                            .as_mut()
+                                            .unwrap()
+                                            .retarget_raw_input()
+                                            .map_err(|error| {
+                                                format!(
+                                                    "failed to hook focused input window: {error}"
+                                                )
+                                            })?;
+                                    }
+                                    Ok((focused, hwnd))
+                                });
+                            focus_completion.send(Message::Focused(result));
+                        }) {
+                            completion.send(Message::Focused(Err(
+                                "keyboard target was not published".to_string(),
+                            )));
+                        }
+                    }
+                    Err(error) => {
+                        completion.send(Message::Focused(Err(format!(
+                            "failed to install live input probe: {error}"
+                        ))));
+                    }
+                },
+            );
+            if let Err(error) = result {
+                sender.send(Message::Focused(Err(format!(
+                    "failed to schedule live input probe: {error}"
+                ))));
+            }
+            None
+        });
+
+        let measurements = Arc::clone(&self.measurements);
+        Border::new()
+            .width(320.0)
+            .height(160.0)
+            .is_tab_stop(true)
+            .element_ref(&self.target)
+            .on_preview_key_down(context.routed_callback(move |_| {
+                measurements.routed.mark(measurements.now());
+                RoutedMessage::handled(Message::Key)
+            }))
+            .content("Focused keyboard measurement target")
+    }
+}
+
+fn run_measurement(
+    options: Options,
+    hwnd: isize,
+    measurements: Arc<Measurements>,
+) -> Result<Report, String> {
+    unsafe {
+        let _ = SetForegroundWindow(HWND(hwnd as *mut _));
+        if GetForegroundWindow() != HWND(hwnd as *mut _) {
+            return Err("measurement window is not foreground".to_string());
+        }
+    }
+    std::thread::sleep(Duration::from_millis(100));
+
+    let sequential = options.warmup + options.samples;
+    for index in 0..sequential {
+        measurements.starts[index].store(measurements.now(), Ordering::Release);
+        inject_keys(1)?;
+        measurements.wait_for_component(index + 1)?;
+    }
+
+    let batch_start = Instant::now();
+    inject_keys(options.batch)?;
+    let expected = sequential + options.batch;
+    measurements.wait_for_component(expected)?;
+    let batch_duration = batch_start.elapsed();
+
+    for (name, stage) in [
+        ("raw window message", &measurements.raw),
+        ("InputKeyboardSource", &measurements.source),
+        ("WinUI PreviewKeyDown", &measurements.routed),
+        ("component update", &measurements.component),
+    ] {
+        let actual = stage.count.load(Ordering::Acquire);
+        if actual != expected {
+            return Err(format!(
+                "{name} observed {actual} keys; expected {expected}; stage correlation is invalid"
+            ));
+        }
+    }
+
+    let range = options.warmup..sequential;
+
+    Ok(Report {
+        samples: options.samples,
+        raw: Distribution::from(differences(
+            range.clone(),
+            "SendInput",
+            "raw window message",
+            &|index| measurements.starts[index].load(Ordering::Acquire),
+            &|index| measurements.raw.get(index),
+        )?),
+        source: Distribution::from(differences(
+            range.clone(),
+            "raw window message",
+            "InputKeyboardSource",
+            &|index| measurements.raw.get(index),
+            &|index| measurements.source.get(index),
+        )?),
+        routed: Distribution::from(differences(
+            range.clone(),
+            "raw window message",
+            "WinUI PreviewKeyDown",
+            &|index| measurements.raw.get(index),
+            &|index| measurements.routed.get(index),
+        )?),
+        reactor: Distribution::from(differences(
+            range.clone(),
+            "WinUI PreviewKeyDown",
+            "component update",
+            &|index| measurements.routed.get(index),
+            &|index| measurements.component.get(index),
+        )?),
+        end_to_end: Distribution::from(differences(
+            range,
+            "SendInput",
+            "component update",
+            &|index| measurements.starts[index].load(Ordering::Acquire),
+            &|index| measurements.component.get(index),
+        )?),
+        batch: options.batch,
+        batch_duration,
+        dispatch: None,
+        native_apply: None,
+    })
+}
+
+fn runtime_distribution(values_us: Vec<f64>) -> Option<RuntimeDistribution> {
+    if values_us.is_empty() {
+        return None;
+    }
+    Some(RuntimeDistribution {
+        count: values_us.len(),
+        distribution: Distribution::from(
+            values_us
+                .into_iter()
+                .map(|value| (value * 1_000.0) as u64)
+                .collect(),
+        ),
+    })
+}
+
+fn differences(
+    range: std::ops::Range<usize>,
+    first_name: &str,
+    second_name: &str,
+    first: &dyn Fn(usize) -> u64,
+    second: &dyn Fn(usize) -> u64,
+) -> Result<Vec<u64>, String> {
+    range
+        .map(|index| {
+            second(index).checked_sub(first(index)).ok_or_else(|| {
+                format!(
+                    "{second_name} preceded {first_name} for key {index}; stage correlation is invalid"
+                )
+            })
+        })
+        .collect()
+}
+
+fn inject_keys(count: usize) -> Result<(), String> {
+    let down = INPUT {
+        r#type: INPUT_KEYBOARD as u32,
+        Anonymous: INPUT_0 {
+            ki: KEYBDINPUT {
+                wVk: F13,
+                ..Default::default()
+            },
+        },
+    };
+    let up = INPUT {
+        r#type: INPUT_KEYBOARD as u32,
+        Anonymous: INPUT_0 {
+            ki: KEYBDINPUT {
+                wVk: F13,
+                dwFlags: KEYEVENTF_KEYUP as u32,
+                ..Default::default()
+            },
+        },
+    };
+    let inputs: Vec<_> = std::iter::repeat_n([down, up], count).flatten().collect();
+    let inserted = unsafe { SendInput(&inputs, size_of::<INPUT>() as i32) };
+    if inserted == inputs.len() as u32 {
+        Ok(())
+    } else {
+        Err(format!(
+            "SendInput inserted {inserted} of {} events",
+            inputs.len()
+        ))
+    }
+}
+
+fn print_report(report: &Report) {
+    println!("samples: {}", report.samples);
+    println!("stage                                  median       p95       p99");
+    print_distribution("SendInput -> raw window message", &report.raw);
+    print_distribution("raw -> InputKeyboardSource", &report.source);
+    print_distribution("raw -> WinUI PreviewKeyDown", &report.routed);
+    print_distribution("WinUI callback -> component update", &report.reactor);
+    print_distribution("SendInput -> component update", &report.end_to_end);
+    if let Some(dispatch) = &report.dispatch {
+        print_distribution(
+            &format!("Reactor dispatch (n={})", dispatch.count),
+            &dispatch.distribution,
+        );
+    }
+    if let Some(native_apply) = &report.native_apply {
+        print_distribution(
+            &format!("native apply (n={})", native_apply.count),
+            &native_apply.distribution,
+        );
+    }
+    println!(
+        "throughput: {} keys in {:.3} ms ({:.0} keys/s)",
+        report.batch,
+        report.batch_duration.as_secs_f64() * 1_000.0,
+        report.batch as f64 / report.batch_duration.as_secs_f64()
+    );
+}
+
+fn print_distribution(name: &str, distribution: &Distribution) {
+    println!(
+        "{name:<36} {:>7.2} us {:>7.2} us {:>7.2} us",
+        distribution.median_ns as f64 / 1_000.0,
+        distribution.p95_ns as f64 / 1_000.0,
+        distribution.p99_ns as f64 / 1_000.0,
+    );
+}
+
+fn main() -> windows_core::Result<()> {
+    let Some(options) = Options::parse().unwrap_or_else(|error| {
+        eprintln!("{error}");
+        std::process::exit(2);
+    }) else {
+        return Ok(());
+    };
+
+    std::thread::spawn(|| {
+        std::thread::sleep(Duration::from_secs(30));
+        eprintln!("live input measurement timed out");
+        std::process::exit(1);
+    });
+
+    App::run_component::<LiveInput>(options)
+}

--- a/crates/tests/libs/reactor_bench/src/live_notepad.rs
+++ b/crates/tests/libs/reactor_bench/src/live_notepad.rs
@@ -1,0 +1,621 @@
+#![windows_subsystem = "console"]
+
+mod allocator;
+
+use std::cell::RefCell;
+use std::rc::Rc;
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+use std::sync::{Arc, Condvar, Mutex};
+use std::time::{Duration, Instant};
+
+use windows::Win32::{
+    GetForegroundWindow, HWND, INPUT, INPUT_0, INPUT_KEYBOARD, KEYBDINPUT, KEYEVENTF_KEYUP,
+    KEYEVENTF_UNICODE, SendInput, SetForegroundWindow,
+};
+use windows_reactor::test::{
+    LiveInputProbe, LiveInputProbeStage, clear_live_performance_times, schedule_live_input_probe,
+    take_live_performance_times,
+};
+use windows_reactor::*;
+
+const WAIT_TIMEOUT: Duration = Duration::from_secs(5);
+const END_KEY: u16 = 0x23;
+
+#[derive(Clone, Copy, PartialEq)]
+struct Options {
+    warmup: usize,
+    samples: usize,
+    text_size: usize,
+}
+
+impl Default for Options {
+    fn default() -> Self {
+        Self {
+            warmup: 100,
+            samples: 1_000,
+            text_size: 0,
+        }
+    }
+}
+
+impl Options {
+    fn parse() -> Result<Option<Self>, String> {
+        let mut options = Self::default();
+        let mut arguments = std::env::args().skip(1);
+        while let Some(argument) = arguments.next() {
+            let target = match argument.as_str() {
+                "--warmup" => &mut options.warmup,
+                "--samples" => &mut options.samples,
+                "--text-size" => &mut options.text_size,
+                "--help" | "-h" => {
+                    println!(
+                        "reactor-live-notepad\n\
+                         \n\
+                         Measures real TextBox input through the controlled reactor-notepad path.\n\
+                         \n\
+                         Options:\n\
+                           --warmup N     Warmup characters (default: 100)\n\
+                           --samples N    Measured characters (default: 1000)\n\
+                           --text-size N  Initial UTF-8/UTF-16 ASCII text length (default: 0)\n\
+                           -h, --help     Print this help"
+                    );
+                    return Ok(None);
+                }
+                _ => return Err(format!("unknown argument: {argument}")),
+            };
+            let value = arguments
+                .next()
+                .ok_or_else(|| format!("{argument} requires a value"))?;
+            *target = value
+                .parse()
+                .map_err(|_| format!("invalid {argument} value: {value}"))?;
+        }
+        if options.samples == 0 {
+            return Err("--samples must be greater than zero".to_string());
+        }
+        Ok(Some(options))
+    }
+}
+
+struct Stage {
+    count: AtomicUsize,
+    timestamps: Vec<AtomicU64>,
+}
+
+impl Stage {
+    fn new(capacity: usize) -> Self {
+        Self {
+            count: AtomicUsize::new(0),
+            timestamps: (0..capacity).map(|_| AtomicU64::new(0)).collect(),
+        }
+    }
+
+    fn mark(&self, timestamp: u64) {
+        let index = self.count.fetch_add(1, Ordering::AcqRel);
+        if let Some(slot) = self.timestamps.get(index) {
+            slot.store(timestamp, Ordering::Release);
+        }
+    }
+
+    fn get(&self, index: usize) -> u64 {
+        self.timestamps[index].load(Ordering::Acquire)
+    }
+}
+
+struct Measurements {
+    origin: Instant,
+    starts: Vec<AtomicU64>,
+    raw_character: Stage,
+    native_changed: Stage,
+    native_ready: Stage,
+    event_callback: Stage,
+    component: Stage,
+    dispatch_complete: Stage,
+    completion: Condvar,
+    completed: Mutex<usize>,
+}
+
+impl Measurements {
+    fn new(capacity: usize) -> Self {
+        Self {
+            origin: Instant::now(),
+            starts: (0..capacity).map(|_| AtomicU64::new(0)).collect(),
+            raw_character: Stage::new(capacity),
+            native_changed: Stage::new(capacity),
+            native_ready: Stage::new(capacity),
+            event_callback: Stage::new(capacity),
+            component: Stage::new(capacity),
+            dispatch_complete: Stage::new(capacity),
+            completion: Condvar::new(),
+            completed: Mutex::new(0),
+        }
+    }
+
+    fn now(&self) -> u64 {
+        self.origin.elapsed().as_nanos() as u64
+    }
+
+    fn mark_probe(&self, stage: LiveInputProbeStage) {
+        let timestamp = self.now();
+        match stage {
+            LiveInputProbeStage::RawCharacter => self.raw_character.mark(timestamp),
+            LiveInputProbeStage::NativeTextChanged => self.native_changed.mark(timestamp),
+            LiveInputProbeStage::NativeTextReady => self.native_ready.mark(timestamp),
+            LiveInputProbeStage::ReactorDispatchComplete => {
+                self.dispatch_complete.mark(timestamp);
+                let mut completed = self.completed.lock().unwrap();
+                *completed += 1;
+                self.completion.notify_one();
+            }
+            LiveInputProbeStage::RawWindowMessage | LiveInputProbeStage::InputKeyboardSource => {}
+        }
+    }
+
+    fn mark_event_callback(&self) {
+        self.event_callback.mark(self.now());
+    }
+
+    fn mark_component(&self) {
+        self.component.mark(self.now());
+    }
+
+    fn wait_for_dispatch(&self, expected: usize) -> Result<(), String> {
+        let completed = self.completed.lock().unwrap();
+        let (completed, timeout) = self
+            .completion
+            .wait_timeout_while(completed, WAIT_TIMEOUT, |completed| *completed < expected)
+            .unwrap();
+        if timeout.timed_out() {
+            Err(format!(
+                "timed out waiting for input {expected}; observed {completed} completed dispatches"
+            ))
+        } else {
+            Ok(())
+        }
+    }
+}
+
+struct Distribution {
+    median_ns: u64,
+    p95_ns: u64,
+    p99_ns: u64,
+}
+
+impl Distribution {
+    fn from(mut values: Vec<u64>) -> Self {
+        values.sort_unstable();
+        Self {
+            median_ns: percentile(&values, 50),
+            p95_ns: percentile(&values, 95),
+            p99_ns: percentile(&values, 99),
+        }
+    }
+}
+
+struct Report {
+    text_size: usize,
+    final_text_size: usize,
+    samples: usize,
+    allocations_per_input: f64,
+    allocated_bytes_per_input: f64,
+    raw: Distribution,
+    winui: Distribution,
+    text_read: Distribution,
+    queue: Distribution,
+    update: Distribution,
+    reconcile: Distribution,
+    reactor_total: Distribution,
+    end_to_end: Distribution,
+}
+
+enum Message {
+    Focused(Result<(bool, isize), String>),
+    Text(String),
+    Report(Box<Result<Report, String>>),
+}
+
+struct LiveNotepad {
+    options: Options,
+    text: String,
+    measurements: Arc<Measurements>,
+    target: ElementRef<TextBox>,
+    probe: Rc<RefCell<Option<LiveInputProbe>>>,
+}
+
+impl Component for LiveNotepad {
+    type Input = Options;
+    type Message = Message;
+
+    fn create(options: &Options, _context: &ComponentContext<Self>) -> Self {
+        Self {
+            options: *options,
+            text: "a".repeat(options.text_size),
+            measurements: Arc::new(Measurements::new(options.warmup + options.samples)),
+            target: ElementRef::new(),
+            probe: Rc::new(RefCell::new(None)),
+        }
+    }
+
+    fn update(&mut self, message: Message, context: &ComponentContext<Self>) {
+        match message {
+            Message::Focused(Ok((true, hwnd))) => {
+                clear_live_performance_times();
+                let options = self.options;
+                let measurements = Arc::clone(&self.measurements);
+                context.spawn_background(move |_| {
+                    Message::Report(Box::new(run_measurement(options, hwnd, measurements)))
+                });
+            }
+            Message::Focused(Ok((false, _))) => {
+                eprintln!("WinUI rejected the TextBox focus request");
+                std::process::exit(1);
+            }
+            Message::Focused(Err(error)) => {
+                eprintln!("{error}");
+                std::process::exit(1);
+            }
+            Message::Text(text) => {
+                self.measurements.mark_component();
+                self.text = text;
+            }
+            Message::Report(report) => match *report {
+                Ok(mut report) => {
+                    report.final_text_size = self.text.len();
+                    let expected =
+                        self.options.text_size + self.options.warmup + self.options.samples;
+                    if report.final_text_size != expected {
+                        eprintln!(
+                            "TextBox ended with {} bytes; expected {expected}; the large-text \
+                             scenario is invalid",
+                            report.final_text_size
+                        );
+                        std::process::exit(1);
+                    }
+                    let (_, native_apply) = take_live_performance_times();
+                    if !native_apply.is_empty() {
+                        eprintln!(
+                            "controlled TextBox input unexpectedly produced {} native apply batches",
+                            native_apply.len()
+                        );
+                        std::process::exit(1);
+                    }
+                    print_report(&report);
+                    std::process::exit(0);
+                }
+                Err(error) => {
+                    eprintln!("{error}");
+                    std::process::exit(1);
+                }
+            },
+        }
+    }
+
+    fn view(&self, _options: &Options, context: &mut ViewContext<Self>) -> View {
+        context.window_title("windows-reactor live Notepad measurement");
+
+        let probe = Rc::clone(&self.probe);
+        let target = self.target.clone();
+        let probe_measurements = Arc::clone(&self.measurements);
+        let sender = context.sender();
+        context.use_effect("setup", (), move || {
+            let completion = sender.clone();
+            let result = schedule_live_input_probe(
+                {
+                    let measurements = Arc::clone(&probe_measurements);
+                    move |stage| measurements.mark_probe(stage)
+                },
+                move |result| match result {
+                    Ok(live_probe) => {
+                        let hwnd = live_probe.window_handle();
+                        *probe.borrow_mut() = Some(live_probe);
+                        let focus_completion = completion.clone();
+                        let focused_probe = Rc::clone(&probe);
+                        if !target.request_focus_result(move |result| {
+                            let result = result
+                                .map_err(|error| format!("focus request failed: {error:?}"))
+                                .and_then(|focused| {
+                                    if focused {
+                                        focused_probe
+                                            .borrow_mut()
+                                            .as_mut()
+                                            .unwrap()
+                                            .retarget_raw_input()
+                                            .map_err(|error| {
+                                                format!(
+                                                    "failed to hook focused input window: {error}"
+                                                )
+                                            })?;
+                                    }
+                                    Ok((focused, hwnd))
+                                });
+                            focus_completion.send(Message::Focused(result));
+                        }) {
+                            completion.send(Message::Focused(Err(
+                                "TextBox target was not published".to_string(),
+                            )));
+                        }
+                    }
+                    Err(error) => {
+                        completion.send(Message::Focused(Err(format!(
+                            "failed to install live input probe: {error}"
+                        ))));
+                    }
+                },
+            );
+            if let Err(error) = result {
+                sender.send(Message::Focused(Err(format!(
+                    "failed to schedule live input probe: {error}"
+                ))));
+            }
+            None
+        });
+
+        let measurements = Arc::clone(&self.measurements);
+        TextBox::new()
+            .text(self.text.clone())
+            .accepts_return(true)
+            .text_wrapping(TextWrapping::Wrap)
+            .element_ref(&self.target)
+            .on_text_changed(context.callback(move |text| {
+                measurements.mark_event_callback();
+                Message::Text(text)
+            }))
+            .into()
+    }
+}
+
+fn run_measurement(
+    options: Options,
+    hwnd: isize,
+    measurements: Arc<Measurements>,
+) -> Result<Report, String> {
+    unsafe {
+        let _ = SetForegroundWindow(HWND(hwnd as *mut _));
+        if GetForegroundWindow() != HWND(hwnd as *mut _) {
+            return Err("measurement window is not foreground".to_string());
+        }
+    }
+    std::thread::sleep(Duration::from_millis(100));
+    inject_virtual_key(END_KEY)?;
+    std::thread::sleep(Duration::from_millis(100));
+
+    let total = options.warmup + options.samples;
+    for index in 0..options.warmup {
+        measurements.starts[index].store(measurements.now(), Ordering::Release);
+        inject_character('x')?;
+        measurements.wait_for_dispatch(index + 1)?;
+    }
+    let allocations_started = allocator::ALLOCATIONS.load(Ordering::Relaxed);
+    let allocated_bytes_started = allocator::allocated_bytes();
+    for index in options.warmup..total {
+        measurements.starts[index].store(measurements.now(), Ordering::Release);
+        inject_character('x')?;
+        measurements.wait_for_dispatch(index + 1)?;
+    }
+    let allocations = allocator::ALLOCATIONS.load(Ordering::Relaxed) - allocations_started;
+    let allocated_bytes = allocator::allocated_bytes() - allocated_bytes_started;
+
+    for (name, stage) in [
+        ("raw WM_CHAR", &measurements.raw_character),
+        ("native TextChanged", &measurements.native_changed),
+        ("native text ready", &measurements.native_ready),
+        ("Reactor event callback", &measurements.event_callback),
+        ("component update", &measurements.component),
+        ("dispatch completion", &measurements.dispatch_complete),
+    ] {
+        let actual = stage.count.load(Ordering::Acquire);
+        if actual != total {
+            return Err(format!(
+                "{name} observed {actual} inputs; expected {total}; stage correlation is invalid"
+            ));
+        }
+    }
+
+    let range = options.warmup..total;
+    Ok(Report {
+        text_size: options.text_size,
+        final_text_size: 0,
+        samples: options.samples,
+        allocations_per_input: allocations as f64 / options.samples as f64,
+        allocated_bytes_per_input: allocated_bytes as f64 / options.samples as f64,
+        raw: distribution(
+            range.clone(),
+            &measurements.starts,
+            &measurements.raw_character,
+            "SendInput",
+            "raw WM_CHAR",
+        )?,
+        winui: distribution(
+            range.clone(),
+            &measurements.raw_character.timestamps,
+            &measurements.native_changed,
+            "raw WM_CHAR",
+            "native TextChanged",
+        )?,
+        text_read: distribution(
+            range.clone(),
+            &measurements.native_changed.timestamps,
+            &measurements.native_ready,
+            "native TextChanged",
+            "native text ready",
+        )?,
+        queue: distribution(
+            range.clone(),
+            &measurements.native_ready.timestamps,
+            &measurements.event_callback,
+            "native text ready",
+            "Reactor event callback",
+        )?,
+        update: distribution(
+            range.clone(),
+            &measurements.event_callback.timestamps,
+            &measurements.component,
+            "Reactor event callback",
+            "component update",
+        )?,
+        reconcile: distribution(
+            range.clone(),
+            &measurements.component.timestamps,
+            &measurements.dispatch_complete,
+            "component update",
+            "dispatch completion",
+        )?,
+        reactor_total: distribution(
+            range.clone(),
+            &measurements.native_ready.timestamps,
+            &measurements.dispatch_complete,
+            "native text ready",
+            "dispatch completion",
+        )?,
+        end_to_end: distribution(
+            range,
+            &measurements.starts,
+            &measurements.dispatch_complete,
+            "SendInput",
+            "dispatch completion",
+        )?,
+    })
+}
+
+fn distribution(
+    range: std::ops::Range<usize>,
+    first: &[AtomicU64],
+    second: &Stage,
+    first_name: &str,
+    second_name: &str,
+) -> Result<Distribution, String> {
+    let values = range
+        .map(|index| {
+            second
+                .get(index)
+                .checked_sub(first[index].load(Ordering::Acquire))
+                .ok_or_else(|| {
+                    format!(
+                        "{second_name} preceded {first_name} for input {index}; correlation is invalid"
+                    )
+                })
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(Distribution::from(values))
+}
+
+fn percentile(values: &[u64], percentile: usize) -> u64 {
+    values[(values.len() - 1) * percentile / 100]
+}
+
+fn inject_character(character: char) -> Result<(), String> {
+    let down = INPUT {
+        r#type: INPUT_KEYBOARD as u32,
+        Anonymous: INPUT_0 {
+            ki: KEYBDINPUT {
+                wScan: character as u16,
+                dwFlags: KEYEVENTF_UNICODE as u32,
+                ..Default::default()
+            },
+        },
+    };
+    let up = INPUT {
+        r#type: INPUT_KEYBOARD as u32,
+        Anonymous: INPUT_0 {
+            ki: KEYBDINPUT {
+                wScan: character as u16,
+                dwFlags: (KEYEVENTF_UNICODE | KEYEVENTF_KEYUP) as u32,
+                ..Default::default()
+            },
+        },
+    };
+    let inputs = [down, up];
+    let inserted = unsafe { SendInput(&inputs, size_of::<INPUT>() as i32) };
+    if inserted == inputs.len() as u32 {
+        Ok(())
+    } else {
+        Err(format!(
+            "SendInput inserted {inserted} of {} events",
+            inputs.len()
+        ))
+    }
+}
+
+fn inject_virtual_key(key: u16) -> Result<(), String> {
+    let down = INPUT {
+        r#type: INPUT_KEYBOARD as u32,
+        Anonymous: INPUT_0 {
+            ki: KEYBDINPUT {
+                wVk: key,
+                ..Default::default()
+            },
+        },
+    };
+    let up = INPUT {
+        r#type: INPUT_KEYBOARD as u32,
+        Anonymous: INPUT_0 {
+            ki: KEYBDINPUT {
+                wVk: key,
+                dwFlags: KEYEVENTF_KEYUP as u32,
+                ..Default::default()
+            },
+        },
+    };
+    let inputs = [down, up];
+    let inserted = unsafe { SendInput(&inputs, size_of::<INPUT>() as i32) };
+    if inserted == inputs.len() as u32 {
+        Ok(())
+    } else {
+        Err(format!(
+            "SendInput inserted {inserted} of {} events",
+            inputs.len()
+        ))
+    }
+}
+
+fn print_report(report: &Report) {
+    println!(
+        "initial text: {} bytes, final text: {} bytes, samples: {}",
+        report.text_size, report.final_text_size, report.samples
+    );
+    println!(
+        "Rust allocations/input: {:.2}, allocated bytes/input: {:.0}",
+        report.allocations_per_input, report.allocated_bytes_per_input
+    );
+    println!("stage                                  median       p95       p99");
+    print_distribution("SendInput -> raw WM_CHAR", &report.raw);
+    print_distribution("raw -> native TextChanged", &report.winui);
+    print_distribution("Text() retrieval", &report.text_read);
+    print_distribution("native queue -> event callback", &report.queue);
+    print_distribution("component message queue", &report.update);
+    print_distribution("update + reconcile", &report.reconcile);
+    print_distribution("Reactor total after Text()", &report.reactor_total);
+    print_distribution("SendInput -> dispatch complete", &report.end_to_end);
+    println!("native apply: none (controlled feedback was suppressed)");
+}
+
+fn print_distribution(name: &str, distribution: &Distribution) {
+    println!(
+        "{name:<36} {:>7.2} us {:>7.2} us {:>7.2} us",
+        distribution.median_ns as f64 / 1_000.0,
+        distribution.p95_ns as f64 / 1_000.0,
+        distribution.p99_ns as f64 / 1_000.0,
+    );
+}
+
+fn main() -> windows_core::Result<()> {
+    let Some(options) = Options::parse().unwrap_or_else(|error| {
+        eprintln!("{error}");
+        std::process::exit(2);
+    }) else {
+        return Ok(());
+    };
+
+    let text_work = options
+        .text_size
+        .max(1_024)
+        .saturating_mul(options.warmup + options.samples) as u64;
+    let timeout = Duration::from_secs(30 + text_work / 500_000);
+    std::thread::spawn(move || {
+        std::thread::sleep(timeout);
+        eprintln!("live Notepad measurement timed out");
+        std::process::exit(1);
+    });
+
+    App::run_component::<LiveNotepad>(options)
+}

--- a/crates/tests/libs/reactor_bench/src/main.rs
+++ b/crates/tests/libs/reactor_bench/src/main.rs
@@ -967,7 +967,7 @@ fn bench_component_leaf(count: usize, iters: u64, reps: u32) -> Row {
     }
 }
 
-fn bench_textbox_input(iters: u64, reps: u32) -> Row {
+fn bench_textbox_input(size: usize, iters: u64, reps: u32) -> Row {
     let mut runtime = RecordingRuntime::default();
     runtime.record_commands(true);
     let mut pump = Pump::new(runtime);
@@ -987,14 +987,16 @@ fn bench_textbox_input(iters: u64, reps: u32) -> Row {
         .event_revision(node, EventId::TextBoxTextChanged)
         .unwrap();
     pump.runtime_mut().record_commands(false);
+    let first = "a".repeat(size);
+    let second = "b".repeat(size);
     let mut value = false;
     let perf = measure(iters, reps, || {
-        let text = if value { "first" } else { "second" };
+        let text = if value { &first } else { &second };
         pump.queue_event(QueuedEvent::new(
             node,
             EventId::TextBoxTextChanged,
             revision,
-            EventPayload::Str(text.to_string()),
+            EventPayload::Str(text.clone()),
         ));
         assert_eq!(pump.dispatch_events(), Ok(1));
         assert_eq!(pump.dispatch_components(1), Ok(1));
@@ -1002,7 +1004,7 @@ fn bench_textbox_input(iters: u64, reps: u32) -> Row {
     });
     Row {
         name: "textbox_input",
-        n: 1,
+        n: size,
         perf,
     }
 }
@@ -1448,7 +1450,9 @@ fn main() {
         bench_component_leaf(512, iters, reps),
         bench_component_leaf(4_096, (iters / 4).max(1), reps),
         bench_component_leaf(16_384, (iters / 16).max(1), reps),
-        bench_textbox_input(iters, reps),
+        bench_textbox_input(8, iters, reps),
+        bench_textbox_input(4_096, (iters / 4).max(1), reps),
+        bench_textbox_input(65_536, (iters / 32).max(1), reps),
         bench_queued_pointer_input(iters, reps),
         bench_routed_key_input(iters, reps),
         bench_component_keyed(

--- a/crates/tests/libs/reactor_bench/src/main.rs
+++ b/crates/tests/libs/reactor_bench/src/main.rs
@@ -54,6 +54,77 @@ struct BenchLeaf {
     active: bool,
 }
 
+struct BenchNotepad {
+    text: String,
+}
+
+struct BenchRoutedInput {
+    events: u64,
+}
+
+struct BenchQueuedInput {
+    events: u64,
+}
+
+impl Component for BenchQueuedInput {
+    type Input = ();
+    type Message = PointerEventInfo;
+
+    fn create(_input: &Self::Input, _context: &ComponentContext<Self>) -> Self {
+        Self { events: 0 }
+    }
+
+    fn update(&mut self, _message: Self::Message, _context: &ComponentContext<Self>) {
+        self.events += 1;
+    }
+
+    fn view(&self, _input: &Self::Input, context: &mut ViewContext<Self>) -> View {
+        Border::new().on_pointer_pressed(context.forward()).into()
+    }
+}
+
+impl Component for BenchRoutedInput {
+    type Input = ();
+    type Message = KeyEventInfo;
+
+    fn create(_input: &Self::Input, _context: &ComponentContext<Self>) -> Self {
+        Self { events: 0 }
+    }
+
+    fn update(&mut self, _message: Self::Message, _context: &ComponentContext<Self>) {
+        self.events += 1;
+    }
+
+    fn view(&self, _input: &Self::Input, context: &mut ViewContext<Self>) -> View {
+        Border::new()
+            .is_tab_stop(true)
+            .on_preview_key_down(context.routed_callback(RoutedMessage::handled))
+            .into()
+    }
+}
+
+impl Component for BenchNotepad {
+    type Input = ();
+    type Message = String;
+
+    fn create(_input: &Self::Input, _context: &ComponentContext<Self>) -> Self {
+        Self {
+            text: String::new(),
+        }
+    }
+
+    fn update(&mut self, message: Self::Message, _context: &ComponentContext<Self>) {
+        self.text = message;
+    }
+
+    fn view(&self, _input: &Self::Input, context: &mut ViewContext<Self>) -> View {
+        TextBox::new()
+            .text(self.text.clone())
+            .on_text_changed(context.forward())
+            .into()
+    }
+}
+
 enum BackgroundMessage {
     Complete,
     Start,
@@ -896,6 +967,125 @@ fn bench_component_leaf(count: usize, iters: u64, reps: u32) -> Row {
     }
 }
 
+fn bench_textbox_input(iters: u64, reps: u32) -> Row {
+    let mut runtime = RecordingRuntime::default();
+    runtime.record_commands(true);
+    let mut pump = Pump::new(runtime);
+    pump.mount_view(View::component::<BenchNotepad>(()))
+        .unwrap();
+    let node = pump
+        .runtime()
+        .commands()
+        .iter()
+        .flatten()
+        .find_map(|command| match command {
+            Command::Create { node, .. } => Some(*node),
+            _ => None,
+        })
+        .unwrap();
+    let revision = pump
+        .event_revision(node, EventId::TextBoxTextChanged)
+        .unwrap();
+    pump.runtime_mut().record_commands(false);
+    let mut value = false;
+    let perf = measure(iters, reps, || {
+        let text = if value { "first" } else { "second" };
+        pump.queue_event(QueuedEvent::new(
+            node,
+            EventId::TextBoxTextChanged,
+            revision,
+            EventPayload::Str(text.to_string()),
+        ));
+        assert_eq!(pump.dispatch_events(), Ok(1));
+        assert_eq!(pump.dispatch_components(1), Ok(1));
+        value = !value;
+    });
+    Row {
+        name: "textbox_input",
+        n: 1,
+        perf,
+    }
+}
+
+fn bench_routed_key_input(iters: u64, reps: u32) -> Row {
+    let mut runtime = RecordingRuntime::default();
+    runtime.record_commands(true);
+    let mut pump = Pump::new(runtime);
+    pump.mount_view(View::component::<BenchRoutedInput>(()))
+        .unwrap();
+    let node = pump
+        .runtime()
+        .commands()
+        .iter()
+        .flatten()
+        .find_map(|command| match command {
+            Command::Create { node, .. } => Some(*node),
+            _ => None,
+        })
+        .unwrap();
+    let revision = pump
+        .event_revision(node, EventId::BorderPreviewKeyDown)
+        .unwrap();
+    pump.runtime_mut().record_commands(false);
+    let event = KeyEventInfo {
+        key: VirtualKey::A,
+        original_key: VirtualKey::A,
+        status: PhysicalKeyStatus::default(),
+        modifiers: InputModifiers::CONTROL,
+    };
+    let perf = measure(iters, reps, || {
+        assert!(
+            pump.runtime_mut()
+                .route_key(node, EventId::BorderPreviewKeyDown, revision, event,)
+        );
+        assert_eq!(pump.dispatch_events(), Ok(1));
+        assert_eq!(pump.dispatch_components(1), Ok(1));
+    });
+    Row {
+        name: "routed_key_input",
+        n: 1,
+        perf,
+    }
+}
+
+fn bench_queued_pointer_input(iters: u64, reps: u32) -> Row {
+    let mut runtime = RecordingRuntime::default();
+    runtime.record_commands(true);
+    let mut pump = Pump::new(runtime);
+    pump.mount_view(View::component::<BenchQueuedInput>(()))
+        .unwrap();
+    let node = pump
+        .runtime()
+        .commands()
+        .iter()
+        .flatten()
+        .find_map(|command| match command {
+            Command::Create { node, .. } => Some(*node),
+            _ => None,
+        })
+        .unwrap();
+    let revision = pump
+        .event_revision(node, EventId::BorderPointerPressed)
+        .unwrap();
+    pump.runtime_mut().record_commands(false);
+    let event = PointerEventInfo::default();
+    let perf = measure(iters, reps, || {
+        pump.queue_event(QueuedEvent::new(
+            node,
+            EventId::BorderPointerPressed,
+            revision,
+            EventPayload::PointerEventInfo(event),
+        ));
+        assert_eq!(pump.dispatch_events(), Ok(1));
+        assert_eq!(pump.dispatch_components(1), Ok(1));
+    });
+    Row {
+        name: "queued_pointer_input",
+        n: 1,
+        perf,
+    }
+}
+
 fn effect_tree(count: usize) -> View {
     View::component::<EffectRoot>(RootInput(effect_senders(count)))
 }
@@ -1258,6 +1448,9 @@ fn main() {
         bench_component_leaf(512, iters, reps),
         bench_component_leaf(4_096, (iters / 4).max(1), reps),
         bench_component_leaf(16_384, (iters / 16).max(1), reps),
+        bench_textbox_input(iters, reps),
+        bench_queued_pointer_input(iters, reps),
+        bench_routed_key_input(iters, reps),
         bench_component_keyed(
             "component_same_order",
             512,

--- a/crates/tests/libs/reactor_selftest/src/fixtures.rs
+++ b/crates/tests/libs/reactor_selftest/src/fixtures.rs
@@ -447,6 +447,8 @@ pub(crate) enum KeyboardMessage {
     LostFocus(FocusEventInfo),
     WindowHandle(Result<isize, String>),
     Activated(Result<isize, String>),
+    InitialFocused(Result<bool, FocusError>),
+    FirstClick(Result<(), String>),
     SecondClick(Result<(), String>),
     SameTargetClick(Result<(), String>),
     SameTargetSettled,
@@ -684,13 +686,35 @@ impl Component for KeyboardInput {
             KeyboardMessage::WindowHandle(Err(error)) => Some(error),
             KeyboardMessage::Activated(Ok(hwnd)) => {
                 self.hwnd = Some(hwnd);
-                let failure = inject_keyboard_focus_click(hwnd).err();
-                if failure.is_none() {
-                    schedule_focus_timeout(context, false);
+                let sender = context.sender();
+                if !self.blur_reference.request_focus_result(move |result| {
+                    sender.send(KeyboardMessage::InitialFocused(result));
+                }) {
+                    Some("keyboard blur target was not published".to_string())
+                } else {
+                    None
                 }
-                failure
             }
             KeyboardMessage::Activated(Err(error)) => Some(error),
+            KeyboardMessage::InitialFocused(Ok(true)) => {
+                let hwnd = self.hwnd.unwrap();
+                context.spawn_background(move |_| {
+                    std::thread::sleep(Duration::from_millis(100));
+                    KeyboardMessage::FirstClick(inject_keyboard_focus_click(hwnd))
+                });
+                None
+            }
+            KeyboardMessage::InitialFocused(Ok(false)) => {
+                Some("WinUI rejected the initial focus-readiness request".to_string())
+            }
+            KeyboardMessage::InitialFocused(Err(error)) => {
+                Some(format!("initial focus-readiness request failed: {error:?}"))
+            }
+            KeyboardMessage::FirstClick(Ok(())) => {
+                schedule_focus_timeout(context, false);
+                None
+            }
+            KeyboardMessage::FirstClick(Err(error)) => Some(error),
             KeyboardMessage::SecondClick(Ok(())) => {
                 schedule_focus_timeout(context, true);
                 None

--- a/crates/tests/libs/reactor_selftest/src/fixtures.rs
+++ b/crates/tests/libs/reactor_selftest/src/fixtures.rs
@@ -408,12 +408,23 @@ impl Component for FocusPublication {
     }
 }
 
+#[derive(Clone, Copy, PartialEq)]
+pub(crate) enum KeyboardClick {
+    First,
+    Second,
+    Focused,
+}
+
 pub(crate) struct KeyboardInput {
     complete: Callback<FixtureResult>,
     reference: ElementRef<Border>,
     blur_reference: ElementRef<Border>,
+    injector: Result<Rc<InputInjector>, String>,
+    click_stage: Option<(KeyboardClick, PointerStage)>,
+    click_attempt: u8,
     focus_observed: bool,
     refocus_observed: bool,
+    second_click_complete: bool,
     same_target_click_started: bool,
     same_target_click_complete: bool,
     same_target_lost_observed: bool,
@@ -448,9 +459,9 @@ pub(crate) enum KeyboardMessage {
     WindowHandle(Result<isize, String>),
     Activated(Result<isize, String>),
     InitialFocused(Result<bool, FocusError>),
-    FirstClick(Result<(), String>),
-    SecondClick(Result<(), String>),
-    SameTargetClick(Result<(), String>),
+    PointerPressed,
+    PointerReleased,
+    ClickRetry(KeyboardClick, PointerStage),
     SameTargetSettled,
     SecondDefocused(Result<bool, FocusError>),
     ProgrammaticRefocused(Result<bool, FocusError>),
@@ -461,6 +472,31 @@ pub(crate) enum KeyboardMessage {
 }
 
 impl KeyboardInput {
+    fn start_click(&mut self, click: KeyboardClick, context: &ComponentContext<Self>) {
+        self.click_stage = Some((click, PointerStage::LeftDown));
+        self.click_attempt = 0;
+        self.retry_click(context);
+    }
+
+    fn advance_click(&mut self, stage: PointerStage, context: &ComponentContext<Self>) {
+        let Some((click, _)) = self.click_stage else {
+            return;
+        };
+        self.click_stage = Some((click, stage));
+        self.click_attempt = 0;
+        self.retry_click(context);
+    }
+
+    fn retry_click(&self, context: &ComponentContext<Self>) {
+        let Some((click, stage)) = self.click_stage else {
+            return;
+        };
+        context.spawn_background(move |_| {
+            std::thread::sleep(Duration::from_millis(100));
+            KeyboardMessage::ClickRetry(click, stage)
+        });
+    }
+
     fn complete_if_ready(&self) {
         if self.focus_observed
             && self.key_observed
@@ -497,8 +533,14 @@ impl Component for KeyboardInput {
             complete: input.complete.clone(),
             reference: ElementRef::new(),
             blur_reference: ElementRef::new(),
+            injector: InputInjector::TryCreate()
+                .map(Rc::new)
+                .map_err(|error| error.to_string()),
+            click_stage: None,
+            click_attempt: 0,
             focus_observed: false,
             refocus_observed: false,
+            second_click_complete: false,
             same_target_click_started: false,
             same_target_click_complete: false,
             same_target_lost_observed: false,
@@ -563,14 +605,6 @@ impl Component for KeyboardInput {
                         ))
                     } else {
                         self.refocus_observed = true;
-                        self.same_target_click_started = true;
-                        let hwnd = self.hwnd.unwrap();
-                        context.spawn_background(move |_| {
-                            std::thread::sleep(Duration::from_millis(100));
-                            let result = inject_keyboard_focus_click(hwnd);
-                            std::thread::sleep(Duration::from_millis(100));
-                            KeyboardMessage::SameTargetClick(result)
-                        });
                         None
                     }
                 } else if self.same_target_click_started && !self.same_target_refocus_observed {
@@ -659,14 +693,7 @@ impl Component for KeyboardInput {
                     None
                 } else {
                     self.lost_focus_observed = true;
-                    let hwnd = self.hwnd.unwrap();
-                    context.spawn_background(move |_| {
-                        std::thread::sleep(Duration::from_millis(100));
-                        KeyboardMessage::SecondClick(
-                            inject_keyboard_focus_click(hwnd)
-                                .map_err(|error| format!("second click failed: {error}")),
-                        )
-                    });
+                    self.start_click(KeyboardClick::Second, context);
                     None
                 }
             }
@@ -697,11 +724,7 @@ impl Component for KeyboardInput {
             }
             KeyboardMessage::Activated(Err(error)) => Some(error),
             KeyboardMessage::InitialFocused(Ok(true)) => {
-                let hwnd = self.hwnd.unwrap();
-                context.spawn_background(move |_| {
-                    std::thread::sleep(Duration::from_millis(100));
-                    KeyboardMessage::FirstClick(inject_keyboard_focus_click(hwnd))
-                });
+                self.start_click(KeyboardClick::First, context);
                 None
             }
             KeyboardMessage::InitialFocused(Ok(false)) => {
@@ -710,24 +733,48 @@ impl Component for KeyboardInput {
             KeyboardMessage::InitialFocused(Err(error)) => {
                 Some(format!("initial focus-readiness request failed: {error:?}"))
             }
-            KeyboardMessage::FirstClick(Ok(())) => {
-                schedule_focus_timeout(context, false);
+            KeyboardMessage::PointerPressed
+                if matches!(self.click_stage, Some((_, PointerStage::LeftDown))) =>
+            {
+                self.advance_click(PointerStage::LeftUp, context);
                 None
             }
-            KeyboardMessage::FirstClick(Err(error)) => Some(error),
-            KeyboardMessage::SecondClick(Ok(())) => {
-                schedule_focus_timeout(context, true);
+            KeyboardMessage::PointerReleased
+                if matches!(self.click_stage, Some((_, PointerStage::LeftUp))) =>
+            {
+                let (click, _) = self.click_stage.take().unwrap();
+                match click {
+                    KeyboardClick::First => schedule_focus_timeout(context, false),
+                    KeyboardClick::Second => {
+                        self.second_click_complete = true;
+                        schedule_focus_timeout(context, true);
+                    }
+                    KeyboardClick::Focused => {
+                        self.same_target_click_complete = true;
+                        context.spawn_background(move |_| {
+                            std::thread::sleep(Duration::from_millis(200));
+                            KeyboardMessage::SameTargetSettled
+                        });
+                    }
+                }
                 None
             }
-            KeyboardMessage::SecondClick(Err(error)) => Some(error),
-            KeyboardMessage::SameTargetClick(Ok(())) => {
-                self.same_target_click_complete = true;
-                context.spawn_background(move |_| {
-                    std::thread::sleep(Duration::from_millis(200));
-                    KeyboardMessage::SameTargetSettled
-                });
-                None
+            KeyboardMessage::PointerPressed | KeyboardMessage::PointerReleased => None,
+            KeyboardMessage::ClickRetry(click, stage)
+                if self.click_stage == Some((click, stage)) =>
+            {
+                self.click_attempt += 1;
+                if self.click_attempt == 20 {
+                    Some(format!(
+                        "keyboard click did not advance {}",
+                        pointer_stage_name(stage)
+                    ))
+                } else {
+                    self.retry_click(context);
+                    None
+                }
             }
+            KeyboardMessage::ClickRetry(_, _) => None,
             KeyboardMessage::SameTargetSettled => {
                 if self.same_target_lost_observed && !self.same_target_refocus_observed {
                     Some("clicking the focused target did not restore focus".to_string())
@@ -744,7 +791,6 @@ impl Component for KeyboardInput {
                     }
                 }
             }
-            KeyboardMessage::SameTargetClick(Err(error)) => Some(error),
             KeyboardMessage::SecondDefocused(Ok(true)) => {
                 self.second_defocus_complete = true;
                 None
@@ -821,6 +867,14 @@ impl Component for KeyboardInput {
                 failure = Some("keyboard blur target was not published".to_string());
             }
         }
+        if failure.is_none()
+            && self.refocus_observed
+            && self.second_click_complete
+            && !self.same_target_click_started
+        {
+            self.same_target_click_started = true;
+            self.start_click(KeyboardClick::Focused, context);
+        }
         if let Some(failure) = failure {
             if !self.complete.call(Err(failure)) {
                 eprintln!("keyboard fixture failure was rejected");
@@ -840,6 +894,24 @@ impl Component for KeyboardInput {
             .unwrap();
             None
         });
+        let click = (self.click_stage, self.click_attempt);
+        let injector = self.injector.clone();
+        let complete = self.complete.clone();
+        context.use_effect("keyboard-click", click, move || {
+            let (click_stage, _) = click;
+            if let Some((_, stage)) = click_stage {
+                let result = injector.and_then(|injector| {
+                    schedule_keyboard_click_stage(stage, injector, complete.clone())
+                });
+                if let Err(error) = result
+                    && !complete.call(Err(error))
+                {
+                    eprintln!("keyboard pointer injection failure was rejected");
+                    std::process::exit(1);
+                }
+            }
+            None
+        });
 
         StackPanel::new().children((
             Border::new()
@@ -850,6 +922,8 @@ impl Component for KeyboardInput {
                 .element_ref(&self.reference)
                 .on_got_focus(context.callback(KeyboardMessage::GotFocus))
                 .on_lost_focus(context.callback(KeyboardMessage::LostFocus))
+                .on_pointer_pressed(context.callback(|_| KeyboardMessage::PointerPressed))
+                .on_pointer_released(context.callback(|_| KeyboardMessage::PointerReleased))
                 .on_preview_key_down(context.routed_callback(|info: KeyEventInfo| {
                     if info.key == F13 {
                         RoutedMessage::handled(KeyboardMessage::Key(info))
@@ -942,38 +1016,61 @@ fn inject_reverse_tab(hwnd: isize) -> Result<(), String> {
     }
 }
 
-fn inject_keyboard_focus_click(handle: isize) -> Result<(), String> {
-    let hwnd = HWND(handle as *mut _);
-    fit_window_to_work_area(hwnd)?;
-    unsafe {
-        let _ = SetForegroundWindow(hwnd);
-        let _ = BringWindowToTop(hwnd);
-    }
-    let injector = InputInjector::TryCreate().map_err(|error| error.to_string())?;
-    let (origin_x, origin_y) = virtual_screen_origin();
-    inject_at(
-        &injector,
-        origin_x,
-        origin_y,
-        InjectedInputMouseOptions::Move | InjectedInputMouseOptions::MoveNoCoalesce,
-    )
-    .map_err(|error| error.to_string())?;
-    inject_at(
-        &injector,
-        origin_x,
-        origin_y,
-        InjectedInputMouseOptions::LeftUp | InjectedInputMouseOptions::RightUp,
-    )
-    .map_err(|error| error.to_string())?;
-    let (x, y) = client_screen_point(hwnd, 0.5, 0.1)?;
-    for options in [
-        InjectedInputMouseOptions::Move | InjectedInputMouseOptions::MoveNoCoalesce,
-        InjectedInputMouseOptions::LeftDown,
-        InjectedInputMouseOptions::LeftUp,
-    ] {
-        inject_at(&injector, x, y, options).map_err(|error| error.to_string())?;
-    }
-    Ok(())
+fn schedule_keyboard_click_stage(
+    stage: PointerStage,
+    injector: Rc<InputInjector>,
+    complete: Callback<FixtureResult>,
+) -> Result<(), String> {
+    schedule_live_window_handle(move |result| {
+        let result = result.and_then(|handle| {
+            let hwnd = HWND(handle as *mut _);
+            if stage == PointerStage::LeftDown {
+                fit_window_to_work_area(hwnd)?;
+                let (x, y) = virtual_screen_origin();
+                inject_at(
+                    &injector,
+                    x,
+                    y,
+                    InjectedInputMouseOptions::Move | InjectedInputMouseOptions::MoveNoCoalesce,
+                )
+                .map_err(|error| error.to_string())?;
+                inject_at(
+                    &injector,
+                    x,
+                    y,
+                    InjectedInputMouseOptions::LeftUp | InjectedInputMouseOptions::RightUp,
+                )
+                .map_err(|error| error.to_string())?;
+            }
+            unsafe {
+                let _ = SetForegroundWindow(hwnd);
+                let _ = BringWindowToTop(hwnd);
+            }
+            let (x, y) = client_screen_point(hwnd, 0.5, 0.1)?;
+            let options = match stage {
+                PointerStage::LeftDown => {
+                    inject_at(
+                        &injector,
+                        x,
+                        y,
+                        InjectedInputMouseOptions::Move | InjectedInputMouseOptions::MoveNoCoalesce,
+                    )
+                    .map_err(|error| error.to_string())?;
+                    InjectedInputMouseOptions::LeftDown
+                }
+                PointerStage::LeftUp => InjectedInputMouseOptions::LeftUp,
+                _ => return Err("invalid keyboard click stage".to_string()),
+            };
+            inject_at(&injector, x, y, options).map_err(|error| error.to_string())
+        });
+        if let Err(error) = result
+            && !complete.call(Err(error))
+        {
+            eprintln!("keyboard pointer injection failure was rejected");
+            std::process::exit(1);
+        }
+    })
+    .map_err(|error| error.to_string())
 }
 
 fn schedule_focus_timeout(context: &ComponentContext<KeyboardInput>, second: bool) {

--- a/crates/tests/libs/reactor_selftest/src/fixtures.rs
+++ b/crates/tests/libs/reactor_selftest/src/fixtures.rs
@@ -409,10 +409,15 @@ impl Component for FocusPublication {
 pub(crate) struct KeyboardInput {
     complete: Callback<FixtureResult>,
     reference: ElementRef<Border>,
+    blur_reference: ElementRef<Border>,
     focus_observed: bool,
     key_observed: bool,
+    key_up_observed: bool,
     character_observed: bool,
     injection_complete: bool,
+    defocus_requested: bool,
+    defocus_complete: bool,
+    lost_focus_observed: bool,
     hwnd: Option<isize>,
 }
 
@@ -420,7 +425,10 @@ pub(crate) enum KeyboardMessage {
     Focused(Result<bool, FocusError>),
     GotFocus(FocusEventInfo),
     Key(KeyEventInfo),
+    KeyUp(KeyEventInfo),
     Character(CharacterEventInfo),
+    Defocused(Result<bool, FocusError>),
+    LostFocus(FocusEventInfo),
     WindowHandle(Result<isize, String>),
     Activated(Result<isize, String>),
     Injected(Result<(), String>),
@@ -430,8 +438,11 @@ impl KeyboardInput {
     fn complete_if_ready(&self) {
         if self.focus_observed
             && self.key_observed
+            && self.key_up_observed
             && self.character_observed
             && self.injection_complete
+            && self.defocus_complete
+            && self.lost_focus_observed
             && !self.complete.call(Ok(()))
         {
             eprintln!("keyboard fixture completion was rejected");
@@ -448,10 +459,15 @@ impl Component for KeyboardInput {
         Self {
             complete: input.complete.clone(),
             reference: ElementRef::new(),
+            blur_reference: ElementRef::new(),
             focus_observed: false,
             key_observed: false,
+            key_up_observed: false,
             character_observed: false,
             injection_complete: false,
+            defocus_requested: false,
+            defocus_complete: false,
+            lost_focus_observed: false,
             hwnd: None,
         }
     }
@@ -461,7 +477,7 @@ impl Component for KeyboardInput {
     }
 
     fn update(&mut self, message: Self::Message, context: &ComponentContext<Self>) {
-        let failure = match message {
+        let mut failure = match message {
             KeyboardMessage::Focused(Ok(true)) => {
                 let hwnd = self.hwnd.unwrap();
                 context.spawn_background(move |_| {
@@ -496,11 +512,41 @@ impl Component for KeyboardInput {
                     None
                 }
             }
+            KeyboardMessage::KeyUp(info) => {
+                if info.key != F13
+                    || info.original_key != F13
+                    || !info.status.is_released
+                    || info.modifiers != InputModifiers::NONE
+                {
+                    Some(format!("unexpected key-up payload: {info:?}"))
+                } else {
+                    self.key_up_observed = true;
+                    None
+                }
+            }
             KeyboardMessage::Character(info) => {
                 if info.character != b'x'.into() || info.status.is_released {
                     Some(format!("unexpected character payload: {info:?}"))
                 } else {
                     self.character_observed = true;
+                    None
+                }
+            }
+            KeyboardMessage::Defocused(Ok(true)) => {
+                self.defocus_complete = true;
+                None
+            }
+            KeyboardMessage::Defocused(Ok(false)) => {
+                Some("WinUI rejected the keyboard defocus request".to_string())
+            }
+            KeyboardMessage::Defocused(Err(error)) => {
+                Some(format!("keyboard defocus request failed: {error:?}"))
+            }
+            KeyboardMessage::LostFocus(info) => {
+                if !info.is_direct || info.state != ElementFocusState::Unfocused {
+                    Some(format!("unexpected lost-focus payload: {info:?}"))
+                } else {
+                    self.lost_focus_observed = true;
                     None
                 }
             }
@@ -536,6 +582,21 @@ impl Component for KeyboardInput {
             }
             KeyboardMessage::Injected(Err(error)) => Some(error),
         };
+        if failure.is_none()
+            && self.key_observed
+            && self.key_up_observed
+            && self.character_observed
+            && self.injection_complete
+            && !self.defocus_requested
+        {
+            self.defocus_requested = true;
+            let sender = context.sender();
+            if !self.blur_reference.request_focus_result(move |result| {
+                sender.send(KeyboardMessage::Defocused(result));
+            }) {
+                failure = Some("keyboard blur target was not published".to_string());
+            }
+        }
         if let Some(failure) = failure {
             if !self.complete.call(Err(failure)) {
                 eprintln!("keyboard fixture failure was rejected");
@@ -556,21 +617,35 @@ impl Component for KeyboardInput {
             None
         });
 
-        Border::new()
-            .is_tab_stop(true)
-            .element_ref(&self.reference)
-            .on_got_focus(context.callback(KeyboardMessage::GotFocus))
-            .on_preview_key_down(context.routed_callback(|info: KeyEventInfo| {
-                if info.key == F13 {
-                    RoutedMessage::handled(KeyboardMessage::Key(info))
-                } else {
-                    RoutedMessage::bubble_without_message()
-                }
-            }))
-            .on_character_received(context.routed_callback(|info: CharacterEventInfo| {
-                RoutedMessage::handled(KeyboardMessage::Character(info))
-            }))
-            .content("Keyboard input target")
+        StackPanel::new().children((
+            Border::new()
+                .is_tab_stop(true)
+                .element_ref(&self.reference)
+                .on_got_focus(context.callback(KeyboardMessage::GotFocus))
+                .on_lost_focus(context.callback(KeyboardMessage::LostFocus))
+                .on_preview_key_down(context.routed_callback(|info: KeyEventInfo| {
+                    if info.key == F13 {
+                        RoutedMessage::handled(KeyboardMessage::Key(info))
+                    } else {
+                        RoutedMessage::bubble_without_message()
+                    }
+                }))
+                .on_key_up(context.routed_callback(|info: KeyEventInfo| {
+                    if info.key == F13 {
+                        RoutedMessage::handled(KeyboardMessage::KeyUp(info))
+                    } else {
+                        RoutedMessage::bubble_without_message()
+                    }
+                }))
+                .on_character_received(context.routed_callback(|info: CharacterEventInfo| {
+                    RoutedMessage::handled(KeyboardMessage::Character(info))
+                }))
+                .content("Keyboard input target"),
+            Border::new()
+                .is_tab_stop(true)
+                .element_ref(&self.blur_reference)
+                .content("Keyboard blur target"),
+        ))
     }
 }
 

--- a/crates/tests/libs/reactor_selftest/src/fixtures.rs
+++ b/crates/tests/libs/reactor_selftest/src/fixtures.rs
@@ -19,7 +19,9 @@ use windows::Win32::{
     HWND, INPUT, INPUT_0, INPUT_KEYBOARD, KEYBDINPUT, KEYEVENTF_KEYUP, KEYEVENTF_UNICODE, POINT,
     RECT,
 };
-use windows_canvas::{CanvasCompositionExt, CanvasImageSource, ColorF, GpuDevice, animated_canvas};
+use windows_canvas::{
+    CanvasCompositionExt, CanvasImageSource, ColorF, GpuDevice, animated_canvas, canvas,
+};
 use windows_collections::IIterable;
 use windows_composition::{Compositor as CompositionCompositor, ContainerVisual, SpriteVisual};
 use windows_reactor::test::{LiveProbe, schedule_live_probe, schedule_live_window_handle};
@@ -411,6 +413,16 @@ pub(crate) struct KeyboardInput {
     reference: ElementRef<Border>,
     blur_reference: ElementRef<Border>,
     focus_observed: bool,
+    refocus_observed: bool,
+    same_target_click_started: bool,
+    same_target_click_complete: bool,
+    same_target_lost_observed: bool,
+    same_target_refocus_observed: bool,
+    second_defocus_requested: bool,
+    second_defocus_complete: bool,
+    second_lost_focus_observed: bool,
+    programmatic_refocus_complete: bool,
+    programmatic_refocus_observed: bool,
     key_observed: bool,
     key_up_observed: bool,
     character_observed: bool,
@@ -422,7 +434,6 @@ pub(crate) struct KeyboardInput {
 }
 
 pub(crate) enum KeyboardMessage {
-    Focused(Result<bool, FocusError>),
     GotFocus(FocusEventInfo),
     Key(KeyEventInfo),
     KeyUp(KeyEventInfo),
@@ -431,6 +442,12 @@ pub(crate) enum KeyboardMessage {
     LostFocus(FocusEventInfo),
     WindowHandle(Result<isize, String>),
     Activated(Result<isize, String>),
+    SecondClick(Result<(), String>),
+    SameTargetClick(Result<(), String>),
+    SameTargetSettled,
+    SecondDefocused(Result<bool, FocusError>),
+    ProgrammaticRefocused(Result<bool, FocusError>),
+    FocusTimeout(bool),
     Injected(Result<(), String>),
 }
 
@@ -443,6 +460,13 @@ impl KeyboardInput {
             && self.injection_complete
             && self.defocus_complete
             && self.lost_focus_observed
+            && self.refocus_observed
+            && self.same_target_click_complete
+            && self.same_target_refocus_observed
+            && self.second_defocus_complete
+            && self.second_lost_focus_observed
+            && self.programmatic_refocus_complete
+            && self.programmatic_refocus_observed
             && !self.complete.call(Ok(()))
         {
             eprintln!("keyboard fixture completion was rejected");
@@ -461,6 +485,16 @@ impl Component for KeyboardInput {
             reference: ElementRef::new(),
             blur_reference: ElementRef::new(),
             focus_observed: false,
+            refocus_observed: false,
+            same_target_click_started: false,
+            same_target_click_complete: false,
+            same_target_lost_observed: false,
+            same_target_refocus_observed: false,
+            second_defocus_requested: false,
+            second_defocus_complete: false,
+            second_lost_focus_observed: false,
+            programmatic_refocus_complete: false,
+            programmatic_refocus_observed: false,
             key_observed: false,
             key_up_observed: false,
             character_observed: false,
@@ -478,26 +512,56 @@ impl Component for KeyboardInput {
 
     fn update(&mut self, message: Self::Message, context: &ComponentContext<Self>) {
         let mut failure = match message {
-            KeyboardMessage::Focused(Ok(true)) => {
-                let hwnd = self.hwnd.unwrap();
-                context.spawn_background(move |_| {
-                    std::thread::sleep(Duration::from_millis(100));
-                    KeyboardMessage::Injected(inject_keyboard(hwnd))
-                });
-                None
-            }
-            KeyboardMessage::Focused(Ok(false)) => {
-                Some("WinUI rejected the keyboard focus request".to_string())
-            }
-            KeyboardMessage::Focused(Err(error)) => {
-                Some(format!("keyboard focus request failed: {error:?}"))
-            }
             KeyboardMessage::GotFocus(info) => {
                 if !info.is_direct || info.state == ElementFocusState::Unfocused {
                     Some(format!("unexpected focus payload: {info:?}"))
-                } else {
-                    self.focus_observed = true;
+                } else if !self.focus_observed {
+                    if info.state != ElementFocusState::Pointer {
+                        Some(format!(
+                            "first click reported unexpected focus state: {info:?}"
+                        ))
+                    } else {
+                        self.focus_observed = true;
+                        let hwnd = self.hwnd.unwrap();
+                        context.spawn_background(move |_| {
+                            std::thread::sleep(Duration::from_millis(100));
+                            KeyboardMessage::Injected(inject_keyboard(hwnd))
+                        });
+                        None
+                    }
+                } else if !self.refocus_observed {
+                    if info.state != ElementFocusState::Pointer {
+                        Some(format!(
+                            "second click reported unexpected focus state: {info:?}"
+                        ))
+                    } else {
+                        self.refocus_observed = true;
+                        self.same_target_click_started = true;
+                        let hwnd = self.hwnd.unwrap();
+                        context.spawn_background(move |_| {
+                            std::thread::sleep(Duration::from_millis(100));
+                            let result = inject_keyboard_focus_click(hwnd);
+                            std::thread::sleep(Duration::from_millis(100));
+                            KeyboardMessage::SameTargetClick(result)
+                        });
+                        None
+                    }
+                } else if self.same_target_click_started && !self.same_target_refocus_observed {
+                    if info.state != ElementFocusState::Pointer {
+                        Some(format!(
+                            "focused click reported unexpected focus state: {info:?}"
+                        ))
+                    } else {
+                        self.same_target_refocus_observed = true;
+                        None
+                    }
+                } else if self.second_lost_focus_observed
+                    && info.state == ElementFocusState::Programmatic
+                {
+                    self.programmatic_refocus_observed = true;
                     None
+                } else {
+                    Some(format!("unexpected additional focus payload: {info:?}"))
                 }
             }
             KeyboardMessage::Key(info) => {
@@ -545,8 +609,29 @@ impl Component for KeyboardInput {
             KeyboardMessage::LostFocus(info) => {
                 if !info.is_direct || info.state != ElementFocusState::Unfocused {
                     Some(format!("unexpected lost-focus payload: {info:?}"))
+                } else if self.second_defocus_requested {
+                    self.second_lost_focus_observed = true;
+                    let sender = context.sender();
+                    if !self.reference.request_focus_result(move |result| {
+                        sender.send(KeyboardMessage::ProgrammaticRefocused(result));
+                    }) {
+                        Some("keyboard target was not published".to_string())
+                    } else {
+                        None
+                    }
+                } else if self.lost_focus_observed && self.same_target_click_started {
+                    self.same_target_lost_observed = true;
+                    None
                 } else {
                     self.lost_focus_observed = true;
+                    let hwnd = self.hwnd.unwrap();
+                    context.spawn_background(move |_| {
+                        std::thread::sleep(Duration::from_millis(100));
+                        KeyboardMessage::SecondClick(
+                            inject_keyboard_focus_click(hwnd)
+                                .map_err(|error| format!("second click failed: {error}")),
+                        )
+                    });
                     None
                 }
             }
@@ -566,16 +651,70 @@ impl Component for KeyboardInput {
             KeyboardMessage::WindowHandle(Err(error)) => Some(error),
             KeyboardMessage::Activated(Ok(hwnd)) => {
                 self.hwnd = Some(hwnd);
-                let sender = context.sender();
-                if !self.reference.request_focus_result(move |result| {
-                    sender.send(KeyboardMessage::Focused(result));
-                }) {
-                    Some("keyboard target was not published".to_string())
-                } else {
-                    None
+                let failure = inject_keyboard_focus_click(hwnd).err();
+                if failure.is_none() {
+                    schedule_focus_timeout(context, false);
                 }
+                failure
             }
             KeyboardMessage::Activated(Err(error)) => Some(error),
+            KeyboardMessage::SecondClick(Ok(())) => {
+                schedule_focus_timeout(context, true);
+                None
+            }
+            KeyboardMessage::SecondClick(Err(error)) => Some(error),
+            KeyboardMessage::SameTargetClick(Ok(())) => {
+                self.same_target_click_complete = true;
+                context.spawn_background(move |_| {
+                    std::thread::sleep(Duration::from_millis(200));
+                    KeyboardMessage::SameTargetSettled
+                });
+                None
+            }
+            KeyboardMessage::SameTargetSettled => {
+                if self.same_target_lost_observed && !self.same_target_refocus_observed {
+                    Some("clicking the focused target did not restore focus".to_string())
+                } else {
+                    self.same_target_refocus_observed = true;
+                    self.second_defocus_requested = true;
+                    let sender = context.sender();
+                    if !self.blur_reference.request_focus_result(move |result| {
+                        sender.send(KeyboardMessage::SecondDefocused(result));
+                    }) {
+                        Some("keyboard blur target was not published".to_string())
+                    } else {
+                        None
+                    }
+                }
+            }
+            KeyboardMessage::SameTargetClick(Err(error)) => Some(error),
+            KeyboardMessage::SecondDefocused(Ok(true)) => {
+                self.second_defocus_complete = true;
+                None
+            }
+            KeyboardMessage::SecondDefocused(Ok(false)) => {
+                Some("WinUI rejected the second keyboard defocus request".to_string())
+            }
+            KeyboardMessage::SecondDefocused(Err(error)) => {
+                Some(format!("second keyboard defocus request failed: {error:?}"))
+            }
+            KeyboardMessage::ProgrammaticRefocused(Ok(true)) => {
+                self.programmatic_refocus_complete = true;
+                None
+            }
+            KeyboardMessage::ProgrammaticRefocused(Ok(false)) => {
+                Some("WinUI rejected the programmatic refocus request".to_string())
+            }
+            KeyboardMessage::ProgrammaticRefocused(Err(error)) => {
+                Some(format!("programmatic refocus request failed: {error:?}"))
+            }
+            KeyboardMessage::FocusTimeout(false) if !self.focus_observed => {
+                Some("first click did not focus the keyboard target".to_string())
+            }
+            KeyboardMessage::FocusTimeout(true) if !self.refocus_observed => {
+                Some("second click did not refocus the keyboard target".to_string())
+            }
+            KeyboardMessage::FocusTimeout(_) => None,
             KeyboardMessage::Injected(Ok(())) => {
                 self.injection_complete = true;
                 None
@@ -619,7 +758,10 @@ impl Component for KeyboardInput {
 
         StackPanel::new().children((
             Border::new()
+                .height(240.0)
                 .is_tab_stop(true)
+                .focus_on_pointer_release(true)
+                .background(Color::transparent())
                 .element_ref(&self.reference)
                 .on_got_focus(context.callback(KeyboardMessage::GotFocus))
                 .on_lost_focus(context.callback(KeyboardMessage::LostFocus))
@@ -640,7 +782,10 @@ impl Component for KeyboardInput {
                 .on_character_received(context.routed_callback(|info: CharacterEventInfo| {
                     RoutedMessage::handled(KeyboardMessage::Character(info))
                 }))
-                .content("Keyboard input target"),
+                .content(canvas(|context| {
+                    context.clear(ColorF::from_rgb8(32, 32, 40));
+                    Ok(())
+                })),
             Border::new()
                 .is_tab_stop(true)
                 .element_ref(&self.blur_reference)
@@ -679,6 +824,47 @@ fn inject_keyboard(hwnd: isize) -> Result<(), String> {
             inputs.len()
         ))
     }
+}
+
+fn inject_keyboard_focus_click(handle: isize) -> Result<(), String> {
+    let hwnd = HWND(handle as *mut _);
+    fit_window_to_work_area(hwnd)?;
+    unsafe {
+        let _ = SetForegroundWindow(hwnd);
+        let _ = BringWindowToTop(hwnd);
+    }
+    let injector = InputInjector::TryCreate().map_err(|error| error.to_string())?;
+    let (origin_x, origin_y) = virtual_screen_origin();
+    inject_at(
+        &injector,
+        origin_x,
+        origin_y,
+        InjectedInputMouseOptions::Move | InjectedInputMouseOptions::MoveNoCoalesce,
+    )
+    .map_err(|error| error.to_string())?;
+    inject_at(
+        &injector,
+        origin_x,
+        origin_y,
+        InjectedInputMouseOptions::LeftUp | InjectedInputMouseOptions::RightUp,
+    )
+    .map_err(|error| error.to_string())?;
+    let (x, y) = client_screen_point(hwnd, 0.5, 0.1)?;
+    for options in [
+        InjectedInputMouseOptions::Move | InjectedInputMouseOptions::MoveNoCoalesce,
+        InjectedInputMouseOptions::LeftDown,
+        InjectedInputMouseOptions::LeftUp,
+    ] {
+        inject_at(&injector, x, y, options).map_err(|error| error.to_string())?;
+    }
+    Ok(())
+}
+
+fn schedule_focus_timeout(context: &ComponentContext<KeyboardInput>, second: bool) {
+    context.spawn_background(move |_| {
+        std::thread::sleep(Duration::from_secs(1));
+        KeyboardMessage::FocusTimeout(second)
+    });
 }
 
 #[derive(Clone, Copy, PartialEq)]

--- a/crates/tests/libs/reactor_selftest/src/fixtures.rs
+++ b/crates/tests/libs/reactor_selftest/src/fixtures.rs
@@ -8,13 +8,17 @@ use windows::UI::Input::Preview::Injection::{
     InjectedInputMouseInfo, InjectedInputMouseOptions, InputInjector,
 };
 use windows::Win32::winuser::{
-    BringWindowToTop, ClientToScreen, DispatchMessageW, GetClientRect, GetMessageW,
-    GetMonitorInfoW, GetSystemMetrics, GetWindowRect, KillTimer, MONITOR_DEFAULTTONEAREST,
-    MONITORINFO, MSG, MonitorFromWindow, PostQuitMessage, SM_CXVIRTUALSCREEN, SM_CYVIRTUALSCREEN,
-    SM_XVIRTUALSCREEN, SM_YVIRTUALSCREEN, SWP_NOSIZE, SWP_NOZORDER, SetForegroundWindow, SetTimer,
-    SetWindowPos, TranslateMessage, WM_TIMER,
+    BringWindowToTop, ClientToScreen, DispatchMessageW, GetClientRect, GetForegroundWindow,
+    GetMessageW, GetMonitorInfoW, GetSystemMetrics, GetWindowRect, KillTimer,
+    MONITOR_DEFAULTTONEAREST, MONITORINFO, MSG, MonitorFromWindow, PostQuitMessage,
+    SM_CXVIRTUALSCREEN, SM_CYVIRTUALSCREEN, SM_XVIRTUALSCREEN, SM_YVIRTUALSCREEN, SWP_NOSIZE,
+    SWP_NOZORDER, SendInput, SetForegroundWindow, SetTimer, SetWindowPos, TranslateMessage,
+    WM_TIMER,
 };
-use windows::Win32::{HWND, POINT, RECT};
+use windows::Win32::{
+    HWND, INPUT, INPUT_0, INPUT_KEYBOARD, KEYBDINPUT, KEYEVENTF_KEYUP, KEYEVENTF_UNICODE, POINT,
+    RECT,
+};
 use windows_canvas::{CanvasCompositionExt, CanvasImageSource, ColorF, GpuDevice, animated_canvas};
 use windows_collections::IIterable;
 use windows_composition::{Compositor as CompositionCompositor, ContainerVisual, SpriteVisual};
@@ -24,6 +28,8 @@ use windows_reactor::*;
 use windows_webview::{EventRegistration, WebView, webview_result};
 
 pub type FixtureResult = Result<(), String>;
+
+const F13: VirtualKey = VirtualKey(0x7C);
 
 #[cfg(feature = "self-contained")]
 pub(crate) struct WebViewLifecycle {
@@ -397,6 +403,206 @@ impl Component for FocusPublication {
                 TextBlock::new().text("focus fixture complete").into()
             }
         }
+    }
+}
+
+pub(crate) struct KeyboardInput {
+    complete: Callback<FixtureResult>,
+    reference: ElementRef<Border>,
+    focus_observed: bool,
+    key_observed: bool,
+    character_observed: bool,
+    injection_complete: bool,
+    hwnd: Option<isize>,
+}
+
+pub(crate) enum KeyboardMessage {
+    Focused(Result<bool, FocusError>),
+    GotFocus(FocusEventInfo),
+    Key(KeyEventInfo),
+    Character(CharacterEventInfo),
+    WindowHandle(Result<isize, String>),
+    Activated(Result<isize, String>),
+    Injected(Result<(), String>),
+}
+
+impl KeyboardInput {
+    fn complete_if_ready(&self) {
+        if self.focus_observed
+            && self.key_observed
+            && self.character_observed
+            && self.injection_complete
+            && !self.complete.call(Ok(()))
+        {
+            eprintln!("keyboard fixture completion was rejected");
+            std::process::exit(1);
+        }
+    }
+}
+
+impl Component for KeyboardInput {
+    type Input = FixtureInput;
+    type Message = KeyboardMessage;
+
+    fn create(input: &Self::Input, _context: &ComponentContext<Self>) -> Self {
+        Self {
+            complete: input.complete.clone(),
+            reference: ElementRef::new(),
+            focus_observed: false,
+            key_observed: false,
+            character_observed: false,
+            injection_complete: false,
+            hwnd: None,
+        }
+    }
+
+    fn input_changed(&mut self, input: &Self::Input, _context: &ComponentContext<Self>) {
+        self.complete = input.complete.clone();
+    }
+
+    fn update(&mut self, message: Self::Message, context: &ComponentContext<Self>) {
+        let failure = match message {
+            KeyboardMessage::Focused(Ok(true)) => {
+                let hwnd = self.hwnd.unwrap();
+                context.spawn_background(move |_| {
+                    std::thread::sleep(Duration::from_millis(100));
+                    KeyboardMessage::Injected(inject_keyboard(hwnd))
+                });
+                None
+            }
+            KeyboardMessage::Focused(Ok(false)) => {
+                Some("WinUI rejected the keyboard focus request".to_string())
+            }
+            KeyboardMessage::Focused(Err(error)) => {
+                Some(format!("keyboard focus request failed: {error:?}"))
+            }
+            KeyboardMessage::GotFocus(info) => {
+                if !info.is_direct || info.state == ElementFocusState::Unfocused {
+                    Some(format!("unexpected focus payload: {info:?}"))
+                } else {
+                    self.focus_observed = true;
+                    None
+                }
+            }
+            KeyboardMessage::Key(info) => {
+                if info.key != F13
+                    || info.original_key != F13
+                    || info.status.is_released
+                    || info.modifiers != InputModifiers::NONE
+                {
+                    Some(format!("unexpected key payload: {info:?}"))
+                } else {
+                    self.key_observed = true;
+                    None
+                }
+            }
+            KeyboardMessage::Character(info) => {
+                if info.character != b'x'.into() || info.status.is_released {
+                    Some(format!("unexpected character payload: {info:?}"))
+                } else {
+                    self.character_observed = true;
+                    None
+                }
+            }
+            KeyboardMessage::WindowHandle(Ok(hwnd)) => {
+                context.spawn_background(move |_| {
+                    unsafe {
+                        let _ = SetForegroundWindow(HWND(hwnd as *mut _));
+                    }
+                    std::thread::sleep(Duration::from_millis(100));
+                    let result = (unsafe { GetForegroundWindow() } == HWND(hwnd as *mut _))
+                        .then_some(hwnd)
+                        .ok_or_else(|| "self-test window could not become foreground".to_string());
+                    KeyboardMessage::Activated(result)
+                });
+                None
+            }
+            KeyboardMessage::WindowHandle(Err(error)) => Some(error),
+            KeyboardMessage::Activated(Ok(hwnd)) => {
+                self.hwnd = Some(hwnd);
+                let sender = context.sender();
+                if !self.reference.request_focus_result(move |result| {
+                    sender.send(KeyboardMessage::Focused(result));
+                }) {
+                    Some("keyboard target was not published".to_string())
+                } else {
+                    None
+                }
+            }
+            KeyboardMessage::Activated(Err(error)) => Some(error),
+            KeyboardMessage::Injected(Ok(())) => {
+                self.injection_complete = true;
+                None
+            }
+            KeyboardMessage::Injected(Err(error)) => Some(error),
+        };
+        if let Some(failure) = failure {
+            if !self.complete.call(Err(failure)) {
+                eprintln!("keyboard fixture failure was rejected");
+                std::process::exit(1);
+            }
+            return;
+        }
+        self.complete_if_ready();
+    }
+
+    fn view(&self, _input: &Self::Input, context: &mut ViewContext<Self>) -> View {
+        let sender = context.sender();
+        context.use_effect("request-focus", (), move || {
+            schedule_live_window_handle(move |result| {
+                sender.send(KeyboardMessage::WindowHandle(result));
+            })
+            .unwrap();
+            None
+        });
+
+        Border::new()
+            .is_tab_stop(true)
+            .element_ref(&self.reference)
+            .on_got_focus(context.callback(KeyboardMessage::GotFocus))
+            .on_preview_key_down(context.routed_callback(|info: KeyEventInfo| {
+                if info.key == F13 {
+                    RoutedMessage::handled(KeyboardMessage::Key(info))
+                } else {
+                    RoutedMessage::bubble_without_message()
+                }
+            }))
+            .on_character_received(context.routed_callback(|info: CharacterEventInfo| {
+                RoutedMessage::handled(KeyboardMessage::Character(info))
+            }))
+            .content("Keyboard input target")
+    }
+}
+
+fn inject_keyboard(hwnd: isize) -> Result<(), String> {
+    if unsafe { GetForegroundWindow() } != HWND(hwnd as *mut _) {
+        return Err("self-test window lost foreground focus".to_string());
+    }
+    let key = |virtual_key, scan_code, flags| INPUT {
+        r#type: INPUT_KEYBOARD as u32,
+        Anonymous: INPUT_0 {
+            ki: KEYBDINPUT {
+                wVk: virtual_key,
+                wScan: scan_code,
+                dwFlags: flags,
+                ..Default::default()
+            },
+        },
+    };
+    let inputs = [
+        key(F13.0 as u16, 0, 0),
+        key(F13.0 as u16, 0, KEYEVENTF_KEYUP as u32),
+        key(0, b'x'.into(), KEYEVENTF_UNICODE as u32),
+        key(0, b'x'.into(), (KEYEVENTF_UNICODE | KEYEVENTF_KEYUP) as u32),
+    ];
+    let inserted = unsafe { SendInput(&inputs, size_of::<INPUT>() as i32) };
+    if inserted == inputs.len() as u32 {
+        Ok(())
+    } else {
+        Err(format!(
+            "SendInput inserted {inserted} of {} keyboard events",
+            inputs.len()
+        ))
     }
 }
 

--- a/crates/tests/libs/reactor_selftest/src/fixtures.rs
+++ b/crates/tests/libs/reactor_selftest/src/fixtures.rs
@@ -423,6 +423,11 @@ pub(crate) struct KeyboardInput {
     second_lost_focus_observed: bool,
     programmatic_refocus_complete: bool,
     programmatic_refocus_observed: bool,
+    tab_cycle_started: bool,
+    tab_defocus_complete: bool,
+    tab_lost_observed: bool,
+    tab_injection_complete: bool,
+    keyboard_refocus_observed: bool,
     key_observed: bool,
     key_up_observed: bool,
     character_observed: bool,
@@ -447,6 +452,8 @@ pub(crate) enum KeyboardMessage {
     SameTargetSettled,
     SecondDefocused(Result<bool, FocusError>),
     ProgrammaticRefocused(Result<bool, FocusError>),
+    TabDefocused(Result<bool, FocusError>),
+    TabInjected(Result<(), String>),
     FocusTimeout(bool),
     Injected(Result<(), String>),
 }
@@ -467,6 +474,10 @@ impl KeyboardInput {
             && self.second_lost_focus_observed
             && self.programmatic_refocus_complete
             && self.programmatic_refocus_observed
+            && self.tab_defocus_complete
+            && self.tab_lost_observed
+            && self.tab_injection_complete
+            && self.keyboard_refocus_observed
             && !self.complete.call(Ok(()))
         {
             eprintln!("keyboard fixture completion was rejected");
@@ -495,6 +506,11 @@ impl Component for KeyboardInput {
             second_lost_focus_observed: false,
             programmatic_refocus_complete: false,
             programmatic_refocus_observed: false,
+            tab_cycle_started: false,
+            tab_defocus_complete: false,
+            tab_lost_observed: false,
+            tab_injection_complete: false,
+            keyboard_refocus_observed: false,
             key_observed: false,
             key_up_observed: false,
             character_observed: false,
@@ -515,6 +531,15 @@ impl Component for KeyboardInput {
             KeyboardMessage::GotFocus(info) => {
                 if !info.is_direct || info.state == ElementFocusState::Unfocused {
                     Some(format!("unexpected focus payload: {info:?}"))
+                } else if self.tab_lost_observed && !self.keyboard_refocus_observed {
+                    if info.state != ElementFocusState::Keyboard {
+                        Some(format!(
+                            "keyboard navigation reported unexpected focus state: {info:?}"
+                        ))
+                    } else {
+                        self.keyboard_refocus_observed = true;
+                        None
+                    }
                 } else if !self.focus_observed {
                     if info.state != ElementFocusState::Pointer {
                         Some(format!(
@@ -609,6 +634,14 @@ impl Component for KeyboardInput {
             KeyboardMessage::LostFocus(info) => {
                 if !info.is_direct || info.state != ElementFocusState::Unfocused {
                     Some(format!("unexpected lost-focus payload: {info:?}"))
+                } else if self.tab_cycle_started {
+                    self.tab_lost_observed = true;
+                    let hwnd = self.hwnd.unwrap();
+                    context.spawn_background(move |_| {
+                        std::thread::sleep(Duration::from_millis(100));
+                        KeyboardMessage::TabInjected(inject_reverse_tab(hwnd))
+                    });
+                    None
                 } else if self.second_defocus_requested {
                     self.second_lost_focus_observed = true;
                     let sender = context.sender();
@@ -708,6 +741,21 @@ impl Component for KeyboardInput {
             KeyboardMessage::ProgrammaticRefocused(Err(error)) => {
                 Some(format!("programmatic refocus request failed: {error:?}"))
             }
+            KeyboardMessage::TabDefocused(Ok(true)) => {
+                self.tab_defocus_complete = true;
+                None
+            }
+            KeyboardMessage::TabDefocused(Ok(false)) => {
+                Some("WinUI rejected the Tab-cycle defocus request".to_string())
+            }
+            KeyboardMessage::TabDefocused(Err(error)) => {
+                Some(format!("Tab-cycle defocus request failed: {error:?}"))
+            }
+            KeyboardMessage::TabInjected(Ok(())) => {
+                self.tab_injection_complete = true;
+                None
+            }
+            KeyboardMessage::TabInjected(Err(error)) => Some(error),
             KeyboardMessage::FocusTimeout(false) if !self.focus_observed => {
                 Some("first click did not focus the keyboard target".to_string())
             }
@@ -732,6 +780,19 @@ impl Component for KeyboardInput {
             let sender = context.sender();
             if !self.blur_reference.request_focus_result(move |result| {
                 sender.send(KeyboardMessage::Defocused(result));
+            }) {
+                failure = Some("keyboard blur target was not published".to_string());
+            }
+        }
+        if failure.is_none()
+            && self.programmatic_refocus_complete
+            && self.programmatic_refocus_observed
+            && !self.tab_cycle_started
+        {
+            self.tab_cycle_started = true;
+            let sender = context.sender();
+            if !self.blur_reference.request_focus_result(move |result| {
+                sender.send(KeyboardMessage::TabDefocused(result));
             }) {
                 failure = Some("keyboard blur target was not published".to_string());
             }
@@ -821,6 +882,37 @@ fn inject_keyboard(hwnd: isize) -> Result<(), String> {
     } else {
         Err(format!(
             "SendInput inserted {inserted} of {} keyboard events",
+            inputs.len()
+        ))
+    }
+}
+
+fn inject_reverse_tab(hwnd: isize) -> Result<(), String> {
+    if unsafe { GetForegroundWindow() } != HWND(hwnd as *mut _) {
+        return Err("self-test window lost foreground focus".to_string());
+    }
+    let key = |virtual_key, flags| INPUT {
+        r#type: INPUT_KEYBOARD as u32,
+        Anonymous: INPUT_0 {
+            ki: KEYBDINPUT {
+                wVk: virtual_key,
+                dwFlags: flags,
+                ..Default::default()
+            },
+        },
+    };
+    let inputs = [
+        key(0x10, 0),
+        key(0x09, 0),
+        key(0x09, KEYEVENTF_KEYUP as u32),
+        key(0x10, KEYEVENTF_KEYUP as u32),
+    ];
+    let inserted = unsafe { SendInput(&inputs, size_of::<INPUT>() as i32) };
+    if inserted == inputs.len() as u32 {
+        Ok(())
+    } else {
+        Err(format!(
+            "SendInput inserted {inserted} of {} keyboard navigation events",
             inputs.len()
         ))
     }

--- a/crates/tests/libs/reactor_selftest/src/runner.rs
+++ b/crates/tests/libs/reactor_selftest/src/runner.rs
@@ -7,8 +7,9 @@ use windows_reactor::*;
 use crate::fixtures::WebViewLifecycle;
 use crate::fixtures::{
     CompositionLifecycle, EncodedImageLifecycle, FixtureInput, FixtureResult, FocusPublication,
-    ImageSourceLifecycle, KeyedNativeMutations, NestedWindowOperation, PointerInjection,
-    ProbeFixture, ProbeInput, SwapChainLifecycle, ThemeResources, TimerLifecycle, WindowLifecycle,
+    ImageSourceLifecycle, KeyboardInput, KeyedNativeMutations, NestedWindowOperation,
+    PointerInjection, ProbeFixture, ProbeInput, SwapChainLifecycle, ThemeResources, TimerLifecycle,
+    WindowLifecycle,
 };
 
 const FIXTURE_TIMEOUT: Duration = Duration::from_secs(15);
@@ -27,6 +28,7 @@ pub(crate) const SUITE_TIMEOUT: Duration = Duration::from_secs(
 enum FixtureKind {
     ContentDialogLifecycle,
     FocusPublication,
+    KeyboardInput,
     EventDelivery,
     EventRevokers,
     ControlledFeedback,
@@ -63,6 +65,10 @@ const FIXTURES: &[Fixture] = &[
     Fixture {
         name: "Focus_PublicationAndRetirement",
         kind: FixtureKind::FocusPublication,
+    },
+    Fixture {
+        name: "Keyboard_RoutedInput",
+        kind: FixtureKind::KeyboardInput,
     },
     Fixture {
         name: "ContentDialog_QueuedReopenLifecycle",
@@ -267,6 +273,7 @@ impl Component for FixtureRunner {
                 .text("ContentDialog lifecycle probe")
                 .into(),
             Some(FixtureKind::FocusPublication) => View::component::<FocusPublication>(input),
+            Some(FixtureKind::KeyboardInput) => View::component::<KeyboardInput>(input),
             Some(FixtureKind::EventDelivery) => {
                 TextBlock::new().text("event delivery probe").into()
             }

--- a/crates/tests/libs/reactor_surface/src/generated_surface.rs
+++ b/crates/tests/libs/reactor_surface/src/generated_surface.rs
@@ -46,8 +46,8 @@ pub struct ExtensionSurface {
     pub name: &'static str,
 }
 pub(crate) const PROJECTED_CONTROL_COUNT: usize = 79usize;
-pub(crate) const PROJECTED_PROPERTY_COUNT: usize = 230usize;
-pub(crate) const PROJECTED_EVENT_COUNT: usize = 63usize;
+pub(crate) const PROJECTED_PROPERTY_COUNT: usize = 232usize;
+pub(crate) const PROJECTED_EVENT_COUNT: usize = 68usize;
 pub(crate) const CAPABILITY_PROPERTY_COUNT: usize = 27usize;
 pub(crate) const STRUCTURAL_COUNT: usize = 65usize;
 pub(crate) const EXTENSION_COUNT: usize = 5;
@@ -457,6 +457,22 @@ fn property_repeat_button_is_enabled(stage: usize) -> View {
         0 | 3 => Grid::new().children((RepeatButton::new(),)),
         1 => Grid::new().children((RepeatButton::new().is_enabled(true),)),
         2 => Grid::new().children((RepeatButton::new().is_enabled(false),)),
+        _ => unreachable!(),
+    }
+}
+fn property_border_is_tab_stop(stage: usize) -> View {
+    match stage {
+        0 | 3 => Grid::new().children((Border::new(),)),
+        1 => Grid::new().children((Border::new().is_tab_stop(true),)),
+        2 => Grid::new().children((Border::new().is_tab_stop(false),)),
+        _ => unreachable!(),
+    }
+}
+fn property_border_allow_focus_on_interaction(stage: usize) -> View {
+    match stage {
+        0 | 3 => Grid::new().children((Border::new(),)),
+        1 => Grid::new().children((Border::new().allow_focus_on_interaction(true),)),
+        2 => Grid::new().children((Border::new().allow_focus_on_interaction(false),)),
         _ => unreachable!(),
     }
 }
@@ -2384,6 +2400,102 @@ fn event_border_on_pointer_canceled(stage: usize) -> View {
             let _ = 0u8;
         }),)),
         2 => Grid::new().children((Border::new().on_pointer_canceled(move || {
+            let _ = 1u8;
+        }),)),
+        _ => unreachable!(),
+    }
+}
+struct BorderPreviewKeyDownEventSurface;
+impl Component for BorderPreviewKeyDownEventSurface {
+    type Input = usize;
+    type Message = ();
+    fn create(_input: &Self::Input, _context: &ComponentContext<Self>) -> Self {
+        Self
+    }
+    fn view(&self, input: &Self::Input, context: &mut ViewContext<Self>) -> View {
+        let marker = *input;
+        match marker {
+            0 | 3 => Grid::new().children((Border::new(),)),
+            1 | 2 => Grid::new().children((Border::new().on_preview_key_down(
+                context.routed_callback(move |_| {
+                    let _ = marker;
+                    RoutedMessage::bubble(())
+                }),
+            ),)),
+            _ => unreachable!(),
+        }
+    }
+}
+fn event_border_on_preview_key_down(stage: usize) -> View {
+    View::component::<BorderPreviewKeyDownEventSurface>(stage)
+}
+struct BorderKeyUpEventSurface;
+impl Component for BorderKeyUpEventSurface {
+    type Input = usize;
+    type Message = ();
+    fn create(_input: &Self::Input, _context: &ComponentContext<Self>) -> Self {
+        Self
+    }
+    fn view(&self, input: &Self::Input, context: &mut ViewContext<Self>) -> View {
+        let marker = *input;
+        match marker {
+            0 | 3 => Grid::new().children((Border::new(),)),
+            1 | 2 => Grid::new().children((Border::new().on_key_up(context.routed_callback(
+                move |_| {
+                    let _ = marker;
+                    RoutedMessage::bubble(())
+                },
+            )),)),
+            _ => unreachable!(),
+        }
+    }
+}
+fn event_border_on_key_up(stage: usize) -> View {
+    View::component::<BorderKeyUpEventSurface>(stage)
+}
+struct BorderCharacterReceivedEventSurface;
+impl Component for BorderCharacterReceivedEventSurface {
+    type Input = usize;
+    type Message = ();
+    fn create(_input: &Self::Input, _context: &ComponentContext<Self>) -> Self {
+        Self
+    }
+    fn view(&self, input: &Self::Input, context: &mut ViewContext<Self>) -> View {
+        let marker = *input;
+        match marker {
+            0 | 3 => Grid::new().children((Border::new(),)),
+            1 | 2 => Grid::new().children((Border::new().on_character_received(
+                context.routed_callback(move |_| {
+                    let _ = marker;
+                    RoutedMessage::bubble(())
+                }),
+            ),)),
+            _ => unreachable!(),
+        }
+    }
+}
+fn event_border_on_character_received(stage: usize) -> View {
+    View::component::<BorderCharacterReceivedEventSurface>(stage)
+}
+fn event_border_on_got_focus(stage: usize) -> View {
+    match stage {
+        0 | 3 => Grid::new().children((Border::new(),)),
+        1 => Grid::new().children((Border::new().on_got_focus(move |_| {
+            let _ = 0u8;
+        }),)),
+        2 => Grid::new().children((Border::new().on_got_focus(move |_| {
+            let _ = 1u8;
+        }),)),
+        _ => unreachable!(),
+    }
+}
+fn event_border_on_lost_focus(stage: usize) -> View {
+    match stage {
+        0 | 3 => Grid::new().children((Border::new(),)),
+        1 => Grid::new().children((Border::new().on_lost_focus(move |_| {
+            let _ = 0u8;
+        }),)),
+        2 => Grid::new().children((Border::new().on_lost_focus(move |_| {
             let _ = 1u8;
         }),)),
         _ => unreachable!(),
@@ -4355,6 +4467,20 @@ pub(crate) static SURFACE_CASES: &[SurfaceCase] = &[
         build: construct_border,
     },
     SurfaceCase {
+        name: "property.Border.IsTabStop",
+        kind: SurfaceKind::Property,
+        stages: 4,
+        subscription_delta: None,
+        build: property_border_is_tab_stop,
+    },
+    SurfaceCase {
+        name: "property.Border.AllowFocusOnInteraction",
+        kind: SurfaceKind::Property,
+        stages: 4,
+        subscription_delta: None,
+        build: property_border_allow_focus_on_interaction,
+    },
+    SurfaceCase {
         name: "property.Border.Padding",
         kind: SurfaceKind::Property,
         stages: 4,
@@ -4507,6 +4633,41 @@ pub(crate) static SURFACE_CASES: &[SurfaceCase] = &[
         stages: 4,
         subscription_delta: Some(1usize),
         build: event_border_on_pointer_canceled,
+    },
+    SurfaceCase {
+        name: "event.Border.PreviewKeyDown",
+        kind: SurfaceKind::Event,
+        stages: 4,
+        subscription_delta: Some(1usize),
+        build: event_border_on_preview_key_down,
+    },
+    SurfaceCase {
+        name: "event.Border.KeyUp",
+        kind: SurfaceKind::Event,
+        stages: 4,
+        subscription_delta: Some(1usize),
+        build: event_border_on_key_up,
+    },
+    SurfaceCase {
+        name: "event.Border.CharacterReceived",
+        kind: SurfaceKind::Event,
+        stages: 4,
+        subscription_delta: Some(1usize),
+        build: event_border_on_character_received,
+    },
+    SurfaceCase {
+        name: "event.Border.GotFocus",
+        kind: SurfaceKind::Event,
+        stages: 4,
+        subscription_delta: Some(1usize),
+        build: event_border_on_got_focus,
+    },
+    SurfaceCase {
+        name: "event.Border.LostFocus",
+        kind: SurfaceKind::Event,
+        stages: 4,
+        subscription_delta: Some(1usize),
+        build: event_border_on_lost_focus,
     },
     SurfaceCase {
         name: "control.BreadcrumbBar.construct",
@@ -7378,6 +7539,24 @@ pub static PROJECTED_PROPERTIES: &[PropertySurface] = &[
     },
     PropertySurface {
         control: "Border",
+        property: "IsTabStop",
+        value: "Bool",
+        adapter: "direct",
+        validation: None,
+        clearable: true,
+        theme_style: false,
+    },
+    PropertySurface {
+        control: "Border",
+        property: "AllowFocusOnInteraction",
+        value: "Bool",
+        adapter: "direct",
+        validation: None,
+        clearable: true,
+        theme_style: false,
+    },
+    PropertySurface {
+        control: "Border",
         property: "Padding",
         value: "Thickness",
         adapter: "direct",
@@ -9398,6 +9577,51 @@ pub static PROJECTED_EVENTS: &[EventSurface] = &[
         control: "Border",
         event: "PointerCanceled",
         payload: "Unit",
+        conversion: "Identity",
+        subscription: "callback",
+        delivery: "registration+deterministic",
+        active_property: None,
+    },
+    EventSurface {
+        control: "Border",
+        event: "PreviewKeyDown",
+        payload: "KeyEventInfo",
+        conversion: "Identity",
+        subscription: "callback",
+        delivery: "registration+deterministic",
+        active_property: None,
+    },
+    EventSurface {
+        control: "Border",
+        event: "KeyUp",
+        payload: "KeyEventInfo",
+        conversion: "Identity",
+        subscription: "callback",
+        delivery: "registration+deterministic",
+        active_property: None,
+    },
+    EventSurface {
+        control: "Border",
+        event: "CharacterReceived",
+        payload: "CharacterEventInfo",
+        conversion: "Identity",
+        subscription: "callback",
+        delivery: "registration+deterministic",
+        active_property: None,
+    },
+    EventSurface {
+        control: "Border",
+        event: "GotFocus",
+        payload: "FocusEventInfo",
+        conversion: "Identity",
+        subscription: "callback",
+        delivery: "registration+deterministic",
+        active_property: None,
+    },
+    EventSurface {
+        control: "Border",
+        event: "LostFocus",
+        payload: "FocusEventInfo",
         conversion: "Identity",
         subscription: "callback",
         delivery: "registration+deterministic",

--- a/crates/tests/libs/reactor_surface/src/generated_surface.rs
+++ b/crates/tests/libs/reactor_surface/src/generated_surface.rs
@@ -32,7 +32,7 @@ pub struct EventSurface {
     pub conversion: &'static str,
     pub subscription: &'static str,
     pub delivery: &'static str,
-    pub active_property: Option<&'static str>,
+    pub active_properties: &'static [&'static str],
 }
 pub struct CapabilityPropertySurface {
     pub capability: &'static str,
@@ -46,7 +46,7 @@ pub struct ExtensionSurface {
     pub name: &'static str,
 }
 pub(crate) const PROJECTED_CONTROL_COUNT: usize = 79usize;
-pub(crate) const PROJECTED_PROPERTY_COUNT: usize = 232usize;
+pub(crate) const PROJECTED_PROPERTY_COUNT: usize = 233usize;
 pub(crate) const PROJECTED_EVENT_COUNT: usize = 68usize;
 pub(crate) const CAPABILITY_PROPERTY_COUNT: usize = 27usize;
 pub(crate) const STRUCTURAL_COUNT: usize = 65usize;
@@ -549,6 +549,14 @@ fn property_border_capture_pointer_on_press(stage: usize) -> View {
         0 | 3 => Grid::new().children((Border::new(),)),
         1 => Grid::new().children((Border::new().capture_pointer_on_press(true),)),
         2 => Grid::new().children((Border::new().capture_pointer_on_press(false),)),
+        _ => unreachable!(),
+    }
+}
+fn property_border_focus_on_pointer_release(stage: usize) -> View {
+    match stage {
+        0 | 3 => Grid::new().children((Border::new(),)),
+        1 => Grid::new().children((Border::new().focus_on_pointer_release(true),)),
+        2 => Grid::new().children((Border::new().focus_on_pointer_release(false),)),
         _ => unreachable!(),
     }
 }
@@ -4544,6 +4552,13 @@ pub(crate) static SURFACE_CASES: &[SurfaceCase] = &[
         build: property_border_capture_pointer_on_press,
     },
     SurfaceCase {
+        name: "property.Border.FocusOnPointerRelease",
+        kind: SurfaceKind::Property,
+        stages: 4,
+        subscription_delta: None,
+        build: property_border_focus_on_pointer_release,
+    },
+    SurfaceCase {
         name: "property.Border.AllowDrop",
         kind: SurfaceKind::Property,
         stages: 4,
@@ -7638,6 +7653,15 @@ pub static PROJECTED_PROPERTIES: &[PropertySurface] = &[
     },
     PropertySurface {
         control: "Border",
+        property: "FocusOnPointerRelease",
+        value: "Bool",
+        adapter: "PointerFocus",
+        validation: None,
+        clearable: true,
+        theme_style: false,
+    },
+    PropertySurface {
+        control: "Border",
         property: "AllowDrop",
         value: "DragDropPolicy",
         adapter: "DropPolicy",
@@ -9463,7 +9487,7 @@ pub static PROJECTED_EVENTS: &[EventSurface] = &[
         conversion: "Identity",
         subscription: "callback",
         delivery: "registration+deterministic",
-        active_property: None,
+        active_properties: &[],
     },
     EventSurface {
         control: "HyperlinkButton",
@@ -9472,7 +9496,7 @@ pub static PROJECTED_EVENTS: &[EventSurface] = &[
         conversion: "Identity",
         subscription: "callback",
         delivery: "registration+deterministic",
-        active_property: None,
+        active_properties: &[],
     },
     EventSurface {
         control: "RepeatButton",
@@ -9481,7 +9505,7 @@ pub static PROJECTED_EVENTS: &[EventSurface] = &[
         conversion: "Identity",
         subscription: "callback",
         delivery: "registration+deterministic",
-        active_property: None,
+        active_properties: &[],
     },
     EventSurface {
         control: "Border",
@@ -9490,7 +9514,7 @@ pub static PROJECTED_EVENTS: &[EventSurface] = &[
         conversion: "Identity",
         subscription: "callback",
         delivery: "registration+deterministic",
-        active_property: Some("drop_policy"),
+        active_properties: &["drop_policy"],
     },
     EventSurface {
         control: "Border",
@@ -9499,7 +9523,7 @@ pub static PROJECTED_EVENTS: &[EventSurface] = &[
         conversion: "Identity",
         subscription: "callback",
         delivery: "registration+deterministic",
-        active_property: Some("drop_policy"),
+        active_properties: &["drop_policy"],
     },
     EventSurface {
         control: "Border",
@@ -9508,7 +9532,7 @@ pub static PROJECTED_EVENTS: &[EventSurface] = &[
         conversion: "Identity",
         subscription: "callback",
         delivery: "registration+deterministic",
-        active_property: None,
+        active_properties: &[],
     },
     EventSurface {
         control: "Border",
@@ -9517,7 +9541,7 @@ pub static PROJECTED_EVENTS: &[EventSurface] = &[
         conversion: "Identity",
         subscription: "callback",
         delivery: "registration+deterministic",
-        active_property: None,
+        active_properties: &[],
     },
     EventSurface {
         control: "Border",
@@ -9526,7 +9550,7 @@ pub static PROJECTED_EVENTS: &[EventSurface] = &[
         conversion: "Identity",
         subscription: "callback",
         delivery: "live:Pointer_RealInputGesture",
-        active_property: Some("capture_pointer_on_press"),
+        active_properties: &["capture_pointer_on_press"],
     },
     EventSurface {
         control: "Border",
@@ -9535,7 +9559,7 @@ pub static PROJECTED_EVENTS: &[EventSurface] = &[
         conversion: "Identity",
         subscription: "callback",
         delivery: "live:Pointer_RealInputGesture",
-        active_property: None,
+        active_properties: &[],
     },
     EventSurface {
         control: "Border",
@@ -9544,7 +9568,7 @@ pub static PROJECTED_EVENTS: &[EventSurface] = &[
         conversion: "Identity",
         subscription: "callback",
         delivery: "live:Pointer_RealInputGesture",
-        active_property: None,
+        active_properties: &[],
     },
     EventSurface {
         control: "Border",
@@ -9553,7 +9577,7 @@ pub static PROJECTED_EVENTS: &[EventSurface] = &[
         conversion: "Identity",
         subscription: "callback",
         delivery: "live:Pointer_RealInputGesture",
-        active_property: None,
+        active_properties: &[],
     },
     EventSurface {
         control: "Border",
@@ -9562,7 +9586,7 @@ pub static PROJECTED_EVENTS: &[EventSurface] = &[
         conversion: "Identity",
         subscription: "callback",
         delivery: "live:Pointer_RealInputGesture",
-        active_property: None,
+        active_properties: &["capture_pointer_on_press", "focus_on_pointer_release"],
     },
     EventSurface {
         control: "Border",
@@ -9571,7 +9595,7 @@ pub static PROJECTED_EVENTS: &[EventSurface] = &[
         conversion: "Identity",
         subscription: "callback",
         delivery: "registration+deterministic",
-        active_property: None,
+        active_properties: &[],
     },
     EventSurface {
         control: "Border",
@@ -9580,7 +9604,7 @@ pub static PROJECTED_EVENTS: &[EventSurface] = &[
         conversion: "Identity",
         subscription: "callback",
         delivery: "registration+deterministic",
-        active_property: None,
+        active_properties: &[],
     },
     EventSurface {
         control: "Border",
@@ -9589,7 +9613,7 @@ pub static PROJECTED_EVENTS: &[EventSurface] = &[
         conversion: "Identity",
         subscription: "callback",
         delivery: "registration+deterministic",
-        active_property: None,
+        active_properties: &[],
     },
     EventSurface {
         control: "Border",
@@ -9598,7 +9622,7 @@ pub static PROJECTED_EVENTS: &[EventSurface] = &[
         conversion: "Identity",
         subscription: "callback",
         delivery: "registration+deterministic",
-        active_property: None,
+        active_properties: &[],
     },
     EventSurface {
         control: "Border",
@@ -9607,7 +9631,7 @@ pub static PROJECTED_EVENTS: &[EventSurface] = &[
         conversion: "Identity",
         subscription: "callback",
         delivery: "registration+deterministic",
-        active_property: None,
+        active_properties: &[],
     },
     EventSurface {
         control: "Border",
@@ -9616,7 +9640,7 @@ pub static PROJECTED_EVENTS: &[EventSurface] = &[
         conversion: "Identity",
         subscription: "callback",
         delivery: "registration+deterministic",
-        active_property: None,
+        active_properties: &[],
     },
     EventSurface {
         control: "Border",
@@ -9625,7 +9649,7 @@ pub static PROJECTED_EVENTS: &[EventSurface] = &[
         conversion: "Identity",
         subscription: "callback",
         delivery: "registration+deterministic",
-        active_property: None,
+        active_properties: &[],
     },
     EventSurface {
         control: "BreadcrumbBar",
@@ -9634,7 +9658,7 @@ pub static PROJECTED_EVENTS: &[EventSurface] = &[
         conversion: "Identity",
         subscription: "callback",
         delivery: "registration+deterministic",
-        active_property: None,
+        active_properties: &[],
     },
     EventSurface {
         control: "TextBox",
@@ -9643,7 +9667,7 @@ pub static PROJECTED_EVENTS: &[EventSurface] = &[
         conversion: "Identity",
         subscription: "always",
         delivery: "registration+deterministic",
-        active_property: None,
+        active_properties: &[],
     },
     EventSurface {
         control: "AutoSuggestBox",
@@ -9652,7 +9676,7 @@ pub static PROJECTED_EVENTS: &[EventSurface] = &[
         conversion: "Identity",
         subscription: "always",
         delivery: "registration+deterministic",
-        active_property: None,
+        active_properties: &[],
     },
     EventSurface {
         control: "AutoSuggestBox",
@@ -9661,7 +9685,7 @@ pub static PROJECTED_EVENTS: &[EventSurface] = &[
         conversion: "Identity",
         subscription: "callback",
         delivery: "registration+deterministic",
-        active_property: None,
+        active_properties: &[],
     },
     EventSurface {
         control: "PasswordBox",
@@ -9670,7 +9694,7 @@ pub static PROJECTED_EVENTS: &[EventSurface] = &[
         conversion: "Identity",
         subscription: "always",
         delivery: "live:Events_NativePayloadDelivery",
-        active_property: None,
+        active_properties: &[],
     },
     EventSurface {
         control: "NumberBox",
@@ -9679,7 +9703,7 @@ pub static PROJECTED_EVENTS: &[EventSurface] = &[
         conversion: "NumberBoxValue",
         subscription: "always",
         delivery: "live:Events_NativePayloadDelivery",
-        active_property: None,
+        active_properties: &[],
     },
     EventSurface {
         control: "Slider",
@@ -9688,7 +9712,7 @@ pub static PROJECTED_EVENTS: &[EventSurface] = &[
         conversion: "Identity",
         subscription: "always",
         delivery: "live:Events_NativePayloadDelivery",
-        active_property: None,
+        active_properties: &[],
     },
     EventSurface {
         control: "TitleBar",
@@ -9697,7 +9721,7 @@ pub static PROJECTED_EVENTS: &[EventSurface] = &[
         conversion: "Identity",
         subscription: "callback",
         delivery: "registration+deterministic",
-        active_property: None,
+        active_properties: &[],
     },
     EventSurface {
         control: "TitleBar",
@@ -9706,7 +9730,7 @@ pub static PROJECTED_EVENTS: &[EventSurface] = &[
         conversion: "Identity",
         subscription: "callback",
         delivery: "registration+deterministic",
-        active_property: None,
+        active_properties: &[],
     },
     EventSurface {
         control: "NavigationView",
@@ -9715,7 +9739,7 @@ pub static PROJECTED_EVENTS: &[EventSurface] = &[
         conversion: "Identity",
         subscription: "always",
         delivery: "registration+deterministic",
-        active_property: None,
+        active_properties: &[],
     },
     EventSurface {
         control: "NavigationView",
@@ -9724,7 +9748,7 @@ pub static PROJECTED_EVENTS: &[EventSurface] = &[
         conversion: "Identity",
         subscription: "callback",
         delivery: "registration+deterministic",
-        active_property: None,
+        active_properties: &[],
     },
     EventSurface {
         control: "NavigationView",
@@ -9733,7 +9757,7 @@ pub static PROJECTED_EVENTS: &[EventSurface] = &[
         conversion: "Selection",
         subscription: "always",
         delivery: "registration+deterministic",
-        active_property: None,
+        active_properties: &[],
     },
     EventSurface {
         control: "SplitView",
@@ -9742,7 +9766,7 @@ pub static PROJECTED_EVENTS: &[EventSurface] = &[
         conversion: "Identity",
         subscription: "always",
         delivery: "registration+deterministic",
-        active_property: None,
+        active_properties: &[],
     },
     EventSurface {
         control: "ToggleSwitch",
@@ -9751,7 +9775,7 @@ pub static PROJECTED_EVENTS: &[EventSurface] = &[
         conversion: "Identity",
         subscription: "always",
         delivery: "live:Events_NativePayloadDelivery",
-        active_property: None,
+        active_properties: &[],
     },
     EventSurface {
         control: "CheckBox",
@@ -9760,7 +9784,7 @@ pub static PROJECTED_EVENTS: &[EventSurface] = &[
         conversion: "Identity",
         subscription: "always",
         delivery: "live:Events_ReplacementAndRevocation",
-        active_property: None,
+        active_properties: &[],
     },
     EventSurface {
         control: "ToggleButton",
@@ -9769,7 +9793,7 @@ pub static PROJECTED_EVENTS: &[EventSurface] = &[
         conversion: "Identity",
         subscription: "always",
         delivery: "registration+deterministic",
-        active_property: None,
+        active_properties: &[],
     },
     EventSurface {
         control: "RadioButton",
@@ -9778,7 +9802,7 @@ pub static PROJECTED_EVENTS: &[EventSurface] = &[
         conversion: "Identity",
         subscription: "always",
         delivery: "registration+deterministic",
-        active_property: None,
+        active_properties: &[],
     },
     EventSurface {
         control: "RadioButtons",
@@ -9787,7 +9811,7 @@ pub static PROJECTED_EVENTS: &[EventSurface] = &[
         conversion: "SelectionIndex",
         subscription: "always",
         delivery: "registration+deterministic",
-        active_property: None,
+        active_properties: &[],
     },
     EventSurface {
         control: "InfoBar",
@@ -9796,7 +9820,7 @@ pub static PROJECTED_EVENTS: &[EventSurface] = &[
         conversion: "Identity",
         subscription: "callback",
         delivery: "registration+deterministic",
-        active_property: None,
+        active_properties: &[],
     },
     EventSurface {
         control: "Image",
@@ -9805,7 +9829,7 @@ pub static PROJECTED_EVENTS: &[EventSurface] = &[
         conversion: "Identity",
         subscription: "callback",
         delivery: "registration+deterministic",
-        active_property: None,
+        active_properties: &[],
     },
     EventSurface {
         control: "Image",
@@ -9814,7 +9838,7 @@ pub static PROJECTED_EVENTS: &[EventSurface] = &[
         conversion: "Identity",
         subscription: "callback",
         delivery: "registration+deterministic",
-        active_property: None,
+        active_properties: &[],
     },
     EventSurface {
         control: "ListBox",
@@ -9823,7 +9847,7 @@ pub static PROJECTED_EVENTS: &[EventSurface] = &[
         conversion: "Selection",
         subscription: "always",
         delivery: "live:Controlled_NativeFeedback",
-        active_property: None,
+        active_properties: &[],
     },
     EventSurface {
         control: "RatingControl",
@@ -9832,7 +9856,7 @@ pub static PROJECTED_EVENTS: &[EventSurface] = &[
         conversion: "RatingValue",
         subscription: "always",
         delivery: "registration+deterministic",
-        active_property: None,
+        active_properties: &[],
     },
     EventSurface {
         control: "Expander",
@@ -9841,7 +9865,7 @@ pub static PROJECTED_EVENTS: &[EventSurface] = &[
         conversion: "Identity",
         subscription: "always",
         delivery: "registration+deterministic",
-        active_property: None,
+        active_properties: &[],
     },
     EventSurface {
         control: "ComboBox",
@@ -9850,7 +9874,7 @@ pub static PROJECTED_EVENTS: &[EventSurface] = &[
         conversion: "SelectionIndex",
         subscription: "always",
         delivery: "registration+deterministic",
-        active_property: None,
+        active_properties: &[],
     },
     EventSurface {
         control: "Pivot",
@@ -9859,7 +9883,7 @@ pub static PROJECTED_EVENTS: &[EventSurface] = &[
         conversion: "SelectionIndex",
         subscription: "always",
         delivery: "registration+deterministic",
-        active_property: None,
+        active_properties: &[],
     },
     EventSurface {
         control: "FlipView",
@@ -9868,7 +9892,7 @@ pub static PROJECTED_EVENTS: &[EventSurface] = &[
         conversion: "SelectionIndex",
         subscription: "always",
         delivery: "registration+deterministic",
-        active_property: None,
+        active_properties: &[],
     },
     EventSurface {
         control: "SelectorBar",
@@ -9877,7 +9901,7 @@ pub static PROJECTED_EVENTS: &[EventSurface] = &[
         conversion: "Selection",
         subscription: "always",
         delivery: "registration+deterministic",
-        active_property: None,
+        active_properties: &[],
     },
     EventSurface {
         control: "TabView",
@@ -9886,7 +9910,7 @@ pub static PROJECTED_EVENTS: &[EventSurface] = &[
         conversion: "SelectionIndex",
         subscription: "always",
         delivery: "registration+deterministic",
-        active_property: None,
+        active_properties: &[],
     },
     EventSurface {
         control: "TabView",
@@ -9895,7 +9919,7 @@ pub static PROJECTED_EVENTS: &[EventSurface] = &[
         conversion: "Identity",
         subscription: "callback",
         delivery: "registration+deterministic",
-        active_property: None,
+        active_properties: &[],
     },
     EventSurface {
         control: "TabView",
@@ -9904,7 +9928,7 @@ pub static PROJECTED_EVENTS: &[EventSurface] = &[
         conversion: "Identity",
         subscription: "callback",
         delivery: "registration+deterministic",
-        active_property: None,
+        active_properties: &[],
     },
     EventSurface {
         control: "TabView",
@@ -9913,7 +9937,7 @@ pub static PROJECTED_EVENTS: &[EventSurface] = &[
         conversion: "Identity",
         subscription: "callback",
         delivery: "registration+deterministic",
-        active_property: None,
+        active_properties: &[],
     },
     EventSurface {
         control: "TeachingTip",
@@ -9922,7 +9946,7 @@ pub static PROJECTED_EVENTS: &[EventSurface] = &[
         conversion: "Identity",
         subscription: "callback",
         delivery: "registration+deterministic",
-        active_property: None,
+        active_properties: &[],
     },
     EventSurface {
         control: "TeachingTip",
@@ -9931,7 +9955,7 @@ pub static PROJECTED_EVENTS: &[EventSurface] = &[
         conversion: "Identity",
         subscription: "callback",
         delivery: "registration+deterministic",
-        active_property: None,
+        active_properties: &[],
     },
     EventSurface {
         control: "DropDownButton",
@@ -9940,7 +9964,7 @@ pub static PROJECTED_EVENTS: &[EventSurface] = &[
         conversion: "Identity",
         subscription: "callback",
         delivery: "registration+deterministic",
-        active_property: None,
+        active_properties: &[],
     },
     EventSurface {
         control: "AppBarButton",
@@ -9949,7 +9973,7 @@ pub static PROJECTED_EVENTS: &[EventSurface] = &[
         conversion: "Identity",
         subscription: "callback",
         delivery: "registration+deterministic",
-        active_property: None,
+        active_properties: &[],
     },
     EventSurface {
         control: "SplitButton",
@@ -9958,7 +9982,7 @@ pub static PROJECTED_EVENTS: &[EventSurface] = &[
         conversion: "Identity",
         subscription: "callback",
         delivery: "registration+deterministic",
-        active_property: None,
+        active_properties: &[],
     },
     EventSurface {
         control: "ColorPicker",
@@ -9967,7 +9991,7 @@ pub static PROJECTED_EVENTS: &[EventSurface] = &[
         conversion: "Identity",
         subscription: "always",
         delivery: "live:Events_NativePayloadDelivery",
-        active_property: None,
+        active_properties: &[],
     },
     EventSurface {
         control: "DatePicker",
@@ -9976,7 +10000,7 @@ pub static PROJECTED_EVENTS: &[EventSurface] = &[
         conversion: "Nullable",
         subscription: "callback",
         delivery: "registration+deterministic",
-        active_property: None,
+        active_properties: &[],
     },
     EventSurface {
         control: "TimePicker",
@@ -9985,7 +10009,7 @@ pub static PROJECTED_EVENTS: &[EventSurface] = &[
         conversion: "Nullable",
         subscription: "callback",
         delivery: "live:Events_NativePayloadDelivery",
-        active_property: None,
+        active_properties: &[],
     },
     EventSurface {
         control: "CalendarDatePicker",
@@ -9994,7 +10018,7 @@ pub static PROJECTED_EVENTS: &[EventSurface] = &[
         conversion: "Nullable",
         subscription: "callback",
         delivery: "live:Events_NativePayloadDelivery",
-        active_property: None,
+        active_properties: &[],
     },
     EventSurface {
         control: "ContentDialog",
@@ -10003,7 +10027,7 @@ pub static PROJECTED_EVENTS: &[EventSurface] = &[
         conversion: "Identity",
         subscription: "always",
         delivery: "registration+deterministic",
-        active_property: None,
+        active_properties: &[],
     },
     EventSurface {
         control: "CalendarView",
@@ -10012,7 +10036,7 @@ pub static PROJECTED_EVENTS: &[EventSurface] = &[
         conversion: "Identity",
         subscription: "callback",
         delivery: "registration+deterministic",
-        active_property: None,
+        active_properties: &[],
     },
     EventSurface {
         control: "ListView",
@@ -10021,7 +10045,7 @@ pub static PROJECTED_EVENTS: &[EventSurface] = &[
         conversion: "SelectionIndex",
         subscription: "always",
         delivery: "live:Events_NativePayloadDelivery",
-        active_property: None,
+        active_properties: &[],
     },
     EventSurface {
         control: "ListView",
@@ -10030,7 +10054,7 @@ pub static PROJECTED_EVENTS: &[EventSurface] = &[
         conversion: "Identity",
         subscription: "callback",
         delivery: "registration+deterministic",
-        active_property: None,
+        active_properties: &[],
     },
     EventSurface {
         control: "TreeView",
@@ -10039,7 +10063,7 @@ pub static PROJECTED_EVENTS: &[EventSurface] = &[
         conversion: "Identity",
         subscription: "callback",
         delivery: "registration+deterministic",
-        active_property: None,
+        active_properties: &[],
     },
     EventSurface {
         control: "GridView",
@@ -10048,7 +10072,7 @@ pub static PROJECTED_EVENTS: &[EventSurface] = &[
         conversion: "Identity",
         subscription: "callback",
         delivery: "registration+deterministic",
-        active_property: None,
+        active_properties: &[],
     },
     EventSurface {
         control: "GridView",
@@ -10057,7 +10081,7 @@ pub static PROJECTED_EVENTS: &[EventSurface] = &[
         conversion: "SelectionIndex",
         subscription: "always",
         delivery: "registration+deterministic",
-        active_property: None,
+        active_properties: &[],
     },
     EventSurface {
         control: "RichEditBox",
@@ -10066,7 +10090,7 @@ pub static PROJECTED_EVENTS: &[EventSurface] = &[
         conversion: "Identity",
         subscription: "always",
         delivery: "registration+deterministic",
-        active_property: None,
+        active_properties: &[],
     },
 ];
 pub static CAPABILITY_PROPERTIES: &[CapabilityPropertySurface] = &[

--- a/crates/tests/libs/reactor_surface/src/runner.rs
+++ b/crates/tests/libs/reactor_surface/src/runner.rs
@@ -195,14 +195,18 @@ impl Component for SurfaceRunner {
             }
             for event in PROJECTED_EVENTS {
                 println!(
-                    "event.{}.{} payload={} conversion={} subscription={} delivery={} active_property={}",
+                    "event.{}.{} payload={} conversion={} subscription={} delivery={} active_properties={}",
                     event.control,
                     event.event,
                     event.payload,
                     event.conversion,
                     event.subscription,
                     event.delivery,
-                    event.active_property.unwrap_or("none")
+                    if event.active_properties.is_empty() {
+                        "none".to_string()
+                    } else {
+                        event.active_properties.join(",")
+                    }
                 );
             }
             for property in CAPABILITY_PROPERTIES {

--- a/crates/tools/reactor/src/bindings.txt
+++ b/crates/tools/reactor/src/bindings.txt
@@ -7,6 +7,10 @@ Microsoft::UI::Dispatching::IDispatcherQueue::TryEnqueueWithPriority
 Microsoft::UI::Dispatching::IDispatcherQueueTimer::{put_Interval, put_IsRepeating, add_Tick, remove_Tick, Start, Stop}
 Microsoft::UI::Input::IPointerPoint::{get_Position, get_Properties}
 Microsoft::UI::Input::IPointerPointProperties::{get_IsLeftButtonPressed, get_IsMiddleButtonPressed, get_IsRightButtonPressed}
+Microsoft::UI::Input::InputKeyboardSource::{add_KeyDown, remove_KeyDown, GetForIsland}
+Microsoft::UI::Xaml::UIElement::get_XamlRoot
+Microsoft::UI::Xaml::Window::get_Content
+Microsoft::UI::Xaml::XamlRoot::get_ContentIsland
 Microsoft::UI::Text::ITextDocument::{GetText, SetText}
 Microsoft::UI::Text::TextGetOptions::None
 Microsoft::UI::Text::TextSetOptions::None
@@ -96,7 +100,7 @@ Microsoft::UI::Xaml::IFrameworkElement::put_Style
 Microsoft::UI::Xaml::IFrameworkElementStatics::{get_WidthProperty, get_HeightProperty, get_MinWidthProperty, get_MaxWidthProperty, get_MinHeightProperty, get_MaxHeightProperty, get_HorizontalAlignmentProperty, get_VerticalAlignmentProperty, get_MarginProperty}
 Microsoft::UI::Xaml::IResourceDictionary::get_MergedDictionaries
 Microsoft::UI::Xaml::ISizeChangedEventArgs::get_NewSize
-Microsoft::UI::Xaml::IUIElement::{CapturePointer, Focus, ReleasePointerCapture, ReleasePointerCaptures, get_XamlRoot, put_XamlRoot, put_Opacity, StartBringIntoView}
+Microsoft::UI::Xaml::IUIElement::{CapturePointer, Focus, ReleasePointerCapture, ReleasePointerCaptures, get_XamlRoot, put_XamlRoot, get_FocusState, put_Opacity, StartBringIntoView}
 Microsoft::UI::Xaml::IUIElement::{add_PointerEntered, add_PointerExited, add_PointerMoved, add_PointerPressed, add_PointerReleased, remove_PointerEntered, remove_PointerExited, remove_PointerMoved, remove_PointerPressed, remove_PointerReleased}
 Microsoft::UI::Xaml::IUIElementStatics::get_OpacityProperty
 Microsoft::UI::Xaml::IWindow2::{get_AppWindow, put_SystemBackdrop}
@@ -104,6 +108,9 @@ Microsoft::UI::Xaml::IWindow::{Activate, Close, Closed, put_Content, put_Title}
 Microsoft::UI::Xaml::IWindow::{put_ExtendsContentIntoTitleBar, SetTitleBar}
 Microsoft::UI::Xaml::IXamlRoot::{get_RasterizationScale, add_Changed, remove_Changed}
 Microsoft::UI::Xaml::Input::IPointerRoutedEventArgs::{GetCurrentPoint, get_Pointer}
+Microsoft::UI::Xaml::Input::IKeyRoutedEventArgs::{get_Key, get_OriginalKey, get_KeyStatus, put_Handled}
+Microsoft::UI::Xaml::Input::ICharacterReceivedRoutedEventArgs::{get_Character, get_KeyStatus, put_Handled}
+Microsoft::UI::Xaml::IRoutedEventArgs::get_OriginalSource
 Microsoft::UI::Xaml::LaunchActivatedEventArgs
 Microsoft::UI::Xaml::Markup::IXamlMetadataProvider
 Microsoft::UI::Xaml::Markup::IXamlType::{}
@@ -131,6 +138,7 @@ Windows::Win32::E_FAIL
 Windows::Win32::ERROR_INSUFFICIENT_BUFFER
 Windows::Win32::GetCurrentPackageFullName
 Windows::Win32::GetDpiForWindow
+Windows::Win32::GetKeyboardState
 Windows::Win32::GetProcessHeap
 Windows::Win32::HeapFree
 Windows::Win32::IDYES

--- a/crates/tools/reactor/src/control_bindings.txt
+++ b/crates/tools/reactor/src/control_bindings.txt
@@ -524,6 +524,7 @@ Microsoft::UI::Xaml::Controls::Viewbox::CreateInstance
 Microsoft::UI::Xaml::Controls::Viewbox::StretchProperty
 Microsoft::UI::Xaml::Controls::WebView2::CreateInstance
 Microsoft::UI::Xaml::DependencyPropertyChangedCallback
+Microsoft::UI::Xaml::FrameworkElement::AllowFocusOnInteractionProperty
 Microsoft::UI::Xaml::FrameworkElement::StyleProperty
 Microsoft::UI::Xaml::FrameworkElement::TagProperty
 Microsoft::UI::Xaml::IDependencyObject::{RegisterPropertyChangedCallback, UnregisterPropertyChangedCallback}
@@ -533,17 +534,23 @@ Microsoft::UI::Xaml::IDragUIOverride::{put_Caption, put_IsCaptionVisible}
 Microsoft::UI::Xaml::IFrameworkElement::get_ActualHeight
 Microsoft::UI::Xaml::IFrameworkElement::get_ActualWidth
 Microsoft::UI::Xaml::IFrameworkElement::get_Tag
+Microsoft::UI::Xaml::IFrameworkElement::put_AllowFocusOnInteraction
 Microsoft::UI::Xaml::IFrameworkElement::put_Tag
 Microsoft::UI::Xaml::IScalarTransition::put_Duration
 Microsoft::UI::Xaml::IUIElement::put_AllowDrop
 Microsoft::UI::Xaml::IUIElement::put_CenterPoint
+Microsoft::UI::Xaml::IUIElement::put_IsTabStop
 Microsoft::UI::Xaml::IUIElement::put_OpacityTransition
 Microsoft::UI::Xaml::IUIElement::put_Scale
 Microsoft::UI::Xaml::IUIElement::put_ScaleTransition
+Microsoft::UI::Xaml::IUIElement::{add_CharacterReceived, remove_CharacterReceived}
 Microsoft::UI::Xaml::IUIElement::{add_DragEnter, remove_DragEnter}
 Microsoft::UI::Xaml::IUIElement::{add_DragLeave, remove_DragLeave}
 Microsoft::UI::Xaml::IUIElement::{add_DragOver, remove_DragOver}
 Microsoft::UI::Xaml::IUIElement::{add_Drop, remove_Drop}
+Microsoft::UI::Xaml::IUIElement::{add_GotFocus, remove_GotFocus}
+Microsoft::UI::Xaml::IUIElement::{add_KeyUp, remove_KeyUp}
+Microsoft::UI::Xaml::IUIElement::{add_LostFocus, remove_LostFocus}
 Microsoft::UI::Xaml::IUIElement::{add_PointerCanceled, remove_PointerCanceled}
 Microsoft::UI::Xaml::IUIElement::{add_PointerCaptureLost, remove_PointerCaptureLost}
 Microsoft::UI::Xaml::IUIElement::{add_PointerEntered, remove_PointerEntered}
@@ -551,6 +558,7 @@ Microsoft::UI::Xaml::IUIElement::{add_PointerExited, remove_PointerExited}
 Microsoft::UI::Xaml::IUIElement::{add_PointerMoved, remove_PointerMoved}
 Microsoft::UI::Xaml::IUIElement::{add_PointerPressed, remove_PointerPressed}
 Microsoft::UI::Xaml::IUIElement::{add_PointerReleased, remove_PointerReleased}
+Microsoft::UI::Xaml::IUIElement::{add_PreviewKeyDown, remove_PreviewKeyDown}
 Microsoft::UI::Xaml::IUIElement::{get_KeyboardAccelerators, put_KeyboardAcceleratorPlacementMode}
 Microsoft::UI::Xaml::IVector3Transition::put_Duration
 Microsoft::UI::Xaml::Input::IKeyboardAccelerator::{put_Key, put_Modifiers, Invoked}
@@ -590,6 +598,7 @@ Microsoft::UI::Xaml::Shapes::Shape::StrokeThicknessProperty
 Microsoft::UI::Xaml::TextTrimming
 Microsoft::UI::Xaml::TextWrapping
 Microsoft::UI::Xaml::UIElement::AllowDropProperty
+Microsoft::UI::Xaml::UIElement::IsTabStopProperty
 Microsoft::UI::Xaml::Vector3Transition::CreateInstance
 Windows::ApplicationModel::DataTransfer::IDataPackageView::{Contains, GetTextAsync, GetStorageItemsAsync}
 Windows::Foundation::Uri::CreateUri

--- a/crates/tools/reactor/src/generate.rs
+++ b/crates/tools/reactor/src/generate.rs
@@ -886,7 +886,7 @@ fn generate_element_event_visitor(control: &ResolvedControl) -> TokenStream {
             if control.event_always_active(event) {
                 quote! { visit(EventId::#id, true); }
             } else {
-                let active_property = event.active_property.as_ref().map(|property| {
+                let active_properties = event.active_properties.iter().map(|property| {
                     let property = ident(property);
                     quote! { || !matches!(value.#property, Property::Inherited) }
                 });
@@ -897,7 +897,7 @@ fn generate_element_event_visitor(control: &ResolvedControl) -> TokenStream {
                             .events
                             .as_ref()
                             .is_some_and(|events| events.#field.is_some())
-                            #active_property,
+                            #(#active_properties)*,
                     );
                 }
             }
@@ -1069,7 +1069,7 @@ fn generate_mounted_event_visitor(control: &ResolvedControl) -> TokenStream {
             if control.event_always_active(event) {
                 quote! { visit(EventId::#id, true); }
             } else {
-                let active_property = event.active_property.as_ref().map(|property| {
+                let active_properties = event.active_properties.iter().map(|property| {
                     let property = ident(property);
                     quote! { || !matches!(values.#property, Property::Inherited) }
                 });
@@ -1080,7 +1080,7 @@ fn generate_mounted_event_visitor(control: &ResolvedControl) -> TokenStream {
                             .events
                             .as_ref()
                             .is_some_and(|events| events.#field.is_some())
-                            #active_property,
+                            #(#active_properties)*,
                     );
                 }
             }

--- a/crates/tools/reactor/src/generate.rs
+++ b/crates/tools/reactor/src/generate.rs
@@ -73,6 +73,10 @@ pub(crate) fn generate(schema: &ResolvedSchema) -> String {
     let mounted_theme_styles = schema.controls.iter().map(generate_mounted_theme_style);
     let mounted_event_visitors = schema.controls.iter().map(generate_mounted_event_visitor);
     let mounted_event_dispatchers = schema.controls.iter().flat_map(generate_event_dispatchers);
+    let mounted_routed_callbacks = schema
+        .controls
+        .iter()
+        .flat_map(generate_mounted_routed_callbacks);
     let mounted_event_observers = schema.controls.iter().flat_map(generate_event_observers);
     let element_parts = schema.controls.iter().map(generate_element_parts);
     let element_props_matches = schema.controls.iter().map(generate_element_props_match);
@@ -244,6 +248,7 @@ pub(crate) fn generate(schema: &ResolvedSchema) -> String {
         pub trait MountedEventsExt {
             fn visit_events(&self, visit: &mut dyn FnMut(EventId, bool));
             fn dispatch_event(&self, event: EventId, payload: &EventPayload) -> Option<bool>;
+            fn routed_callback(&self, event: EventId) -> Option<RoutedEventCallback>;
             fn observe_event(
                 &self,
                 event: EventId,
@@ -278,6 +283,13 @@ pub(crate) fn generate(schema: &ResolvedSchema) -> String {
             fn dispatch_event(&self, event: EventId, payload: &EventPayload) -> Option<bool> {
                 match (self, event, payload) {
                     #(#mounted_event_dispatchers,)*
+                    _ => None,
+                }
+            }
+
+            fn routed_callback(&self, event: EventId) -> Option<RoutedEventCallback> {
+                match (self, event) {
+                    #(#mounted_routed_callbacks,)*
                     _ => None,
                 }
             }
@@ -600,7 +612,12 @@ fn generate_event_group(control: &ResolvedControl) -> TokenStream {
     let fields = control.events.iter().map(|event| {
         let field = ident(&event.field);
         let payload = event_callback_type(event);
-        quote! { #field: Option<Callback<#payload>> }
+        let callback = if event.routed {
+            quote! { RoutedCallback<#payload> }
+        } else {
+            quote! { Callback<#payload> }
+        };
+        quote! { #field: Option<#callback> }
     });
     quote! {
         #[derive(Clone, Debug, Default, PartialEq)]
@@ -662,7 +679,12 @@ fn generate_mounted_props_structure(control: &ResolvedControl) -> TokenStream {
         let fields = control.events.iter().map(|event| {
             let field = ident(&event.field);
             let payload = event_callback_type(event);
-            quote! { #field: Option<Callback<#payload>>, }
+            let callback = if event.routed {
+                quote! { RoutedCallback<#payload> }
+            } else {
+                quote! { Callback<#payload> }
+            };
+            quote! { #field: Option<#callback>, }
         });
         quote! { #(#fields)* }
     };
@@ -1107,6 +1129,7 @@ fn generate_event_dispatchers(control: &ResolvedControl) -> Vec<TokenStream> {
     control
         .events
         .iter()
+        .filter(|event| !event.routed)
         .map(|event| {
             let field = ident(&event.field);
             let id = ident(&format!("{}{}", control.name, event.name));
@@ -1146,6 +1169,36 @@ fn generate_event_dispatchers(control: &ResolvedControl) -> Vec<TokenStream> {
                         EventId::#id,
                         #payload_pattern,
                     ) => values.#field.as_ref().map(|callback| #call)
+                }
+            }
+        })
+        .collect()
+}
+
+fn generate_mounted_routed_callbacks(control: &ResolvedControl) -> Vec<TokenStream> {
+    let name = ident(&control.name);
+    control
+        .events
+        .iter()
+        .filter(|event| event.routed)
+        .map(|event| {
+            let field = ident(&event.field);
+            let id = ident(&format!("{}{}", control.name, event.name));
+            let payload = ident(&event.payload);
+            if has_grouped_events(control) {
+                quote! {
+                    (Self::#name(values), EventId::#id) => values
+                        .events
+                        .as_ref()
+                        .and_then(|events| events.#field.clone())
+                        .map(RoutedEventCallback::#payload)
+                }
+            } else {
+                quote! {
+                    (Self::#name(values), EventId::#id) => values
+                        .#field
+                        .clone()
+                        .map(RoutedEventCallback::#payload)
                 }
             }
         })
@@ -1507,7 +1560,12 @@ fn generate_element(control: &ResolvedControl) -> TokenStream {
         let fields = control.events.iter().map(|event| {
             let field = ident(&event.field);
             let payload = event_callback_type(event);
-            quote! { #field: Option<Callback<#payload>>, }
+            let callback = if event.routed {
+                quote! { RoutedCallback<#payload> }
+            } else {
+                quote! { Callback<#payload> }
+            };
+            quote! { #field: Option<#callback>, }
         });
         quote! { #(#fields)* }
     };
@@ -1790,7 +1848,14 @@ fn generate_element(control: &ResolvedControl) -> TokenStream {
         } else {
             quote! { self.#field }
         };
-        if event.payload == "Unit" {
+        if event.routed {
+            quote! {
+                pub fn #field(mut self, callback: RoutedCallback<#payload>) -> Self {
+                    #assignment = Some(callback);
+                    self
+                }
+            }
+        } else if event.payload == "Unit" {
             quote! {
                 pub fn #field(mut self, callback: impl IntoUnitCallback) -> Self {
                     #assignment = Some(callback.into_unit_callback());

--- a/crates/tools/reactor/src/generate_surface.rs
+++ b/crates/tools/reactor/src/generate_surface.rs
@@ -284,9 +284,64 @@ pub(crate) fn generate(schema: &ResolvedSchema) -> String {
             let case_name = format!("event.{}.{}", control.name, event.name);
             let control_name = ident(&control.name);
             let field = ident(&event.field);
+            let subscription_delta = usize::from(!control.event_always_active(event));
+            let cleared = wrap_control(control, quote! { #control_name::new() });
+            if event.routed {
+                let component = ident(&format!("{}{}EventSurface", control.name, event.name));
+                let initial = wrap_control(
+                    control,
+                    quote! {
+                        #control_name::new().#field(context.routed_callback(move |_| {
+                            let _ = marker;
+                            RoutedMessage::bubble(())
+                        }))
+                    },
+                );
+                event_builders.push(quote! {
+                    struct #component;
+
+                    impl Component for #component {
+                        type Input = usize;
+                        type Message = ();
+
+                        fn create(
+                            _input: &Self::Input,
+                            _context: &ComponentContext<Self>,
+                        ) -> Self {
+                            Self
+                        }
+
+                        fn view(
+                            &self,
+                            input: &Self::Input,
+                            context: &mut ViewContext<Self>,
+                        ) -> View {
+                            let marker = *input;
+                            match marker {
+                                0 | 3 => #cleared,
+                                1 | 2 => #initial,
+                                _ => unreachable!(),
+                            }
+                        }
+                    }
+
+                    fn #function(stage: usize) -> View {
+                        View::component::<#component>(stage)
+                    }
+                });
+                cases.push(quote! {
+                    SurfaceCase {
+                        name: #case_name,
+                        kind: SurfaceKind::Event,
+                        stages: 4,
+                        subscription_delta: Some(#subscription_delta),
+                        build: #function,
+                    }
+                });
+                continue;
+            }
             let first_callback = event_callback(event, false);
             let alternate_callback = event_callback(event, true);
-            let cleared = wrap_control(control, quote! { #control_name::new() });
             let initial = wrap_control(
                 control,
                 quote! { #control_name::new().#field(#first_callback) },
@@ -295,7 +350,6 @@ pub(crate) fn generate(schema: &ResolvedSchema) -> String {
                 control,
                 quote! { #control_name::new().#field(#alternate_callback) },
             );
-            let subscription_delta = usize::from(!control.event_always_active(event));
             event_builders.push(quote! {
                 fn #function(stage: usize) -> View {
                     match stage {

--- a/crates/tools/reactor/src/generate_surface.rs
+++ b/crates/tools/reactor/src/generate_surface.rs
@@ -425,10 +425,7 @@ pub(crate) fn generate(schema: &ResolvedSchema) -> String {
                 "callback"
             };
             let delivery = event_delivery_owner(control, event);
-            let active_property = event
-                .active_property
-                .as_ref()
-                .map_or_else(|| quote! { None }, |property| quote! { Some(#property) });
+            let active_properties = &event.active_properties;
             quote! {
                 EventSurface {
                     control: #control_name,
@@ -437,7 +434,7 @@ pub(crate) fn generate(schema: &ResolvedSchema) -> String {
                     conversion: #conversion,
                     subscription: #subscription,
                     delivery: #delivery,
-                    active_property: #active_property,
+                    active_properties: &[#(#active_properties),*],
                 }
             }
         })
@@ -485,7 +482,7 @@ pub(crate) fn generate(schema: &ResolvedSchema) -> String {
             pub conversion: &'static str,
             pub subscription: &'static str,
             pub delivery: &'static str,
-            pub active_property: Option<&'static str>,
+            pub active_properties: &'static [&'static str],
         }
 
         pub struct CapabilityPropertySurface {

--- a/crates/tools/reactor/src/generate_winui.rs
+++ b/crates/tools/reactor/src/generate_winui.rs
@@ -1591,8 +1591,15 @@ fn generate_event_arm(control: &ResolvedControl, event: &ResolvedEvent) -> Token
                     Ok(info) => {
                         let handled =
                             sink.route_key(node, EventId::#event_id, revision, info);
-                        if let Some(args) = args.as_ref() {
-                            _ = args.SetHandled(handled);
+                        if let Some(args) = args.as_ref()
+                            && let Err(error) = args.SetHandled(handled)
+                        {
+                            sink.error(
+                                node,
+                                EventId::#event_id,
+                                revision,
+                                native_error(error),
+                            );
                         }
                     }
                     Err(error) => {
@@ -1616,8 +1623,15 @@ fn generate_event_arm(control: &ResolvedControl, event: &ResolvedEvent) -> Token
                     Ok(info) => {
                         let handled =
                             sink.route_character(node, EventId::#event_id, revision, info);
-                        if let Some(args) = args.as_ref() {
-                            _ = args.SetHandled(handled);
+                        if let Some(args) = args.as_ref()
+                            && let Err(error) = args.SetHandled(handled)
+                        {
+                            sink.error(
+                                node,
+                                EventId::#event_id,
+                                revision,
+                                native_error(error),
+                            );
                         }
                     }
                     Err(error) => {

--- a/crates/tools/reactor/src/generate_winui.rs
+++ b/crates/tools/reactor/src/generate_winui.rs
@@ -1165,6 +1165,7 @@ fn generate_event_arm(control: &ResolvedControl, event: &ResolvedEvent) -> Token
             &event.source,
             EventPayloadSource::SenderProperty { interface, .. } if interface == &event.interface
         );
+    let text_input_probe = control.name == "TextBox" && event.name == "TextChanged";
     let callback = match &event.source {
         EventPayloadSource::Unit => quote! {
             move |_, _| {
@@ -1373,13 +1374,23 @@ fn generate_event_arm(control: &ResolvedControl, event: &ResolvedEvent) -> Token
                         }
                     }
                 }
-            } else {
+            } else if text_input_probe {
                 quote! {
                     {
                         #event_source
                         move |_, _| {
+                            #[cfg(feature = "test")]
+                            test::record_live_input_probe_stage(
+                                test::LiveInputProbeStage::NativeTextChanged,
+                            );
                             match event_source.#property() {
-                                Ok(value) => #enqueue_payload,
+                                Ok(value) => {
+                                    #[cfg(feature = "test")]
+                                    test::record_live_input_probe_stage(
+                                        test::LiveInputProbeStage::NativeTextReady,
+                                    );
+                                    #enqueue_payload;
+                                }
                                 #nullable_error
                                 Err(error) => sink.error(
                                     node,
@@ -1388,6 +1399,22 @@ fn generate_event_arm(control: &ResolvedControl, event: &ResolvedEvent) -> Token
                                     native_error(error),
                                 ),
                             }
+                        }
+                    }
+                }
+            } else {
+                quote! {
+                    {
+                        #event_source
+                        move |_, _| match event_source.#property() {
+                            Ok(value) => #enqueue_payload,
+                            #nullable_error
+                            Err(error) => sink.error(
+                                node,
+                                EventId::#event_id,
+                                revision,
+                                native_error(error),
+                            ),
                         }
                     }
                 }

--- a/crates/tools/reactor/src/generate_winui.rs
+++ b/crates/tools/reactor/src/generate_winui.rs
@@ -100,6 +100,7 @@ pub(crate) fn generate_control_bindings_filter(schema: &ResolvedSchema) -> Strin
                 | Some(PropertyAdapter::NumberBoxValue)
                 | Some(PropertyAdapter::PathData)
                 | Some(PropertyAdapter::PointerCapture)
+                | Some(PropertyAdapter::PointerFocus)
                 | Some(PropertyAdapter::PointerEvent)
                 | Some(PropertyAdapter::RatingValue)
                 | Some(PropertyAdapter::DragInfo)
@@ -1063,9 +1064,9 @@ fn generate_event_arm(control: &ResolvedControl, event: &ResolvedEvent) -> Token
     let interface = path_ident(&event.interface);
     let method = ident(&event.name);
     let payload = ident(&event.payload);
-    let pointer_capture = (event.name == "PointerPressed").then(|| {
+    let pointer_press_policy = (event.name == "PointerPressed").then(|| {
         quote! {
-            info.capture_succeeded = match sink.capture_pointer_on_press(node, &element, args) {
+            info.capture_succeeded = match sink.apply_pointer_press_policy(node, &element, args) {
                 Ok(value) => value,
                 Err(error) => {
                     sink.error(node, EventId::#event_id, revision, error);
@@ -1076,7 +1077,13 @@ fn generate_event_arm(control: &ResolvedControl, event: &ResolvedEvent) -> Token
     });
     let pointer_release = (event.name == "PointerReleased").then(|| {
         quote! {
-            if let Err(error) = sink.release_pointer_after_event(node, &element, args) {
+            if let Err(error) = sink.apply_pointer_release_policy(
+                node,
+                EventId::#event_id,
+                revision,
+                &element,
+                args,
+            ) {
                 sink.error(node, EventId::#event_id, revision, error);
                 return;
             }
@@ -1166,6 +1173,12 @@ fn generate_event_arm(control: &ResolvedControl, event: &ResolvedEvent) -> Token
             EventPayloadSource::SenderProperty { interface, .. } if interface == &event.interface
         );
     let text_input_probe = control.name == "TextBox" && event.name == "TextChanged";
+    let got_focus = event.name == "GotFocus";
+    let pending_focus_state = if got_focus {
+        quote! { sink.take_pending_focus_state(node) }
+    } else {
+        quote! { None }
+    };
     let callback = match &event.source {
         EventPayloadSource::Unit => quote! {
             move |_, _| {
@@ -1557,7 +1570,7 @@ fn generate_event_arm(control: &ResolvedControl, event: &ResolvedEvent) -> Token
                             info.window_y = f64::from(position.y);
                         }
                     }
-                    #pointer_capture
+                    #pointer_press_policy
                     #pointer_release
                     sink.enqueue(
                         node,
@@ -1625,7 +1638,14 @@ fn generate_event_arm(control: &ResolvedControl, event: &ResolvedEvent) -> Token
                     let result = args
                         .as_ref()
                         .ok_or_else(windows_core::Error::empty)
-                        .and_then(|args| focus_event_info(&element, args));
+                        .and_then(|args| {
+                            focus_event_info(
+                                &element,
+                                args,
+                                #pending_focus_state,
+                                #got_focus,
+                            )
+                        });
                     match result {
                         Ok(info) => sink.enqueue(
                             node,
@@ -2024,7 +2044,10 @@ fn generate_set_property(control: &ResolvedControl, property: &ResolvedProperty)
             ) => set_rich_edit_text(control, value)
         };
     }
-    if property.adapter == Some(PropertyAdapter::PointerCapture) {
+    if matches!(
+        property.adapter,
+        Some(PropertyAdapter::PointerCapture | PropertyAdapter::PointerFocus)
+    ) {
         return quote! {
             (Handle::#control_name(_), PropertyId::#property_id, PropertyValue::Bool(_)) => {
                 Err(RuntimeError::UnsupportedKind)
@@ -2340,7 +2363,10 @@ fn generate_clear_property(control: &ResolvedControl, property: &ResolvedPropert
             }
         };
     }
-    if property.adapter == Some(PropertyAdapter::PointerCapture) {
+    if matches!(
+        property.adapter,
+        Some(PropertyAdapter::PointerCapture | PropertyAdapter::PointerFocus)
+    ) {
         return quote! {
             (Handle::#control_name(_), PropertyId::#property_id) => {
                 Err(RuntimeError::UnsupportedKind)

--- a/crates/tools/reactor/src/generate_winui.rs
+++ b/crates/tools/reactor/src/generate_winui.rs
@@ -85,7 +85,8 @@ pub(crate) fn generate_control_bindings_filter(schema: &ResolvedSchema) -> Strin
                             .to_string(),
                     );
                 }
-                Some(PropertyAdapter::ClockIdentifier)
+                Some(PropertyAdapter::CharacterEvent)
+                | Some(PropertyAdapter::ClockIdentifier)
                 | Some(PropertyAdapter::ContentDialogResult)
                 | Some(PropertyAdapter::FontWeight)
                 | Some(PropertyAdapter::HorizontalContentAlignment)
@@ -94,6 +95,7 @@ pub(crate) fn generate_control_bindings_filter(schema: &ResolvedSchema) -> Strin
                 | Some(PropertyAdapter::InspectableStringList)
                 | Some(PropertyAdapter::ItemTag)
                 | Some(PropertyAdapter::ItemTags)
+                | Some(PropertyAdapter::KeyEvent)
                 | Some(PropertyAdapter::NavigationDisplayMode)
                 | Some(PropertyAdapter::NumberBoxValue)
                 | Some(PropertyAdapter::PathData)
@@ -103,6 +105,7 @@ pub(crate) fn generate_control_bindings_filter(schema: &ResolvedSchema) -> Strin
                 | Some(PropertyAdapter::DragInfo)
                 | Some(PropertyAdapter::DropData)
                 | Some(PropertyAdapter::DropPolicy)
+                | Some(PropertyAdapter::FocusEvent)
                 | Some(PropertyAdapter::ResourceOverrides)
                 | Some(PropertyAdapter::ResourceStyle)
                 | Some(PropertyAdapter::RichEditText)
@@ -1535,6 +1538,83 @@ fn generate_event_arm(control: &ResolvedControl, event: &ResolvedEvent) -> Token
                         revision,
                         EventPayload::PointerEventInfo(info),
                     );
+                }
+            }
+        },
+        EventPayloadSource::KeyEvent => quote! {
+            move |_, args| {
+                let result = args
+                    .as_ref()
+                    .ok_or_else(windows_core::Error::empty)
+                    .and_then(key_event_info);
+                match result {
+                    Ok(info) => {
+                        let handled =
+                            sink.route_key(node, EventId::#event_id, revision, info);
+                        if let Some(args) = args.as_ref() {
+                            _ = args.SetHandled(handled);
+                        }
+                    }
+                    Err(error) => {
+                        sink.error(
+                            node,
+                            EventId::#event_id,
+                            revision,
+                            native_error(error),
+                        );
+                    }
+                }
+            }
+        },
+        EventPayloadSource::CharacterEvent => quote! {
+            move |_, args| {
+                let result = args
+                    .as_ref()
+                    .ok_or_else(windows_core::Error::empty)
+                    .and_then(character_event_info);
+                match result {
+                    Ok(info) => {
+                        let handled =
+                            sink.route_character(node, EventId::#event_id, revision, info);
+                        if let Some(args) = args.as_ref() {
+                            _ = args.SetHandled(handled);
+                        }
+                    }
+                    Err(error) => {
+                        sink.error(
+                            node,
+                            EventId::#event_id,
+                            revision,
+                            native_error(error),
+                        );
+                    }
+                }
+            }
+        },
+        EventPayloadSource::FocusEvent => quote! {
+            {
+                let element = value.cast::<UIElement>().map_err(native_error)?;
+                move |_, args| {
+                    let result = args
+                        .as_ref()
+                        .ok_or_else(windows_core::Error::empty)
+                        .and_then(|args| focus_event_info(&element, args));
+                    match result {
+                        Ok(info) => sink.enqueue(
+                            node,
+                            EventId::#event_id,
+                            revision,
+                            EventPayload::FocusEventInfo(info),
+                        ),
+                        Err(error) => {
+                            sink.error(
+                                node,
+                                EventId::#event_id,
+                                revision,
+                                native_error(error),
+                            );
+                        }
+                    }
                 }
             }
         },

--- a/crates/tools/reactor/src/schema.rs
+++ b/crates/tools/reactor/src/schema.rs
@@ -128,6 +128,7 @@ pub(crate) enum PropertyAdapter {
     NumberBoxValue,
     PathData,
     PointerCapture,
+    PointerFocus,
     PointerEvent,
     DragInfo,
     DropData,
@@ -192,6 +193,7 @@ impl PropertyAdapter {
             Self::DropPolicy
             | Self::KeyAccelerators
             | Self::PointerCapture
+            | Self::PointerFocus
             | Self::ResourceOverrides
             | Self::RichEditText
             | Self::RichTextBlocks => PropertyAdapterCapabilities {
@@ -361,6 +363,13 @@ impl PropertyAdapter {
                 true,
                 "pointer_capture requires Border.CapturePointerOnPress",
             ),
+            Self::PointerFocus => property(
+                OneOf(&[(BORDER, "FocusOnPointerRelease")]),
+                None,
+                "Bool",
+                true,
+                "pointer_focus requires Border.FocusOnPointerRelease",
+            ),
             Self::RatingValue => property(
                 OneOf(&[(RATING_CONTROL, "Value")]),
                 ValueType("F64", true),
@@ -510,7 +519,7 @@ pub(crate) struct Event {
     #[serde(default)]
     pub(crate) adapter: Option<PropertyAdapter>,
     #[serde(default)]
-    pub(crate) active_property: Option<String>,
+    pub(crate) active_properties: Vec<String>,
     #[serde(default)]
     pub(crate) routed: bool,
 }
@@ -608,7 +617,7 @@ pub(crate) struct ResolvedEvent {
     pub(crate) source: EventPayloadSource,
     pub(crate) conversion: EventPayloadConversion,
     pub(crate) subscription: EventSubscription,
-    pub(crate) active_property: Option<String>,
+    pub(crate) active_properties: Vec<String>,
     pub(crate) routed: bool,
 }
 
@@ -893,6 +902,7 @@ impl Schema {
                         format!("get_{}", property.name)
                     }
                     Some(PropertyAdapter::PointerCapture) => "add_PointerPressed".to_string(),
+                    Some(PropertyAdapter::PointerFocus) => "add_PointerReleased".to_string(),
                     Some(PropertyAdapter::DropPolicy) => "put_AllowDrop".to_string(),
                     _ => format!("put_{}", property.name),
                 };
@@ -1106,15 +1116,16 @@ impl Schema {
                         control.type_name, event.name
                     ));
                 }
-                if let Some(active_property) = event.active_property.as_deref()
-                    && !properties
+                for active_property in &event.active_properties {
+                    if !properties
                         .iter()
-                        .any(|property| property.field == active_property)
-                {
-                    return Err(format!(
-                        "{}.{} active_property `{active_property}` is not a property field",
-                        control.type_name, event.name
-                    ));
+                        .any(|property| property.field == *active_property)
+                    {
+                        return Err(format!(
+                            "{}.{} active property `{active_property}` is not a property field",
+                            control.type_name, event.name
+                        ));
+                    }
                 }
                 if event.adapter.is_some()
                     && !matches!(
@@ -1624,7 +1635,7 @@ impl Schema {
                     source,
                     conversion,
                     subscription,
-                    active_property: event.active_property,
+                    active_properties: event.active_properties,
                     routed: event.routed,
                 });
             }

--- a/crates/tools/reactor/src/schema.rs
+++ b/crates/tools/reactor/src/schema.rs
@@ -110,6 +110,8 @@ pub(crate) struct Property {
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub(crate) enum PropertyAdapter {
+    CharacterEvent,
+    FocusEvent,
     ClockIdentifier,
     ContentDialogResult,
     ImageUri,
@@ -119,6 +121,7 @@ pub(crate) enum PropertyAdapter {
     ImplicitScale,
     ImplicitScaleTransition,
     KeyAccelerators,
+    KeyEvent,
     ItemTag,
     ItemTags,
     NavigationDisplayMode,
@@ -201,17 +204,20 @@ impl PropertyAdapter {
                 uses_dependency_property: false,
                 uses_property_setter: true,
             },
-            Self::ClockIdentifier
+            Self::CharacterEvent
+            | Self::ClockIdentifier
             | Self::ContentDialogResult
             | Self::DragInfo
             | Self::DropData
             | Self::FontWeight
+            | Self::FocusEvent
             | Self::HorizontalContentAlignment
             | Self::ImageUri
             | Self::InspectableString
             | Self::InspectableStringList
             | Self::ItemTag
             | Self::ItemTags
+            | Self::KeyEvent
             | Self::NavigationDisplayMode
             | Self::NumberBoxValue
             | Self::PathData
@@ -419,6 +425,13 @@ impl PropertyAdapter {
             Self::PointerEvent => {
                 PropertyAdapterKind::EventOnly("pointer_event is an event-only adapter")
             }
+            Self::KeyEvent => PropertyAdapterKind::EventOnly("key_event is an event-only adapter"),
+            Self::CharacterEvent => {
+                PropertyAdapterKind::EventOnly("character_event is an event-only adapter")
+            }
+            Self::FocusEvent => {
+                PropertyAdapterKind::EventOnly("focus_event is an event-only adapter")
+            }
             Self::DragInfo | Self::DropData => {
                 PropertyAdapterKind::EventOnly("drag adapters are event-only")
             }
@@ -498,6 +511,8 @@ pub(crate) struct Event {
     pub(crate) adapter: Option<PropertyAdapter>,
     #[serde(default)]
     pub(crate) active_property: Option<String>,
+    #[serde(default)]
+    pub(crate) routed: bool,
 }
 
 #[derive(Deserialize)]
@@ -594,6 +609,7 @@ pub(crate) struct ResolvedEvent {
     pub(crate) conversion: EventPayloadConversion,
     pub(crate) subscription: EventSubscription,
     pub(crate) active_property: Option<String>,
+    pub(crate) routed: bool,
 }
 
 pub(crate) struct ResolvedSlot {
@@ -648,6 +664,9 @@ pub(crate) enum EventPayloadSource {
     EventArgsTreeNodeContent { interface: String, property: String },
     SenderRichEditText { interface: String, property: String },
     PointerEvent,
+    KeyEvent,
+    CharacterEvent,
+    FocusEvent,
     SenderItemTags { interface: String, property: String },
 }
 
@@ -682,7 +701,13 @@ impl EventPayloadSource {
                 interface,
                 property,
             } => Some((interface, property)),
-            Self::Unit | Self::DragInfo { .. } | Self::DropData { .. } | Self::PointerEvent => None,
+            Self::Unit
+            | Self::DragInfo { .. }
+            | Self::DropData { .. }
+            | Self::PointerEvent
+            | Self::KeyEvent
+            | Self::CharacterEvent
+            | Self::FocusEvent => None,
         }
     }
 
@@ -1097,6 +1122,9 @@ impl Schema {
                         Some(
                             PropertyAdapter::ItemTags
                                 | PropertyAdapter::PointerEvent
+                                | PropertyAdapter::KeyEvent
+                                | PropertyAdapter::CharacterEvent
+                                | PropertyAdapter::FocusEvent
                                 | PropertyAdapter::DragInfo
                                 | PropertyAdapter::DropData
                         )
@@ -1242,6 +1270,20 @@ impl Schema {
                             },
                             ReadValueConversion::Identity,
                         )
+                    } else if event.adapter == Some(PropertyAdapter::FocusEvent) {
+                        if event.property.is_some()
+                            || !matches!(event.name.as_str(), "GotFocus" | "LostFocus")
+                        {
+                            return Err(format!(
+                                "{}.{} has an invalid focus_event contract",
+                                control.type_name, event.name
+                            ));
+                        }
+                        (
+                            "FocusEventInfo".to_string(),
+                            EventPayloadSource::FocusEvent,
+                            ReadValueConversion::Identity,
+                        )
                     } else if event.adapter == Some(PropertyAdapter::PointerEvent) {
                         if event.property.is_some()
                             || !matches!(
@@ -1261,6 +1303,32 @@ impl Schema {
                         (
                             "PointerEventInfo".to_string(),
                             EventPayloadSource::PointerEvent,
+                            ReadValueConversion::Identity,
+                        )
+                    } else if event.adapter == Some(PropertyAdapter::KeyEvent) {
+                        if event.property.is_some()
+                            || !matches!(event.name.as_str(), "PreviewKeyDown" | "KeyUp")
+                        {
+                            return Err(format!(
+                                "{}.{} has an invalid key_event contract",
+                                control.type_name, event.name
+                            ));
+                        }
+                        (
+                            "KeyEventInfo".to_string(),
+                            EventPayloadSource::KeyEvent,
+                            ReadValueConversion::Identity,
+                        )
+                    } else if event.adapter == Some(PropertyAdapter::CharacterEvent) {
+                        if event.property.is_some() || event.name != "CharacterReceived" {
+                            return Err(format!(
+                                "{}.{} has an invalid character_event contract",
+                                control.type_name, event.name
+                            ));
+                        }
+                        (
+                            "CharacterEventInfo".to_string(),
+                            EventPayloadSource::CharacterEvent,
                             ReadValueConversion::Identity,
                         )
                     } else if matches!(
@@ -1534,6 +1602,18 @@ impl Schema {
                     payload = format!("Optional{payload}");
                 }
 
+                if event.routed
+                    != matches!(
+                        source,
+                        EventPayloadSource::KeyEvent | EventPayloadSource::CharacterEvent
+                    )
+                {
+                    return Err(format!(
+                        "{}.{} routed events require a key_event or character_event adapter",
+                        control.type_name, event.name
+                    ));
+                }
+
                 events.push(ResolvedEvent {
                     field: event
                         .field
@@ -1545,6 +1625,7 @@ impl Schema {
                     conversion,
                     subscription,
                     active_property: event.active_property,
+                    routed: event.routed,
                 });
             }
 

--- a/crates/tools/reactor/src/schema.rs
+++ b/crates/tools/reactor/src/schema.rs
@@ -1620,7 +1620,8 @@ impl Schema {
                     )
                 {
                     return Err(format!(
-                        "{}.{} routed events require a key_event or character_event adapter",
+                        "{}.{} routed must be true exactly when using a key_event or \
+                         character_event adapter",
                         control.type_name, event.name
                     ));
                 }

--- a/crates/tools/reactor/src/winui.toml
+++ b/crates/tools/reactor/src/winui.toml
@@ -160,6 +160,10 @@ name = "CapturePointerOnPress"
 adapter = "pointer_capture"
 
 [[control.property]]
+name = "FocusOnPointerRelease"
+adapter = "pointer_focus"
+
+[[control.property]]
 name = "AllowDrop"
 field = "drop_policy"
 adapter = "drop_policy"
@@ -168,13 +172,13 @@ adapter = "drop_policy"
 name = "DragEnter"
 field = "on_drag_enter"
 adapter = "drag_info"
-active_property = "drop_policy"
+active_properties = ["drop_policy"]
 
 [[control.event]]
 name = "DragOver"
 field = "on_drag_over"
 adapter = "drag_info"
-active_property = "drop_policy"
+active_properties = ["drop_policy"]
 
 [[control.event]]
 name = "DragLeave"
@@ -188,7 +192,7 @@ adapter = "drop_data"
 [[control.event]]
 name = "PointerPressed"
 adapter = "pointer_event"
-active_property = "capture_pointer_on_press"
+active_properties = ["capture_pointer_on_press"]
 
 [[control.event]]
 name = "PointerMoved"
@@ -205,6 +209,7 @@ adapter = "pointer_event"
 [[control.event]]
 name = "PointerReleased"
 adapter = "pointer_event"
+active_properties = ["capture_pointer_on_press", "focus_on_pointer_release"]
 
 [[control.event]]
 name = "PointerCaptureLost"

--- a/crates/tools/reactor/src/winui.toml
+++ b/crates/tools/reactor/src/winui.toml
@@ -107,7 +107,13 @@ name = "Click"
 
 [[control]]
 type = "Microsoft.UI.Xaml.Controls.Border"
-capabilities = ["layout", "content"]
+capabilities = ["layout", "content", "focus"]
+
+[[control.property]]
+name = "IsTabStop"
+
+[[control.property]]
+name = "AllowFocusOnInteraction"
 
 [[control.property]]
 name = "Padding"
@@ -205,6 +211,29 @@ name = "PointerCaptureLost"
 
 [[control.event]]
 name = "PointerCanceled"
+
+[[control.event]]
+name = "PreviewKeyDown"
+adapter = "key_event"
+routed = true
+
+[[control.event]]
+name = "KeyUp"
+adapter = "key_event"
+routed = true
+
+[[control.event]]
+name = "CharacterReceived"
+adapter = "character_event"
+routed = true
+
+[[control.event]]
+name = "GotFocus"
+adapter = "focus_event"
+
+[[control.event]]
+name = "LostFocus"
+adapter = "focus_event"
 
 [[control]]
 type = "Microsoft.UI.Xaml.Controls.BreadcrumbBar"

--- a/docs/crates/windows-reactor.md
+++ b/docs/crates/windows-reactor.md
@@ -267,7 +267,9 @@ Border::new()
 The routed callback inspects an owned payload and decides whether the native event is handled.
 Its optional component message still enters the normal queue, so `Component::update` and
 reconciliation never run inside the WinUI callback. Return `bubble_without_message` for keys such
-as Tab that should retain their normal XAML behavior.
+as Tab that should retain their normal XAML behavior. Input bubbles when the component queue is
+already full. Once handled, its deferred message retains its native FIFO position and waits for
+component queue capacity.
 
 `KeyEventInfo` includes the mapped and original virtual key, physical-key status, and modifier
 state. `CharacterEventInfo::character` is one UTF-16 code unit so surrogate pairs are preserved

--- a/docs/crates/windows-reactor.md
+++ b/docs/crates/windows-reactor.md
@@ -239,6 +239,41 @@ above, `context.forward()` is the shortest form.
 Keep event-driven state changes in `update`, and keep `view` focused on turning the current state
 into controls. That makes the direction of data flow easy to follow.
 
+## Handle keyboard input on custom surfaces
+
+`Border` can act as a focusable interaction surface around Canvas, Composition, or another custom
+view. Enable tab focus, opt into pointer focus, and use routed callbacks for input events whose
+WinUI `Handled` value must be set before the native callback returns:
+
+```rust,ignore
+Border::new()
+    .is_tab_stop(true)
+    .allow_focus_on_interaction(true)
+    .on_preview_key_down(context.routed_callback(|info: KeyEventInfo| {
+        match info.key {
+            VirtualKey::LEFT => RoutedMessage::handled(Message::MoveLeft),
+            VirtualKey::RIGHT => RoutedMessage::handled(Message::MoveRight),
+            _ => RoutedMessage::bubble_without_message(),
+        }
+    }))
+    .on_character_received(context.routed_callback(|info: CharacterEventInfo| {
+        RoutedMessage::handled(Message::Character(info.character))
+    }))
+    .on_got_focus(context.callback(Message::Focused))
+    .on_lost_focus(context.callback(Message::Blurred))
+    .content(custom_surface)
+```
+
+The routed callback inspects an owned payload and decides whether the native event is handled.
+Its optional component message still enters the normal queue, so `Component::update` and
+reconciliation never run inside the WinUI callback. Return `bubble_without_message` for keys such
+as Tab that should retain their normal XAML behavior.
+
+`KeyEventInfo` includes the mapped and original virtual key, physical-key status, and modifier
+state. `CharacterEventInfo::character` is one UTF-16 code unit so surrogate pairs are preserved
+without lossy conversion. `ElementRef<Border>` supports programmatic focus when pointer or tab
+focus is not sufficient.
+
 ## Split the UI into understandable pieces
 
 For small, stateless pieces, use an ordinary function that returns `View`:
@@ -480,6 +515,8 @@ events. The [`gallery`](../../crates/samples/reactor/gallery) is a control catal
 together in a larger application. See the [`composition`](../../crates/samples/composition),
 [`webview`](../../crates/samples/webview/reactor), and
 [Canvas](../../crates/samples/canvas) samples only when the app needs those integrations.
+The [`canvas-editor`](../../crates/samples/canvas/editor) sample uses a focusable Canvas surface
+with pointer selection, routed keyboard navigation, character labels, and focus visuals.
 
 ---
 
@@ -540,6 +577,12 @@ Canvas owns its devices, swap chains, image sources, resize handling, and recove
 owns application visual trees and animations. WebView users receive the CoreWebView2 object rather
 than Reactor's XAML control.
 
+Routed keyboard callbacks are stored separately from ordinary event callbacks. WinUI key and
+character arguments are copied into owned payloads, the callback decides `Handled` synchronously,
+and any resulting component message is placed in the existing native-event FIFO. This preserves
+native event order without running component code or reconciliation across a WinRT callback.
+Callback replacements publish transactionally and do not replace the native subscription.
+
 ### Code generation
 
 `crates/tools/reactor` refreshes pinned WinUI, Windows App SDK, and WebView2 metadata, resolves
@@ -582,6 +625,7 @@ feature removes that allowance so the live surface build checks all generated te
 | Generated WinUI surface | `cargo run -p test-reactor-surface -- --headless` |
 | Planner benchmarks | `cargo run -p test-reactor-bench --release` |
 | Live grid benchmark | `cargo run -p test-reactor-bench --bin reactor-live-grid --release` |
+| Live input benchmark | `cargo run -p test-reactor-bench --bin reactor-live-input --release` |
 
 The generated surface test covers projected controls, properties, events, content, collections,
 slots, attachments, virtual items, and TreeView nodes. Handwritten self-tests own imperative

--- a/docs/crates/windows-reactor.md
+++ b/docs/crates/windows-reactor.md
@@ -242,13 +242,13 @@ into controls. That makes the direction of data flow easy to follow.
 ## Handle keyboard input on custom surfaces
 
 `Border` can act as a focusable interaction surface around Canvas, Composition, or another custom
-view. Enable tab focus, opt into pointer focus, and use routed callbacks for input events whose
-WinUI `Handled` value must be set before the native callback returns:
+view. Enable tab focus and native post-event pointer focus, then use routed callbacks for input
+events whose WinUI `Handled` value must be set before the native callback returns:
 
 ```rust,ignore
 Border::new()
     .is_tab_stop(true)
-    .allow_focus_on_interaction(true)
+    .focus_on_pointer_release(true)
     .on_preview_key_down(context.routed_callback(|info: KeyEventInfo| {
         match info.key {
             VirtualKey::LEFT => RoutedMessage::handled(Message::MoveLeft),
@@ -271,8 +271,10 @@ as Tab that should retain their normal XAML behavior.
 
 `KeyEventInfo` includes the mapped and original virtual key, physical-key status, and modifier
 state. `CharacterEventInfo::character` is one UTF-16 code unit so surrogate pairs are preserved
-without lossy conversion. `ElementRef<Border>` supports programmatic focus when pointer or tab
-focus is not sufficient.
+without lossy conversion. `focus_on_pointer_release(true)` queues a native
+`FocusState::Pointer` request from the routed pointer event. The request runs after the native
+callback returns. It works when a child such as Canvas is the direct hit-test source.
+`ElementRef<Border>` supports other programmatic focus cases.
 
 ## Split the UI into understandable pieces
 

--- a/docs/crates/windows-reactor.md
+++ b/docs/crates/windows-reactor.md
@@ -586,7 +586,7 @@ than Reactor's XAML control.
 Routed keyboard callbacks are stored separately from ordinary event callbacks. WinUI key and
 character arguments are copied into owned payloads, the callback decides `Handled` synchronously,
 and any resulting component message is placed in the existing native-event FIFO. This preserves
-native event order without running component code or reconciliation across a WinRT callback.
+native event order without running `Component::update` or reconciliation across a WinRT callback.
 Callback replacements publish transactionally and do not replace the native subscription.
 
 ### Code generation

--- a/docs/crates/windows-reactor.md
+++ b/docs/crates/windows-reactor.md
@@ -518,9 +518,9 @@ together in a larger application. See the [`composition`](../../crates/samples/c
 [`webview`](../../crates/samples/webview/reactor), and
 [Canvas](../../crates/samples/canvas) samples only when the app needs those integrations.
 The [`canvas-keyboard`](../../crates/samples/canvas/keyboard) sample is a focusable custom-rendered
-line editor with pointer caret placement, routed navigation and edit keys, UTF-16 character input,
-and visible focus state. It shows when custom input is useful without replacing `TextBox` for
-ordinary text editing.
+text surface with routed edit keys, UTF-16 character input, visible focus state, and a standard
+WinUI button that demonstrates focus transfer. It shows when custom input is useful without
+replacing `TextBox` for ordinary text editing.
 
 ---
 

--- a/docs/crates/windows-reactor.md
+++ b/docs/crates/windows-reactor.md
@@ -515,8 +515,10 @@ events. The [`gallery`](../../crates/samples/reactor/gallery) is a control catal
 together in a larger application. See the [`composition`](../../crates/samples/composition),
 [`webview`](../../crates/samples/webview/reactor), and
 [Canvas](../../crates/samples/canvas) samples only when the app needs those integrations.
-The [`canvas-editor`](../../crates/samples/canvas/editor) sample uses a focusable Canvas surface
-with pointer selection, routed keyboard navigation, character labels, and focus visuals.
+The [`canvas-keyboard`](../../crates/samples/canvas/keyboard) sample is a focusable custom-rendered
+line editor with pointer caret placement, routed navigation and edit keys, UTF-16 character input,
+and visible focus state. It shows when custom input is useful without replacing `TextBox` for
+ordinary text editing.
 
 ---
 
@@ -626,10 +628,19 @@ feature removes that allowance so the live surface build checks all generated te
 | Planner benchmarks | `cargo run -p test-reactor-bench --release` |
 | Live grid benchmark | `cargo run -p test-reactor-bench --bin reactor-live-grid --release` |
 | Live input benchmark | `cargo run -p test-reactor-bench --bin reactor-live-input --release` |
+| Live Notepad benchmark | `cargo run -p test-reactor-bench --bin reactor-live-notepad --release` |
 
 The generated surface test covers projected controls, properties, events, content, collections,
 slots, attachments, virtual items, and TreeView nodes. Handwritten self-tests own imperative
 references, retirement, and other OS interactions.
+
+The live Notepad benchmark uses the same controlled `TextBox` shape as the `reactor-notepad`
+sample. It injects Unicode keyboard input and measures raw `WM_CHAR`, WinUI `TextChanged`,
+`Text()` retrieval, Reactor event and component queues, reconciliation, Rust allocations, and
+whether controlled feedback causes a native write-back. Use `--text-size` to test document-size
+scaling. Run the release build with its window in the foreground and leave the machine idle while
+collecting results. The test-only probes add instrumentation overhead, and the injected
+`KEYEVENTF_UNICODE` path does not measure physical-key translation or IME composition.
 
 Pass `--filter <name>` to run matching handwritten fixtures. For example:
 


### PR DESCRIPTION
Adds efficient routed keyboard input to `windows-reactor` for custom-rendered controls such as Canvas-based editors.

Native callbacks can synchronously decide whether an event is handled while component messages remain deferred through Reactor's FIFO queue. The change also adds owned keyboard, character, modifier, physical-key, and focus payloads, plus reusable pointer-release focus handling.

Includes:

- Generated keyboard and focus events for `Border`
- `focus_on_pointer_release` for Canvas-backed interaction surfaces
- Backpressure that preserves accepted input and event ordering
- A focused `canvas-keyboard` sample
- Deterministic and live coverage for keyboard, character, pointer, and focus behavior
- Routed-input and controlled `TextBox` profiling
- Reactor module and import cleanup

Normal text editors should continue using `TextBox`; the new APIs support controls that require custom rendering and input handling.