### PR TITLE
`windows-clang` retain constant type dependencies

### DIFF
--- a/crates/libs/clang/src/collector.rs
+++ b/crates/libs/clang/src/collector.rs
@@ -16,15 +16,24 @@ impl Collector {
         Default::default()
     }
 
-    pub fn insert(&mut self, item: Item) {
+    pub fn insert(&mut self, item: Item) -> bool {
         let name = item.to_string();
+        if self.0.get(&name).is_some_and(Item::is_type)
+            && matches!(
+                item,
+                Item::Const(_) | Item::GuidConst(_) | Item::PropertyKeyConst(_)
+            )
+        {
+            return false;
+        }
         if let (Some(Item::Typedef(existing)), Item::Typedef(candidate)) =
             (self.0.get(&name), &item)
             && (existing.is_direct_pointer_alias() || !candidate.is_direct_pointer_alias())
         {
-            return;
+            return false;
         }
         self.0.insert(name, item);
+        true
     }
 
     /// Keep only entries whose name satisfies `keep`.

--- a/crates/libs/clang/src/const.rs
+++ b/crates/libs/clang/src/const.rs
@@ -5,6 +5,7 @@ pub struct Const {
     pub name: String,
     pub ty: Option<metadata::Type>,
     pub value: metadata::Value,
+    pub(crate) evaluated_type: Option<String>,
 }
 
 impl Const {
@@ -33,6 +34,7 @@ impl Const {
                 name,
                 ty: Some(ty),
                 value,
+                evaluated_type: None,
             }));
         }
 
@@ -45,7 +47,40 @@ impl Const {
             name,
             ty: None,
             value,
+            evaluated_type: None,
         }))
+    }
+
+    /// Restore the named expression type that batch evaluation folded to a plain integer.
+    pub(crate) fn apply_evaluated_type(
+        &mut self,
+        namespace: &str,
+        ref_map: &HashMap<String, String>,
+        tag_rename: &HashMap<String, String>,
+        local_types: &HashSet<String>,
+    ) {
+        if self.ty.is_some() {
+            return;
+        }
+        let Some(type_name) = self.evaluated_type.take() else {
+            return;
+        };
+        let type_name = tag_rename.get(&type_name).unwrap_or(&type_name);
+        let known_type = local_types.contains(type_name)
+            || ref_map.contains_key(type_name)
+            || semantic_scalar(type_name).is_some()
+            || fundamental_scalar(type_name).is_some()
+            || void_pointer_alias(type_name).is_some()
+            || canonical_hresult(type_name).is_some();
+        if !known_type {
+            return;
+        }
+        let Some(bits) = const_value_bits(&self.value) else {
+            return;
+        };
+        if let Some(value) = named_cast_value(namespace, ref_map, None, type_name, bits, false) {
+            self.value = value;
+        }
     }
 
     /// Parse file-scope floating-point `const` variables that flat metadata would otherwise lose.
@@ -67,6 +102,7 @@ impl Const {
             name,
             ty: None,
             value,
+            evaluated_type: None,
         })
     }
 
@@ -273,6 +309,37 @@ impl Const {
         }
         Ok(results)
     }
+
+    pub(crate) fn undefined_macros(
+        input: &str,
+        names: &[String],
+        index: &Index,
+        args: &[&str],
+    ) -> Result<HashSet<String>, Error> {
+        let input_basename = Path::new(input)
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or(input);
+        let prefix = format!("#include \"{input_basename}\"\n");
+        let synthetic = format!("{input}.__rdl_defined__.cpp");
+        undefined_names(&prefix, &synthetic, names, index, args)
+    }
+
+    pub(crate) fn undefined_macros_str(
+        content: &str,
+        names: &[String],
+        index: &Index,
+        args: &[&str],
+    ) -> Result<HashSet<String>, Error> {
+        let prefix = format!("{content}\n");
+        undefined_names(
+            &prefix,
+            "__rdl_input_text_defined__.cpp",
+            names,
+            index,
+            args,
+        )
+    }
 }
 
 /// Disable clang's error cap so bad probe enums do not abort the TU before later valid macros.
@@ -280,6 +347,54 @@ fn with_unlimited_errors<'a>(args: &[&'a str]) -> Vec<&'a str> {
     let mut out = args.to_vec();
     out.push("-ferror-limit=0");
     out
+}
+
+/// Return names that the final preprocessor state explicitly reports as undefined.
+fn undefined_names(
+    prefix: &str,
+    synthetic: &str,
+    names: &[String],
+    index: &Index,
+    args: &[&str],
+) -> Result<HashSet<String>, Error> {
+    if names.is_empty() {
+        return Ok(HashSet::new());
+    }
+
+    let mut source = String::from(prefix);
+    for name in names {
+        if !is_c_identifier(name) {
+            continue;
+        }
+        source.push_str(&format!(
+            "#ifdef {name}\n\
+             enum {{ __rdl_defined_{name} = 1 }};\n\
+             #else\n\
+             enum {{ __rdl_undefined_{name} = 1 }};\n\
+             #endif\n"
+        ));
+    }
+
+    let args = with_unlimited_errors(args);
+    let tu = index.parse_unsaved(
+        synthetic,
+        &source,
+        &args,
+        CXTranslationUnit_KeepGoing | CXTranslationUnit_SkipFunctionBodies,
+    )?;
+    let mut undefined = HashSet::new();
+    for child in tu.cursor().children() {
+        if child.is_from_main_file() && child.kind() == CXCursor_EnumDecl {
+            for constant in child.children() {
+                if constant.kind() == CXCursor_EnumConstantDecl
+                    && let Some(name) = constant.name().strip_prefix("__rdl_undefined_")
+                {
+                    undefined.insert(name.to_string());
+                }
+            }
+        }
+    }
+    Ok(undefined)
 }
 
 /// Counts top-level comma-separated macro-expansion results for the shape gate.
@@ -306,7 +421,7 @@ fn eval_probe(name: &str) -> String {
 /// Missing gates mean a preceding macro swallowed later enum declarations, so the caller
 /// retries those names; failed gates are real rejects and are not retried.
 fn collect_eval_results(tu: &TranslationUnit) -> (Vec<Const>, HashSet<String>) {
-    let mut evals: Vec<(String, u64, i64, Option<metadata::Type>)> = vec![];
+    let mut evals: Vec<(String, u64, i64, Option<metadata::Type>, Option<String>)> = vec![];
     let mut eval_seen: HashSet<String> = HashSet::new();
     let mut ok_seen: HashSet<String> = HashSet::new();
     let mut nc_seen: HashSet<String> = HashSet::new();
@@ -325,7 +440,14 @@ fn collect_eval_results(tu: &TranslationUnit) -> (Vec<Const>, HashSet<String>) {
             if let Some((unsigned, signed)) = child.evaluate_integer() {
                 let ty = child.ty();
                 let semantic = pointer_sized_abi(&ty.ty().name());
-                evals.push((original_name.to_string(), unsigned, signed, semantic));
+                let evaluated_type = evaluated_type_name(child);
+                evals.push((
+                    original_name.to_string(),
+                    unsigned,
+                    signed,
+                    semantic,
+                    evaluated_type,
+                ));
             }
             continue;
         }
@@ -364,8 +486,8 @@ fn collect_eval_results(tu: &TranslationUnit) -> (Vec<Const>, HashSet<String>) {
 
     let kept = evals
         .into_iter()
-        .filter(|(name, _, _, _)| type_ok.contains(name) && shape_ok.contains(name))
-        .map(|(name, unsigned, signed, ty)| {
+        .filter(|(name, _, _, _, _)| type_ok.contains(name) && shape_ok.contains(name))
+        .map(|(name, unsigned, signed, ty, evaluated_type)| {
             let value = if let Some(ty) = &ty {
                 native_integer_value(unsigned, signed, ty)
             } else {
@@ -376,11 +498,26 @@ fn collect_eval_results(tu: &TranslationUnit) -> (Vec<Const>, HashSet<String>) {
                     signs.get(&name).copied(),
                 )
             };
-            Const { name, ty, value }
+            Const {
+                name,
+                ty,
+                value,
+                evaluated_type,
+            }
         })
         .collect();
 
     (kept, present)
+}
+
+fn evaluated_type_name(cursor: Cursor) -> Option<String> {
+    let ty = cursor.ty();
+    if ty.ty().name().is_empty() {
+        return None;
+    }
+    let spelling = ty.spelling();
+    let name = spelling.strip_prefix("const ").unwrap_or(&spelling);
+    is_c_identifier(name).then(|| name.to_string())
 }
 
 /// Type an evaluated integer from size/signedness probes, with a value-based fallback.
@@ -932,7 +1069,17 @@ fn parse_named_cast(
 ) -> Option<metadata::Value> {
     let (digits, _suffix) = split_int_suffix(lit);
     let raw: u64 = parse_int_digits(digits)?;
+    named_cast_value(namespace, ref_map, header_names, type_name, raw, negate)
+}
 
+fn named_cast_value(
+    namespace: &str,
+    ref_map: &HashMap<String, String>,
+    header_names: Option<&HashMap<String, String>>,
+    type_name: &str,
+    raw: u64,
+    negate: bool,
+) -> Option<metadata::Value> {
     if let Some(ty) = semantic_scalar(type_name) {
         return scalar_value(&ty, raw, negate);
     }
@@ -979,6 +1126,23 @@ fn parse_named_cast(
         metadata::TypeName::named(ns, type_name),
         Box::new(metadata::Value::I64(v)),
     ))
+}
+
+fn const_value_bits(value: &metadata::Value) -> Option<u64> {
+    Some(match value {
+        metadata::Value::Bool(v) => *v as u64,
+        metadata::Value::U8(v) => *v as u64,
+        metadata::Value::I8(v) => *v as i64 as u64,
+        metadata::Value::U16(v) => *v as u64,
+        metadata::Value::I16(v) => *v as i64 as u64,
+        metadata::Value::U32(v) => *v as u64,
+        metadata::Value::I32(v) => *v as i64 as u64,
+        metadata::Value::U64(v) => *v,
+        metadata::Value::I64(v) => *v as u64,
+        metadata::Value::USize(v) => *v,
+        metadata::Value::ISize(v) => *v as u64,
+        _ => return None,
+    })
 }
 
 /// Parse a named cast of a complemented integer literal such as `(SOCKET)(~0)`.

--- a/crates/libs/clang/src/cx.rs
+++ b/crates/libs/clang/src/cx.rs
@@ -866,13 +866,12 @@ impl Type {
                         .to_string()
                 };
                 let definition = decl.definition();
-                if self.kind() == CXType_Record
-                    && parser.header_root.is_none()
+                if parser.header_root.is_none()
                     && ns == parser.namespace
                     && decl.has_definition()
                     && (!definition.is_from_main_file() || !parser.symbols.is_empty())
                 {
-                    parser.pending_records.push(definition);
+                    parser.pending_definitions.push(definition);
                 }
                 // Incomplete namespaced records remain unresolved. Deciding whether a particular
                 // use can be represented by an opaque declaration requires usage-shape analysis.

--- a/crates/libs/clang/src/lib.rs
+++ b/crates/libs/clang/src/lib.rs
@@ -78,10 +78,13 @@ pub(crate) struct Parser<'a> {
     pub tag_rename: &'a HashMap<String, String>,
     /// Enum reprs taken from integer typedefs in the C flags/enum idiom.
     pub enum_merge: &'a HashMap<String, &'static str>,
+    /// Typedef declarations visible through this translation unit's include graph.
+    pub typedefs: &'a HashMap<String, Cursor>,
     pub tu: &'a TranslationUnit,
     pub pending_typedefs: Vec<Cursor>,
-    pub pending_records: Vec<Cursor>,
-    pub pending_macros: Vec<String>,
+    pub pending_definitions: Vec<Cursor>,
+    pending_macros: BTreeMap<String, PendingMacro>,
+    pub pending_constant_refs: HashSet<String>,
     processing_dependency: bool,
     /// Per-header mode: incomplete pointer-only records emitted as opaque structs.
     pub pending_opaque: Vec<(String, String)>,
@@ -111,6 +114,16 @@ struct NamespaceSpec<'a> {
     symbols: &'a HashSet<String>,
 }
 
+enum PendingMacro {
+    Direct(Box<Const>),
+    Evaluate,
+}
+
+enum InputSource<'a> {
+    File(&'a str),
+    Content(&'a str),
+}
+
 impl<'a> Parser<'a> {
     #[expect(clippy::too_many_arguments)]
     fn new(
@@ -120,6 +133,7 @@ impl<'a> Parser<'a> {
         ref_map: &'a HashMap<String, String>,
         tag_rename: &'a HashMap<String, String>,
         enum_merge: &'a HashMap<String, &'static str>,
+        typedefs: &'a HashMap<String, Cursor>,
         macro_defs: &'a HashMap<String, Vec<String>>,
         tu: &'a TranslationUnit,
         symbols: &'a HashSet<String>,
@@ -133,10 +147,12 @@ impl<'a> Parser<'a> {
             header_names: None,
             tag_rename,
             enum_merge,
+            typedefs,
             tu,
             pending_typedefs: vec![],
-            pending_records: vec![],
-            pending_macros: vec![],
+            pending_definitions: vec![],
+            pending_macros: BTreeMap::new(),
+            pending_constant_refs: HashSet::new(),
             processing_dependency: false,
             pending_opaque: vec![],
             flag_enums: HashSet::new(),
@@ -155,6 +171,31 @@ impl<'a> Parser<'a> {
             return;
         }
         collector.insert(Item::Fn(item));
+    }
+
+    fn track_constant_refs(&mut self, item: &Item) {
+        if self.header_root.is_none() {
+            item_refs(item, &mut self.pending_constant_refs);
+        }
+    }
+
+    fn finalize_direct_macros(&mut self, collector: &mut Collector, undefined: &HashSet<String>) {
+        let pending = std::mem::take(&mut self.pending_macros);
+        for (name, state) in pending {
+            match state {
+                PendingMacro::Direct(c) if !undefined.contains(&name) => {
+                    let item = Item::Const(*c);
+                    if collector.insert(item) {
+                        let item = collector.get(&name).unwrap();
+                        self.track_constant_refs(item);
+                    }
+                }
+                PendingMacro::Direct(_) => {}
+                PendingMacro::Evaluate => {
+                    self.pending_macros.insert(name, PendingMacro::Evaluate);
+                }
+            }
+        }
     }
 
     /// Processes one cursor, inserting items or queuing macros for the second pass.
@@ -302,6 +343,7 @@ impl<'a> Parser<'a> {
                             name,
                             ty: None,
                             value: const_value,
+                            evaluated_type: None,
                         }));
                     }
                 } else if !self.ref_map.contains_key(&e.name) {
@@ -343,12 +385,22 @@ impl<'a> Parser<'a> {
                 }
             }
             CXCursor_MacroDefinition => {
+                let name = child.name();
+                let namespaced = self.header_root.is_none();
+                if namespaced {
+                    self.pending_macros.remove(&name);
+                }
                 if let Some(c) = Const::parse(child, self)? {
-                    collector.insert(Item::Const(c));
+                    if namespaced {
+                        self.pending_macros
+                            .insert(name, PendingMacro::Direct(Box::new(c)));
+                    } else {
+                        collector.insert(Item::Const(c));
+                    }
                 } else if !child.is_macro_builtin()
                     && !child.is_macro_function_like()
-                    && !child.name().is_empty()
-                    && !child.name().starts_with('_')
+                    && !name.is_empty()
+                    && !name.starts_with('_')
                 {
                     // Non-type keywords and string literals are not integer constants.
                     let tokens = self.tu.tokenize(child.extent());
@@ -374,7 +426,7 @@ impl<'a> Parser<'a> {
                         && body_is_balanced
                     {
                         // Defer object-like macro constants to the batch evaluator.
-                        self.pending_macros.push(child.name());
+                        self.pending_macros.insert(name, PendingMacro::Evaluate);
                     }
                 }
             }
@@ -444,12 +496,14 @@ impl<'a> Parser<'a> {
                     && !self.ref_map.contains_key(&name)
                     && !collector.contains_key(&name)
                 {
-                    collector.insert(Item::PropertyKeyConst(PropertyKeyConst {
+                    let item = Item::PropertyKeyConst(PropertyKeyConst {
                         name,
                         ty: ty.to_string(),
                         uuid,
                         pid,
-                    }));
+                    });
+                    self.track_constant_refs(&item);
+                    collector.insert(item);
                 }
             }
             // `IID_XXX` variables can provide UUIDs missing from interface declarations.
@@ -471,7 +525,9 @@ impl<'a> Parser<'a> {
                     && !self.ref_map.contains_key(&c.name)
                     && !collector.contains_key(&c.name)
                 {
-                    collector.insert(Item::Const(c));
+                    let item = Item::Const(c);
+                    self.track_constant_refs(&item);
+                    collector.insert(item);
                 }
             }
             _ => {}
@@ -501,6 +557,7 @@ impl<'a> Parser<'a> {
                             name,
                             ty: None,
                             value: const_value,
+                            evaluated_type: None,
                         }));
                     }
                 }
@@ -1244,6 +1301,7 @@ impl Clang {
 
         let empty_ref: HashMap<String, String> = HashMap::new();
         let empty_symbols: HashSet<String> = HashSet::new();
+        let typedefs = build_typedef_map(tu);
         let mut all_opaque: Vec<(String, String)> = vec![];
         // Macro constants are per-bucket values but are deduplicated globally.
         let mut all_consts: Vec<(String, Vec<String>)> = vec![];
@@ -1257,6 +1315,7 @@ impl Clang {
                 &empty_ref,
                 &tag_rename,
                 &enum_merge,
+                &typedefs,
                 &macro_defs,
                 tu,
                 &empty_symbols,
@@ -1269,11 +1328,12 @@ impl Clang {
                 parser.process_cursor(child, collector, extern_c)?;
             }
 
+            parser.finalize_direct_macros(collector, &HashSet::new());
             collector.apply_iid_vars(&parser.iid_vars);
 
             let pending = std::mem::take(&mut parser.pending_macros);
             if !pending.is_empty() {
-                all_consts.push((stem.clone(), pending));
+                all_consts.push((stem.clone(), pending.into_keys().collect()));
             }
             for (_ns, name) in std::mem::take(&mut parser.pending_opaque) {
                 all_opaque.push((stem.clone(), name));
@@ -1385,24 +1445,46 @@ impl Clang {
         // Pass 1: learn unique type-name owners across specs. Shared typedef artifacts stay
         // local by being dropped from the owner table.
         let mut owners: HashMap<String, Option<String>> = HashMap::new();
-        for spec in specs {
-            let ref_map = build_ref_map(reference, spec.namespace);
-            let mut collector = Collector::new();
-            for (_, tu) in &parsed.h_tus {
-                self.process_tu(tu, &mut collector, &ref_map, spec)?;
-            }
-            for (_, tu) in &parsed.str_tus {
-                self.process_tu(tu, &mut collector, &ref_map, spec)?;
-            }
-            for name in collector.keys() {
-                owners
-                    .entry(name.clone())
-                    .and_modify(|owner| {
-                        if owner.as_deref() != Some(spec.namespace) {
-                            *owner = None;
-                        }
-                    })
-                    .or_insert_with(|| Some(spec.namespace.to_string()));
+        if specs.len() > 1 {
+            for spec in specs {
+                let ref_map = build_ref_map(reference, spec.namespace);
+                let mut collector = Collector::new();
+                for (input, tu) in &parsed.h_tus {
+                    self.process_tu(
+                        tu,
+                        InputSource::File(input),
+                        &parsed.index,
+                        &arg_refs,
+                        &mut collector,
+                        &ref_map,
+                        spec,
+                    )?;
+                }
+                for (content, tu) in &parsed.str_tus {
+                    self.process_tu(
+                        tu,
+                        InputSource::Content(content),
+                        &parsed.index,
+                        &arg_refs,
+                        &mut collector,
+                        &ref_map,
+                        spec,
+                    )?;
+                }
+                for name in collector
+                    .iter()
+                    .filter(|(_, item)| item.is_type())
+                    .map(|(name, _)| name)
+                {
+                    owners
+                        .entry(name.clone())
+                        .and_modify(|owner| {
+                            if owner.as_deref() != Some(spec.namespace) {
+                                *owner = None;
+                            }
+                        })
+                        .or_insert_with(|| Some(spec.namespace.to_string()));
+                }
             }
         }
         let in_house: HashMap<String, String> = owners
@@ -1418,17 +1500,27 @@ impl Clang {
             let mut collector = Collector::new();
 
             for (input, tu) in &parsed.h_tus {
-                let pending = self.process_tu(tu, &mut collector, &ref_map, spec)?;
-                for c in Const::evaluate_macros(input, &pending, &parsed.index, &arg_refs)? {
-                    collector.insert(Item::Const(c));
-                }
+                self.process_tu(
+                    tu,
+                    InputSource::File(input),
+                    &parsed.index,
+                    &arg_refs,
+                    &mut collector,
+                    &ref_map,
+                    spec,
+                )?;
             }
 
             for (content, tu) in &parsed.str_tus {
-                let pending = self.process_tu(tu, &mut collector, &ref_map, spec)?;
-                for c in Const::evaluate_macros_str(content, &pending, &parsed.index, &arg_refs)? {
-                    collector.insert(Item::Const(c));
-                }
+                self.process_tu(
+                    tu,
+                    InputSource::Content(content),
+                    &parsed.index,
+                    &arg_refs,
+                    &mut collector,
+                    &ref_map,
+                    spec,
+                )?;
             }
 
             outputs.push(emit_module(spec.namespace, &collector)?);
@@ -1437,14 +1529,18 @@ impl Clang {
         Ok(outputs)
     }
 
-    /// Processes one translation unit and returns macros needing batch evaluation.
+    /// Processes one translation unit, including deferred macro evaluation and dependencies.
+    #[expect(clippy::too_many_arguments)]
     fn process_tu(
         &self,
         tu: &TranslationUnit,
+        source: InputSource<'_>,
+        index: &Index,
+        args: &[&str],
         collector: &mut Collector,
         ref_map: &HashMap<String, String>,
         spec: &NamespaceSpec<'_>,
-    ) -> Result<Vec<String>, Error> {
+    ) -> Result<(), Error> {
         for diag in tu.diagnostics() {
             if diag.is_err() {
                 return Err(Error::new(
@@ -1462,6 +1558,13 @@ impl Clang {
         // Give nested records synthetic names keyed by tag or source location.
         assign_nested_names(tu, &mut tag_rename);
         let enum_merge = merge_enum_typedef_idiom(tu, &mut tag_rename);
+        let typedefs = build_typedef_map(tu);
+        let enum_definitions = build_enum_definition_map(tu, &tag_rename);
+        let local_types: HashSet<_> = typedefs
+            .keys()
+            .chain(enum_definitions.keys())
+            .cloned()
+            .collect();
         let macro_defs = collect_macro_defs(tu);
 
         let mut parser = Parser::new(
@@ -1471,6 +1574,7 @@ impl Clang {
             ref_map,
             &tag_rename,
             &enum_merge,
+            &typedefs,
             &macro_defs,
             tu,
             spec.symbols,
@@ -1500,13 +1604,62 @@ impl Clang {
             parser.process_cursor(child, collector, false)?;
         }
 
+        let direct_names: Vec<_> = parser
+            .pending_macros
+            .iter()
+            .filter(|(_, state)| matches!(state, PendingMacro::Direct(_)))
+            .map(|(name, _)| name.clone())
+            .collect();
+        let undefined = match source {
+            InputSource::File(input) => Const::undefined_macros(input, &direct_names, index, args)?,
+            InputSource::Content(content) => {
+                Const::undefined_macros_str(content, &direct_names, index, args)?
+            }
+        };
+        parser.finalize_direct_macros(collector, &undefined);
+
+        let names: Vec<_> = parser.pending_macros.keys().cloned().collect();
+        let evaluated = match source {
+            InputSource::File(input) => Const::evaluate_macros(input, &names, index, args)?,
+            InputSource::Content(content) => {
+                Const::evaluate_macros_str(content, &names, index, args)?
+            }
+        };
+        for mut constant in evaluated {
+            constant.apply_evaluated_type(spec.namespace, ref_map, &tag_rename, &local_types);
+            let name = constant.name.clone();
+            let item = Item::Const(constant);
+            if collector.insert(item) {
+                let item = collector.get(&name).unwrap();
+                parser.track_constant_refs(item);
+            }
+        }
+
+        // Constants have no type cursor, so queue local typedefs named by their emitted values.
+        let mut referenced: Vec<_> = std::mem::take(&mut parser.pending_constant_refs)
+            .into_iter()
+            .collect();
+        referenced.sort();
+        for name in referenced {
+            if !collector.get(&name).is_some_and(Item::is_type)
+                && !parser.ref_map.contains_key(&name)
+            {
+                if let Some(cursor) = parser.typedefs.get(&name) {
+                    parser.pending_typedefs.push(*cursor);
+                }
+                if let Some(cursor) = enum_definitions.get(&name) {
+                    parser.pending_definitions.push(*cursor);
+                }
+            }
+        }
+
         // Drain referenced type dependencies; parsing one definition can enqueue more.
         let mut seen_typedefs: HashSet<String> = HashSet::new();
-        let mut seen_records: HashSet<String> = HashSet::new();
+        let mut seen_definitions: HashSet<String> = HashSet::new();
         let mut typedef_index = 0;
-        let mut record_index = 0;
+        let mut definition_index = 0;
         while typedef_index < parser.pending_typedefs.len()
-            || record_index < parser.pending_records.len()
+            || definition_index < parser.pending_definitions.len()
         {
             while typedef_index < parser.pending_typedefs.len() {
                 let cursor = parser.pending_typedefs[typedef_index];
@@ -1514,7 +1667,7 @@ impl Clang {
                 let name = cursor.name();
                 // Skip anything already resolved.
                 if !seen_typedefs.insert(name.clone())
-                    || collector.contains_key(&name)
+                    || collector.get(&name).is_some_and(Item::is_type)
                     || parser.ref_map.contains_key(&name)
                 {
                     continue;
@@ -1526,10 +1679,10 @@ impl Clang {
                 }
             }
 
-            while record_index < parser.pending_records.len() {
-                let cursor = parser.pending_records[record_index];
-                record_index += 1;
-                if seen_records.insert(cursor.usr()) {
+            while definition_index < parser.pending_definitions.len() {
+                let cursor = parser.pending_definitions[definition_index];
+                definition_index += 1;
+                if seen_definitions.insert(cursor.usr()) {
                     parser.processing_dependency = true;
                     let result = parser.process_cursor(cursor, collector, false);
                     parser.processing_dependency = false;
@@ -1541,7 +1694,7 @@ impl Clang {
         // Apply `IID_IFoo` variables to interfaces that lack `uuid` attributes.
         collector.apply_iid_vars(&parser.iid_vars);
 
-        Ok(parser.pending_macros)
+        Ok(())
     }
 }
 
@@ -1934,6 +2087,7 @@ mod tests {
             name: "D3DFMT_X8R8G8B8".to_string(),
             ty: None,
             value: metadata::Value::U32(22),
+            evaluated_type: None,
         }));
 
         let collectors: BTreeMap<String, Collector> =

--- a/crates/libs/clang/src/naming.rs
+++ b/crates/libs/clang/src/naming.rs
@@ -24,6 +24,51 @@ pub(crate) fn build_tag_rename_map(tu: &TranslationUnit) -> HashMap<String, Stri
     map
 }
 
+/// Index typedef declarations visible in one translation unit.
+pub(crate) fn build_typedef_map(tu: &TranslationUnit) -> HashMap<String, Cursor> {
+    fn collect(cursor: Cursor, map: &mut HashMap<String, Cursor>) {
+        for child in cursor.children() {
+            if child.kind() == CXCursor_LinkageSpec {
+                collect(child, map);
+            } else if child.kind() == CXCursor_TypedefDecl {
+                map.entry(child.name()).or_insert(child);
+            }
+        }
+    }
+
+    let mut map = HashMap::new();
+    collect(tu.cursor(), &mut map);
+    map
+}
+
+/// Index named enum definitions visible in one translation unit by source and public names.
+pub(crate) fn build_enum_definition_map(
+    tu: &TranslationUnit,
+    tag_rename: &HashMap<String, String>,
+) -> HashMap<String, Cursor> {
+    fn collect(
+        cursor: Cursor,
+        tag_rename: &HashMap<String, String>,
+        map: &mut HashMap<String, Cursor>,
+    ) {
+        for child in cursor.children() {
+            if child.kind() == CXCursor_LinkageSpec {
+                collect(child, tag_rename, map);
+            } else if child.kind() == CXCursor_EnumDecl && child.is_definition() {
+                let name = child.name();
+                map.entry(name.clone()).or_insert(child);
+                if let Some(public) = tag_rename.get(&name) {
+                    map.entry(public.clone()).or_insert(child);
+                }
+            }
+        }
+    }
+
+    let mut map = HashMap::new();
+    collect(tu.cursor(), tag_rename, &mut map);
+    map
+}
+
 /// Merge `enum _FOO { ... }; typedef DWORD FOO;` into one public enum.
 ///
 /// The typedef supplies the backing type and signedness; the enum supplies the members.

--- a/crates/libs/clang/src/typedef.rs
+++ b/crates/libs/clang/src/typedef.rs
@@ -103,7 +103,7 @@ impl Typedef {
                 .get(&tag)
                 .cloned()
                 .unwrap_or_else(|| tag.clone());
-            if parser.header_root.is_none() && inner_kind == CXType_Record {
+            if parser.header_root.is_none() {
                 // Pull the backing definition into namespaced output before deciding whether this
                 // typedef is the public name or a secondary alias.
                 inner.to_type(parser);

--- a/crates/tests/libs/clang/input/const_dependency.hpp
+++ b/crates/tests/libs/clang/input/const_dependency.hpp
@@ -1,0 +1,38 @@
+#include "const_dependency_inc.inl"
+
+#define STATUS_LITERAL ((IncludedStatus)7)
+#define STATUS_CHAINED ((ChainedStatus)9)
+#define STATUS_EVALUATED ((IncludedStatus)(1 + 2))
+#define STATUS_FUNDAMENTAL ((DWORD)(1 + 2))
+#define STATUS_BASE 4
+#define STATUS_NONCAST ((STATUS_BASE) + 1)
+#define STATUS_REDEFINED ((ChainedStatus)(1 + 2))
+#undef STATUS_REDEFINED
+#define STATUS_REDEFINED (4 + 5)
+#define STATUS_DIRECT_REDEFINED ((UnusedStatus)1)
+#undef STATUS_DIRECT_REDEFINED
+#define STATUS_DIRECT_REDEFINED 9
+#define STATUS_DIRECT_FLOAT 1.5
+#define STATUS_TERMINAL_UNDEF ((UnusedStatus)3)
+#undef STATUS_TERMINAL_UNDEF
+#define STATUS_DROPPED_REDEFINITION ((UnusedStatus)2)
+#undef STATUS_DROPPED_REDEFINITION
+#define STATUS_DROPPED_REDEFINITION(value) value
+#define STATUS_ENUM ((ConstantState)1)
+#define STATUS_ENUM_TAG ((_ConstantState)(1 + 1))
+#define STATUS_TAG_ONLY ((TagOnlyStatus)(1 + 1))
+#define STATUS_MERGED ((MergedStatus)(1 + 1))
+
+#define STATUS_TYPE_SHADOW ((TypeShadowStatus)(1 + 2))
+#define TypeShadowStatus unsigned int
+#define FunctionShadowStatus(value) value
+#define STATUS_FUNCTION_SHADOW ((FunctionShadowStatus)(1 + 2))
+#define STATUS_NUMERIC_SHADOW NumericShadowStatus
+#define NumericShadowStatus 6
+extern int runtime_status;
+#define STATUS_RUNTIME ((RuntimeStatus)runtime_status)
+
+typedef unsigned int MacroNameCollision;
+#define MacroNameCollision 1
+#undef MacroNameCollision
+#define MacroNameCollision(value) value

--- a/crates/tests/libs/clang/input/const_dependency_inc.inl
+++ b/crates/tests/libs/clang/input/const_dependency_inc.inl
@@ -1,0 +1,21 @@
+typedef unsigned short IncludedStatus;
+typedef IncludedStatus ChainedStatus;
+typedef unsigned long DWORD;
+typedef unsigned short UnusedStatus;
+typedef unsigned short TypeShadowStatus;
+typedef unsigned short FunctionShadowStatus;
+typedef unsigned short NumericShadowStatus;
+typedef unsigned short RuntimeStatus;
+
+typedef enum _ConstantState : unsigned int {
+    ConstantStateReady = 1,
+} ConstantState;
+
+enum TagOnlyStatus : unsigned short {
+    TagOnlyReady = 1,
+};
+
+enum _MergedStatus {
+    MergedStatusReady = 1,
+};
+typedef unsigned long MergedStatus;

--- a/crates/tests/libs/clang/input/const_dependency_type_collision.hpp
+++ b/crates/tests/libs/clang/input/const_dependency_type_collision.hpp
@@ -1,0 +1,3 @@
+typedef unsigned short CollisionStatus;
+
+#define COLLISION_STATUS_VALUE ((CollisionStatus)3)

--- a/crates/tests/libs/clang/input/const_dependency_value_collision.hpp
+++ b/crates/tests/libs/clang/input/const_dependency_value_collision.hpp
@@ -1,0 +1,1 @@
+#define CollisionStatus 5

--- a/crates/tests/libs/clang/tests/clang.rs
+++ b/crates/tests/libs/clang/tests/clang.rs
@@ -530,6 +530,108 @@ fn namespaced_record_dependencies_preserve_layout() {
         .unwrap();
 }
 
+#[test]
+fn namespaced_constants_retain_type_dependencies() {
+    let scratch = std::path::Path::new(env!("OUT_DIR")).join("const_dependency");
+    std::fs::create_dir_all(&scratch).unwrap();
+    let rdl = scratch.join("out.rdl");
+
+    {
+        let _guard = test_clang::libclang_guard();
+        windows_clang::clang()
+            .input("input/const_dependency.hpp")
+            .output(&rdl)
+            .namespace("ConstDependency")
+            .write()
+            .unwrap();
+    }
+
+    let contents = std::fs::read_to_string(&rdl).unwrap();
+    assert!(contents.contains("type IncludedStatus = u16"));
+    assert!(contents.contains("type ChainedStatus = u16"));
+    assert!(contents.contains("STATUS_LITERAL: IncludedStatus = 7"));
+    assert!(contents.contains("STATUS_CHAINED: ChainedStatus = 9"));
+    assert!(contents.contains("STATUS_EVALUATED: IncludedStatus = 3"));
+    assert!(contents.contains("STATUS_FUNDAMENTAL: u32 = 3"));
+    assert!(contents.contains("STATUS_NONCAST: i32 = 5"));
+    assert!(contents.contains("STATUS_REDEFINED: i32 = 9"));
+    assert!(contents.contains("STATUS_DIRECT_REDEFINED: i32 = 9"));
+    assert!(contents.contains("STATUS_DIRECT_FLOAT: f64 = 1.5"));
+    assert!(!contents.contains("STATUS_TERMINAL_UNDEF"));
+    assert!(!contents.contains("STATUS_DROPPED_REDEFINITION"));
+    assert!(contents.contains("#[repr(u32)]"));
+    assert!(contents.contains("enum ConstantState"));
+    assert!(contents.contains("ConstantStateReady = 1"));
+    assert!(contents.contains("STATUS_ENUM: ConstantState = 1"));
+    assert!(contents.contains("STATUS_ENUM_TAG: ConstantState = 2"));
+    assert!(contents.contains("enum TagOnlyStatus"));
+    assert!(contents.contains("TagOnlyReady = 1"));
+    assert!(contents.contains("STATUS_TAG_ONLY: TagOnlyStatus = 2"));
+    assert!(contents.contains("enum MergedStatus"));
+    assert!(contents.contains("MergedStatusReady = 1"));
+    assert!(contents.contains("STATUS_MERGED: MergedStatus = 2"));
+    assert!(contents.contains("STATUS_TYPE_SHADOW: u32 = 3"));
+    assert!(contents.contains("STATUS_FUNCTION_SHADOW: FunctionShadowStatus = 3"));
+    assert!(contents.contains("type FunctionShadowStatus = u16"));
+    assert!(contents.contains("STATUS_NUMERIC_SHADOW: i32 = 6"));
+    assert!(!contents.contains("STATUS_RUNTIME"));
+    assert!(!contents.contains("type DWORD"));
+    assert!(!contents.contains("type UnusedStatus"));
+    assert!(!contents.contains("type TypeShadowStatus"));
+    assert!(!contents.contains("type NumericShadowStatus"));
+    assert!(!contents.contains("type RuntimeStatus"));
+    assert!(contents.contains("type MacroNameCollision = u32"));
+    windows_rdl::reader()
+        .input(&rdl)
+        .output(scratch.join("out.winmd"))
+        .write()
+        .unwrap();
+
+    let collision_rdl = scratch.join("collision.rdl");
+    {
+        let _guard = test_clang::libclang_guard();
+        windows_clang::clang()
+            .input("input/const_dependency_value_collision.hpp")
+            .input("input/const_dependency_type_collision.hpp")
+            .output(&collision_rdl)
+            .namespace("ConstDependencyCollision")
+            .write()
+            .unwrap();
+    }
+
+    let collision = std::fs::read_to_string(&collision_rdl).unwrap();
+    assert!(collision.contains("type CollisionStatus = u16"));
+    assert!(collision.contains("COLLISION_STATUS_VALUE: CollisionStatus = 3"));
+    assert!(!collision.contains("const CollisionStatus"));
+    windows_rdl::reader()
+        .input(&collision_rdl)
+        .output(scratch.join("collision.winmd"))
+        .write()
+        .unwrap();
+
+    let collision_reverse_rdl = scratch.join("collision_reverse.rdl");
+    {
+        let _guard = test_clang::libclang_guard();
+        windows_clang::clang()
+            .input("input/const_dependency_type_collision.hpp")
+            .input("input/const_dependency_value_collision.hpp")
+            .output(&collision_reverse_rdl)
+            .namespace("ConstDependencyCollision")
+            .write()
+            .unwrap();
+    }
+
+    let collision_reverse = std::fs::read_to_string(&collision_reverse_rdl).unwrap();
+    assert!(collision_reverse.contains("type CollisionStatus = u16"));
+    assert!(collision_reverse.contains("COLLISION_STATUS_VALUE: CollisionStatus = 3"));
+    assert!(!collision_reverse.contains("const CollisionStatus"));
+    windows_rdl::reader()
+        .input(&collision_reverse_rdl)
+        .output(scratch.join("collision_reverse.winmd"))
+        .write()
+        .unwrap();
+}
+
 fn run(name: &str) {
     let input_path = format!("input/{name}.h");
     let expected_path = format!("expected/{name}.rdl");

--- a/docs/crates/windows-clang.md
+++ b/docs/crates/windows-clang.md
@@ -151,13 +151,15 @@ The scraper preserves:
 - SAL and IDL optionality, buffer sizing, retval, and interface-selection annotations;
 - `uuid`, `noreturn`, alignment, `dllimport`, and deprecation attributes;
 - calling conventions, packing, unions, scoped enums, bit fields, and typedefs;
-- explicit constant casts and C integer literal types;
+- explicit constant casts, including casts whose expressions require batch evaluation, and C
+  integer literal types;
 - GUID values from `DEFINE_GUID`, `DEFINE_OLEGUID`, and `DEFINE_KNOWN_FOLDER`;
 - `DEFINE_ENUM_FLAG_OPERATORS` as a flags-enum signal;
 - symbol-to-DLL mappings recovered from import libraries.
 
 Namespaced scrapes follow referenced record definitions from included headers. Available layouts
 are emitted for both by-value and pointer dependencies; they are not replaced with opaque records.
+Typedefs referenced only by constants are retained in the same namespace.
 Per-header scrapes discover the same definitions globally and retain them in their owning header
 partition.
 


### PR DESCRIPTION
Addresses item 13 in #4902.

Namespaced scrapes could emit a constant that referenced a typedef from an included header without emitting the typedef itself. This keeps those local typedef and enum dependencies when they are only used by constants.

For macros that need evaluation, the type now comes from Clang's post-preprocessing AST instead of being guessed from the macro tokens. This handles macro shadows, redefinitions, rejected expressions, and same-named declarations without trying to match types across unrelated translation units.

Includes regression coverage for typedef chains, enum backing definitions, macro final state, and cross-input name collisions.